### PR TITLE
Task: split out site and api routes

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -6,7 +6,7 @@
 
 (defconfig bootstrap-username
   "Defines the bootstrap database username."
-  {:default "cmr"})
+  {:default "CMR_BOOTSTRAP"})
 
 (defconfig bootstrap-password
   "Defines the bootstrap database password."

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -89,7 +89,7 @@
 
     (route/not-found "Not Found")))
 
-(defn default-error-format-fn
+(defn default-error-format
   "Determine the format that errors should be returned in based on the default-format
   key set on the ExceptionInfo object passed in as parameter e. Defaults to json if
   the default format has not been set to :xml."
@@ -103,7 +103,7 @@
       nested-params/wrap-nested-params
       api-errors/invalid-url-encoding-handler
       mp/wrap-multipart-params
-      (api-errors/exception-handler default-error-format-fn)
+      (api-errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
       (context/build-request-context-handler system)
       common-routes/pretty-print-response-handler

--- a/search-app/README.md
+++ b/search-app/README.md
@@ -4,8 +4,27 @@ Provides a public search API for concepts in the CMR.
 
 ## API Documentation
 
-API Docs are located in api_docs.md. They can be generated into the static site by running `lein generate-docs` This takes a while so we will commit the generated file for now so building the uberjar does not take a very long time. You can also generate the documents with a pre-started REPL by running `(load-file "./support/generate_docs.clj")` If you're running the REPL from dev-system you need to correct the path to generate_docs.clj.
+API docs for the search-app project are located in `api_docs.md`. They can be
+generated into the static site by running the following:
+
+```
+$ lein generate-docs
+```
+
+Due to the fact that this generally takes a while on most systems, we have
+generated it and committed the resulting file in order to bring the total
+build time (e.g, creating an uberjar) down.
+
+Additionally, you can also generate the documents with a pre-started REPL by
+running:
+
+```clj
+(load-file "./support/generate_docs.clj")
+```
+
+Note that if you're running the REPL from `dev-system` you need to correct the
+path to `generate_docs.clj`.
 
 ## License
 
-Copyright © 2014 NASA
+Copyright © 2014, 2017 NASA

--- a/search-app/README.md
+++ b/search-app/README.md
@@ -8,22 +8,8 @@ API docs for the search-app project are located in `api_docs.md`. They can be
 generated into the static site by running the following:
 
 ```
-$ lein generate-docs
+$ lein with-profile docs generate-docs
 ```
-
-Due to the fact that this generally takes a while on most systems, we have
-generated it and committed the resulting file in order to bring the total
-build time (e.g, creating an uberjar) down.
-
-Additionally, you can also generate the documents with a pre-started REPL by
-running:
-
-```clj
-(load-file "./support/generate_docs.clj")
-```
-
-Note that if you're running the REPL from `dev-system` you need to correct the
-path to `generate_docs.clj`.
 
 ## License
 

--- a/search-app/dev/user.clj
+++ b/search-app/dev/user.clj
@@ -4,7 +4,7 @@
             [cmr.search.system :as system]
             [cmr.common.log :refer (debug info warn error)]
             [cmr.common.api.web-server :as web]
-            [cmr.search.api.routes :as routes]
+            [cmr.search.web.routes :as routes]
             [cmr.common.dev.repeat-last-request :as repeat-last-request :refer (repeat-last-request)]
             [cmr.common.dev.util :as d]
             [cmr.transmit.config :as transmit-config]
@@ -24,7 +24,7 @@
 
   ; (tunnel-system)
   (let [web-server (web/create-web-server (transmit-config/search-port)
-                                          (repeat-last-request/wrap-api routes/make-api))]
+                                          (repeat-last-request/wrap-api routes/handlers))]
     (assoc (system/create-system) :web web-server)))
 
 (defn start

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -21,6 +21,7 @@
                  [org.clojure/tools.nrepl "0.2.12"]
                  [net.sf.saxon/Saxon-HE "9.7.0-7"]
                  [com.github.fge/json-schema-validator "2.2.6"]
+                 [selmer "1.10.7"]
 
                  ;; Temporary inclusion of libraries needed for swagger UI until the dev portal is
                  ;; done.

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -5,22 +5,22 @@
 (defproject nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"
   :description "Provides a public search API for concepts in the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
-                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+  :dependencies [[com.github.fge/json-schema-validator "2.2.6"]
+                 [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-                 [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
-                 [nasa-cmr/cmr-orbits-lib "0.1.0-SNAPSHOT"]
-                 [ring/ring-core "1.5.0"]
-                 [ring/ring-json "0.4.0"]
                  [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-orbits-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [net.sf.saxon/Saxon-HE "9.7.0-7"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.clojure/data.csv "0.1.3"]
                  [org.clojure/tools.nrepl "0.2.12"]
-                 [net.sf.saxon/Saxon-HE "9.7.0-7"]
-                 [com.github.fge/json-schema-validator "2.2.6"]
+                 [ring/ring-core "1.5.0"]
+                 [ring/ring-json "0.4.0"]
                  [selmer "1.10.7"]
 
                  ;; Temporary inclusion of libraries needed for swagger UI until the dev portal is

--- a/search-app/src/cmr/search/api/keyword.clj
+++ b/search-app/src/cmr/search/api/keyword.clj
@@ -24,7 +24,6 @@
   keyword-map        A single GCMD keyword with each of its subfields as a key in a map. If the
                      keyword does not have a value for a subfield, that key will not be present in
                      the map."
-
   (:require [compojure.core :refer :all]
             [cheshire.core :as json]
             [camel-snake-kebab.core :as csk]

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -333,7 +333,7 @@
         [(msg/mixed-arity-parameter-msg mixed-param)]))
     (f request)))
 
-(defn default-error-format-fn
+(defn default-error-format
   "Determine the format that errors should be returned in based on the request URI."
   [{:keys [uri]} _e]
   (if (or (re-find #"/caches" uri)

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -4,14 +4,11 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [cmr.acl.core :as acl]
-   [cmr.collection-renderer.api.routes :as collection-renderer-routes]
-   [cmr.common-app.api-docs :as api-docs]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search.query-model :as common-qm]
    [cmr.common.api.context :as context]
-   [cmr.common.api.errors :as errors]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as concepts]
    [cmr.common.log :refer (debug info warn error)]
@@ -20,7 +17,6 @@
    [cmr.common.util :as util]
    [cmr.common.xml :as cx]
    [cmr.search.api.community-usage-metrics :as metrics-api]
-   [cmr.search.api.request-context-user-augmenter :as context-augmenter]
    [cmr.search.api.humanizer :as humanizers-api]
    [cmr.search.api.keyword :as keyword-api]
    [cmr.search.api.tags-api :as tags-api]
@@ -54,13 +50,8 @@
    [cmr.search.services.result-format-helper :as rfh]
    [cmr.umm-spec.versioning :as umm-version]
    [compojure.core :refer :all]
-   [compojure.route :as route]
    [inflections.core :as inf]
    [ring.middleware.json :as ring-json]
-   [ring.middleware.keyword-params :as keyword-params]
-   [ring.middleware.nested-params :as nested-params]
-   [ring.middleware.params :as params]
-   [ring.swagger.ui :as ring-swagger-ui]
    [ring.util.codec :as codec]
    [ring.util.request :as request]
    [ring.util.response :as r]))
@@ -115,7 +106,6 @@
               mt/echo10
               mt/iso19115
               mt/iso-smap}})
-
 
 (def find-by-concept-id-concept-types
   #{:collection :granule})
@@ -315,20 +305,46 @@
      :headers {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)}
      :body results}))
 
-(def robots-txt-response
-  "Returns the robots.txt response."
-  {:status 200
-   :body (slurp (io/resource "public/robots.txt"))})
+(defn find-query-str-mixed-arity-param
+  "Return the first parameter that has mixed arity, i.e., appears with both single and multivalued in
+  the query string. e.g. foo=1&foo[bar]=2 is mixed arity, so is foo[]=1&foo[bar]=2. foo=1&foo[]=2 is
+  not. Parameter with mixed arity will be flagged as invalid later."
+  [query-str]
+  (when query-str
+    (let [query-str (-> query-str
+                        (str/replace #"%5B" "[")
+                        (str/replace #"%5D" "]")
+                        (str/replace #"\[\]" ""))]
+      (last (some #(re-find % query-str)
+                  [#"(^|&)(.*?)=.*?\2\["
+                   #"(^|&)(.*?)\[.*?\2="])))))
 
-(defn- build-routes [system]
+(defn mixed-arity-param-handler
+  "Detect query string with mixed arity and throws a 400 error. Mixed arity param is when a single
+  value param is mixed with multivalue. One specific case of this is for improperly expressed options
+  in the query string, e.g., granule_ur=*&granule_ur[pattern]=true. Ring parameter handling throws
+  500 error when it happens. This middleware handler returns a 400 error early to avoid the 500 error
+  from Ring."
+  [f]
+  (fn [request]
+    (when-let [mixed-param (find-query-str-mixed-arity-param (:query-string request))]
+      (svc-errors/throw-service-errors
+        :bad-request
+        [(msg/mixed-arity-parameter-msg mixed-param)]))
+    (f request)))
+
+(defn default-error-format-fn
+  "Determine the format that errors should be returned in based on the request URI."
+  [{:keys [uri]} _e]
+  (if (or (re-find #"/caches" uri)
+          (re-find #"/keywords" uri))
+    mt/json
+    mt/xml))
+
+(defn build-routes [system]
   (let [relative-root-url (get-in system [:public-conf :relative-root-url])]
     (routes
-      ;; Return robots.txt from the root /robots.txt and at the context (e.g. /search/robots.txt)
-      (GET "/robots.txt" req robots-txt-response)
-
       (context relative-root-url []
-        (GET "/robots.txt" req robots-txt-response)
-
         ;; Add routes for tagging
         tags-api/tag-api-routes
 
@@ -337,21 +353,6 @@
 
         ;; Add routes for community usage metrics
         metrics-api/community-usage-metrics-routes
-
-        ;; Add routes for API documentation
-        (api-docs/docs-routes
-         (get-in system [:public-conf :protocol])
-         relative-root-url
-         "public/index.html")
-
-        ;; This is a temporary inclusion of the swagger UI until the dev portal is done.
-        (ring-swagger-ui/swagger-ui "/swagger_ui"
-                                    :swagger-docs (str relative-root-url "/site/swagger.json")
-                                    :validator-url nil)
-
-
-        ;; Routes for collection html resources
-        (collection-renderer-routes/resource-routes system)
 
         ;; Retrieve by cmr concept id or concept id and revision id
         ;; Matches URL paths of the form /concepts/:concept-id[/:revision-id][.:format],
@@ -422,71 +423,4 @@
          #(acl/verify-ingest-management-permission % :update))
 
         (GET "/tiles" {params :params context :request-context}
-          (find-tiles context params)))
-
-      (route/not-found "Not Found"))))
-
-(defn copy-of-body-handler
-  "Copies the body into a new attribute called :body-copy so that after a post of form content type
-  the original body can still be read. The default ring params reads the body and parses it and we
-  don't have access to it."
-  [f]
-  (fn [request]
-    (let [^String body (slurp (:body request))]
-      (f (assoc request
-                :body-copy body
-                :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
-
-(defn find-query-str-mixed-arity-param
-  "Return the first parameter that has mixed arity, i.e., appears with both single and multivalued in
-  the query string. e.g. foo=1&foo[bar]=2 is mixed arity, so is foo[]=1&foo[bar]=2. foo=1&foo[]=2 is
-  not. Parameter with mixed arity will be flagged as invalid later."
-  [query-str]
-  (when query-str
-    (let [query-str (-> query-str
-                        (str/replace #"%5B" "[")
-                        (str/replace #"%5D" "]")
-                        (str/replace #"\[\]" ""))]
-      (last (some #(re-find % query-str)
-                  [#"(^|&)(.*?)=.*?\2\["
-                   #"(^|&)(.*?)\[.*?\2="])))))
-
-(defn mixed-arity-param-handler
-  "Detect query string with mixed arity and throws a 400 error. Mixed arity param is when a single
-  value param is mixed with multivalue. One specific case of this is for improperly expressed options
-  in the query string, e.g., granule_ur=*&granule_ur[pattern]=true. Ring parameter handling throws
-  500 error when it happens. This middleware handler returns a 400 error early to avoid the 500 error
-  from Ring."
-  [f]
-  (fn [request]
-    (when-let [mixed-param (find-query-str-mixed-arity-param (:query-string request))]
-      (svc-errors/throw-service-errors
-        :bad-request
-        [(msg/mixed-arity-parameter-msg mixed-param)]))
-    (f request)))
-
-(defn default-error-format-fn
-  "Determine the format that errors should be returned in based on the request URI."
-  [{:keys [uri]} _e]
-  (if (or (re-find #"/caches" uri)
-          (re-find #"/keywords" uri))
-    mt/json
-    mt/xml))
-
-(defn make-api [system]
-  (-> (build-routes system)
-      ;; add-authentication-handler adds the token and client id for user to the context
-      ;; add-user-id-and-sids-handler lazy adds the user id and sids for that token
-      ;; Need to maintain this order (works backwards).
-      context-augmenter/add-user-id-and-sids-handler
-      acl/add-authentication-handler
-      keyword-params/wrap-keyword-params
-      nested-params/wrap-nested-params
-      errors/invalid-url-encoding-handler
-      mixed-arity-param-handler
-      (errors/exception-handler default-error-format-fn)
-      common-routes/add-request-id-response-handler
-      (context/build-request-context-handler system)
-      common-routes/pretty-print-response-handler
-      params/wrap-params
-      copy-of-body-handler))
+          (find-tiles context params))))))

--- a/search-app/src/cmr/search/services/acl_service.clj
+++ b/search-app/src/cmr/search/services/acl_service.clj
@@ -15,7 +15,8 @@
   true)
 
 (def concept-type->applicable-field
-  "A mapping of concept type to the field in the ACL indicating if it is collection or granule applicable."
+  "A mapping of concept type to the field in the ACL indicating if it is collection or granule
+  applicable."
   {:granule :granule-applicable
    :collection :collection-applicable})
 

--- a/search-app/src/cmr/search/services/json_parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/json_parameters/conversion.clj
@@ -63,7 +63,7 @@
    :and :and
    :not :not})
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Validations
 
 (defn- concept-type-validation
@@ -103,7 +103,7 @@
     (errors/throw-service-error
       :bad-request "Temporal condition with only exclude_boundary is invalid.")))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- query-condition-name->condition-type
   "Returns the query condition type based on the given concept-type and param-name."
@@ -126,7 +126,10 @@
                           (:value value)
                           (case-sensitive-field? concept-type condition-name value)
                           (:pattern value))
-    (cqm/string-condition condition-name value (case-sensitive-field? concept-type condition-name) false)))
+    (cqm/string-condition condition-name
+                          value
+                          (case-sensitive-field? concept-type condition-name)
+                          false)))
 
 (defmulti parse-json-condition
   "Converts a JSON query condition into a query model condition"

--- a/search-app/src/cmr/search/services/query_execution.clj
+++ b/search-app/src/cmr/search/services/query_execution.clj
@@ -52,7 +52,9 @@
        (or (nil? sort-keys) (= (cqm/default-sort-keys concept-type) sort-keys))))
 
 (defn- specific-items-from-elastic-query?
-  "Returns true if the query is only for specific items that will come directly from elastic search.
+  "Returns true if the query is only for specific items that will come directly from elastic
+  search.
+
   This query type is split out because it is faster to bypass ACLs and apply them afterwards
   than to apply them ahead of time to the query."
   [{:keys [result-format all-revisions?] :as query}]
@@ -104,7 +106,10 @@
         concept-ids (query->concept-ids query)
         items (metadata-cache/get-latest-formatted-concepts
                context concept-ids result-format skip-acls?)
-        results (results/map->Results {:hits (count items) :items items :result-format result-format})]
+        results (results/map->Results
+                  {:hits (count items)
+                   :items items
+                   :result-format result-format})]
     (common-qe/post-process-query-result-features context query nil results)))
 
 (defmethod common-qe/execute-query :specific-elastic-items

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -73,7 +73,6 @@
     cmr.search.validators.temporal
     cmr.search.validators.validation))
 
-
 (defn- sanitize-aql-params
   "When content-type is not set for aql searches, the aql will get mistakenly parsed into params.
   This function removes it, santizes the params and returns the end result."
@@ -84,7 +83,8 @@
 ;; CMR-2553 Remove this function.
 (defn- drop-ignored-params
   "At times, there are unsupported search params in parameter search that we simply want to ignore
-  rather than raise error. This function removes tag-namespace from the params and returns the params."
+  rather than raise error. This function removes tag-namespace from the params and returns the
+  params."
   [params]
   (let [drop-params-fn (fn [p]
                          (if (map? p)
@@ -129,7 +129,8 @@
 
                                            (psn/replace-provider-short-names context)
                                            (pv/validate-parameters concept-type)
-                                           (common-params/parse-parameter-query context concept-type)))
+                                           (common-params/parse-parameter-query
+                                             context concept-type)))
         [find-concepts-time results] (u/time-execution
                                        (common-search/find-concepts context
                                                                     concept-type
@@ -145,9 +146,9 @@
   concept id and native provider id along with hit count and timing info."
   [context concept-type params json-query]
   (let [[query-creation-time query] (u/time-execution
-                                      (-> (jp/parse-json-query concept-type
-                                                               (common-params/sanitize-params params)
-                                                               json-query)))
+                                      (jp/parse-json-query concept-type
+                                                           (common-params/sanitize-params params)
+                                                           json-query))
 
         [find-concepts-time results] (u/time-execution
                                        (common-search/find-concepts context
@@ -189,7 +190,9 @@
   (errors/throw-service-error
     :not-found
     (format
-      "Concept with concept-id [%s] and revision-id [%s] could not be found." concept-id revision-id)))
+      "Concept with concept-id [%s] and revision-id [%s] could not be found."
+      concept-id
+      revision-id)))
 
 (defn find-concept-by-id
   "Executes a search to metadata-db and returns the concept with the given cmr-concept-id."
@@ -220,7 +223,8 @@
   [context result-format concept-id revision-id]
   ;; We don't store revision id in the search index, so we can't use shortcuts for json/atom
   ;; like we do in find-concept-by-id.
-  (let [concept (metadata-cache/get-formatted-concept context concept-id revision-id result-format)]
+  (let [concept (metadata-cache/get-formatted-concept
+                  context concept-id revision-id result-format)]
     (when-not concept
       (throw-concept-revision-not-found concept-id revision-id))
     {:results (:metadata concept)
@@ -258,7 +262,6 @@
          results (qe/execute-query context query)]
      (:items results))))
 
-
 (defn get-provider-holdings
   "Executes elasticsearch search to get provider holdings"
   [context params]
@@ -272,8 +275,12 @@
         ;; get a mapping of collection to granule count
         collection-granule-count (idx/get-collection-granule-counts context provider-ids)
         ;; combine the granule count into collections to form provider holdings
-        provider-holdings (map #(assoc % :granule-count (get collection-granule-count (:concept-id %) 0))
-                               collections)]
+        provider-holdings (map
+                            #(assoc % :granule-count (get
+                                                       collection-granule-count
+                                                       (:concept-id %)
+                                                       0))
+                            collections)]
     [provider-holdings
      (ph/provider-holdings->string
        (:result-format params) provider-holdings {:echo-compatible? (= "true" echo-compatible)})]))

--- a/search-app/src/cmr/search/services/tagging_service.clj
+++ b/search-app/src/cmr/search/services/tagging_service.clj
@@ -26,7 +26,9 @@
   "/")
 
 (def ^:private association-conflict-error-message
-  "Failed to %s tag [%s] with collection [%s] because it conflicted with a concurrent %s on the same tag and collection. This means that someone is sending the same request to the CMR at the same time.")
+  "Failed to %s tag [%s] with collection [%s] because it conflicted with a concurrent %s on the
+  same tag and collection. This means that someone is sending the same request to the CMR at the
+  same time.")
 
 (defn- context->user-id
   "Returns user id of the token in the context. Throws an error if no token is provided"
@@ -35,7 +37,7 @@
     (util/lazy-get context :user-id)
     (errors/throw-service-error :unauthorized msg/token-required-for-tag-modification)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Metadata DB Concept Map Manipulation
 
 (defn- tag->new-concept
@@ -50,12 +52,12 @@
    :revision-id 1
    :format mt/edn})
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API
 
 (defn create-tag
-  "Creates the tag saving it as a revision in metadata db. Returns the concept id and revision id of
-  the saved tag."
+  "Creates the tag saving it as a revision in metadata db. Returns the concept id and revision id
+  of the saved tag."
   [context tag-json-str]
   (let [user-id (context->user-id context)
         tag (-> (tv/create-tag-json->tag tag-json-str)
@@ -137,7 +139,8 @@
     {:concept-id concept-id, :revision-id revision-id}))
 
 (defn- delete-tag-association
-  "Delete the tag association with the given native-id using the given embedded metadata-db context."
+  "Delete the tag association with the given native-id using the given embedded metadata-db
+  context."
   [mdb-context native-id]
   (let [existing-concept (first (mdb-ss/find-concepts mdb-context
                                                       {:concept-type :tag-association
@@ -250,7 +253,8 @@
 
 (defn- update-tag-associations-with-query
   "Based on the input operation type (:insert or :delete), insert or delete tag associations
-  identified by the json query. Throws service error if the tag with the given tag key is not found."
+  identified by the json query. Throws service error if the tag with the given tag key is not
+  found."
   [context tag-key json-query operation]
   (let [tag-concept (fetch-tag-concept context tag-key)
         query (-> (jp/parse-json-query :collection {} json-query)

--- a/search-app/src/cmr/search/site/routes.clj
+++ b/search-app/src/cmr/search/site/routes.clj
@@ -11,23 +11,10 @@
    [cmr.common.api.context :as context]
    [cmr.common-app.api-docs :as api-docs]))
 
-(defn get-landing-pages
-  ""
-  [request]
-  {:status 200
-   :body "TBD"})
-
 (defn build-routes [system]
   (let [relative-root-url (get-in system [:public-conf :relative-root-url])]
     (routes
       (context relative-root-url []
-        ;; Landing pages - Note that the landing pages must come before the
-        ;; api-docs, since api-docs/docs-routes also use a context of "site"
-        ;; but have the last entry as a 404 renderer, and as such, would
-        ;; prevent any pages in the "site" context from rendering after that
-        ;; point.
-        (GET "/site/collections/landing-pages" req
-          (get-landing-pages req))
         ;; Add routes for API documentation
         (api-docs/docs-routes
           (get-in system [:public-conf :protocol])

--- a/search-app/src/cmr/search/site/routes.clj
+++ b/search-app/src/cmr/search/site/routes.clj
@@ -11,10 +11,23 @@
    [cmr.common.api.context :as context]
    [cmr.common-app.api-docs :as api-docs]))
 
+(defn get-landing-pages
+  ""
+  [request]
+  {:status 200
+   :body "TBD"})
+
 (defn build-routes [system]
   (let [relative-root-url (get-in system [:public-conf :relative-root-url])]
     (routes
       (context relative-root-url []
+        ;; Landing pages - Note that the landing pages must come before the
+        ;; api-docs, since api-docs/docs-routes also use a context of "site"
+        ;; but have the last entry as a 404 renderer, and as such, would
+        ;; prevent any pages in the "site" context from rendering after that
+        ;; point.
+        (GET "/site/collections/landing-pages" req
+          (get-landing-pages req))
         ;; Add routes for API documentation
         (api-docs/docs-routes
           (get-in system [:public-conf :protocol])

--- a/search-app/src/cmr/search/site/routes.clj
+++ b/search-app/src/cmr/search/site/routes.clj
@@ -1,0 +1,28 @@
+(ns cmr.search.site.routes
+  "This namespace is the one responsible for the routes intended for human
+  consumption."
+  (:require
+   ;; Third-party libs
+   [compojure.core :refer :all]
+   [ring.swagger.ui :as ring-swagger-ui]
+
+   ;; CMR libs
+   [cmr.collection-renderer.api.routes :as collection-renderer-routes]
+   [cmr.common.api.context :as context]
+   [cmr.common-app.api-docs :as api-docs]))
+
+(defn build-routes [system]
+  (let [relative-root-url (get-in system [:public-conf :relative-root-url])]
+    (routes
+      (context relative-root-url []
+        ;; Add routes for API documentation
+        (api-docs/docs-routes
+          (get-in system [:public-conf :protocol])
+          relative-root-url
+          "public/index.html")
+        (ring-swagger-ui/swagger-ui
+          "/swagger_ui"
+          :swagger-docs (str relative-root-url "/site/swagger.json")
+          :validator-url nil)
+        ;; Routes for collection html resources such as css, js, etc.
+        (collection-renderer-routes/resource-routes system)))))

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -109,7 +109,9 @@
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           coll-cache/refresh-collections-cache-for-granule-acls-job
                           jvm-info/log-jvm-statistics-job])}]
-    (transmit-config/system-with-connections sys [:index-set :echo-rest :metadata-db :kms :cubby])))
+    (transmit-config/system-with-connections
+      sys
+      [:index-set :echo-rest :metadata-db :kms :cubby])))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,
@@ -121,7 +123,6 @@
                            (common-sys/start component-order))]
     (info "System started")
     started-system))
-
 
 (defn stop
   "Performs side effects to shut down the system and release its

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -9,7 +9,7 @@
    [cmr.common-app.services.jvm-info :as jvm-info]
    [cmr.common-app.services.kms-fetcher :as kf]
    [cmr.common-app.services.search.elastic-search-index :as common-idx]
-   [cmr.common.api.web-server :as web]
+   [cmr.common.api.web-server :as web-server]
    [cmr.common.cache :as cache]
    [cmr.common.cache.in-memory-cache :as mem-cache]
    [cmr.common.config :as cfg :refer [defconfig]]
@@ -21,13 +21,13 @@
    [cmr.metadata-db.system :as mdb-system]
    [cmr.orbits.orbits-runtime :as orbits-runtime]
    [cmr.search.api.request-context-user-augmenter :as context-augmenter]
-   [cmr.search.api.routes :as routes]
    [cmr.search.data.elastic-search-index :as idx]
    [cmr.search.data.metadata-retrieval.metadata-cache :as metadata-cache]
    [cmr.search.data.metadata-retrieval.metadata-transformer :as metadata-transformer]
    [cmr.search.models.query :as q]
    [cmr.search.services.acls.collections-cache :as coll-cache]
    [cmr.search.services.query-execution.has-granules-results-feature :as hgrf]
+   [cmr.search.web.routes :as routes]
    [cmr.transmit.config :as transmit-config]))
 
 ;; Design based on http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts
@@ -79,7 +79,7 @@
              ;; from oracle.
              :embedded-systems {:metadata-db metadata-db}
              :search-index (common-idx/create-elastic-search-index)
-             :web (web/create-web-server (transmit-config/search-port) routes/make-api)
+             :web (web-server/create-web-server (transmit-config/search-port) routes/handlers)
              :nrepl (nrepl/create-nrepl-if-configured (search-nrepl-port))
              ;; Caches added to this list must be explicitly cleared in query-service/clear-cache
              :caches {idx/index-cache-name (mem-cache/create-in-memory-cache)

--- a/search-app/src/cmr/search/web/routes.clj
+++ b/search-app/src/cmr/search/web/routes.clj
@@ -57,7 +57,7 @@
       nested-params/wrap-nested-params
       errors/invalid-url-encoding-handler
       api-routes/mixed-arity-param-handler
-      (errors/exception-handler api-routes/default-error-format-fn)
+      (errors/exception-handler api-routes/default-error-format)
       common-routes/add-request-id-response-handler
       (context/build-request-context-handler system)
       common-routes/pretty-print-response-handler

--- a/search-app/src/cmr/search/web/routes.clj
+++ b/search-app/src/cmr/search/web/routes.clj
@@ -5,18 +5,50 @@
   (e.g., robots.txt)."
   (:require
     [clojure.java.io :as io]
+    [clojure.string :as str]
     [cmr.acl.core :as acl]
     [cmr.common.api.errors :as errors]
     [cmr.common.api.context :as context]
     [cmr.common-app.api.routes :as common-routes]
+    [cmr.common.mime-types :as mt]
+    [cmr.common.services.errors :as svc-errors]
     [cmr.search.api.request-context-user-augmenter :as context-augmenter]
     [cmr.search.api.routes :as api-routes]
+    [cmr.search.services.messages.common-messages :as msg]
     [cmr.search.site.routes :as site-routes]
     [compojure.core :refer :all]
     [compojure.route :as route]
     [ring.middleware.keyword-params :as keyword-params]
     [ring.middleware.nested-params :as nested-params]
     [ring.middleware.params :as params]))
+
+(defn find-query-str-mixed-arity-param
+  "Return the first parameter that has mixed arity, i.e., appears with both single and multivalued in
+  the query string. e.g. foo=1&foo[bar]=2 is mixed arity, so is foo[]=1&foo[bar]=2. foo=1&foo[]=2 is
+  not. Parameter with mixed arity will be flagged as invalid later."
+  [query-str]
+  (when query-str
+    (let [query-str (-> query-str
+                        (str/replace #"%5B" "[")
+                        (str/replace #"%5D" "]")
+                        (str/replace #"\[\]" ""))]
+      (last (some #(re-find % query-str)
+                  [#"(^|&)(.*?)=.*?\2\["
+                   #"(^|&)(.*?)\[.*?\2="])))))
+
+(defn mixed-arity-param-handler
+  "Detect query string with mixed arity and throws a 400 error. Mixed arity param is when a single
+  value param is mixed with multivalue. One specific case of this is for improperly expressed options
+  in the query string, e.g., granule_ur=*&granule_ur[pattern]=true. Ring parameter handling throws
+  500 error when it happens. This middleware handler returns a 400 error early to avoid the 500 error
+  from Ring."
+  [f]
+  (fn [request]
+    (when-let [mixed-param (find-query-str-mixed-arity-param (:query-string request))]
+      (svc-errors/throw-service-errors
+        :bad-request
+        [(msg/mixed-arity-parameter-msg mixed-param)]))
+    (f request)))
 
 (defn copy-of-body-handler
   "Copies the body into a new attribute called :body-copy so that after a post
@@ -28,6 +60,14 @@
       (f (assoc request
                 :body-copy body
                 :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
+
+(defn default-error-format
+  "Determine the format that errors should be returned in based on the request URI."
+  [{:keys [uri]} _e]
+  (if (or (re-find #"/caches" uri)
+          (re-find #"/keywords" uri))
+    mt/json
+    mt/xml))
 
 (def robots-txt-response
   "Returns the robots.txt response."
@@ -56,8 +96,8 @@
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
       errors/invalid-url-encoding-handler
-      api-routes/mixed-arity-param-handler
-      (errors/exception-handler api-routes/default-error-format)
+      mixed-arity-param-handler
+      (errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
       (context/build-request-context-handler system)
       common-routes/pretty-print-response-handler

--- a/search-app/src/cmr/search/web/routes.clj
+++ b/search-app/src/cmr/search/web/routes.clj
@@ -1,0 +1,68 @@
+(ns cmr.search.web.routes
+  "This namespace is the one responsible for combining the routes intended for
+  use by libraries and applications (API routes) and the routes intended for
+  human consumption (site routes). It also provides routes that apply to both
+  (e.g., robots.txt)."
+  (:require
+   ;; Third-party libs
+   [clojure.java.io :as io]
+   [compojure.core :refer :all]
+   [compojure.route :as route]
+   [ring.middleware.keyword-params :as keyword-params]
+   [ring.middleware.nested-params :as nested-params]
+   [ring.middleware.params :as params]
+
+   ;; CMR libs
+   [cmr.acl.core :as acl]
+   [cmr.common.api.errors :as errors]
+   [cmr.common.api.context :as context]
+   [cmr.common-app.api.routes :as common-routes]
+   [cmr.search.api.request-context-user-augmenter :as context-augmenter]
+   [cmr.search.api.routes :as api-routes]
+   [cmr.search.site.routes :as site-routes]))
+
+(defn copy-of-body-handler
+  "Copies the body into a new attribute called :body-copy so that after a post
+  of form content type the original body can still be read. The default ring
+  params reads the body and parses it and we don't have access to it."
+  [f]
+  (fn [request]
+    (let [^String body (slurp (:body request))]
+      (f (assoc request
+                :body-copy body
+                :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
+
+(def robots-txt-response
+  "Returns the robots.txt response."
+  {:status 200
+   :body (slurp (io/resource "public/robots.txt"))})
+
+(defn build-routes [system]
+  (let [relative-root-url (get-in system [:public-conf :relative-root-url])]
+    (routes
+      ;; Return robots.txt from the root /robots.txt and at the context (e.g.
+      ;; /search/robots.txt)
+      (GET "/robots.txt" req robots-txt-response)
+      (context relative-root-url []
+        (GET "/robots.txt" req robots-txt-response))
+      (api-routes/build-routes system)
+      (site-routes/build-routes system)
+      (route/not-found "Not Found"))))
+
+(defn handlers [system]
+  (-> (build-routes system)
+      ;; add-authentication-handler adds the token and client id for user to
+      ;; the context add-user-id-and-sids-handler lazy adds the user id and
+      ;; sids for that token Need to maintain this order (works backwards).
+      context-augmenter/add-user-id-and-sids-handler
+      acl/add-authentication-handler
+      keyword-params/wrap-keyword-params
+      nested-params/wrap-nested-params
+      errors/invalid-url-encoding-handler
+      api-routes/mixed-arity-param-handler
+      (errors/exception-handler api-routes/default-error-format-fn)
+      common-routes/add-request-id-response-handler
+      (context/build-request-context-handler system)
+      common-routes/pretty-print-response-handler
+      params/wrap-params
+      copy-of-body-handler))

--- a/search-app/src/cmr/search/web/routes.clj
+++ b/search-app/src/cmr/search/web/routes.clj
@@ -4,22 +4,19 @@
   human consumption (site routes). It also provides routes that apply to both
   (e.g., robots.txt)."
   (:require
-   ;; Third-party libs
-   [clojure.java.io :as io]
-   [compojure.core :refer :all]
-   [compojure.route :as route]
-   [ring.middleware.keyword-params :as keyword-params]
-   [ring.middleware.nested-params :as nested-params]
-   [ring.middleware.params :as params]
-
-   ;; CMR libs
-   [cmr.acl.core :as acl]
-   [cmr.common.api.errors :as errors]
-   [cmr.common.api.context :as context]
-   [cmr.common-app.api.routes :as common-routes]
-   [cmr.search.api.request-context-user-augmenter :as context-augmenter]
-   [cmr.search.api.routes :as api-routes]
-   [cmr.search.site.routes :as site-routes]))
+    [clojure.java.io :as io]
+    [cmr.acl.core :as acl]
+    [cmr.common.api.errors :as errors]
+    [cmr.common.api.context :as context]
+    [cmr.common-app.api.routes :as common-routes]
+    [cmr.search.api.request-context-user-augmenter :as context-augmenter]
+    [cmr.search.api.routes :as api-routes]
+    [cmr.search.site.routes :as site-routes]
+    [compojure.core :refer :all]
+    [compojure.route :as route]
+    [ring.middleware.keyword-params :as keyword-params]
+    [ring.middleware.nested-params :as nested-params]
+    [ring.middleware.params :as params]))
 
 (defn copy-of-body-handler
   "Copies the body into a new attribute called :body-copy so that after a post

--- a/search-app/test/cmr/search/test/api/routes.clj
+++ b/search-app/test/cmr/search/test/api/routes.clj
@@ -4,20 +4,8 @@
   (:use ring.mock.request))
 
 (def ^:private api (#'cmr.search.api.routes/build-routes
-                     {:public-conf {:protocol "https" :relative-root-url "/search"}}))
-
-(deftest find-query-str-mixed-arity-param
-  (testing "find-query-str-mixed-arity-param finds parameter with mixed arity correctly"
-    (are [query-str found]
-         (= found
-            (r/find-query-str-mixed-arity-param query-str))
-
-         "foo=1&foo[bar]=2" "foo"
-         "foo[]=1&foo[bar]=2" "foo"
-         "foo=0&foo[]=1&foo[]=2" nil
-         "foo[bar]=1&foo[x]=2" nil
-         "foo=1&options[foo][pattern]=true" nil
-         "foo[]=1&options[foo][pattern]=true" nil)))
+                     {:public-conf {:protocol "https"
+                                    :relative-root-url "/search"}}))
 
 (deftest find-concept-id-and-revision-id-from-path-w-extension
   (testing "concept-id"

--- a/search-app/test/cmr/search/test/api/routes.clj
+++ b/search-app/test/cmr/search/test/api/routes.clj
@@ -6,33 +6,6 @@
 (def ^:private api (#'cmr.search.api.routes/build-routes
                      {:public-conf {:protocol "https" :relative-root-url "/search"}}))
 
-(defn- substring?
-  [test-value string]
-  (.contains string test-value))
-
-(deftest cmr-welcome-page
-  (testing "visited on a path without a trailing slash"
-    (let [response (api (request :get "https://cmr.example.com/search"))]
-      (testing "redirects permanently to the version with a trailing slash"
-        (is (= (:status response) 301))
-        (is (= (:headers response) {"Location" "https://cmr.example.com/search/"})))))
-
-  (testing "visited on a path with a trailing slash"
-    (let [response (api (request :get "https://cmr.example.com/search/"))]
-      (testing "produces a HTTP 200 success response"
-        (is (= (:status response) 200)))
-      (testing "returns the welcome page HTML"
-        (is (substring? "The CMR Search API" (:body response)))))))
-
-(deftest test-404
-  (testing "a 404 is returned for a missing document"
-    (is (= 404 (:status (api (request :get "https://cmr.example.com/search/site/NOT-A-PAGE.html")))))))
-
-(deftest cmr-api-documentation-page
-  (let [response (api (request :get "https://cmr.example.com/search/site/search_api_docs.html"))]
-    (testing "uses the incoming host and scheme for its documentation endpoints"
-      (is (substring? "https://cmr.example.com/search/collections" (:body response))))))
-
 (deftest find-query-str-mixed-arity-param
   (testing "find-query-str-mixed-arity-param finds parameter with mixed arity correctly"
     (are [query-str found]

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -1,0 +1,34 @@
+(ns cmr.search.test.site.routes
+  (:require [clojure.test :refer :all]
+            [cmr.search.site.routes :as r])
+  (:use ring.mock.request))
+
+(def ^:private site (#'cmr.search.site.routes/build-routes
+                     {:public-conf {:protocol "https" :relative-root-url "/search"}}))
+
+(defn- substring?
+  [test-value string]
+  (.contains string test-value))
+
+(deftest cmr-welcome-page
+  (testing "visited on a path without a trailing slash"
+    (let [response (site (request :get "https://cmr.example.com/search"))]
+      (testing "redirects permanently to the version with a trailing slash"
+        (is (= (:status response) 301))
+        (is (= (:headers response) {"Location" "https://cmr.example.com/search/"})))))
+
+  (testing "visited on a path with a trailing slash"
+    (let [response (site (request :get "https://cmr.example.com/search/"))]
+      (testing "produces a HTTP 200 success response"
+        (is (= (:status response) 200)))
+      (testing "returns the welcome page HTML"
+        (is (substring? "The CMR Search API" (:body response)))))))
+
+(deftest test-404
+  (testing "a 404 is returned for a missing document"
+    (is (= 404 (:status (site (request :get "https://cmr.example.com/search/site/NOT-A-PAGE.html")))))))
+
+(deftest cmr-api-documentation-page
+  (let [response (site (request :get "https://cmr.example.com/search/site/search_api_docs.html"))]
+    (testing "uses the incoming host and scheme for its documentation endpoints"
+      (is (substring? "https://cmr.example.com/search/collections" (:body response))))))

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -4,7 +4,8 @@
   (:use ring.mock.request))
 
 (def ^:private site (#'cmr.search.site.routes/build-routes
-                     {:public-conf {:protocol "https" :relative-root-url "/search"}}))
+                     {:public-conf {:protocol "https"
+                                    :relative-root-url "/search"}}))
 
 (defn- substring?
   [test-value string]
@@ -15,7 +16,8 @@
     (let [response (site (request :get "https://cmr.example.com/search"))]
       (testing "redirects permanently to the version with a trailing slash"
         (is (= (:status response) 301))
-        (is (= (:headers response) {"Location" "https://cmr.example.com/search/"})))))
+        (is (= (:headers response)
+               {"Location" "https://cmr.example.com/search/"})))))
 
   (testing "visited on a path with a trailing slash"
     (let [response (site (request :get "https://cmr.example.com/search/"))]
@@ -26,9 +28,18 @@
 
 (deftest test-404
   (testing "a 404 is returned for a missing document"
-    (is (= 404 (:status (site (request :get "https://cmr.example.com/search/site/NOT-A-PAGE.html")))))))
+    (is (= 404
+           (:status
+             (site
+               (request
+                 :get
+                 "https://cmr.example.com/search/site/NOT-A-PAGE.html")))))))
 
 (deftest cmr-api-documentation-page
-  (let [response (site (request :get "https://cmr.example.com/search/site/search_api_docs.html"))]
+  (let [response (site
+                   (request
+                     :get
+                     "https://cmr.example.com/search/site/search_api_docs.html"))]
     (testing "uses the incoming host and scheme for its documentation endpoints"
-      (is (substring? "https://cmr.example.com/search/collections" (:body response))))))
+      (is (substring?
+            "https://cmr.example.com/search/collections" (:body response))))))

--- a/search-app/test/cmr/search/test/web/routes.clj
+++ b/search-app/test/cmr/search/test/web/routes.clj
@@ -1,0 +1,20 @@
+(ns cmr.search.test.web.routes
+  (:require [clojure.test :refer :all]
+            [cmr.search.web.routes :as r])
+  (:use ring.mock.request))
+
+(def ^:private web (#'cmr.search.web.routes/build-routes
+                     {:public-conf {:protocol "https"
+                                    :relative-root-url "/search"}}))
+
+(deftest find-query-str-mixed-arity-param
+  (testing "find-query-str-mixed-arity-param finds parameter with mixed arity correctly"
+    (are [query-str found]
+         (= found
+            (r/find-query-str-mixed-arity-param query-str))
+         "foo=1&foo[bar]=2" "foo"
+         "foo[]=1&foo[bar]=2" "foo"
+         "foo=0&foo[]=1&foo[]=2" nil
+         "foo[bar]=1&foo[x]=2" nil
+         "foo=1&options[foo][pattern]=true" nil
+         "foo[]=1&options[foo][pattern]=true" nil)))


### PR DESCRIPTION
This is part of the CMR-3988 feature work (adding landing pages to the search-app). 

In particular, it: 
* separates `api` routes from `site` routes
* adds a new `web` namespace for combining these two
* moves the handlers to that new namespace (which is also the new namespace used when setting up the web server)

In the next change set, the number of routes in the new `site` namespace will increase, making the need for the separation even more clear.