### PR TITLE
CMR-4089: Fix checkout command to install metadata-preview gem from a…

### DIFF
--- a/collection-renderer-lib/support/install_gems.sh
+++ b/collection-renderer-lib/support/install_gems.sh
@@ -30,7 +30,7 @@ currDir=$PWD
 cd $tmpGemDir
 if [ ! -z "$commit" ]
   then
-    git co -b tmp $commit
+    git checkout -b tmp $commit
     echo "Building metadata preview gem off commit id: $commit"
   else
     echo "Building metadata preview gem off HEAD"


### PR DESCRIPTION
Fix the git checkout command used to install the metadata preview gem.