### PR TITLE
CMR-3968: Added the bulk update tables.

### DIFF
--- a/ingest-app/src/migrations/005_create_bulk_update_tables.clj
+++ b/ingest-app/src/migrations/005_create_bulk_update_tables.clj
@@ -30,6 +30,6 @@
   "Migrates the database down from version 5."
   []
   (println "migrations.005-create-bulk-update-tables down...")
-  (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.bulk_update_task_status")
   (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.bulk_update_coll_status")
+  (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.bulk_update_task_status")
   (j/db-do-commands (config/db) "DROP SEQUENCE CMR_INGEST.task_id_seq"))

--- a/ingest-app/src/migrations/005_create_bulk_update_tables.clj
+++ b/ingest-app/src/migrations/005_create_bulk_update_tables.clj
@@ -1,0 +1,35 @@
+(ns migrations.005-create-bulk-update-tables
+  (:require [clojure.java.jdbc :as j]
+            [config.migrate-config :as config]))
+
+(defn up
+  "Migrates the database up to version 5."
+  []
+  (println "migrations.005-create-bulk-update-tables up...")
+  (j/db-do-commands (config/db) "CREATE TABLE CMR_INGEST.bulk_update_task_status (
+                              TASK_ID NUMBER NOT NULL,
+                              PROVIDER_ID  VARCHAR(10) NOT NULL,
+                              REQUEST_JSON_BODY  BLOB NOT NULL,
+                              STATUS VARCHAR(20),
+                              STATUS_MESSAGE   VARCHAR(255),
+                              CONSTRAINT BULK_UPDATE_TASK_STATUS_PK PRIMARY KEY (TASK_ID)
+                              )")
+  (j/db-do-commands (config/db) "CREATE TABLE CMR_INGEST.bulk_update_coll_status (
+                              TASK_ID NUMBER NOT NULL,
+                              CONCEPT_ID VARCHAR(255) NOT NULL,
+                              STATUS VARCHAR(20),
+                              STATUS_MESSAGE  VARCHAR(255),
+                              CONSTRAINT BULK_UPDATE_COLL_STATUS_PK PRIMARY KEY (TASK_ID,CONCEPT_ID),
+                              CONSTRAINT BULK_UPDATE_COLL_STATUA_FK FOREIGN KEY (TASK_ID)
+                              REFERENCES BULK_UPDATE_TASK_STATUS(TASK_ID)
+                              )")
+  (j/db-do-commands (config/db) "CREATE INDEX idx_blk_upd_tsk_pi ON CMR_INGEST.bulk_update_task_status(PROVIDER_ID)")
+  (j/db-do-commands (config/db) "CREATE SEQUENCE CMR_INGEST.task_id_seq"))
+
+(defn down
+  "Migrates the database down from version 5."
+  []
+  (println "migrations.005-create-bulk-update-tables down...")
+  (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.bulk_update_task_status")
+  (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.bulk_update_coll_status")
+  (j/db-do-commands (config/db) "DROP SEQUENCE CMR_INGEST.task_id_seq"))


### PR DESCRIPTION
Ran the setup-oracle.sh. The ingest migration part was successful:
------------------------------------------------------------------------
 Building cmr-ingest-app 0.1.0-SNAPSHOT (base,system,user,provided,dev)
------------------------------------------------------------------------
17-Apr-12 14:04:06 mbp-sxu2.edn.ecs.nasa.gov INFO [user] - Custom user.clj loaded.
migrations.001-create-quartz-tables up...
migrations.002-create-provider-acl-hash-table up...
migrations.003-update-provider-acl-hash-table up...
migrations.004-update-quartz-to-2-2-2 up...
migrations.005-create-bulk-update-tables up...