### PR TITLE
Task: CMR-4075 EUI for CMR Search pages

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1,7 +1,5 @@
 ## API Documentation
 
-***
-
 See the [CMR Client Partner User Guide](https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide) for a general guide to developing a client utilizing the CMR Search API.
 Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum) to ask questions, make suggestions and discuss topics like future CMR capabilities.
 

--- a/search-app/docs/site.md
+++ b/search-app/docs/site.md
@@ -1,6 +1,4 @@
-## Site Routes and Web Resources Documentation
-
-***
+## Site Routes &amp; Web Resources Documentation
 
 See also the [API Documentation](search_api_docs.html).
 
@@ -40,11 +38,13 @@ Additionally, static assets are made available at the site root, serving CSS and
 
 ### <a name="redirects"></a> Redirects
 
-The following temporary redirects are currently defined, to assist with the migration to a better organized documentation URL structure.
+The following redirects are defined in order to assist with a better organized documentation URL structure.
 
-| Path            | Destination                |
-| --------------- | -------------------------- |
-| site/docs/api   | site/search_api_docs.html  |
-| site/docs/site  | site/search_site_docs.html |
+| Path                       | Destination         |
+| -------------------------- | ------------------- |
+| site/search_api_docs.html  | site/docs/api.html  |
+| site/search_site_docs.html | site/docs/site.html |
+| site/docs/api              | site/docs/api.html  |
+| site/docs/site             | site/docs/site.html |
 
-Each of these return an HTTP response status code of `307`. Once the docs reorganization is complete, the redirections will be reversed and the status code will be `301`.
+Each of these are provided as means of providing backwards compatibility for users who have bookmarked the old URLs. They return an HTTP response status code of `301`.

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -72,32 +72,7 @@
                 [lein-shell "0.4.0"]
                 [venantius/yagni "0.1.4"]]}}
 
-  :aliases {"generate-docs"
-            ["exec" "-ep"
-             (pr-str '(do
-                       (use 'cmr.common-app.api-docs)
-                       (use 'clojure.java.io)
-                       (let [json-target (file "resources/public/site/JSONQueryLanguage.json")
-                             aql-target (file "resources/public/site/IIMSAQLQueryLanguage.xsd")
-                             swagger-target (file "resources/public/site/swagger.json")]
-                         (println "Copying JSON Query Language Schema to" (str json-target))
-                         (make-parents json-target)
-                         (copy (file "resources/schema/JSONQueryLanguage.json")
-                               json-target)
-                         (println "Copying AQL Schema to" (str aql-target))
-                         (copy (file "resources/schema/IIMSAQLQueryLanguage.xsd")
-                               aql-target)
-                         (println "Copying swagger.json file to " (str swagger-target))
-                         (copy (file "resources/schema/swagger.json")
-                               swagger-target))
-                       (generate
-                         "CMR Search"
-                         "docs/api.md"
-                         "resources/public/site/search_api_docs.html")
-                       (generate
-                         "CMR Search"
-                         "docs/site.md"
-                         "resources/public/site/search_site_docs.html")))]
+  :aliases {"generate-docs" ["run" "-m" "cmr.search.site.static" "all"]
             ;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out

--- a/search-app/resources/templates/base.html
+++ b/search-app/resources/templates/base.html
@@ -3,33 +3,30 @@
 {% block title %}CMR Search{% endblock %}
 
 {% block top-nav %}
-<div class="masthead clearfix">
-  <div class="inner">
-    <h3 class="masthead-brand"><a href="/">CMR</a></h3>
-    <ul class="nav masthead-nav">
-      <li><a href="{{ base-url }}site/docs">Documentation</a></li>
-      <li><a href="{{ base-url }}site/collections/directory">Directory</a></li>
-      <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
-      <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
-      <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner's Guide</a></li>
-    </ul>
-  </div>
+<div class="eui-masthead-logo eui-application-logo">
+  <h1><a href="{{ base-url }}">CMR Search</a></h1>
 </div>
+<nav class="main-nav" role="navigation">
+  <ul class="main-nav-list">
+    <li><a href="{{ base-url }}site/docs">Documentation</a></li>
+    <li><a href="{{ base-url }}site/collections/directory">Directory</a></li>
+    <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
+    <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
+    <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner's Guide</a></li>
+    <li><a href="https://github.com/nasa/Common-Metadata-Repository">Github</a></li>
+  </ul>
+</nav>
 {% endblock %}
 
 {% block footer %}
-<div class="mastfoot">
-  <div class="row">
-    <div class="col-lg-12">
-      <ul class="nav nav-justified">
-        <!-- This first list element is optional. It displays the version of the app/service currently deployed and displays it in an EUI badge component -->
-        <li>NASA Official: Stephen Berrick</li>
-        <li><a href="http://www.nasa.gov/FOIA/index.html">FOIA</a></li>
-        <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
-        <li><a href="http://www.usa.gov/">USA.gov</a></li>
-        <li><a href="javascript:feedback.showForm();">Feedback</a></li>
-      </ul>
-    </div>
-  </div>
-</div>
+<nav class="main-nav" role="navigation">
+  <ul class="nav main-nav-list">
+    <!-- This first list element is optional. It displays the version of the app/service currently deployed and displays it in an EUI badge component -->
+    <li>NASA Official: Stephen Berrick</li>
+    <li><a href="http://www.nasa.gov/FOIA/index.html">FOIA</a></li>
+    <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
+    <li><a href="http://www.usa.gov/">USA.gov</a></li>
+    <li><a href="javascript:feedback.showForm();">Feedback</a></li>
+  </ul>
+</nav>
 {% endblock %}

--- a/search-app/resources/templates/directory-links.html
+++ b/search-app/resources/templates/directory-links.html
@@ -3,12 +3,10 @@
 {% block title %}CMR Search - Directory of Collections Landing Pages{% endblock %}
 
 {% block main-content %}
-<div class="inner cover">
-  <h1 class="cover-heading">Directory of Collections Landing Pages</h1>
-  <ul>
+<h2>Directory of Collections Landing Pages</h2>
+<ul>
   {% for link in links %}
-    <li><a href="{{ base-url }}{{ link.href }}">{{ link.text }}</a></li>
+  <li><a href="{{ base-url }}{{ link.href }}">{{ link.text }}</a></li>
   {% endfor %}
-  </ul>
-</div>
+</ul>
 {% endblock %}

--- a/search-app/resources/templates/eosdis-directory-links.html
+++ b/search-app/resources/templates/eosdis-directory-links.html
@@ -3,12 +3,11 @@
 {% block title %}CMR Search - Directory of Landing Pages for EOSDIS Collections{% endblock %}
 
 {% block main-content %}
-<div class="inner cover">
-  <h1 class="cover-heading">Directory of Landing Pages for EOSDIS Collections</h1>
-  <ul>
+<h2 class="cover-heading">Directory of Collections Landing Pages</h2>
+<h3 class="cover-heading">EOSDIS</h3>
+<ul>
   {% for provider in providers %}
-    <li><a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a></li>
+  <li><a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a></li>
   {% endfor %}
-  </ul>
-</div>
+</ul>
 {% endblock %}

--- a/search-app/resources/templates/index.html
+++ b/search-app/resources/templates/index.html
@@ -1,14 +1,17 @@
 {% extends "templates/base.html" %}
 
 {% block main-content %}
-<div class="inner cover">
-  <h1 class="cover-heading">CMR Search</h1>
-  <p class="lead">
-    The Common Metadata Repository (CMR) is an earth science metadata
-    repository for NASA EOSDIS data. The CMR Search API provides access
-    to this metadata.</p>
-  <p class="lead">
-    <a href="/site/docs/api" class="btn btn-lg btn-default">Learn more</a>
+<section class="eui-hero" style="background: url('https://cdn.earthdata.nasa.gov/conduit/upload/947/LANCE_header_MODISAqua2.jpg') no-repeat top center">
+  <h2 class="eui-hero__title">CMR Search</h2>
+  <p class="eui-hero__subtitle">
+  The Common Metadata Repository (CMR) is a high-performance, high-quality,
+  continuously evolving metadata system that catalogs Earth Science data and
+  service metadata records. These metadata records are registered, modified,
+  discovered, and accessed through programmatic interfaces leveraging standard
+  protocols and APIs.
   </p>
-</div>
+  <p>
+    <a href="/site/docs/api" class="eui-btn--blue">Learn more</a>
+  </p>
+</section>
 {% endblock %}

--- a/search-app/resources/templates/index.html
+++ b/search-app/resources/templates/index.html
@@ -6,9 +6,9 @@
   <p class="eui-hero__subtitle">
   The Common Metadata Repository (CMR) is a high-performance, high-quality,
   continuously evolving metadata system that catalogs Earth Science data and
-  service metadata records. These metadata records are registered, modified,
-  discovered, and accessed through programmatic interfaces leveraging standard
-  protocols and APIs.
+  associated service metadata records. These metadata records are registered,
+  modified, discovered, and accessed through programmatic interfaces leveraging
+  standard protocols and APIs.
   </p>
   <p>
     <a href="/site/docs/api" class="eui-btn--blue">Learn more</a>

--- a/search-app/resources/templates/provider-tag-landing-links.html
+++ b/search-app/resources/templates/provider-tag-landing-links.html
@@ -3,12 +3,12 @@
 {% block title %}CMR Search - Landing Pages for the {{ provider-name}} {{ tag-name }} Collections{% endblock %}
 
 {% block main-content %}
-<div class="inner cover">
-  <h1 class="cover-heading">Landing Pages for the {{ provider-name}} {{ tag-name }} Collections</h1>
-  <ul>
+<h2 class="cover-heading">Directory of Collections Landing Pages</h2>
+<h3 class="cover-heading">{{ tag-name }}</h3>
+<h4 class="cover-heading">Landing Pages for {{ provider-name}}</h4>
+<ul>
   {% for link in links %}
-    <li><a href="{{ link.href }}">{{ link.text }}</a></li>
+  <li><a href="{{ link.href }}">{{ link.text }}</a></li>
   {% endfor %}
-  </ul>
-</div>
+</ul>
 {% endblock %}

--- a/search-app/resources/templates/search-docs-static.html
+++ b/search-app/resources/templates/search-docs-static.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block title %}{{ site-title }} - {{ page-title }}{% endblock %}
+
+{% block main-content %}
+{{ page-content|safe }}
+{% endblock %}

--- a/search-app/resources/templates/search-docs.html
+++ b/search-app/resources/templates/search-docs.html
@@ -1,14 +1,12 @@
 {% extends "templates/base.html" %}
 
 {% block main-content %}
-<div class="inner cover">
-  <h1 class="cover-heading">CMR Search</h1>
-  <p class="lead">
-    Documentation for CMR Search is broken out into two different usage sections:
-  </p>
-  <ul>
-    <li><a href="{{ base-url }}site/docs/api">API Documentation</a> - How to access the search API via an HTTP client</li>
-    <li><a href="{{ base-url }}site/docs/site">Site Documentation</a> - View site routes and web resources</li>
-  </ul>
-</div>
+<h2>Documentation</h2>
+<p class="lead">
+  Documentation for CMR Search is split out into two different usage sections:
+</p>
+<ul>
+  <li><a href="{{ base-url }}site/docs/api">API Documentation</a> - How to access the search API via an HTTP client</li>
+  <li><a href="{{ base-url }}site/docs/site">Site Documentation</a> - View site routes and web resources</li>
+</ul>
 {% endblock %}

--- a/search-app/resources/templates/structure.html
+++ b/search-app/resources/templates/structure.html
@@ -8,10 +8,11 @@
 
     {% block head-pre-css %}
     {% endblock %}
-    <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="{{ base-url }}site/bootstrap.min.css">
+    <!-- EUI -->
+    <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
+    <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/docs/assets/docs.css" rel="stylesheet" />
     <!-- Custom styles for this template -->
-    <link rel="stylesheet" href="{{ base-url }}site/cover.css">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -21,30 +22,37 @@
     {% block head-end %}
     {% endblock %}
   </head>
+  <body class="eui-layout docs">
 
-  <body>
-    <div class="site-wrapper">
-      <div class="site-wrapper-inner">
-        <div class="cover-container">
-          {% block top-nav %}
-          {% endblock %}
-
-          {% block main-content %}
-          {% endblock %}
-
-          {% block footer %}
-          {% endblock %}
-        </div>
+    <header class="doc-mast">
+      <div class="container">
+        {% block top-nav %}
+        {% endblock %}
       </div>
-    </div>
-    <!-- Bootstrap core JavaScript
-    ================================================== -->
+    </header>
+
+    <main>
+      <div class="container">
+        {% block main-content %}
+        {% endblock %}
+      </div>
+    </main>
+
+    <footer>
+      <div class="container">
+        {% block footer %}
+        {% endblock %}
+      </div>
+    </footer>
+
     <!-- Placed at the end of the document so the pages load faster -->
     {% block body-post-scripts %}
     <script src="https://fbm.earthdata.nasa.gov/for/CMR/feedback.js" type="text/javascript"></script>
     <script type="text/javascript"> feedback.init({showIcon: false}); </script>
-    <script src="{{ base-url }}site/jquery.min.js"></script>
-    <script src="{{ base-url }}site/bootstrap.min.js"></script>
+    <!-- Reference JQuery before eui.js-->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+    <!-- Latest compiled JavaScript-->
+    <script src="https://cdn.earthdata.nasa.gov/eui/1.1.3/js/eui.js"></script>
     {% endblock %}
     {% block body-end %}
     {% endblock %}

--- a/search-app/resources/templates/structure.html
+++ b/search-app/resources/templates/structure.html
@@ -8,12 +8,12 @@
 
     {% block head-pre-css %}
     {% endblock %}
+    {% block head-css %}
     <!-- EUI -->
     <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
     <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/docs/assets/docs.css" rel="stylesheet" />
-    <!-- Custom styles for this template -->
-
+    {% endblock %}
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -119,7 +119,7 @@
   (merge
    (base-page context)
    {:links [{:href "site/collections/directory/eosdis"
-             :text "Directory for EOSDIS Collections"}]}))
+             :text "EOSDIS Collections"}]}))
 
 (defn get-eosdis-directory-links
   "Generate the data necessary to render EOSDIS directory page links."

--- a/search-app/src/cmr/search/site/pages.clj
+++ b/search-app/src/cmr/search/site/pages.clj
@@ -6,6 +6,10 @@
    [ring.util.response :as ring-util]
    [selmer.parser :as selmer]))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Utility functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn render-template
   "A utility function for preparing template pages."
   ([context template]
@@ -13,6 +17,15 @@
   ([context template page-data]
     (ring-util/response
      (selmer/render-file template page-data))))
+
+(defn render-html
+  "A utility function for preparing template pages."
+  ([context template]
+    (render-html context template (data/base-page context)))
+  ([context template page-data]
+    (ring-util/content-type
+     (render-template context template page-data)
+     "text/html")))
 
 (defn render-xml
   "A utility function for preparing XML templates."
@@ -23,20 +36,24 @@
      (render-template context template page-data)
      "text/xml")))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; HTML page-genereating functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn home
   "Prepare the home page template."
   [context]
-  (render-template context "templates/index.html" (data/get-index context)))
+  (render-html context "templates/index.html" (data/get-index context)))
 
 (defn search-docs
   "Prepare the top-level search docs page."
   [context]
-  (render-template context "templates/search-docs.html"))
+  (render-html context "templates/search-docs.html"))
 
 (defn search-site-docs
   "Prepare the site-specific (non-API) docs page."
   [context]
-  (render-template context "templates/search-site-docs.html"))
+  (render-html context "templates/search-site-docs.html"))
 
 (defn collections-directory
   "Prepare the page that links to all sub-directory pages.
@@ -44,7 +61,7 @@
   For now, this is just a page with a single link (the EOSDIS collections
   directory)."
   [context]
-  (render-template
+  (render-html
    context
    "templates/directory-links.html"
    (data/get-directory-links context)))
@@ -52,7 +69,7 @@
 (defn eosdis-collections-directory
   "Prepare the EOSDIS directory page that provides links to all the providers."
   [context]
-  (render-template
+  (render-html
    context
    "templates/eosdis-directory-links.html"
    (data/get-eosdis-directory-links context)))
@@ -61,10 +78,14 @@
   "Prepare the page that provides links to collection landing pages based
   upon a provider and a tag."
   [context provider-id tag]
-  (render-template
+  (render-html
    context
    "templates/provider-tag-landing-links.html"
    (data/get-provider-tag-landing-links context provider-id tag)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; XML resource-genereating functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn sitemap-master
   "Prepare the XML page that provides the master sitemap, which collects all

--- a/search-app/src/cmr/search/site/pages.clj
+++ b/search-app/src/cmr/search/site/pages.clj
@@ -3,38 +3,7 @@
   ready-to-serve pages."
   (:require
    [cmr.search.site.data :as data]
-   [ring.util.response :as ring-util]
-   [selmer.parser :as selmer]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Utility functions
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn render-template
-  "A utility function for preparing template pages."
-  ([context template]
-    (render-template context template (data/base-page context)))
-  ([context template page-data]
-    (ring-util/response
-     (selmer/render-file template page-data))))
-
-(defn render-html
-  "A utility function for preparing template pages."
-  ([context template]
-    (render-html context template (data/base-page context)))
-  ([context template page-data]
-    (ring-util/content-type
-     (render-template context template page-data)
-     "text/html")))
-
-(defn render-xml
-  "A utility function for preparing XML templates."
-  ([context template]
-    (render-xml context template (data/base-page context)))
-  ([context template page-data]
-    (ring-util/content-type
-     (render-template context template page-data)
-     "text/xml")))
+   [cmr.search.site.util :refer [render-html render-xml]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; HTML page-genereating functions

--- a/search-app/src/cmr/search/site/routes.clj
+++ b/search-app/src/cmr/search/site/routes.clj
@@ -32,20 +32,32 @@
         (GET "/site/docs"
              {context :request-context}
              (pages/search-docs context))
-        ;; XXX Eventually we will have better-organized docs resources; until
-        ;; then, let's redirect to where they are.
+        ;; Support better organization of documentation URLs and support old
+        ;; URLs
         (GET "/site/docs/api"
              {context :request-context}
              (redirect
               (str (config/application-public-root-url context)
-                   "site/search_api_docs.html")
+                   "site/docs/api.html")
               307))
         (GET "/site/docs/site"
              {context :request-context}
              (redirect
               (str (config/application-public-root-url context)
-                   "site/search_site_docs.html")
+                   "site/docs/site.html")
               307))
+        (GET "/site/search_api_docs.html"
+             {context :request-context}
+             (redirect
+              (str (config/application-public-root-url context)
+                   "site/docs/api.html")
+              301))
+        (GET "/site/search_site_docs.html"
+             {context :request-context}
+             (redirect
+              (str (config/application-public-root-url context)
+                   "site/docs/site.html")
+              301))
         (GET "/site/collections/directory"
              {context :request-context}
              (pages/collections-directory context))

--- a/search-app/src/cmr/search/site/static.clj
+++ b/search-app/src/cmr/search/site/static.clj
@@ -1,0 +1,62 @@
+(ns cmr.search.site.static
+  "The functions of this namespace are specifically responsible for returning
+  ready-to-serve pages."
+  (:require
+   [clojure.java.io :as io]
+   [cmr.search.site.util :as util])
+  (:gen-class))
+
+(defn prepare-docs
+  "Copy the static docs support files to where they will be served as static
+  content."
+  []
+  (println "Preparing docs generator ...")
+  (let [json-target (io/file "resources/public/site/JSONQueryLanguage.json")
+        aql-target (io/file "resources/public/site/IIMSAQLQueryLanguage.xsd")
+        swagger-target (io/file "resources/public/site/swagger.json")]
+    (println " * Copying JSON Query Language Schema to" (str json-target))
+    (io/make-parents json-target)
+    (io/copy (io/file "resources/schema/JSONQueryLanguage.json")
+             json-target)
+    (println " * Copying AQL Schema to" (str aql-target))
+    (io/copy (io/file "resources/schema/IIMSAQLQueryLanguage.xsd")
+             aql-target)
+    (println " * Copying swagger.json file to " (str swagger-target))
+    (io/copy (io/file "resources/schema/swagger.json")
+             swagger-target)))
+
+(defn generate-api-docs
+  "Generate CMR Search API docs."
+  []
+  (util/generate-docs "CMR Search"
+                      "API Documentation"
+                      "docs/api.md"
+                      "templates/search-docs-static.html"
+                      "resources/public/site/docs/api.html"))
+
+
+(defn generate-site-docs
+  "Generate CMR Search docs for routes and web resources."
+  []
+  (util/generate-docs "CMR Search"
+                      "Site Routes & Web Resource Documentation"
+                      "docs/site.md"
+                      "templates/search-docs-static.html"
+                      "resources/public/site/docs/site.html"))
+
+(defn -main
+  "The entrypoint for command-line static docs generation. Example usage:
+
+  $ lein run -m cmr.search.site.static prep
+  $ lein run -m cmr.search.site.static api
+  $ lein run -m cmr.search.site.static site
+  $ lein run -m cmr.search.site.static all"
+  [doc-type]
+  (case (keyword doc-type)
+    :prep (prepare-docs)
+    :api (generate-api-docs)
+    :site (generate-site-docs)
+    :all (do
+          (-main :prep)
+          (-main :api)
+          (-main :site))))

--- a/search-app/src/cmr/search/site/util.clj
+++ b/search-app/src/cmr/search/site/util.clj
@@ -2,12 +2,13 @@
   "The functions of this namespace are specifically responsible for returning
   ready-to-serve pages."
   (:require
+   [cmr.common-app.api-docs :as api-docs]
    [cmr.search.site.data :as data]
    [ring.util.response :as ring-util]
    [selmer.parser :as selmer]))
 
 (defn render-template
-  "A utility function for preparing template pages."
+  "A utility function for preparing templates."
   ([context template]
     (render-template context template (data/base-page context)))
   ([context template page-data]
@@ -15,7 +16,7 @@
      (selmer/render-file template page-data))))
 
 (defn render-html
-  "A utility function for preparing template pages."
+  "A utility function for preparing HTML templates."
   ([context template]
     (render-html context template (data/base-page context)))
   ([context template page-data]
@@ -31,3 +32,17 @@
     (ring-util/content-type
      (render-template context template page-data)
      "text/xml")))
+
+(defn generate-docs
+  "A utility function for rendering CMR search docs using Selmer."
+  [site-title page-title md-source template-file out-file]
+  (api-docs/generate page-title
+                     md-source
+                     out-file
+                     (fn []
+                      (selmer/render-file
+                        template-file
+                        {:base-url "../../"
+                         :site-title site-title
+                         :page-title page-title
+                         :page-content (api-docs/md->html (slurp md-source))}))))

--- a/search-app/src/cmr/search/site/util.clj
+++ b/search-app/src/cmr/search/site/util.clj
@@ -1,0 +1,33 @@
+(ns cmr.search.site.util
+  "The functions of this namespace are specifically responsible for returning
+  ready-to-serve pages."
+  (:require
+   [cmr.search.site.data :as data]
+   [ring.util.response :as ring-util]
+   [selmer.parser :as selmer]))
+
+(defn render-template
+  "A utility function for preparing template pages."
+  ([context template]
+    (render-template context template (data/base-page context)))
+  ([context template page-data]
+    (ring-util/response
+     (selmer/render-file template page-data))))
+
+(defn render-html
+  "A utility function for preparing template pages."
+  ([context template]
+    (render-html context template (data/base-page context)))
+  ([context template page-data]
+    (ring-util/content-type
+     (render-template context template page-data)
+     "text/html")))
+
+(defn render-xml
+  "A utility function for preparing XML templates."
+  ([context template]
+    (render-xml context template (data/base-page context)))
+  ([context template page-data]
+    (ring-util/content-type
+     (render-template context template page-data)
+     "text/xml")))

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -57,7 +57,7 @@
 (deftest cmr-api-documentation-page
   (let [response (site
                    (request
-                     :get (str base-url "/site/search_api_docs.html")))]
+                     :get (str base-url "/site/docs/api.html")))]
     (testing "uses the incoming host and scheme for the docs endpoint"
       (is (= (:status response) 200))
       (is (substring? "API Documentation" (:body response)))
@@ -67,11 +67,11 @@
 (deftest cmr-site-documentation-page
   (let [response (site
                    (request
-                     :get (str base-url "/site/search_site_docs.html")))]
+                     :get (str base-url "/site/docs/site.html")))]
     (testing "uses the incoming host and scheme for the docs endpoint"
       (is (= (:status response) 200))
       (is (substring?
-            "Site Routes and Web Resources Documentation" (:body response))))))
+            "Site Routes &amp; Web Resources Documentation" (:body response))))))
 
 (deftest cmr-all-documentation-page
   (let [response (site (request :get (str base-url "/site/docs")))]
@@ -86,11 +86,23 @@
     (testing "clean docs URL for api docs performs redirect"
       (is (= (:status response) 307))
       (is (substring?
-            "site/search_api_docs.html"
+            "site/docs/api.html"
             (get-in response [:headers "Location"])))))
   (let [response (site (request :get (str base-url "/site/docs/site")))]
     (testing "clean docs URL for site docs performs redirect"
       (is (= (:status response) 307))
       (is (substring?
-            "site/search_site_docs.html"
+            "site/docs/site.html"
+            (get-in response [:headers "Location"])))))
+  (let [response (site (request :get (str base-url "/site/search_api_docs.html")))]
+    (testing "clean docs URL for api docs performs redirect"
+      (is (= (:status response) 301))
+      (is (substring?
+            "site/docs/api.html"
+            (get-in response [:headers "Location"])))))
+  (let [response (site (request :get (str base-url "/site/search_site_docs.html")))]
+    (testing "clean docs URL for site docs performs redirect"
+      (is (= (:status response) 301))
+      (is (substring?
+            "site/docs/site.html"
             (get-in response [:headers "Location"]))))))

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -23,13 +23,15 @@
       (testing "produces a HTTP 200 success response"
         (is (= (:status response) 200)))
       (testing "returns the welcome page HTML"
-        (is (substring? "The CMR Search API" (:body response))))))
+        (is (substring? "The Common Metadata Repository"
+                        (:body response))))))
   (testing "visited on a path with a trailing slash"
     (let [response (site (request :get (str base-url "/")))]
       (testing "produces a HTTP 200 success response"
         (is (= (:status response) 200)))
       (testing "returns the welcome page HTML"
-        (is (substring? "The CMR Search API" (:body response)))))))
+        (is (substring? "The Common Metadata Repository"
+                        (:body response)))))))
 
 (deftest collections-directory-page
   (testing "collections directory page returns content"
@@ -40,7 +42,7 @@
         (is (substring? "Directory of Collections Landing Pages"
                         (:body response))))
       (testing "page has a link to EOSDIS collections directory"
-        (is (substring? "Directory for EOSDIS Collections"
+        (is (substring? "EOSDIS Collections"
                         (:body response)))))))
 
 (deftest test-404

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -42,7 +42,7 @@
 (defn- make-links
   [data]
   (string/join
-    "\n  \n    "
+    "\n  \n  "
     (map make-link data)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -55,7 +55,7 @@
 
 (def expected-top-level-links
   (make-links [{:href (str base-url "site/collections/directory/eosdis")
-                :text "Directory for EOSDIS Collections"}]))
+                :text "EOSDIS Collections"}]))
 
 (def expected-eosdis-level-links
   (let [url (str base-url "site/collections/directory")
@@ -250,4 +250,7 @@
       (is (= (:status response) 200))
       (is (string/includes?
            (:body response)
-           "Directory of Landing Pages for EOSDIS Collections")))))
+           "Directory of Collections Landing Pages"))
+      (is (string/includes?
+           (:body response)
+           "EOSDIS")))))


### PR DESCRIPTION
This change adds support for EUI styling in the CMR Search pages, including the static documentation pages.

The static docs are still generated using `cmr.common-app.api-docs` but with the new CMR Search Selmer templates. In order to do this, `api-docs/generate` needed to be refactored to allow for overriding the default HTML generation.

Note that since `common-app` has changed (`search-app` now expects the presence of some new functions in `common-app`), you will need to reinstall local jars: `lein modules do clean, install, clean`.