### PR TITLE
CMR-4039: Removed the non-hdf links in the granule json result.

### DIFF
--- a/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
@@ -105,7 +105,7 @@
                        :data_center data-center
                        :time_start start-date
                        :time_end end-date
-                       :links (seq (remove-nonhdf-links (seq (map atom/atom-link->attribute-map atom-links))))
+                       :links (seq (remove-nonhdf-links (map atom/atom-link->attribute-map atom-links)))
                        :online_access_flag online-access-flag
                        :browse_flag browse-flag
                        :day_night_flag day-night

--- a/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
@@ -83,7 +83,7 @@
     ;; remove entries with nil value
     (util/remove-nil-keys result)))
 
-(defn- remove-nonhdf-links
+(defn remove-nonhdf-links
   "Remove the granule links whose type is not application/x-hdfeos"
   [links]
   (remove (fn[x](not="application/x-hdfeos" (:type x))) links))

--- a/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
@@ -83,6 +83,11 @@
     ;; remove entries with nil value
     (util/remove-nil-keys result)))
 
+(defn- remove-nonhdf-links
+  "Remove the granule links whose type is not application/x-hdfeos"
+  [links]
+  (remove (fn[x](not="application/x-hdfeos" (:type x))) links))
+ 
 (defmethod atom-reference->json :granule
   [results concept-type reference]
   (let [{:keys [id title updated dataset-id producer-gran-id size original-format
@@ -100,7 +105,7 @@
                        :data_center data-center
                        :time_start start-date
                        :time_end end-date
-                       :links (seq (map atom/atom-link->attribute-map atom-links))
+                       :links (seq (remove-nonhdf-links (seq (map atom/atom-link->attribute-map atom-links))))
                        :online_access_flag online-access-flag
                        :browse_flag browse-flag
                        :day_night_flag day-night

--- a/search-app/test/cmr/search/test/results_handlers/atom_json_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/atom_json_results_handler.clj
@@ -1,0 +1,10 @@
+(ns cmr.search.test.results-handlers.atom-json-results-handler
+  (:require 
+    [clojure.test :refer :all]
+    [cmr.search.results-handlers.atom-json-results-handler :as atom-json-results-handler]))
+
+(deftest remove-nonhdf-links-test
+  (is (= [{:type "application/x-hdfeos" :other "other"}]
+         (#'atom-json-results-handler/remove-nonhdf-links [{:type "application/x-hdfeos" :other "other"}
+                                                           {:type "other type" :other "other"}
+                                                           {:other "other"}]))))

--- a/search-app/test/cmr/search/test/results_handlers/atom_json_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/atom_json_results_handler.clj
@@ -5,6 +5,6 @@
 
 (deftest remove-nonhdf-links-test
   (is (= [{:type "application/x-hdfeos" :other "other"}]
-         (#'atom-json-results-handler/remove-nonhdf-links [{:type "application/x-hdfeos" :other "other"}
-                                                           {:type "other type" :other "other"}
-                                                           {:other "other"}]))))
+         (atom-json-results-handler/remove-nonhdf-links [{:type "application/x-hdfeos" :other "other"}
+                                                         {:type "other type" :other "other"}
+                                                         {:other "other"}]))))

--- a/system-int-test/src/cmr/system_int_test/data2/atom.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom.clj
@@ -7,14 +7,14 @@
    [clojure.data.xml :as x]
    [clojure.string :as str]
    [cmr.common.concepts :as cu]
-   [cmr.common.util :as util]
    [cmr.common.xml :as cx]
+   [cmr.common.util :as util]
+   [cmr.search.results-handlers.atom-json-results-handler :as atom-json-results-handler]
    [cmr.search.results-handlers.atom-results-handler :as atom-results-handler]
    [cmr.spatial.line-string :as l]
    [cmr.spatial.mbr :as m]
    [cmr.spatial.point :as p]
    [cmr.spatial.polygon :as poly]
-   [cmr.umm-spec.date-util :as date-util]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.data2.facets :as facets]
    [cmr.system-int-test.data2.granule :as dg]
@@ -23,6 +23,7 @@
    [cmr.umm.collection.entry-id :as eid]
    [cmr.umm.echo10.spatial :as echo-s]
    [cmr.umm.related-url-helper :as ru]
+   [cmr.umm-spec.date-util :as date-util]
    [cmr.umm.start-end-date :as sed]
    [cmr.umm.umm-spatial :as umm-s]))
 
@@ -181,7 +182,7 @@
      :original-format (cx/string-at-path entry-elem [:originalFormat])
      :data-center (cx/string-at-path entry-elem [:dataCenter])
      :links (seq
-              (remove (fn[x](not="application/x-hdfeos" (:type x)))
+              (atom-json-results-handler/remove-nonhdf-links
                 (seq (map :attrs (cx/elements-at-path entry-elem [:link])))))
      :orbit (parse-orbit-attribs (cx/attrs-at-path entry-elem [:orbit]))
      :orbit-calculated-spatial-domains (seq
@@ -364,7 +365,7 @@
        :original-format (atom-results-handler/metadata-format->atom-original-format (name format-key))
        :data-center (:provider-id (cu/parse-concept-id concept-id))
        :links (seq 
-                (remove (fn[x](not= "application/x-hdfeos" (:type x)))
+                (atom-json-results-handler/remove-nonhdf-links
                   (seq (granule-related-urls->links related-urls))))
        :orbit (when orbit (into {} orbit))
        :orbit-calculated-spatial-domains (seq orbit-calculated-spatial-domains)

--- a/system-int-test/src/cmr/system_int_test/data2/atom.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom.clj
@@ -180,7 +180,9 @@
      :size (cx/double-at-path entry-elem [:granuleSizeMB])
      :original-format (cx/string-at-path entry-elem [:originalFormat])
      :data-center (cx/string-at-path entry-elem [:dataCenter])
-     :links (seq (map :attrs (cx/elements-at-path entry-elem [:link])))
+     :links (seq
+              (remove (fn[x](not="application/x-hdfeos" (:type x)))
+                (seq (map :attrs (cx/elements-at-path entry-elem [:link])))))
      :orbit (parse-orbit-attribs (cx/attrs-at-path entry-elem [:orbit]))
      :orbit-calculated-spatial-domains (seq
                                          (map
@@ -361,7 +363,9 @@
        :size size
        :original-format (atom-results-handler/metadata-format->atom-original-format (name format-key))
        :data-center (:provider-id (cu/parse-concept-id concept-id))
-       :links (seq (granule-related-urls->links related-urls))
+       :links (seq 
+                (remove (fn[x](not= "application/x-hdfeos" (:type x)))
+                  (seq (granule-related-urls->links related-urls))))
        :orbit (when orbit (into {} orbit))
        :orbit-calculated-spatial-domains (seq orbit-calculated-spatial-domains)
        :start (some->> (:temporal granule) (sed/start-date :granule))

--- a/system-int-test/src/cmr/system_int_test/data2/atom.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom.clj
@@ -183,7 +183,7 @@
      :data-center (cx/string-at-path entry-elem [:dataCenter])
      :links (seq
               (atom-json-results-handler/remove-nonhdf-links
-                (seq (map :attrs (cx/elements-at-path entry-elem [:link])))))
+                (map :attrs (cx/elements-at-path entry-elem [:link]))))
      :orbit (parse-orbit-attribs (cx/attrs-at-path entry-elem [:orbit]))
      :orbit-calculated-spatial-domains (seq
                                          (map
@@ -366,7 +366,7 @@
        :data-center (:provider-id (cu/parse-concept-id concept-id))
        :links (seq 
                 (atom-json-results-handler/remove-nonhdf-links
-                  (seq (granule-related-urls->links related-urls))))
+                  (granule-related-urls->links related-urls)))
        :orbit (when orbit (into {} orbit))
        :orbit-calculated-spatial-domains (seq orbit-calculated-spatial-domains)
        :start (some->> (:temporal granule) (sed/start-date :granule))

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -1,18 +1,20 @@
 (ns cmr.system-int-test.data2.atom-json
   "Contains helper functions for converting granules into the expected map of parsed json results."
-  (:require [cmr.spatial.polygon :as poly]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.line-string :as l]
-            [cmr.spatial.mbr :as m]
-            [cheshire.core :as json]
-            [cmr.common.util :as util]
-            [clojure.string :as str]
-            [camel-snake-kebab.core :as csk]
-            [cmr.umm.umm-spatial :as umm-s]
-            [cmr.umm.echo10.spatial :as echo-s]
-            [cmr.system-int-test.data2.atom :as atom]
-            [cmr.system-int-test.data2.facets :as f]
-            [cmr.common.date-time-parser :as dtp]))
+  (:require 
+    [camel-snake-kebab.core :as csk]
+    [cheshire.core :as json]
+    [clojure.string :as str]
+    [cmr.common.date-time-parser :as dtp]
+    [cmr.common.util :as util]
+    [cmr.search.results-handlers.atom-json-results-handler :as atom-json-results-handler]
+    [cmr.spatial.line-string :as l]
+    [cmr.spatial.mbr :as m]
+    [cmr.spatial.point :as p]
+    [cmr.spatial.polygon :as poly]
+    [cmr.system-int-test.data2.atom :as atom]
+    [cmr.system-int-test.data2.facets :as f]
+    [cmr.umm.echo10.spatial :as echo-s]
+    [cmr.umm.umm-spatial :as umm-s]))
 
 (defn json-polygons->polygons
   [polygons]
@@ -147,7 +149,7 @@
        :size (parse-double granule-size)
        :original-format original-format
        :data-center data-center
-       :links (seq (remove (fn[x](not="application/x-hdfeos" (:type x))) (seq links)))
+       :links (seq (atom-json-results-handler/remove-nonhdf-links (seq links)))
        :orbit (parse-orbit orbit)
        :orbit-calculated-spatial-domains (seq (map parse-ocsd orbit-calculated-spatial-domains))
        :start (some-> time-start dtp/parse-datetime)

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -149,7 +149,7 @@
        :size (parse-double granule-size)
        :original-format original-format
        :data-center data-center
-       :links (seq (atom-json-results-handler/remove-nonhdf-links (seq links)))
+       :links (seq (atom-json-results-handler/remove-nonhdf-links links))
        :orbit (parse-orbit orbit)
        :orbit-calculated-spatial-domains (seq (map parse-ocsd orbit-calculated-spatial-domains))
        :start (some-> time-start dtp/parse-datetime)

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -147,7 +147,7 @@
        :size (parse-double granule-size)
        :original-format original-format
        :data-center data-center
-       :links (seq links)
+       :links (seq (remove (fn[x](not="application/x-hdfeos" (:type x))) (seq links)))
        :orbit (parse-orbit orbit)
        :orbit-calculated-spatial-domains (seq (map parse-ocsd orbit-calculated-spatial-domains))
        :start (some-> time-start dtp/parse-datetime)


### PR DESCRIPTION
For integration tests, granule_search_format_test.clj contains many tests that compare the expected links and the actual links.