### PR TITLE
CMR-3999: Added revision date format validation and updated api doc.

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -122,7 +122,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
         * [Hierarchical JSON facets](#hierarchical-json-facets)
   * [Search for Tiles](#search-for-tiles)
   * [Retrieve Controlled Keywords](#retrieve-controlled-keywords)
-  * [Find collections that have been deleted](#deleted-collections)
+  * [Find collections that have been deleted after a given date](#deleted-collections)
   * [Tagging](#tagging)
     * [Tag Access Control](#tag-access-control)
     * [Creating a Tag](#creating-a-tag)
@@ -2472,9 +2472,9 @@ __Example Response__
 }
 ```
 
-### <a name="deleted-collections"></a> Find collections that have been deleted
+### <a name="deleted-collections"></a> Find collections that have been deleted after a given date
 
-To support metadata harvesting, a harvesting client can search CMR for collections that are deleted within a time period. The only search parameter supported is `revision_date` and its format is the same as the `revision_date` parameter in regular collection search. The only supported result format is xml references. The response is the references to the highest non-tombstone collection revisions of the collections that are deleted within the given revision date period. e.g.
+To support metadata harvesting, a harvesting client can search CMR for collections that are deleted after a given date. The only search parameter supported is `revision_date` and its format is slightly different from the `revision_date` parameter in regular collection search in that only one revision date can be provided and it can only be a starting date, not a date range. The only supported result format is xml references. The response is the references to the highest non-tombstone collection revisions of the collections that are deleted. e.g.
 
 The following search will return the last revision of the collections that are deleted since 01/20/2017.
 

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -700,7 +700,7 @@
                                (:revision_date params))]
     (if (sequential? revision-date)
       (if (> (count revision-date) 1)
-        [(format "Only one revision date is allowed, but was %s" (count revision-date))]
+        [(format "Only one revision date is allowed, but %s were provided." (count revision-date))]
         (validate-deleted-colls-revision-date-str (first revision-date)))
       (validate-deleted-colls-revision-date-str revision-date))))
 

--- a/system-int-test/test/cmr/system_int_test/search/deleted_collections_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/deleted_collections_search_test.clj
@@ -166,7 +166,7 @@
           (search/get-search-failure-xml-data
            (search/find-deleted-collections
             {:revision-date ["2016-01-01T01:00:00Z" "2017-01-01T01:00:00Z"]}))]
-      (is (= [400 ["Only one revision date is allowed, but was 2"]]
+      (is (= [400 ["Only one revision date is allowed, but 2 were provided."]]
              [status errors]))))
 
   (testing "unsupported format for deleted collections search"


### PR DESCRIPTION
We only returning the highest revision of the deleted collections with the deleted-collections endpoint after a given date. This PR enforces the revision date validation to make sure that clients can't submit revision date ranges like in the regular search.