### PR TITLE
Task: enable dynamic switching between CMR run modes

### DIFF
--- a/dev-system/dev/refresh_persistent_settings.clj
+++ b/dev-system/dev/refresh_persistent_settings.clj
@@ -9,3 +9,33 @@
 (def logging-level
   "The logging level to use locally"
   (atom :error))
+
+(def legacy?
+  "Whether to run the dev-system with legacy services enabled and configured"
+  (atom false))
+
+(def aws?
+  "Whether to use AWS for messaging when running the dev-system"
+  (atom false))
+
+(defonce default-run-mode
+  ;; Note that `defonce` doesn't yet have the new(ish) support of docstrings
+  ;; that `def` does. See https://dev.clojure.org/jira/browse/CLJ-1148.
+  ^{:doc "Allow the default run mode to be set via the ENV or JVM options. In
+         practice, this is done in the following manner:
+
+         $ lein with-profile +run-external repl
+
+         or
+
+         $ lein with-profile +run-in-memory repl"}
+  (or (keyword (System/getProperty "cmr.runmode"))
+      :in-memory))
+
+(def run-modes
+  "The data structure that maintains the run modes for each individual
+  component"
+  (atom {:elastic default-run-mode
+         :echo default-run-mode
+         :db default-run-mode
+         :messaging default-run-mode}))

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -27,7 +27,12 @@
 (selmer/cache-off!)
 
 (defonce system nil)
-(defonce mode (or (keyword (System/getProperty "cmr.runmode")) :in-memory))
+(defonce default-run-mode
+  (or (keyword (System/getProperty "cmr.runmode")) :in-memory))
+(defonce run-modes {:elastic default-run-mode
+                    :echo default-run-mode
+                    :db default-run-mode
+                    :messaging default-run-mode})
 (defonce legacy? false)
 (defonce aws? false)
 
@@ -38,21 +43,40 @@
           (fn [app-map]
             (u/map-values #(assoc-in % [:log :level] level) app-map))))
 
-(defn set-mode!
-  "Set the mode to use when starting/resetting. Valid options are:
+(defn set-modes!
+  "Set the mode to use when starting/resetting. One or more modes may
+  be set at a time by passing one or more of the following keyword
+  arguments, where `VALUE` is any alowed run mode:
 
+  * `:elastic VALUE`
+  * `:echo VALUE`
+  * `:db VALUE`
+  * `:messaging VALUE`
+
+  Allowed run mode values are currently:
   * :in-memory
-  * :external"
-  [new-mode]
-  (alter-var-root #'mode (constantly new-mode)))
+  * :external
 
-(defn use-legacy?
+  Examples:
+  ```
+  => (set-mode! :db :external)
+  => (set-modes! :elastic :in-memory :echo :external)
+  ```"
+  [& {:keys [elastic echo db messaging] :as new-modes}]
+  (->> new-modes
+       (remove #(nil? (val %)))
+       (into {})
+       (merge run-modes)
+       (constantly)
+       (alter-var-root #'run-modes)))
+
+(defn set-legacy
   "Passing `true` to this function will cause legacy configuration to be used
   during starts/resets."
   [bool]
   (alter-var-root #'legacy? (constantly bool)))
 
-(defn use-aws?
+(defn set-aws
   "Passing `true` to this function will cause AWS queues to be used during
   starts/resets."
   [bool]
@@ -88,46 +112,44 @@
   (transmit-config/set-administrators-group-legacy-guid! "316520E041894014E050007F010038C4"))
 
 (defn start
-  "Starts the current development system, taking the following optional
-  keyword arguments, where `VALUE` is any alowed run mode:
+  "Starts the current development system, taking optional keyword arguments for
+  various run modes (see the docstring for `set-modes!` for more details).
 
-  * `:elastic VALUE`
-  * `:echo VALUE`
-  * `:db VALUE`
-  * `:messaging VALUE`
+  Note that when one or more explicit modes are passed as arguments, the global
+  `run-modes` data structure is updated.
 
-  If a run mode for a particular component is not passed, its value is set to
-  the global run mode. If no mode has been set, the ns-level `mode` variable
-  will be set to `:in-memory`.
-
-  Note that when an explicit mode is passed as an argument, not only will CMR
-  be started in that mode, but the ns-level `user/mode` variable will be reset
-  to the given value."
-  [& {:keys [elastic echo db messaging]
-       :or {elastic mode} {echo mode} {db mode} {messaging mode}}]
-  (set-mode! new-mode)
+  If a run mode for a particular component is not passed, its value taken from
+  what is already in the `run-modes` global data structure. If no mode has been
+  set, the default from initialization will be used."
+  ;; Note that even through the named args are not used, they are provided as
+  ;; a means of self-documentation.
+  [& {:keys [elastic echo db messaging] :as new-modes}]
+  (when-not (empty? new-modes)
+    (apply set-modes! (mapcat seq new-modes)))
   (config/reset-config-values)
 
   (jobs/set-default-job-start-delay! (* 3 3600))
 
   (system/set-gorilla-repl-port! 8090)
 
-  (system/set-dev-system-elastic-type! elastic)
+  (system/set-dev-system-elastic-type! (:elastic run-modes))
   ;; NOTE: External ECHO does not work with the automated tests. The automated
   ;; tests expect they can interact with the Mock ECHO to setup users, acls,
   ;; and other ECHO objects.
-  (system/set-dev-system-echo-type! echo)
+  (system/set-dev-system-echo-type! (:echo run-modes))
   ;; IMPORTANT: MAKE SURE YOU DISABLE SYMANTEC ANTIVIRUS BEFORE STARTING THE
-  ;; TESTS WITH EXTERNAL DB (renable them when you're done)
-  (system/set-dev-system-db-type! db)
+  ;; TESTS WITH EXTERNAL DB (re-enable them when you're done)
+  (system/set-dev-system-db-type! (:db run-modes))
+  ;; If you would like to run CMR with :aws instead of :in-memory or :external,
+  ;; be sure to call `(set-aws true)` in the REPL.
   (if aws?
     (system/set-dev-system-message-queue-type! :aws)
-    (system/set-dev-system-message-queue-type! messaging))
+    (system/set-dev-system-message-queue-type! (:messaging run-modes)))
 
   (sit-sys/set-logging-level @settings/logging-level)
 
   ;; If you would like to run CMR with legacy support, then be sure to call
-  ;; `(use-legacy true)` in the REPL. There is currently no lein profile or
+  ;; `(set-legacy true)` in the REPL. There is currently no lein profile or
   ;; command line option for this.
   (when legacy?
     (configure-for-legacy-services))
@@ -156,22 +178,28 @@
                     (when s (system/stop s)))))
 
 (defn reset
-  "Resets the development environment, reloading any changed namespaces and
-  restarting the CMR services.
+  "Resets the development environment, taking optional keyword arguments for
+  various run modes (see the docstring for `set-modes!` for more details).
+  Environment resetting includes the reloading of any changed namespaces and
+  the restarting the CMR services.
 
-  Note that when an explicit mode is passed as an argument, not only will CMR
-  be restarted in that mode, but the namespace-level `user/mode` variable will
-  be reset to the given value."
-  ([]
-    (reset mode))
-  ([new-mode]
-    ;; Stop the system integration test system
-    (sit-sys/stop)
-    ; Stops the running code
-    (stop)
-    ; Refreshes all of the code and then restarts the system
-    (set-mode! new-mode)
-    (refresh :after 'user/start)))
+  Note that when one or more explicit modes are passed as arguments, the global
+  `run-modes` data structure is updated.
+
+  If a run mode for a particular component is not passed, its value taken from
+  what is already in the `run-modes` global data structure. If no mode has been
+  set, the default from initialization will be used."
+  ;; Note that even through the named args are not used, they are provided as
+  ;; a means of self-documentation.
+  [& {:keys [elastic echo db messaging] :as new-modes}]
+  (when-not (empty? new-modes)
+    (apply set-modes! (mapcat seq new-modes)))
+  ;; Stop the system integration test system
+  (sit-sys/stop)
+  ; Stops the running code
+  (stop)
+  ; Refreshes all of the code and then restarts the system
+  (refresh :after 'user/start))
 
 (defn run-all-tests-future
   "Runs all tests asynchronously, with :fail-fast? and :speak? enabled."

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -27,6 +27,9 @@
 (selmer/cache-off!)
 
 (defonce system nil)
+(defonce mode (or (keyword (System/getProperty "cmr.runmode")) :in-memory))
+(defonce legacy? false)
+(defonce aws? false)
 
 (defn configure-systems-logging
   "Configures the systems in the system map to the indicated level"
@@ -34,6 +37,26 @@
   (update system :apps
           (fn [app-map]
             (u/map-values #(assoc-in % [:log :level] level) app-map))))
+
+(defn set-mode!
+  "Set the mode to use when starting/resetting. Valid options are:
+
+  * :in-memory
+  * :external"
+  [new-mode]
+  (alter-var-root #'mode (constantly new-mode)))
+
+(defn use-legacy?
+  "Passing `true` to this function will cause legacy configuration to be used
+  during starts/resets."
+  [bool]
+  (alter-var-root #'legacy? (constantly bool)))
+
+(defn use-aws?
+  "Passing `true` to this function will cause AWS queues to be used during
+  starts/resets."
+  [bool]
+  (alter-var-root #'aws? (constantly bool)))
 
 (defn set-logging-level!
   "Sets the logging level to the given setting. Puts the level in refresh-persistent-settings
@@ -58,47 +81,56 @@
   (config/set-config-value! :echo-rest-port 3012)
   (config/set-config-value! :echo-rest-context "/legacy-services/rest")
   (config/set-config-value! :dev-system-db-type :in-memory)
-  ;; Hard coded here and in legacy-services/echo/echo-env/support/db/bootstrap/business/system_acls_changeLog.xml
-  ;; so that ACLs that are bootstrapped in kernel reference same Administrators group in bootstrapped CMR.
+  ;; Hard coded here and here:
+  ;; * legacy-services/echo/echo-env/support/db/bootstrap/business/system_acls_changeLog.xml
+  ;; so that ACLs that are bootstrapped in kernel reference same Administrators group in
+  ;; bootstrapped CMR.
   (transmit-config/set-administrators-group-legacy-guid! "316520E041894014E050007F010038C4"))
 
 (defn start
-  "Starts the current development system."
-  []
+  "Starts the current development system, taking the following optional
+  keyword arguments, where `VALUE` is any alowed run mode:
+
+  * `:elastic VALUE`
+  * `:echo VALUE`
+  * `:db VALUE`
+  * `:messaging VALUE`
+
+  If a run mode for a particular component is not passed, its value is set to
+  the global run mode. If no mode has been set, the ns-level `mode` variable
+  will be set to `:in-memory`.
+
+  Note that when an explicit mode is passed as an argument, not only will CMR
+  be started in that mode, but the ns-level `user/mode` variable will be reset
+  to the given value."
+  [& {:keys [elastic echo db messaging]
+       :or {elastic mode} {echo mode} {db mode} {messaging mode}}]
+  (set-mode! new-mode)
   (config/reset-config-values)
 
   (jobs/set-default-job-start-delay! (* 3 3600))
 
   (system/set-gorilla-repl-port! 8090)
 
-  ;; Comment/uncomment these lines to switch between external and internal settings.
-
-  (system/set-dev-system-elastic-type! :in-memory)
-  ; (system/set-dev-system-elastic-type! :external)
-
-  ;; Note external ECHO does not work with the automated tests. The automated tests expect they
-  ;; can interact with the Mock ECHO to setup users, acls, and other ECHO objects.
-  (system/set-dev-system-echo-type! :in-memory)
-  ; (system/set-dev-system-echo-type! :external)
-
-
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  ;; MAKE SURE YOU DISABLE SYMANTEC ANTIVIRUS BEFORE STARTING THE TESTS WITH EXTERNAL DB
-  ;; Renable them when you're done
-
-  (system/set-dev-system-db-type! :in-memory)
-  ; (system/set-dev-system-db-type! :external)
-
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-  (system/set-dev-system-message-queue-type! :in-memory)
-  ; (system/set-dev-system-message-queue-type! :external)
-  ; (system/set-dev-system-message-queue-type! :aws)
+  (system/set-dev-system-elastic-type! elastic)
+  ;; NOTE: External ECHO does not work with the automated tests. The automated
+  ;; tests expect they can interact with the Mock ECHO to setup users, acls,
+  ;; and other ECHO objects.
+  (system/set-dev-system-echo-type! echo)
+  ;; IMPORTANT: MAKE SURE YOU DISABLE SYMANTEC ANTIVIRUS BEFORE STARTING THE
+  ;; TESTS WITH EXTERNAL DB (renable them when you're done)
+  (system/set-dev-system-db-type! db)
+  (if aws?
+    (system/set-dev-system-message-queue-type! :aws)
+    (system/set-dev-system-message-queue-type! messaging))
 
   (sit-sys/set-logging-level @settings/logging-level)
 
-  ;; Uncomment this to force CMR to use Legacy Services
-  ; (configure-for-legacy-services)
+  ;; If you would like to run CMR with legacy support, then be sure to call
+  ;; `(use-legacy true)` in the REPL. There is currently no lein profile or
+  ;; command line option for this.
+  (when legacy?
+    (configure-for-legacy-services))
 
   (let [s (-> (system/create-system)
               (configure-systems-logging @settings/logging-level)
@@ -114,7 +146,7 @@
                     (constantly
                       (system/start s))))
 
-  (d/touch-user-clj))
+    (d/touch-user-clj))
 
 (defn stop
   "Shuts down and destroys the current development system."
@@ -123,14 +155,23 @@
                   (fn [s]
                     (when s (system/stop s)))))
 
-(defn reset []
-  ;; Stop the system integration test system
-  (sit-sys/stop)
-  ; Stops the running code
-  (stop)
-  ; Refreshes all of the code and then restarts the system
-  (refresh :after 'user/start))
+(defn reset
+  "Resets the development environment, reloading any changed namespaces and
+  restarting the CMR services.
 
+  Note that when an explicit mode is passed as an argument, not only will CMR
+  be restarted in that mode, but the namespace-level `user/mode` variable will
+  be reset to the given value."
+  ([]
+    (reset mode))
+  ([new-mode]
+    ;; Stop the system integration test system
+    (sit-sys/stop)
+    ; Stops the running code
+    (stop)
+    ; Refreshes all of the code and then restarts the system
+    (set-mode! new-mode)
+    (refresh :after 'user/start)))
 
 (defn run-all-tests-future
   "Runs all tests asynchronously, with :fail-fast? and :speak? enabled."

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -36,8 +36,17 @@
             (u/map-values #(assoc-in % [:log :level] level) app-map))))
 
 (defn- maybe-set-all-modes
-  "A utility function for (conditionally) setting all the values of a map to
-  the same value."
+  "A utility function that will set all the keys of `settings/run-modes`
+  to the value associated with the passed parameter `all` only if `all` is not
+  `nil`. In the event that `all` is `nil`, the run modes passed in will be
+  returned as-is.
+
+  This behaviour makes the function conditionally side-effect generating.
+
+  Note that when a non-`nil` value for `all` is provided, a `deref`-ed copy of
+  `settings/run-modes` is used as the starting accumulator for usage in a
+  reduce. The old run modes values aren't used, however -- just their keys; the
+  values are overwritten with what is stored in the `all` variable."
   [all new-modes]
   (let [old-modes @settings/run-modes]
     (if (nil? all)
@@ -68,9 +77,9 @@
   => (set-modes! :elastic :in-memory :echo :external)
   ```"
   ;; Note that the keys are listed below as a means of self-documentation; they
-  ;; are not actually used individuall, but rather as a whole with the
+  ;; are not actually used individually, but rather as a whole with the
   ;; `new-modes` hash map.
-  [& {:keys [all elastic echo db messaging] :as new-modes}]
+  [& {:keys [all _elastic _echo _db _messaging] :as new-modes}]
   (->> new-modes
        (maybe-set-all-modes all)
        (remove #(nil? (val %)))
@@ -131,12 +140,12 @@
   Note that when one or more explicit modes are passed as arguments, the global
   `run-modes` data structure is updated.
 
-  If a run mode for a particular component is not passed, its value taken from
-  what is already in the `run-modes` global data structure. If no mode has been
-  set, the default from initialization will be used."
+  If a run mode for a particular component is not passed, its value is taken
+  from what is already in the `run-modes` global data structure. If no mode has
+  been set, the default from initialization will be used."
   ;; Note that even through the named args are not used, they are provided as
   ;; a means of self-documentation.
-  [& {:keys [elastic echo db messaging] :as new-modes}]
+  [& {:keys [_elastic _echo _db _messaging] :as new-modes}]
 
   (config/reset-config-values)
 
@@ -205,7 +214,7 @@
   set, the default from initialization will be used."
   ;; Note that even through the named args are not used, they are provided as
   ;; a means of self-documentation.
-  [& {:keys [elastic echo db messaging] :as new-modes}]
+  [& {:keys [_elastic _echo _db _messaging] :as new-modes}]
   (when-not (empty? new-modes)
     (apply set-modes! (mapcat seq new-modes)))
   ;; Stop the system integration test system

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -105,7 +105,19 @@
                 [lein-bikeshed "0.4.1"]
                 [lein-kibit "0.1.2"]
                 [lein-shell "0.4.0"]
-                [venantius/yagni "0.1.4"]]}}
+                [venantius/yagni "0.1.4"]]}
+    ;; The following run-* profiles are used in conjunction with other lein
+    ;; profiles to set the default CMR run mode and may be used in the
+    ;; following manner:
+    ;;
+    ;;   $ lein with-profile +run-external repl
+    ;;
+    ;; which will use dev and the other default profiles in addition to
+    ;; run-external (or whichever run mode profile is given).
+    :run-in-memory {
+      :jvm-opts ["-Dcmr.runmode=in-memory"]}
+    :run-external {
+      :jvm-opts ["-Dcmr.runmode=external"]}}
   :aliases {;; Creates the checkouts directory to the local projects
             "create-checkouts" ~create-checkouts-commands
             ;; Alias to test2junit for consistency with lein-test-out

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -359,7 +359,7 @@
                               (when %
                                 (start-fn %))
                               (catch Exception e
-                                (error e "Failure during startup")
+                                (error e (format "Failure of %s app during startup" app))
                                 (stop-components (stop-apps system) :pre-components)
                                 (stop-components (stop-apps system) :post-components)
                                 (throw e))))))


### PR DESCRIPTION
This change allows for the switching between `:in-memory` and `:external` CMR run modes. It supports both component-wide (all at once) run modes as well as setting run modes on individual components (one- or a-few-at-a-time). Previous behaviour required the commenting out and `(reset)`ing in the REPL. While calling a `(reset)` is still required, one may now simply set the appropriate CMR run modes in order to switch, without having to change any code.

Ways in which one may change the run modes:

* in the newly-extended function calls that now accept parameters (and set the run modes implicitly):
   * `(start :db external :messaging :internal)`  
   * `(start :all :external)`
   * `(reset :all :external)`
  
* explicitly setting run modes with the new convenience function `set-modes!`: 
   * set just one run mode: `(set-modes! :db :external)`
   * a few run modes at once: `(set-modes! :echo :external :elastic :in-memory)`
   * all at once: `(set-modes! :all :external)`

* from the command line, using the JVM options support in new `project.clj` profiles:
   * `$ lein with-profile +run-external repl`
   * `$ lein with-profile +run-in-memory repl`

Note that the old usage is still supported:
 * `(start)`
 * `(reset)`

Both of those will use whatever has been set in the settings data structure `run-modes`.

Notes:
 * all of the above methods eventually use the same code path to set the run modes (in other words, there are not three internal implementations)
* if no mode is supplied, the default of `:in-memory` will be used
* additional logic has been introduced for handling (and setting) `legacy` and `aws` boolean variables; if these are set to true, the applicable code paths will execute (again, without having to comment/uncomment anything)