### PR TITLE
Feature: add static analysis

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -25,25 +25,39 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies ~(into '[[org.clojure/tools.namespace "0.2.11"]
-                                [pjstadig/humane-test-output "0.8.1"]
-                                [proto-repl "0.3.1"]]
-                          dev-cmr-deps)
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test" "int_test"]
-         :test-paths ["test" "int_test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
+  :profiles {
+    :dev {:dependencies ~(into '[[org.clojure/tools.namespace "0.2.11"]
+                                 [pjstadig/humane-test-output "0.8.1"]
+                                 [proto-repl "0.3.1"]]
+                           dev-cmr-deps)
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test" "int_test"]
+          :test-paths ["test" "int_test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
 
-   ;; This profile specifically here for generating documentation. It's faster than using the regular
-   ;; profile. An agent pool is being started when using the default profile which causes the wait of
-   ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
-   ;; Generate docs with: lein with-profile docs generate-docs
-   :docs {}
+    ;; This profile specifically here for generating documentation. It's faster
+    ;; than using the regular profile. An agent pool is being started when
+    ;; using the default profile which causes the wait of 60 seconds before
+    ;; allowing the JVM to shutdown since no call to shutdown-agents is made.
+    ;; Generate docs with: lein with-profile docs generate-docs
+    :docs {}
 
-   :uberjar {:main cmr.access-control.runner
-             :aot :all}}
+    :uberjar {:main cmr.access-control.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :test-paths ["test" "int_test"]
   :aliases {"generate-docs" ["exec" "-ep" (pr-str '(do
                                                      (use 'cmr.common-app.api-docs)
@@ -59,4 +73,12 @@
                                         :let [project-dir (.replace (name group-artifact) "cmr-" "")]]
                                     ["shell" "ln" "-s" (str "../../" project-dir) "checkouts/,"]))
             ;; Alias to test2junit for consistency with lein-test-out.
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -45,7 +45,7 @@
 
     :uberjar {:main cmr.access-control.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -12,7 +12,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -7,10 +7,31 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
-             "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -21,17 +21,38 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}
-   :uberjar {:main cmr.bootstrap.runner
-             :aot :all}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    :uberjar {:main cmr.bootstrap.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   ;; Database migrations run by executing "lein migrate"
   :aliases {"create-user" ["exec" "-p" "./support/create_user.clj"]
             "drop-user" ["exec" "-p" "./support/drop_user.clj"]
             ;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -28,7 +28,7 @@
           :source-paths ["src" "dev" "test"]}
     :uberjar {:main cmr.bootstrap.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -23,18 +23,39 @@
   :resource-paths ["resources" ~gem-install-path]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [proto-repl "0.3.1"]
-                        [pjstadig/humane-test-output "0.8.1"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [proto-repl "0.3.1"]
+                         [pjstadig/humane-test-output "0.8.1"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {"install-gems" ["shell"
                             "support/install_gems.sh"
                             ~jruby-version
                             ~cmr-metadata-preview-repo]
             "clean-gems" ["shell" "rm" "-rf" ~gem-install-path]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -31,7 +31,7 @@
           :source-paths ["src" "dev" "test"]
           :injections [(require 'pjstadig.humane-test-output)
                        (pjstadig.humane-test-output/activate!)]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -21,7 +21,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -16,10 +16,31 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
-             "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -52,13 +52,15 @@
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [criterium "0.4.4"]
-                        [proto-repl "0.3.1"]
-                        [clj-http "2.0.0"]]
-         :jvm-opts ^:replace ["-server"]
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [criterium "0.4.4"]
+                         [proto-repl "0.3.1"]
+                         [clj-http "2.0.0"]]
+          :jvm-opts ^:replace ["-server"]
+                               ;; XXX Note that profiling can be kept in a profile,
+                               ;;     with no need to comment/uncomment.
                                ;; Uncomment this to enable assertions. Turn off during performance tests.
                                ; "-ea"
 
@@ -67,6 +69,27 @@
                                ; "-Dcom.sun.management.jmxremote.ssl=false"
                                ; "-Dcom.sun.management.jmxremote.authenticate=false"
                                ; "-Dcom.sun.management.jmxremote.port=1098"]
-         :source-paths ["src" "dev" "test"]}}
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
-             "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -70,7 +70,7 @@
                                ; "-Dcom.sun.management.jmxremote.authenticate=false"
                                ; "-Dcom.sun.management.jmxremote.port=1098"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/cubby-app/project.clj
+++ b/cubby-app/project.clj
@@ -27,7 +27,7 @@
                        (pjstadig.humane-test-output/activate!)]}
     :uberjar {:main cmr.cubby.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/cubby-app/project.clj
+++ b/cubby-app/project.clj
@@ -16,19 +16,40 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test" "int_test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
-   :uberjar {:main cmr.cubby.runner
-             :aot :all}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test" "int_test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    :uberjar {:main cmr.cubby.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :test-paths ["int_test"]
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -64,38 +64,60 @@
              "-Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog"
              "-Dorg.eclipse.jetty.LEVEL=INFO"
              "-Dorg.eclipse.jetty.websocket.LEVEL=INFO"]
-  :profiles
-  {:dev-dependencies {:dependencies [[ring-mock "0.1.5"]
-                                     [org.clojure/tools.namespace "0.2.11"]
-                                     [org.clojars.gjahad/debug-repl "0.3.3"]
-                                     [pjstadig/humane-test-output "0.8.1"]
-                                     [debugger "0.2.0"]
-                                     [criterium "0.4.4"]
-                                     ;; Must be listed here as metadata db depends on it.
-                                     [drift "1.5.3"]
-                                     [proto-repl-charts "0.3.1"]
-                                     [proto-repl "0.3.1"]
-                                     [proto-repl-sayid "0.1.3"]]
-
-                      ;; Use the following to enable JMX profiling with visualvm
-                      ;:jvm-opts ^:replace ["-server"
-                      ;                     "-Dcom.sun.management.jmxremote"
-                      ;                     "-Dcom.sun.management.jmxremote.ssl=false"
-                      ;                     "-Dcom.sun.management.jmxremote.authenticate=false"
-                      ;                     "-Dcom.sun.management.jmxremote.port=1098"]
-                      :source-paths ["src" "dev" "test"]
-                      :injections [(require 'pjstadig.humane-test-output)
-                                   (pjstadig.humane-test-output/activate!)]}
-   ;; This is to separate the dependencies from the dev-config specified in profiles.clj
-   :dev [:dev-dependencies :dev-config]
-   :uberjar {:main cmr.dev-system.runner
-             ;; See http://stephen.genoprime.com/2013/11/14/uberjar-with-titan-dependency.html
-             :uberjar-merge-with {#"org\.apache\.lucene\.codecs\.*" [slurp str spit]}
-             :aot :all}}
+  :profiles {
+    :dev-dependencies {:dependencies [[ring-mock "0.1.5"]
+                                      [org.clojure/tools.namespace "0.2.11"]
+                                      [org.clojars.gjahad/debug-repl "0.3.3"]
+                                      [pjstadig/humane-test-output "0.8.1"]
+                                      [debugger "0.2.0"]
+                                      [criterium "0.4.4"]
+                                      ;; Must be listed here as metadata db depends on it.
+                                      [drift "1.5.3"]
+                                      [proto-repl-charts "0.3.1"]
+                                      [proto-repl "0.3.1"]
+                                      [proto-repl-sayid "0.1.3"]]
+                       ;; XXX Note that profiling can be kept in a profile,
+                       ;;     with no need to comment/uncomment.
+                       ;; Use the following to enable JMX profiling with visualvm
+                       ;:jvm-opts ^:replace ["-server"
+                       ;                     "-Dcom.sun.management.jmxremote"
+                       ;                     "-Dcom.sun.management.jmxremote.ssl=false"
+                       ;                     "-Dcom.sun.management.jmxremote.authenticate=false"
+                       ;                     "-Dcom.sun.management.jmxremote.port=1098"]
+                       :source-paths ["src" "dev" "test"]
+                       :injections [(require 'pjstadig.humane-test-output)
+                                    (pjstadig.humane-test-output/activate!)]}
+    ;; This is to separate the dependencies from the dev-config specified in profiles.clj
+    :dev [:dev-dependencies :dev-config]
+    :uberjar {:main cmr.dev-system.runner
+              ;; See http://stephen.genoprime.com/2013/11/14/uberjar-with-titan-dependency.html
+              :uberjar-merge-with {#"org\.apache\.lucene\.codecs\.*" [slurp str spit]}
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {;; Creates the checkouts directory to the local projects
             "create-checkouts" ~create-checkouts-commands
             ;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Installs the Elasticsearch Marvel plugin locally.
             ;; Visit http://localhost:9210/_plugin/marvel/sense/index.html
-            "install-marvel" ["shell" "./support/install-marvel.sh"]})
+            "install-marvel" ["shell" "./support/install-marvel.sh"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -93,7 +93,7 @@
               ;; See http://stephen.genoprime.com/2013/11/14/uberjar-with-titan-dependency.html
               :uberjar-merge-with {#"org\.apache\.lucene\.codecs\.*" [slurp str spit]}
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -21,7 +21,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -16,10 +16,31 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -57,7 +57,7 @@
           ;                      "-Dcom.sun.management.jmxremote.port=1098"]
           :source-paths ["src" "dev"]}
     :uberjar {:aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -36,27 +36,40 @@
         cmr.es-spatial-plugin.SpatialScriptFactory
         cmr.es-spatial-plugin.SpatialSearchPlugin]
 
-  :profiles
-  {:dev {:dependencies [[nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-                        [org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [criterium "0.4.4"]]
+  :profiles {
+    :dev {:dependencies [[nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                         [org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [criterium "0.4.4"]]
 
-         :global-vars {*warn-on-reflection* true
+          :global-vars {*warn-on-reflection* true
                        *assert* false}
 
-         ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
-         ;; See https://github.com/technomancy/leiningen/wiki/Faster
-         :jvm-opts ^:replace ["-server"]
-                                ;; important to allow logging to standard out
-         ;                      "-Des.foreground=true"
-         ;                      ;; Use the following to enable JMX profiling with visualvm
-         ;                      "-Dcom.sun.management.jmxremote"
-         ;                      "-Dcom.sun.management.jmxremote.ssl=false"
-         ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
-         ;                      "-Dcom.sun.management.jmxremote.port=1098"]
-         :source-paths ["src" "dev"]}
-   :uberjar {:aot :all}}
+          ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
+          ;; See https://github.com/technomancy/leiningen/wiki/Faster
+          :jvm-opts ^:replace ["-server"]
+                                 ;; important to allow logging to standard out
+          ;                      "-Des.foreground=true"
+          ;                      ;; Use the following to enable JMX profiling with visualvm
+          ;                      "-Dcom.sun.management.jmxremote"
+          ;                      "-Dcom.sun.management.jmxremote.ssl=false"
+          ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
+          ;                      "-Dcom.sun.management.jmxremote.port=1098"]
+          :source-paths ["src" "dev"]}
+    :uberjar {:aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
 
   :aliases {;; Packages the spatial search plugin
             "package" ["do"
@@ -78,4 +91,12 @@
                                 "package,"
                                 "shell" "install_plugin_into_workload.sh" ~plugin-zip-name "spatialsearch-plugin"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/index-set-app/project.clj
+++ b/index-set-app/project.clj
@@ -31,7 +31,7 @@
 
     :uberjar {:main cmr.index-set.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/index-set-app/project.clj
+++ b/index-set-app/project.clj
@@ -14,25 +14,46 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
-                        [proto-repl "0.3.1"]
-                        [clj-http "2.0.0"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test" "int_test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
+                         [proto-repl "0.3.1"]
+                         [clj-http "2.0.0"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test" "int_test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
 
-   :integration-test {:test-paths ["int_test"]
-                      :dependencies [[clj-http "2.0.0"]]}
+    :integration-test {:test-paths ["int_test"]
+                       :dependencies [[clj-http "2.0.0"]]}
 
-   :uberjar {:main cmr.index-set.runner
-             :aot :all}}
+    :uberjar {:main cmr.index-set.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :test-paths ["test" "int_test"]
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -24,7 +24,7 @@
           :source-paths ["src" "dev" "test"]}
     :uberjar {:main cmr.indexer.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -17,14 +17,35 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}
-   :uberjar {:main cmr.indexer.runner
-             :aot :all}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    :uberjar {:main cmr.indexer.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -28,19 +28,32 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
 
-   ;; This profile specifically here for generating documentation. It's faster than using the regular
-   ;; profile. An agent pool is being started when using the default profile which causes the wait of
-   ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
-   ;; Generate docs with: lein with-profile docs generate-docs
-   :docs {}
-   :uberjar {:main cmr.ingest.runner
-             :aot :all}}
+    ;; This profile specifically here for generating documentation. It's faster than using the regular
+    ;; profile. An agent pool is being started when using the default profile which causes the wait of
+    ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
+    ;; Generate docs with: lein with-profile docs generate-docs
+    :docs {}
+    :uberjar {:main cmr.ingest.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
 
   :aliases {"generate-docs" ["exec" "-ep" (pr-str '(do
                                                     (use 'cmr.common-app.api-docs)
@@ -54,4 +67,12 @@
             ;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -41,7 +41,7 @@
     :docs {}
     :uberjar {:main cmr.ingest.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -17,7 +17,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -12,10 +12,31 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -38,7 +38,7 @@
                        :dependencies [[clj-http "2.0.0"]]}
     :uberjar {:main cmr.metadata-db.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -23,21 +23,34 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [proto-repl "0.3.1"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        [clj-http "2.0.0"]
-                        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test" "int_test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
-   :integration-test {:test-paths ["int_test"]
-                      :dependencies [[clj-http "2.0.0"]]}
-   :uberjar {:main cmr.metadata-db.runner
-             :aot :all}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [proto-repl "0.3.1"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         [clj-http "2.0.0"]
+                         [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test" "int_test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    :integration-test {:test-paths ["int_test"]
+                       :dependencies [[clj-http "2.0.0"]]}
+    :uberjar {:main cmr.metadata-db.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :test-paths ["test" "int_test"]
   ;; Database migrations run by executing "lein migrate"
   :aliases {"create-user" ["exec" "-p" "./support/create_user.clj"]
@@ -45,4 +58,12 @@
             ;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -20,7 +20,7 @@
           :source-paths ["src" "dev" "test"]}
     :uberjar {:main cmr.mock-echo.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -12,13 +12,34 @@
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}
-   :uberjar {:main cmr.mock-echo.runner
-             :aot :all}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    :uberjar {:main cmr.mock-echo.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/oracle-lib/project.clj
+++ b/oracle-lib/project.clj
@@ -32,11 +32,35 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
-
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            ;; Eastwood needs special handling with libs that include oracle
+            ;; drivers in the deps, in particulear:
+            ;;   java.lang.ClassNotFoundException: oracle.dms.console.DMSConsole
+            "eastwood" ["with-profile" "lint" "eastwood"
+                        "{:namespaces [:source-paths] :exclude-namespaces [cmr.oracle.connection]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/oracle-lib/project.clj
+++ b/oracle-lib/project.clj
@@ -37,7 +37,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/oracle-lib/src/cmr/oracle/connection.clj
+++ b/oracle-lib/src/cmr/oracle/connection.clj
@@ -14,6 +14,8 @@
    ;; This is required as an attempt to avoid NoClassDefFoundError occasionally during startup.
    ;; See CMR-3156
    (oracle.security.o5logon O5Logon)
+   ;;
+   ;(oracle.dms.console DMSConsole)
    (oracle.ucp.admin UniversalConnectionPoolManagerImpl)
    (oracle.ucp.jdbc PoolDataSourceFactory)))
 

--- a/oracle-lib/src/cmr/oracle/connection.clj
+++ b/oracle-lib/src/cmr/oracle/connection.clj
@@ -14,8 +14,6 @@
    ;; This is required as an attempt to avoid NoClassDefFoundError occasionally during startup.
    ;; See CMR-3156
    (oracle.security.o5logon O5Logon)
-   ;;
-   ;(oracle.dms.console DMSConsole)
    (oracle.ucp.admin UniversalConnectionPoolManagerImpl)
    (oracle.ucp.jdbc PoolDataSourceFactory)))
 

--- a/orbits-lib/project.clj
+++ b/orbits-lib/project.clj
@@ -56,7 +56,7 @@
           :resource-paths ["resources" "test_resources" ~dev-gem-install-path]
           :injections [(require 'pjstadig.humane-test-output)
                        (pjstadig.humane-test-output/activate!)]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/orbits-lib/project.clj
+++ b/orbits-lib/project.clj
@@ -47,16 +47,37 @@
   :resource-paths ["resources"]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [proto-repl "0.3.1"]
-                        [pjstadig/humane-test-output "0.8.1"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]
-         :resource-paths ["resources" "test_resources" ~dev-gem-install-path]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [proto-repl "0.3.1"]
+                         [pjstadig/humane-test-output "0.8.1"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]
+          :resource-paths ["resources" "test_resources" ~dev-gem-install-path]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {"install-gems" ~(install-gems-command dev-gem-install-path dev-gem-versions)
             "clean-gems" ["shell" "rm" "-rf" ~dev-gem-install-path]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/project.clj
+++ b/project.clj
@@ -27,5 +27,7 @@
                                         "virtual-product-app"
                                         "es-spatial-plugin"]}}}
   :aliases {
+    "kibit" ["modules" "kibit"]
+    "eastwood" ["modules" "eastwood"]
     "lint" ["modules" "lint"]})
 

--- a/project.clj
+++ b/project.clj
@@ -25,5 +25,7 @@
                                         "metadata-db-app"
                                         "search-app"
                                         "virtual-product-app"
-                                        "es-spatial-plugin"]}}})
+                                        "es-spatial-plugin"]}}}
+  :aliases {
+    "lint" ["modules" "lint"]})
 

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -57,7 +57,7 @@
     :uberjar {:main cmr.search.runner
               :aot :all}
 
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -34,27 +34,42 @@
                  :timeout 120000}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[ring-mock "0.1.5"]
-                        [org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [criterium "0.4.4"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        ;; Must be listed here as metadata db depends on it.
-                        [drift "1.5.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
+  :profiles {
+    :dev {:dependencies [[ring-mock "0.1.5"]
+                         [org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [criterium "0.4.4"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         ;; Must be listed here as metadata db depends on it.
+                         [drift "1.5.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
 
-   ;; This profile specifically here for generating documentation. It's faster than using the regular
-   ;; profile. An agent pool is being started when using the default profile which causes the wait of
-   ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
-   ;; Generate docs with: lein with-profile docs generate-docs
-   :docs {}
+    ;; This profile specifically here for generating documentation. It's
+    ;; faster than using the regular profile. An agent pool is being started
+    ;; when using the default profile which causes the wait of 60 seconds
+    ;; before allowing the JVM to shutdown since no call to shutdown-agents is
+    ;; made. Generate docs with: lein with-profile docs generate-docs
+    :docs {}
 
-   :uberjar {:main cmr.search.runner
-             :aot :all}}
+    :uberjar {:main cmr.search.runner
+              :aot :all}
+
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
 
   :aliases {"generate-docs"
             ["exec" "-ep"
@@ -81,4 +96,12 @@
             ;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/spatial-lib/project.clj
+++ b/spatial-lib/project.clj
@@ -38,23 +38,44 @@
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [criterium "0.4.4"]
-                        [proto-repl "0.3.1"]
-                        [pjstadig/humane-test-output "0.8.1"]]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]
-         :jvm-opts ^:replace ["-server"]
-                             ;; Uncomment this to enable assertions. Turn off during performance tests.
-                             ; "-ea"
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [criterium "0.4.4"]
+                         [proto-repl "0.3.1"]
+                         [pjstadig/humane-test-output "0.8.1"]]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]
+          :jvm-opts ^:replace ["-server"]
+                              ;; Uncomment this to enable assertions. Turn off during performance tests.
+                              ; "-ea"
 
-                             ;; Use the following to enable JMX profiling with visualvm
-                             ;  "-Dcom.sun.management.jmxremote"
-                             ;  "-Dcom.sun.management.jmxremote.ssl=false"
-                             ;  "-Dcom.sun.management.jmxremote.authenticate=false"
-                             ;  "-Dcom.sun.management.jmxremote.port=1098"]
-         :source-paths ["src" "dev" "test"]}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+                              ;; Use the following to enable JMX profiling with visualvm
+                              ;  "-Dcom.sun.management.jmxremote"
+                              ;  "-Dcom.sun.management.jmxremote.ssl=false"
+                              ;  "-Dcom.sun.management.jmxremote.authenticate=false"
+                              ;  "-Dcom.sun.management.jmxremote.port=1098"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/spatial-lib/project.clj
+++ b/spatial-lib/project.clj
@@ -56,7 +56,7 @@
                               ;  "-Dcom.sun.management.jmxremote.authenticate=false"
                               ;  "-Dcom.sun.management.jmxremote.port=1098"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -38,15 +38,36 @@
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Dclojure.compiler.direct-linking=true"]
 
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [nasa-cmr/cmr-vdd-spatial-viz "0.1.0-SNAPSHOT"]
-                        [pjstadig/humane-test-output "0.8.1"]]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]
-         :jvm-opts ^:replace ["-server"
-                              "-XX:-OmitStackTraceInFastThrow"]
-         :source-paths ["src" "dev"]}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [nasa-cmr/cmr-vdd-spatial-viz "0.1.0-SNAPSHOT"]
+                         [pjstadig/humane-test-output "0.8.1"]]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]
+          :jvm-opts ^:replace ["-server"
+                               "-XX:-OmitStackTraceInFastThrow"]
+          :source-paths ["src" "dev"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -48,7 +48,7 @@
           :jvm-opts ^:replace ["-server"
                                "-XX:-OmitStackTraceInFastThrow"]
           :source-paths ["src" "dev"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -12,11 +12,31 @@
   :plugins [[test2junit "1.2.1"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test"]}}
-
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -17,7 +17,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "test"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/umm-lib/project.clj
+++ b/umm-lib/project.clj
@@ -33,7 +33,7 @@
           :source-paths ["src" "dev" "test"]
           :injections [(require 'pjstadig.humane-test-output)
                        (pjstadig.humane-test-output/activate!)]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/umm-lib/project.clj
+++ b/umm-lib/project.clj
@@ -15,23 +15,44 @@
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        [criterium "0.4.4"]
-                        [proto-repl "0.3.1"]]
-         :jvm-opts ^:replace ["-server"]
-                              ;; Uncomment this to enable assertions. Turn off during performance tests.
-                              ; "-ea"
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         [criterium "0.4.4"]
+                         [proto-repl "0.3.1"]]
+          :jvm-opts ^:replace ["-server"]
+                               ;; Uncomment this to enable assertions. Turn off during performance tests.
+                               ; "-ea"
 
-                              ;; Use the following to enable JMX profiling with visualvm
-                              ;; "-Dcom.sun.management.jmxremote"
-                              ;; "-Dcom.sun.management.jmxremote.ssl=false"
-                              ;; "-Dcom.sun.management.jmxremote.authenticate=false"
-                              ;; "-Dcom.sun.management.jmxremote.port=1098"]
-         :source-paths ["src" "dev" "test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}}
-  :aliases { ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+                               ;; Use the following to enable JMX profiling with visualvm
+                               ;; "-Dcom.sun.management.jmxremote"
+                               ;; "-Dcom.sun.management.jmxremote.ssl=false"
+                               ;; "-Dcom.sun.management.jmxremote.authenticate=false"
+                               ;; "-Dcom.sun.management.jmxremote.port=1098"]
+          :source-paths ["src" "dev" "test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
+  :aliases {;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/umm-spec-lib/project.clj
+++ b/umm-spec-lib/project.clj
@@ -12,27 +12,47 @@
             [lein-exec "0.3.2"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [pjstadig/humane-test-output "0.8.1"]
-                        [criterium "0.4.4"]
-                        [proto-repl "0.3.1"]
-                        [clj-http "2.0.0"]]
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [pjstadig/humane-test-output "0.8.1"]
+                         [criterium "0.4.4"]
+                         [proto-repl "0.3.1"]
+                         [clj-http "2.0.0"]]
 
-         ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
-         ;; See https://github.com/technomancy/leiningen/wiki/Faster
-         :jvm-opts ^:replace ["-server"]
-         ;                      ;; Use the following to enable JMX profiling with visualvm
-         ;                      "-Dcom.sun.management.jmxremote"
-         ;                      "-Dcom.sun.management.jmxremote.ssl=false"
-         ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
-         ;                      "-Dcom.sun.management.jmxremote.port=1098"]
+          ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
+          ;; See https://github.com/technomancy/leiningen/wiki/Faster
+          :jvm-opts ^:replace ["-server"]
+          ;                      ;; Use the following to enable JMX profiling with visualvm
+          ;                      "-Dcom.sun.management.jmxremote"
+          ;                      "-Dcom.sun.management.jmxremote.ssl=false"
+          ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
+          ;                      "-Dcom.sun.management.jmxremote.port=1098"]
 
-         :source-paths ["src" "dev" "test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}}
-
+          :source-paths ["src" "dev" "test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :aliases {"generate-umm-records" ["exec" "-ep" "(do (use 'cmr.umm-spec.record-generator) (generate-umm-records))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/umm-spec-lib/project.clj
+++ b/umm-spec-lib/project.clj
@@ -32,7 +32,7 @@
           :source-paths ["src" "dev" "test"]
           :injections [(require 'pjstadig.humane-test-output)
                        (pjstadig.humane-test-output/activate!)]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/vdd-spatial-viz/project.clj
+++ b/vdd-spatial-viz/project.clj
@@ -17,7 +17,7 @@
                          [org.clojars.gjahad/debug-repl "0.3.3"]]
           :jvm-opts ^:replace ["-server"]
           :source-paths ["src" "dev" "viz"]}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.

--- a/vdd-spatial-viz/project.clj
+++ b/vdd-spatial-viz/project.clj
@@ -12,13 +12,33 @@
 
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "viz"]}}
-
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "viz"]}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   ;; Must be manually run before running lein install
   :aliases {"compile-coffeescript" ["exec" "-ep" "(common-viz.util/compile-coffeescript (vdd-core.core/config))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -15,18 +15,39 @@
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :repl-options {:init-ns user}
-  :profiles
-  {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
-                        [org.clojars.gjahad/debug-repl "0.3.3"]
-                        [pjstadig/humane-test-output "0.8.1"]]
-         :jvm-opts ^:replace ["-server"]
-         :source-paths ["src" "dev" "test" "int_test"]
-         :injections [(require 'pjstadig.humane-test-output)
-                      (pjstadig.humane-test-output/activate!)]}
-   :uberjar {:main cmr.virtual-product.runner
-             :aot :all}}
+  :profiles {
+    :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                         [org.clojars.gjahad/debug-repl "0.3.3"]
+                         [pjstadig/humane-test-output "0.8.1"]]
+          :jvm-opts ^:replace ["-server"]
+          :source-paths ["src" "dev" "test" "int_test"]
+          :injections [(require 'pjstadig.humane-test-output)
+                       (pjstadig.humane-test-output/activate!)]}
+    :uberjar {:main cmr.virtual-product.runner
+              :aot :all}
+    ;; This profile is used for linting and static analisys. To run for this
+    ;; project, use `lein lint` from inside the project directory. To run for
+    ;; all projects at the same time, use the same command but from the top-
+    ;; level directory.
+    :lint {
+      :source-paths ^:replace ["src"]
+      :test-paths ^:replace []
+      :plugins [[jonase/eastwood "0.2.3"]
+                [lein-ancient "0.6.10"]
+                [lein-bikeshed "0.4.1"]
+                [lein-kibit "0.1.2"]
+                [lein-shell "0.4.0"]
+                [venantius/yagni "0.1.4"]]}}
   :test-paths ["test" "int_test"]
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]})
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit" ["do" ["with-profile" "lint" "shell" "echo" "== Kibit =="]
+                          ["with-profile" "lint" "kibit"]]
+            "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed" ["with-profile" "lint" "bikeshed"]
+            "yagni" ["with-profile" "lint" "yagni"]
+            "check-deps" ["with-profile" "lint" "ancient"]
+            "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -25,7 +25,7 @@
                        (pjstadig.humane-test-output/activate!)]}
     :uberjar {:main cmr.virtual-product.runner
               :aot :all}
-    ;; This profile is used for linting and static analisys. To run for this
+    ;; This profile is used for linting and static analysis. To run for this
     ;; project, use `lein lint` from inside the project directory. To run for
     ;; all projects at the same time, use the same command but from the top-
     ;; level directory.


### PR DESCRIPTION
This change adds support for various Clojure static analysis tools.

For subprojects:
 * a new profile has been added with new lein plugins for running the tools against the codebase
 * new aliases have been added that conveniently wrap the longer lein commands for the new profile

For the top-level project:
 * support has been added for running the most useful new static analysis commands across all projects
 * note that the CI/CD script has not yet been updated to use these (depends on future code cleanup work)

Future work:
 * there are pending branches which address the kibit issues
 * once those are addressed, we can update the CI/CD script to run `lein kibit` at the top-level
 * once we address the eastwood errors, we can add the combo command `lein lint` to the CI/CD script (which does both kibit and eastwood in one command)