### PR TITLE
CMR-3849 and CMR-3950 Additional data center and contact person iso mappings

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -349,13 +349,20 @@
         (update :MiddleName #(when (seq %) %)) ; nil if empty
         (assoc :LastName (last names))))))
 
+(defn- iso-contact-person-roles
+  "If not a metadata author, return default role"
+  [roles role-default]
+  (if (contains? (set roles) "Metadata Author")
+    ["Metadata Author"]
+    [role-default]))
+
 (defn- expected-contact-person
  "Return an expected ISO contact person. Role is based on whether it is a contact person associated
  with a data center or standalone contact person"
  [person role]
  (-> person
      (dissoc :Uuid)
-     (assoc :Roles [role])
+     (update :Roles iso-contact-person-roles role)
      update-person-names
      (update :ContactInformation #(expected-iso-contact-information % "DataContactURL"))))
 

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -131,20 +131,20 @@
   [projects]
   (for [proj projects]
     (let [{short-name :ShortName
-           long-name  :LongName 
+           long-name  :LongName
            start-date :StartDate
            end-date   :EndDate
            campaigns  :Campaigns} proj]
       [:gmi:operation
        [:gmi:MI_Operation
-     (let [start-date-str (when start-date 
+     (let [start-date-str (when start-date
                             (str "StartDate: " start-date))
            end-date-str (when end-date
                           (str " EndDate: " end-date))
            date-str (if start-date-str
                       (str start-date-str " " end-date-str)
                       end-date-str)]
-       (when date-str 
+       (when date-str
         [:gmi:description
          (char-string date-str)]))
         [:gmi:identifier
@@ -293,6 +293,7 @@
        [:gmd:hierarchyLevel
         [:gmd:MD_ScopeCode {:codeList (str (:ngdc iso/code-lists) "#MD_ScopeCode")
                             :codeListValue "series"} "series"]]
+       (data-contact/generate-metadata-author-contact-persons (:ContactPersons c))
        (if-let [archive-centers (data-contact/generate-archive-centers (:DataCenters c))]
         archive-centers
         [:gmd:contact {:gco:nilReason "missing"}])

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -293,6 +293,7 @@
        [:gmd:hierarchyLevel
         [:gmd:MD_ScopeCode {:codeList (str (:ngdc iso/code-lists) "#MD_ScopeCode")
                             :codeListValue "series"} "series"]]
+       (data-contact/generate-data-center-metadata-author-contact-persons (:DataCenters c))
        (data-contact/generate-metadata-author-contact-persons (:ContactPersons c))
        (if-let [archive-centers (data-contact/generate-archive-centers (:DataCenters c))]
         archive-centers

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/data_contact.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/data_contact.clj
@@ -155,14 +155,6 @@
    [:gmd:pointOfContact
      (generate-data-center data-center iso-role)]))
 
-(defn generate-data-center-contact-persons
- "Generate the contact persons for the data center. "
- [data-centers]
- (for [data-center data-centers
-       :let [data-center-name (generate-data-center-name data-center)]]
-  (map #(generate-contact-person % :gmd:pointOfContact data-center-name)
-       (:ContactPersons data-center))))
-
 (defn- generate-contact-group
  "Generate a contact group in ISO. A contact group is distinguished from a contact person by not
   having an individualName."
@@ -190,9 +182,28 @@
             (filter #(not (contains? (set (:Roles %)) "Metadata Author")) contact-persons))))
 
 (defn generate-metadata-author-contact-persons
+  "Generate contact person entries for metadata authors"
   [contact-persons]
   (seq (map #(generate-contact-person % :gmd:contact)
             (filter #(contains? (set (:Roles %)) "Metadata Author") contact-persons))))
+
+(defn generate-data-center-contact-persons
+ "Generate the non-metatata author contact persons for the data center. "
+ [data-centers]
+ (for [data-center data-centers
+       :let [data-center-name (generate-data-center-name data-center)
+             contact-persons (filter #(not (contains? (set (:Roles %)) "Metadata Author"))
+                                     (:ContactPersons data-center))]]
+  (map #(generate-contact-person % :gmd:pointOfContact data-center-name) contact-persons)))
+
+(defn generate-data-center-metadata-author-contact-persons
+ "Generate the metadata author contact persons for the data center. "
+ [data-centers]
+ (for [data-center data-centers
+       :let [data-center-name (generate-data-center-name data-center)
+             contact-persons (filter #(contains? (set (:Roles %)) "Metadata Author")
+                                     (:ContactPersons data-center))]]
+  (map #(generate-contact-person % :gmd:contact data-center-name) contact-persons)))
 
 (defn generate-contact-groups
  "Generate contact groups in ISO."

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -85,6 +85,7 @@
                                        :Type "CREATE"}
                                       {:Date (t/date-time 2013)
                                        :Type "UPDATE"}]))]]
+
       ;; input file is valid
       (check-failure
        (is (empty? (core/validate-xml :collection metadata-format metadata))
@@ -109,7 +110,9 @@
                     ;; The RelatedUrls field get reshuffled during the conversions,
                     ;; so we compare RelatedUrls as a set.
                     expected (update expected :RelatedUrls set)
-                    actual (update actual :RelatedUrls set)]]
+                    actual (update actual :RelatedUrls set)
+                    expected (update expected :ContactPersons set)
+                    actual (update actual :ContactPersons set)]]
 
         ;; Taking the parsed UMM and converting it to another format produces the expected UMM
         (check-failure
@@ -151,7 +154,9 @@
           ;; The RelatedUrls field get reshuffled during the conversions,
           ;; so we compare RelatedUrls as a set.
           expected (update expected :RelatedUrls set)
-          actual (update actual :RelatedUrls set)]
+          actual (update actual :RelatedUrls set)
+          expected (update expected :ContactPersons set)
+          actual (update actual :ContactPersons set)]
       (is (= expected actual)
           (str "Unable to roundtrip with format " metadata-format)))))
 


### PR DESCRIPTION
Map contacts from the citedResponsibleParty path and do not drop contacts with an organization that does not have a corresponding data center.