### PR TITLE
CMR-4095: preview gem pushed a new fix; Update CMR to refer to the ne…

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -14,7 +14,7 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-      "de738b9"))
+      "2f3acec"))
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
Metadata preview added a new fix and the new commit is at 2f3acec. Update CMR to refer to it.