### PR TITLE
Added deleted-collections endpoint for harvesting client

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -124,6 +124,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
         * [Hierarchical JSON facets](#hierarchical-json-facets)
   * [Search for Tiles](#search-for-tiles)
   * [Retrieve Controlled Keywords](#retrieve-controlled-keywords)
+  * [Find collections that have been deleted](#deleted-collections)
   * [Tagging](#tagging)
     * [Tag Access Control](#tag-access-control)
     * [Creating a Tag](#creating-a-tag)
@@ -2471,6 +2472,48 @@ __Example Response__
     } ]
   } ]
 }
+```
+
+### <a name="deleted-collections"></a> Find collections that have been deleted
+
+To support metadata harvesting, a harvesting client can search CMR for collections that are deleted within a time period. The only search parameter supported is `revision_date` and its format is the same as the `revision_date` parameter in regular collection search. The only supported result format is xml references. The response is the references to the highest non-tombstone collection revisions of the collections that are deleted within the given revision date period. e.g.
+
+The following search will return the last revision of the collections that are deleted since 01/20/2017.
+
+    curl -i "%CMR-ENDPOINT%/deleted-collections?revision_date=2017-01-20T00:00:00Z&pretty=true"
+
+__Example Response__
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=UTF-8
+CMR-Hits: 3
+
+<?xml version="1.0" encoding="UTF-8"?>
+<results>
+    <hits>3</hits>
+    <took>10</took>
+    <references>
+        <reference>
+            <name>Dataset1</name>
+            <id>C1200000001-PROV1</id>
+            <location>%CMR-ENDPOINT%/concepts/C1200000001-PROV1/1</location>
+            <revision-id>4</revision-id>
+        </reference>
+        <reference>
+            <name>Dataset2</name>
+            <id>C1200000002-PROV1</id>
+            <location>%CMR-ENDPOINT%/concepts/C1200000002-PROV1/1</location>
+            <revision-id>1</revision-id>
+        </reference>
+        <reference>
+            <name>Dataset3</name>
+            <id>C1200000003-PROV1</id>
+            <location>%CMR-ENDPOINT%/concepts/C1200000003-PROV1/1</location>
+            <revision-id>8</revision-id>
+        </reference>
+    </references>
+</results>
 ```
 
 ### <a name="tagging"></a> Tagging

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -666,3 +666,33 @@
     (when (seq errors)
       (errors/throw-service-errors :bad-request errors)))
   params)
+
+(def ^:private valid-deleted-collections-search-params
+  "Valid parameters for deleted collections search"
+  #{:revision-date
+    :revision_date
+    :result-format})
+
+(defn- unrecognized-deleted-colls-params-validation
+  "Validates that no invalid parameters were supplied to deleted collections search"
+  [params]
+  (map #(format "Parameter [%s] was not recognized." (csk/->snake_case_string %))
+       (set/difference (set (keys params)) valid-deleted-collections-search-params)))
+
+(defn- deleted-colls-result-format-validation
+  "Validates that the only result format support by deleted collections search is :xml"
+  [params]
+  (when-not (= :xml (:result-format params))
+    [(format (str "Result format [%s] is not supported by deleted collections search. "
+                  "The only format that is supported is xml.")
+             (name (:result-format params)))]))
+
+(defn validate-deleted-collections-params
+  "Validates the query parameters passed in with deleted collections search.
+   Throws exceptions to send to the user if a validation fails."
+  [params]
+  (let [errors (mapcat #(% params)
+                       [unrecognized-deleted-colls-params-validation
+                        deleted-colls-result-format-validation])]
+    (when (seq errors)
+      (errors/throw-service-errors :bad-request errors))))

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -308,7 +308,7 @@
   "Executes elasticsearch searches to find collections that have deleted revisions.
    Returns a list of concept-ids of the collections."
   [context params]
-  ;;1/ Find all collection revisions that are deleted satisfy the original search params
+  ;; Find all collection revisions that are deleted satisfying the original search params
   (let [query (make-concepts-query context :collection params)
         condition (gc/and-conds
                    [(:condition query)
@@ -355,8 +355,9 @@
                                   #(apply max (map :revision-id %))
                                   (group-by :concept-id (:items results)))
           highest-revisions (filter
-                             #((set highest-coll-revisions)
-                               [(:concept-id %) (:revision-id %)])
+                             (fn [coll]
+                               ((set highest-coll-revisions)
+                                [(:concept-id coll) (:revision-id coll)]))
                              (:items results))]
       (-> results
           (assoc :items highest-revisions)
@@ -364,12 +365,12 @@
 
 (defn get-deleted-collections
   "Executes elasticsearch searches to find collections that are deleted.
-   This only finds collections that are truely deleted and not searchable.
+   This only finds collections that are truly deleted and not searchable.
    Collections that are deleted, then later ingested again are not included in the result.
    Returns references to the highest collection revision prior to the collection tombstone."
   [context params]
   (pv/validate-deleted-collections-params params)
-  ;; 1/ Find all collection revisions that are deleted after satify the revision-date query -> c1
+  ;; 1/ Find all collection revisions that are deleted satisfying the revision-date query -> c1
   ;; 2/ Filters out any collections c1 that still exists -> c2
   ;; 3/ Find all collection revisions for the c2, return the highest revisions that are visible
   (let [start-time (System/currentTimeMillis)
@@ -384,7 +385,7 @@
         ;; when results is nil, hits is 0
         results (or results {:hits 0 :items []})
         total-took (- (System/currentTimeMillis) start-time)
-        ;; construt the response results string
+        ;; construct the response results string
         results-str (common-search/search-results->response
                      context
                      ;; pass in a fake query to get the desired response format

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -304,7 +304,7 @@
      (ph/provider-holdings->string
        (:result-format params) provider-holdings {:echo-compatible? (= "true" echo-compatible)})]))
 
-(defn get-collections-with-deleted-revisions
+(defn- get-collections-with-deleted-revisions
   "Executes elasticsearch searches to find collections that have deleted revisions.
    Returns a list of concept-ids of the collections."
   [context params]
@@ -368,6 +368,7 @@
    Collections that are deleted, then later ingested again are not included in the result.
    Returns references to the highest collection revision prior to the collection tombstone."
   [context params]
+  (pv/validate-deleted-collections-params params)
   ;; 1/ Find all collection revisions that are deleted after satify the revision-date query -> c1
   ;; 2/ Filters out any collections c1 that still exists -> c2
   ;; 3/ Find all collection revisions for the c2, return the highest revisions that are visible

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -1,40 +1,40 @@
 (ns cmr.system-int-test.utils.search-util
   "provides search related utilities."
-  (:require 
-    [camel-snake-kebab.core :as csk]
-    [cheshire.core :as json]
-    [clj-http.client :as client]
-    [clj-time.coerce :as tc]
-    [clj-time.core :as t]
-    [clojure.data.xml :as x]
-    [clojure.set :as set]
-    [clojure.string :as str]
-    [clojure.test :refer :all]
-    [clojure.walk]
-    [cmr.common-app.test.side-api :as side]
-    [cmr.common.concepts :as cs]
-    [cmr.common.mime-types :as mime-types]
-    [cmr.common.test.time-util :as tu]
-    [cmr.common.time-keeper :as tk]
-    [cmr.common.util :as util]
-    [cmr.common.xml :as cx]
-    [cmr.system-int-test.data2.aql :as aql]
-    [cmr.system-int-test.data2.aql-additional-attribute]
-    [cmr.system-int-test.data2.atom :as da]
-    [cmr.system-int-test.data2.atom-json :as dj]
-    [cmr.system-int-test.data2.facets :as f]
-    [cmr.system-int-test.data2.kml :as dk]
-    [cmr.system-int-test.data2.opendata :as od]
-    [cmr.system-int-test.data2.provider-holdings :as ph]
-    [cmr.system-int-test.system :as s]
-    [cmr.system-int-test.utils.dev-system-util :as dev-util]
-    [cmr.system-int-test.utils.fast-xml :as fx]
-    [cmr.system-int-test.utils.url-helper :as url]
-    [cmr.transmit.config :as transmit-config]
-    [cmr.umm.dif.dif-collection]
-    [cmr.umm.iso-mends.iso-mends-collection]
-    [cmr.umm.iso-smap.iso-smap-collection]
-    [ring.util.codec :as codec]))
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [cheshire.core :as json]
+   [clj-http.client :as client]
+   [clj-time.coerce :as tc]
+   [clj-time.core :as t]
+   [clojure.data.xml :as x]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [clojure.walk]
+   [cmr.common-app.test.side-api :as side]
+   [cmr.common.concepts :as cs]
+   [cmr.common.mime-types :as mime-types]
+   [cmr.common.test.time-util :as tu]
+   [cmr.common.time-keeper :as tk]
+   [cmr.common.util :as util]
+   [cmr.common.xml :as cx]
+   [cmr.system-int-test.data2.aql :as aql]
+   [cmr.system-int-test.data2.aql-additional-attribute]
+   [cmr.system-int-test.data2.atom :as da]
+   [cmr.system-int-test.data2.atom-json :as dj]
+   [cmr.system-int-test.data2.facets :as f]
+   [cmr.system-int-test.data2.kml :as dk]
+   [cmr.system-int-test.data2.opendata :as od]
+   [cmr.system-int-test.data2.provider-holdings :as ph]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.dev-system-util :as dev-util]
+   [cmr.system-int-test.utils.fast-xml :as fx]
+   [cmr.system-int-test.utils.url-helper :as url]
+   [cmr.transmit.config :as transmit-config]
+   [cmr.umm.dif.dif-collection]
+   [cmr.umm.iso-mends.iso-mends-collection]
+   [cmr.umm.iso-smap.iso-smap-collection]
+   [ring.util.codec :as codec]))
 
 (defn enable-writes
   "Enables writes for tags / tag associations."
@@ -611,6 +611,16 @@
        :results (json/decode (:body response))}
       response)))
 
+(defn find-deleted-collections
+  "Returns the references that are found by searching deleted collections"
+  [params]
+  (get-search-failure-xml-data
+   (let [response (client/get (url/search-deleted-collections-url)
+                              {:query-params params
+                               :connection-manager (s/conn-mgr)
+                               :throw-exceptions false})]
+     (parse-reference-response false response))))
+
 (defn clear-caches
   "Clears caches in the search application"
   []
@@ -649,11 +659,11 @@
       ;; Freeze time in test
       (tk/set-time-override! (tu/n->date-time now-n))
       ;; Freeze time on CMR side
-      (side/eval-form 
+      (side/eval-form
         `(do (require 'cmr.common.test.time-util) (tk/set-time-override! (tu/n->date-time ~now-n))))
       (f)
       (finally
         ;; Resume time in test
         (tk/clear-current-time!)
         ;; Resume time on CMR side
-        (side/eval-form `(tk/clear-current-time!)))))) 
+        (side/eval-form `(tk/clear-current-time!))))))

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -613,12 +613,15 @@
 
 (defn find-deleted-collections
   "Returns the references that are found by searching deleted collections"
-  [params]
-  (get-search-failure-xml-data
-   (let [response (client/get (url/search-deleted-collections-url)
+  ([params]
+   (find-deleted-collections params nil))
+  ([params format-key]
+   (let [accept (when format-key
+                  (mime-types/format->mime-type format-key))
+         response (client/get (url/search-deleted-collections-url)
                               {:query-params params
                                :connection-manager (s/conn-mgr)
-                               :throw-exceptions false})]
+                               :accept accept})]
      (parse-reference-response false response))))
 
 (defn clear-caches

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -293,6 +293,11 @@
   []
   (format "http://localhost:%s/tiles" (transmit-config/search-port)))
 
+(defn search-deleted-collections-url
+  "URL to search for deleted collections"
+  []
+  (format "http://localhost:%s/deleted-collections" (transmit-config/search-port)))
+
 (defn provider-holdings-url
   "Returns the URL for retrieving provider holdings."
   []

--- a/system-int-test/test/cmr/system_int_test/search/deleted_collections_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/deleted_collections_search_test.clj
@@ -1,0 +1,146 @@
+(ns cmr.system-int-test.search.deleted-collections-search-test
+  "Integration test for searching deleted collections. Searching deleted collections Returns the
+   xml references to the highest collection revisions prior to the tombstones for collections that
+   are deleted after a given revision date."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.util :refer [are2] :as util]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.umm-spec.umm-spec-core :as umm-spec]))
+
+(use-fixtures :each (join-fixtures
+                      [(ingest/reset-fixture {"provguid1" "PROV1"})
+                       (dev-sys-util/freeze-resume-time-fixture)]))
+
+(deftest search-deleted-collections
+  (let [;; coll1 is a collection that has deleted collection revision and is re-ingeested
+        ;; it will not be found as a deleted collection
+        coll1-1 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset1"
+                                                                      :Version "v1"
+                                                                      :ShortName "s1"}))
+        concept1 {:provider-id "PROV1"
+                  :concept-type :collection
+                  :native-id (:EntryTitle coll1-1)}
+        _ (ingest/delete-concept concept1)
+        coll1-3 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset1"
+                                                                      :Version "v2"
+                                                                      :ShortName "s1"}))
+
+        ;; coll2 is a collection that is deleted
+        coll2-1 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset2"
+                                                                      :Version "v1"
+                                                                      :ShortName "s2"}))
+        coll2-2 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset2"
+                                                                      :Version "v2"
+                                                                      :ShortName "s2"}))
+        concept2 {:provider-id "PROV1"
+                  :concept-type :collection
+                  :native-id (:EntryTitle coll2-2)}
+        _ (ingest/delete-concept concept2)
+
+        ;; coll3 is a collection that is deleted and with multiple tombstones
+        coll3-1 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset3"
+                                                                      :Version "v1"
+                                                                      :ShortName "s3"}))
+        concept3 {:provider-id "PROV1"
+                  :concept-type :collection
+                  :native-id (:EntryTitle coll3-1)}
+        _ (ingest/delete-concept concept3)
+        coll3-3 (d/ingest-umm-spec-collection "PROV1"
+                                              (data-umm-c/collection {:EntryTitle "Dataset3"
+                                                                      :Version "v2"
+                                                                      :ShortName "s3"}))
+        _ (ingest/delete-concept concept3)
+
+        ;; coll4 is a collection that has no deleted revisions
+        coll4 (d/ingest-umm-spec-collection "PROV1"
+                                            (data-umm-c/collection {:EntryTitle "Dataset4"
+                                                                    :Version "v4"
+                                                                    :ShortName "s4"}))]
+    (index/wait-until-indexed)
+    (testing "search for deleted collections"
+      (let [deleted-collections (search/find-deleted-collections {})]
+        (d/refs-match? [coll2-2 coll3-3] deleted-collections)))))
+
+(deftest search-collections-by-revision-date
+  ;; We only test in memory mode here as this test uses time-keeper to freeze time. This will not
+  ;; work for external db mode since the revision date would be set automatically by oracle
+  ;; when concepts are saved and would not depend on the current time in time-keeper.
+  (s/only-with-in-memory-database
+   (let [;; coll1 is deleted in 2015
+         _ (dev-sys-util/freeze-time! "2015-01-01T10:00:00Z")
+         coll1-1 (d/ingest-umm-spec-collection "PROV1"
+                                               (data-umm-c/collection {:EntryTitle "Dataset1"
+                                                                       :Version "v1"
+                                                                       :ShortName "s1"}))
+         _ (ingest/delete-concept {:provider-id "PROV1"
+                                   :concept-type :collection
+                                   :native-id (:EntryTitle coll1-1)})
+
+         ;; coll2 is deleted in 2016
+         _ (dev-sys-util/freeze-time! "2016-01-01T10:00:00Z")
+         coll2-1 (d/ingest-umm-spec-collection "PROV1"
+                                               (data-umm-c/collection {:EntryTitle "Dataset2"
+                                                                       :Version "v1"
+                                                                       :ShortName "s2"}))
+         _ (ingest/delete-concept {:provider-id "PROV1"
+                                   :concept-type :collection
+                                   :native-id (:EntryTitle coll2-1)})
+
+         ;; coll3 is created in 2016 and deleted in 2017
+         coll3-1 (d/ingest-umm-spec-collection "PROV1"
+                                               (data-umm-c/collection {:EntryTitle "Dataset3"
+                                                                       :Version "v1"
+                                                                       :ShortName "s3"}))
+         _ (dev-sys-util/freeze-time! "2017-04-01T10:00:00Z")
+         _ (ingest/delete-concept {:provider-id "PROV1"
+                                   :concept-type :collection
+                                   :native-id (:EntryTitle coll3-1)})
+
+         ;;; coll4 is a collection that has no deleted revisions
+         coll4 (d/ingest-umm-spec-collection "PROV1"
+                                             (data-umm-c/collection {:EntryTitle "Dataset4"
+                                                                     :Version "v4"
+                                                                     :ShortName "s4"}))]
+     (index/wait-until-indexed)
+
+     (testing "search for deleted collections with revision date"
+       (util/are2 [colls revision-date]
+         (let [references (search/find-deleted-collections {"revision_date[]" revision-date})]
+           (d/refs-match? colls references))
+
+         "revision date starting at 2015 - find all deleted collections"
+         [coll1-1 coll2-1 coll3-1] "2015-01-01T01:00:00Z,"
+
+         "revision date starting at 2016 - find coll2 and coll3"
+         [coll2-1 coll3-1] "2016-01-01T01:00:00Z,"
+
+         "revision date starting at 2017 - find coll3"
+         [coll3-1] "2017-01-01T01:00:00Z,"
+
+         "revision date starting at 2017, different search parameter format - find coll3"
+         [coll3-1] "2017-01-01T01:00:00Z"
+
+         "revision date between 2015 and 2016 - find coll1"
+         [coll1-1] "2015-01-01T01:00:00Z,2016-01-01T01:00:00Z"
+
+         "revision date between 2016 and 2017 - find coll2"
+         [coll2-1] "2016-01-01T01:00:00Z,2017-01-01T01:00:00Z"
+
+         "revision date ending at 2015 - find no deleted collections"
+         [] ",2015-01-01T01:00:00Z"
+
+         "revision date ending at 2017 - find coll1 and coll2"
+         [coll1-1 coll2-1] ",2017-01-01T01:00:00Z")))))


### PR DESCRIPTION
To support metadata harvesting, a harvesting client can search CMR for collections that are deleted within a time period. The only search parameter supported is `revision_date` and its format is the same as the `revision_date` parameter in regular collection search. The only supported result format is xml references. The response is the references to the highest non-tombstone collection revisions of the collections that are deleted within the given revision date period.