### PR TITLE
Task: tweak docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,26 @@ There are several `lein` plugins that have been added to CMR for performing
 various tasks either at individual subproject levels, or at the top-level for
 all subprojects.
 
-#### `lein ancient`
+#### Dependency Versions
 
-Some of the projects currently have support for checking if dependency versions
-are outdated. This is done with the `lein ancient` command, but will only work
-if the given subproject has added the ancient plugin in its `project.clj` file.
+The linting profile in each project also includes the `lein-ancient` plugin
+as well as an alias for it called `check-deps`. As such, each project may be
+checked for out-of-date dependency versions with the following:
+
+* `lein check-deps`
+
+Additionally, this same command is provided at the top-level for running
+against all projects at once. Note that this command fails with the first
+project that fails. If many subprojects are failing their dependency version
+checks and you wish to see all of these, you may use your system shell:
+
+```sh
+for DIR in `ls -1d */project.clj|xargs dirname`
+do
+  cd $DIR && echo "Checking $DIR ..." && lein check-deps
+  cd - &> /dev/null
+done
+```
 
 #### Static Analysis and Linting
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,70 @@ once.
 4. `lein uberjar`
 5. `java -classpath ./target/<NAME OF SERVICE>-0.1.0-SNAPSHOT-standalone.jar <MAIN METHOD OF SERVICE>`
 
-# Code structure
+## Checking Dependencies, Static Analysis, and Tests
+
+There are several `lein` plugins that have been added to CMR for performing
+various tasks either at individual subproject levels, or at the top-level for
+all subprojects.
+
+#### `lein ancient`
+
+Some of the projects currently have support for checking if dependency versions
+are outdated. This is done with the `lein ancient` command, but will only work
+if the given subproject has added the ancient plugin in its `project.clj` file.
+
+#### Static Analysis and Linting
+
+At the individual, subproject level, the following commands are available:
+
+* `lein kibit`
+* `lein eastwood`
+* `lein lint` (a higher-order task combining `compile`, `kibit`, and
+  `eastwood`)
+* `lein bikeshed`
+* `lein yagni`
+
+Each of those is a `lein` alias that wraps the given command's use from the
+`lint` profile.
+
+Across all subprojects, the following are available for use from the top-level
+directory:
+
+* `lein kibit`
+* `lein eastwood`
+* `lein lint`
+
+Each of those is a `lein` alias that takes advantage of `lein modules` and the
+fact that all subprojects share the same static analysis commands.
+
+#### Testing CMR
+
+There are two modes of testing the CMR:
+
+* From the REPL
+* Utilizing the CI/CD script to run against an Oracle database
+
+For the first, the steps are as follows:
+
+1. Ensure you have set up your development environment in `dev-system`
+2. If you have built any `.jar` files, run `lein clean`
+3. Start the REPL: `lein repl`
+4. Once in the REPL, start the in-memory services: `(reset)`
+5. Run the tests: `(run-all-tests)` or `(run-all-tests-future)`
+
+Depending upon your IDE/editor, you may have shortcuts available to you for
+starting/restarting the services and/or running the tests. To find out what
+these are you can contact a CMR core dev.
+
+In order to run the tests against an Oracle database, it is recommended that
+you use an Oracle VM built specifically for this purpose. You will also need
+configuration and authentication information that will be set as environment
+variables. Be sure to contact a CMR core dev for this information. Once these
+are in place, you will be able to run the following:
+
+`./dev-system/support/build-and-test-ci.sh`
+
+## Code structure
 
 The CMR is made up of several small services called microservices. These are
 small purposed-based services that do a small set of things well.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ running the CMR as a single process or as multiple processes.
 4. `lein repl`
 5. Once given a Clojure prompt, run `(reset)`
 
+Note that the `reset` action could potentially take a while, not only due to
+the code reloading for a large number of namespaces, but for bootstrapping
+services as well as starting up worker threads.
+
 #### Building and Running CMR Dev System from a Jar
 
 1. `cd cmr/dev-system`

--- a/README.md
+++ b/README.md
@@ -1,40 +1,70 @@
 # Common Metadata Repository
+
 Visit the CMR at [https://earthdata.nasa.gov/about/science-system-description/eosdis-components/common-metadata-repository](https://earthdata.nasa.gov/about/science-system-description/eosdis-components/common-metadata-repository)
 
 
 ## About
-The Common Metadata Repository (CMR) is an earth science metadata repository for [NASA](http://nasa.gov) [EOSDIS](https://earthdata.nasa.gov) data. The CMR Search API provides access to this metadata.
+
+The Common Metadata Repository (CMR) is an earth science metadata repository
+for [NASA](http://nasa.gov) [EOSDIS](https://earthdata.nasa.gov) data. The CMR
+Search API provides access to this metadata.
 
 ## Client-facing Components
+
 - Search
-  - Allows the user to search by collections, granules, and concepts with a myriad of different query types
+  - Allows the user to search by collections, granules, and concepts with a
+    myriad of different query types
   - API Docs: https://cmr.earthdata.nasa.gov/search/site/search_api_docs.html
 
 - Ingest
-  - Ingest refers to the process of validating, inserting, updating, or deleting metadata in the CMR system and affects only the metadata for the specific Data Partner. The CMR allows Data Partners to ingest metadata records through a RESTful API
+  - Ingest refers to the process of validating, inserting, updating, or
+    deleting metadata in the CMR system and affects only the metadata for the
+    specific Data Partner. The CMR allows Data Partners to ingest metadata
+    records through a RESTful API
   - API Docs: https://cmr.earthdata.nasa.gov/ingest/site/ingest_api_docs.html
 
 - Access Control
-  - Access Control Lists (ACLs) are the mechanism by which users are granted access to perform different operations in the CMR. CMR ACLs follow the same design as ECHO ACLs which in turn are derived from the generic ACL design pattern used in many other systems. At a high level, an ACL is a mapping of actors (subjects) to resources (object) to operations (predicate). For instance, a CMR ACL might specify that all Registered users have READ access to ASTER data or all users in a provider operations group have permissions to ingest data for a particular provider.
+  - Access Control Lists (ACLs) are the mechanism by which users are granted
+    access to perform different operations in the CMR. CMR ACLs follow the
+    same design as ECHO ACLs which in turn are derived from the generic ACL
+    design pattern used in many other systems. At a high level, an ACL is a
+    mapping of actors (subjects) to resources (object) to operations
+    (predicate). For instance, a CMR ACL might specify that all Registered
+    users have READ access to ASTER data or all users in a provider operations
+    group have permissions to ingest data for a particular provider.
   - API Docs: https://cmr.earthdata.nasa.gov/access-control/site/access_control_api_docs.html
 
 ## Our Development Environment
-  - Mac OSX
-  - Atom: https://atom.io/
-  - Proto-Repl: https://atom.io/packages/proto-repl
-    - Installed and configured according to this guide: https://git.io/atom_clojure_setup
+
+- Mac OSX
+- Atom: https://atom.io/
+- Proto-Repl: https://atom.io/packages/proto-repl
+  - Installed and configured according to this guide: https://git.io/atom_clojure_setup
 
 ## Prerequisites
+
 - Java 1.8.0 or higher
 - Leiningen (http://leiningen.org) 2.5.1 or above.
-  - We've had success with Homebrew and with the install script on the Leiningen website.
+  - We've had success with Homebrew and with the install script on the
+    Leiningen website.
 
 ## Building and Running the CMR
-The CMR is a system consisting of multiple services. The services can be run individually or can run in a single process. Running in a single process makes local development easier because it avoids having to start many different processes. The dev-system project allows the CMR to be run from a single REPL or Jar file. If you're developing a client against the CMR you can build and run the entire CMR with no external dependencies from this Jar file and use that instance for local testing. The sections below contain instructions for running the CMR as a single process or as multiple processes.
+
+The CMR is a system consisting of multiple services. The services can be run
+individually or can run in a single process. Running in a single process makes
+local development easier because it avoids having to start many different
+processes. The dev-system project allows the CMR to be run from a single REPL
+or Jar file. If you're developing a client against the CMR you can build and
+run the entire CMR with no external dependencies from this Jar file and use
+that instance for local testing. The sections below contain instructions for
+running the CMR as a single process or as multiple processes.
 
 #### Building and Running CMR Dev System in a REPL
 
-1. Install Oracle JDBC Jars into your local maven repository following instructions in `oracle-lib/README.md`. The CMR must have these libraries to build but it does not depend on Oracle DB when running locally. It uses a local in memory database by default.
+1. Install Oracle JDBC Jars into your local maven repository following
+   instructions in `oracle-lib/README.md`. The CMR must have these libraries to
+   build but it does not depend on Oracle DB when running locally. It uses a
+   local in memory database by default.
 2. `cd cmr/dev-system`
 3. `./support/setup_local_dev.sh`
 4. `lein repl`
@@ -45,11 +75,16 @@ The CMR is a system consisting of multiple services. The services can be run ind
 1. `cd cmr/dev-system`
 2. `./support/setup_local_dev.sh`
 3. `lein uberjar`
-4. See CMR Development Guide to read about specifying options and setting environment variables
+4. See CMR Development Guide to read about specifying options and setting
+   environment variables
 
 #### Building and Running separate CMR Applications
-This will build all of the applications, but will put each jar into the appropriate /target directory for each application.
-The command shown in step 3 is an example. For the proper command to start up each application, see the `Applications` section below. Note: Steps 1 and 2 only need to be completed once.
+
+This will build all of the applications, but will put each jar into the
+appropriate /target directory for each application. The command shown in step
+3 is an example. For the proper command to start up each application, see the
+`Applications` section below. Note: Steps 1 and 2 only need to be completed
+once.
 
 1. `cd cmr/dev-system`
 2. `./support/build.sh CMR_BUILD_UBERJARS`
@@ -58,16 +93,26 @@ The command shown in step 3 is an example. For the proper command to start up ea
 5. `java -classpath ./target/<NAME OF SERVICE>-0.1.0-SNAPSHOT-standalone.jar <MAIN METHOD OF SERVICE>`
 
 # Code structure
-The CMR is made up of several small services called microservices. These are small purposed-based services that do a small set of things well.
+
+The CMR is made up of several small services called microservices. These are
+small purposed-based services that do a small set of things well.
+
 - For more reading on microservices: https://martinfowler.com/articles/microservices.html
 
 ### The Microservices
-Each microservice has a README file in its root directory, which provides a short overview of the service's functionality.
-There are a number of main applications, as well as several libraries and support applications.
+
+Each microservice has a README file in its root directory, which provides a
+short overview of the service's functionality. There are a number of main
+applications, as well as several libraries and support applications.
 
 #### Applications:
+
 - access-control-app
-  - The mechanism by which users are granted access to perform different operations in the CMR. Also maintains groups and access control rules. Note that users access is provided by either ECHO or URS as an external dependency. The mock-echo application implements both of the necessary interfaces for local testing.
+  - The mechanism by which users are granted access to perform different
+    operations in the CMR. Also maintains groups and access control rules.
+    Note that users access is provided by either ECHO or URS as an external
+    dependency. The mock-echo application implements both of the necessary
+    interfaces for local testing.
   - Main method: cmr.access_control.runner
 
 - bootstrap-app
@@ -76,11 +121,14 @@ There are a number of main applications, as well as several libraries and suppor
   - See /bootstrap-app/README.md for a list of lein and uberjar commands
 
 - cubby-app
-  - Centralized caching for the CMR. Ideally each application will cache internally, but for situations that require centralized caching, we use Cubby.
+  - Centralized caching for the CMR. Ideally each application will cache
+    internally, but for situations that require centralized caching, we use
+    Cubby.
   - Main method: cmr.cubby.runner
 
 - dev-system
-  - An app that combines together the separate microservices of the CMR into a single application to make it simpler to develop and run
+  - An app that combines together the separate microservices of the CMR into a
+    single application to make it simpler to develop and run
   - Main method: cmr.dev_system.runner
 
 - indexer-app
@@ -88,7 +136,9 @@ There are a number of main applications, as well as several libraries and suppor
   - Main method: cmr.indexer.runner
 
 - ingest-app
-  - The Ingest app is responsible for collaborating with metadata db and indexer components of the CMR system to maintain the lifecycle of concepts coming into the system
+  - The Ingest app is responsible for collaborating with metadata db and
+    indexer components of the CMR system to maintain the lifecycle of concepts
+    coming into the system
   - Main method: cmr.ingest.runner
 
 - search-app
@@ -99,11 +149,14 @@ There are a number of main applications, as well as several libraries and suppor
   - Black-box, system-level tests to ensure functionality of the CMR
 
 - virtual-product-app
-  - Adds the concept of Virtual Products to the CMR. In short: Virtual Products represent products at a data provider that are generated on demand from users when they are ordered or downloaded through a URL
+  - Adds the concept of Virtual Products to the CMR. In short: Virtual
+    Products represent products at a data provider that are generated on
+    demand from users when they are ordered or downloaded through a URL
   - Main method: cmr.virtual_product.runner
 
 - index-set-app
-  - An application that maintains the set of indexes in elasticsearch for multiple concept types
+  - An application that maintains the set of indexes in elasticsearch for
+    multiple concept types
   - Main method: cmr.index_set.runner
 
 - metadata-db-app
@@ -111,10 +164,14 @@ There are a number of main applications, as well as several libraries and suppor
   - Main method: cmr.metadata_db.runner
 
 - mock-echo-app
-  - This mocks out the ECHO REST API and the URS API as well. Its purpose is to make it easier to integration test the CMR system without having to run a full instance of ECHO. It won't mock it perfectly or completely. It will only implement the minimum necessary to enable integration testing.
+  - This mocks out the ECHO REST API and the URS API as well. Its purpose is
+    to make it easier to integration test the CMR system without having to run
+    a full instance of ECHO. It won't mock it perfectly or completely. It will
+    only implement the minimum necessary to enable integration testing.
   - Main method: cmr.mock_echo.runner
 
 #### Libraries:
+
 - acl-lib
   - Contains utilities for retrieving and working with ACLs
 
@@ -134,7 +191,8 @@ There are a number of main applications, as well as several libraries and suppor
   - Contains utilities for connecting to and manipulating data in Oracle
 
 - orbits-lib
-  - Clojure wrapper of a Ruby implementation of the Backtrack Orbit Search Algorithm (BOSA)
+  - Clojure wrapper of a Ruby implementation of the Backtrack Orbit Search
+    Algorithm (BOSA)
 
 - message-queue-lib
   - A library for interfacing with RabbitMQ, AWS SQS, and an in memory message queue
@@ -146,12 +204,16 @@ There are a number of main applications, as well as several libraries and suppor
   - The Transmit Library defines functions for invoking CMR services
 
 - umm-lib
-  - This is the old source of UMM schemas and translation code. Since the advent of umm-spec-lib it is actively in the process of being removed
+  - This is the old source of UMM schemas and translation code. Since the
+    advent of umm-spec-lib it is actively in the process of being removed
 
 - umm-spec-lib
-  - The UMM Spec lib contains JSON schemas that defined the Unified Metadata Model, as well as mappings to other supported formats, and code to migrate collections between any supported formats.
+  - The UMM Spec lib contains JSON schemas that defined the Unified Metadata
+    Model, as well as mappings to other supported formats, and code to migrate
+    collections between any supported formats.
 
 ## Further Reading
+
 - CMR Client Partner User Guide: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide
 - CMR Data Partner User Guide: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Data+Partner+User+Guide
 - CMR Client Developer Forum: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ running the CMR as a single process or as multiple processes.
    local in memory database by default.
 2. `cd cmr`
 3. `./dev-system/support/setup_local_dev.sh`
+4. `cd dev-system`
 4. `lein repl`
 5. Once given a Clojure prompt, run `(reset)`
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ running the CMR as a single process or as multiple processes.
    instructions in `oracle-lib/README.md`. The CMR must have these libraries to
    build but it does not depend on Oracle DB when running locally. It uses a
    local in memory database by default.
-2. `cd cmr/dev-system`
-3. `./support/setup_local_dev.sh`
+2. `cd cmr`
+3. `./dev-system/support/setup_local_dev.sh`
 4. `lein repl`
 5. Once given a Clojure prompt, run `(reset)`
 

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -1,10 +1,13 @@
 # cmr-dev-system
 
-Dev System combines together the separate microservices of the CMR into a single application to make it simpler to develop.
+Dev System combines together the separate microservices of the CMR into a
+single application to make it simpler to develop.
 
 ## Setting up for local development.
 
-You can setup locally for running the CMR in memory by doing the following. You'll need a URS username that's been granted access to the repository. After this has completed you can start a REPL in dev-system.
+You can setup locally for running the CMR in memory by doing the following.
+You'll need a URS username that's been granted access to the repository. After
+this has completed you can start a REPL in dev-system.
 
 1. git clone ***REMOVED***
 2. cd cmr
@@ -12,12 +15,16 @@ You can setup locally for running the CMR in memory by doing the following. You'
 
 ## Setting up profiles.clj
 
-You will need to create profiles.clj in dev-system in order to set multiple environment variable passwords.  This can be accomplished by copying the contents of profiles.example.clj into a new file called profiles.clj.  Make sure to edit the CHANGE_ME values.
+You will need to create profiles.clj in dev-system in order to set multiple
+environment variable passwords.  This can be accomplished by copying the
+contents of profiles.example.clj into a new file called profiles.clj.  Make
+sure to edit the CHANGE_ME values.
 
 ## Security of dev system
 
-Dev system is meant to be used for testing only. It provides a control API that allows unrestricted access to shutdown the system, evaluate arbitrary code, remove all data, etc.
-
+Dev system is meant to be used for testing only. It provides a control API
+that allows unrestricted access to shutdown the system, evaluate arbitrary
+code, remove all data, etc.
 
 ## License
 

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -1,28 +1,32 @@
 # cmr-dev-system
 
-Dev System combines together the separate microservices of the CMR into a
-single application to make it simpler to develop.
+`dev-system` combines the separate microservices of the CMR into a single
+application to make it simpler to develop.
 
 ## Setting up for local development.
 
-You can setup locally for running the CMR in memory by doing the following.
-You'll need a URS username that's been granted access to the repository. After
-this has completed you can start a REPL in dev-system.
+While a full production deployment of CMR depends upon various services (e.g.,
+databases, message queues, portions of AWS, etc.), for development purposes it
+is possible to run CMR locally without these.
 
-1. `git clone git@github.com:nasa/Common-Metadata-Repository.git`
-2. `cd cmr`
-3. `dev-system/support/setup_local_dev.sh`
+To do so, perform the following:
+
+1. Clone the repo: `git clone git@github.com:nasa/Common-Metadata-Repository.git`
+2. Switch to the working dir: `cd cmr`
+3. Copy `profiles.example.clj` to `profiles.clj`
+4. Configure `profiles.clj` (see below)
+3. Run the local setup script: `dev-system/support/setup_local_dev.sh`
 
 ## Setting up profiles.clj
 
-You will need to create profiles.clj in dev-system in order to set multiple
-environment variable passwords.  This can be accomplished by copying the
-contents of profiles.example.clj into a new file called profiles.clj.  Make
-sure to edit the CHANGE_ME values.
+As noted above, you will need to create a `profiles.clj` in the `dev-system`
+directory. This will provide configuration/authentication information required
+by CMR for a local, in-memory "deployment". You will need to contact a core
+CMR developmer for the appropriate values for each key in `profiles.clj`.
 
-## Security of dev system
+## Security of `dev-system`
 
-Dev system is meant to be used for testing only. It provides a control API
+`dev-system` is meant to be used for testing only. It provides a control API
 that allows unrestricted access to shutdown the system, evaluate arbitrary
 code, remove all data, etc.
 

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -9,9 +9,9 @@ You can setup locally for running the CMR in memory by doing the following.
 You'll need a URS username that's been granted access to the repository. After
 this has completed you can start a REPL in dev-system.
 
-1. git clone ***REMOVED***
-2. cd cmr
-3. dev-system/support/setup_local_dev.sh
+1. `git clone git@github.com:nasa/Common-Metadata-Repository.git`
+2. `cd cmr`
+3. `dev-system/support/setup_local_dev.sh`
 
 ## Setting up profiles.clj
 

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -11,7 +11,7 @@ is possible to run CMR locally without these.
 
 To do so, perform the following:
 
-1. Clone the repo: `git clone git@github.com:nasa/Common-Metadata-Repository.git`
+1. Clone the repo: `git clone git@github.com:nasa/Common-Metadata-Repository.git cmr`
 2. Switch to the working dir: `cd cmr`
 3. Copy `profiles.example.clj` to `profiles.clj`
 4. Configure `profiles.clj` (see below)

--- a/dev-system/support/setup_local_dev.sh
+++ b/dev-system/support/setup_local_dev.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-# This script is used to setup CMR for local development. It assumes you have cloned the whole repo,
-# installed leiningen and Java
+# This script is used to setup CMR for local development. It assumes you have
+# cloned the whole repo, installed leiningen and Java.
+#
+# Additionally, this script assumes it is being executed in the parent
+# directory of the the dev-system project.
 
 date && echo "Installing all apps" &&
 lein modules do clean, install, clean

--- a/oracle-lib/README.md
+++ b/oracle-lib/README.md
@@ -4,19 +4,32 @@ Contains utilities for connecting to and manipulating data in Oracle.
 
 ## Instructions for Obtaining Oracle Jars
 
-Oracle Jars are not installed on public maven servers so they must be manually obtained and installed.
+Oracle Jars are not installed on public maven servers so they must be manually
+obtained and installed.
 
 ### Configuring a Private Repository
 
-If you have the jars located on a internal maven repository you can configure the location of that through the environment variable `CMR_ORACLE_JAR_REPO`. This will be used dynamically as the repository location in the leiningen project.
+If you have the jars located on a internal maven repository you can configure
+the location of that through the environment variable `CMR_ORACLE_JAR_REPO`.
+This will be used dynamically as the repository location in the leiningen
+project.
 
 ### Manually installing the Oracle JDBC Jars
 
-1. Download oracle Jars from Oracle's website. You can usually google for each for the jar files such as "oracle ucp jar" to find the location of each jar file. You need to download `ojdbc6.jar`, `ucp.jar`, and `ons.jar`. Make sure to get the version matching the versions specified in `project.clj`.
+1. Download oracle Jars from Oracle's website. You can usually google for
+   each of the jar files with a search term such as "oracle ucp jar" to find
+   the location of each jar file. You need to download the following:
+
+  * `ojdbc6.jar` - Orcale JDBC Driver
+  * `ucp.jar` - Universal Connection Pool (not bundled with the JDBC driver)
+  * `ons.jar` - Oracle Notification Services (should be on the same page as
+    the JDBC driver)
+
+  In each case, be sure you get the version matching the versions specified
+  in the `project.clj`.
 2. Put the Jars in `oracle-lib/support`
-3. Run `install_oracle_jars.sh` in `oracle-lib/support` which will install the oracle jars in your local maven repository.
-
-
+3. From `oracle-lib`, run `./support/install_oracle_jars.sh` which will
+   install the oracle jars in your local maven repository.
 
 ## License
 

--- a/oracle-lib/support/install_oracle_jars.sh
+++ b/oracle-lib/support/install_oracle_jars.sh
@@ -4,25 +4,35 @@
 # This must match the version of oracle in project.clj
 VERSION=11.2.0.4
 
+PROJECT_DIR=oracle-lib
+SUPPORT_DIR=support
+PWD=$(pwd)
+BASE_DIR=$(basename $PWD)
+
+if [ "$BASE_DIR" = "$PROJECT_DIR" ] ; then
+    PREFIX=./${SUPPORT_DIR}/
+elif [ "$BASE_DIR" = "support" ] ; then
+    PREFIX="./"
+fi
+
+echo "PREFIX: $PREFIX"
+
 # Check that jars are available
-if ! [ -e "ojdbc6.jar" ]
-then
+if ! [ -e "${PREFIX}ojdbc6.jar" ] ; then
   echo "ojdbc6.jar was not found on current path. Download Oracle JDBC Driver Jars and put on current path" >&2
   exit 1
 fi
-if ! [ -e "ons.jar" ]
-then
+if ! [ -e "${PREFIX}ons.jar" ] ; then
   echo "ons.jar was not found on current path. Download Oracle JDBC Driver Jars and put on current path" >&2
   exit 1
 fi
-if ! [ -e "ucp.jar" ]
-then
+if ! [ -e "${PREFIX}ucp.jar" ] ; then
   echo "ucp.jar was not found on current path. Download Oracle JDBC Driver Jars and put on current path" >&2
   exit 1
 fi
 
 echo "Installing oracle jars into local maven repository" >&2
 
-mvn install:install-file -Dfile=ojdbc6.jar -DartifactId=ojdbc6 -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true
-mvn install:install-file -Dfile=ons.jar -DartifactId=ons -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true
-mvn install:install-file -Dfile=ucp.jar -DartifactId=ucp -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true
+mvn install:install-file -Dfile=${PREFIX}ojdbc6.jar -DartifactId=ojdbc6 -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true
+mvn install:install-file -Dfile=${PREFIX}ons.jar -DartifactId=ons -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true
+mvn install:install-file -Dfile=${PREFIX}ucp.jar -DartifactId=ucp -Dversion=${VERSION} -DgroupId=com.oracle -Dpackaging=jar -DcreateChecksum=true

--- a/project.clj
+++ b/project.clj
@@ -29,5 +29,6 @@
   :aliases {
     "kibit" ["modules" "kibit"]
     "eastwood" ["modules" "eastwood"]
-    "lint" ["modules" "lint"]})
+    "lint" ["modules" "lint"]
+    "check-deps" ["modules" "check-deps"]})
 


### PR DESCRIPTION
As part of the new-dev onboarding, this updates the docs.

In particular, the following were done:

* Added docs for testing
* Added docs for new static analysis features
* Added missing steps in old docs
* Updated commands for consistency
* Updated a script to be used from either the top-level (as originally documented) or from `dev-system`
* Updated READMEs with long lines to be more easily read in the terminal