### PR TITLE
Cmr 3971 - Bulk Update Queueing

### DIFF
--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -19,6 +19,7 @@
    [cmr.index-set.system :as index-set-system]
    [cmr.indexer.config :as indexer-config]
    [cmr.indexer.system :as indexer-system]
+   [cmr.ingest.config :as ingest-config]
    [cmr.ingest.data.memory-db :as ingest-data]
    [cmr.ingest.system :as ingest-system]
    [cmr.message-queue.config :as rmq-conf]
@@ -160,6 +161,7 @@
   (-> (indexer-config/queue-config)
       (rmq-conf/merge-configs (vp-config/queue-config))
       (rmq-conf/merge-configs (access-control-config/queue-config))
+      (rmq-conf/merge-configs (ingest-config/queue-config))
       mem-queue/create-memory-queue-broker
       wrapper/create-queue-broker-wrapper))
 
@@ -169,6 +171,7 @@
   (-> (indexer-config/queue-config)
       (rmq-conf/merge-configs (vp-config/queue-config))
       (rmq-conf/merge-configs (access-control-config/queue-config))
+      (rmq-conf/merge-configs (ingest-config/queue-config))
       (assoc :ttls ttls)))
 
 ;; for legacy reasons :external refers to Rabbit MQ

--- a/ingest-app/src/cmr/ingest/api/ingest.clj
+++ b/ingest-app/src/cmr/ingest/api/ingest.clj
@@ -370,7 +370,7 @@
         body (str/trim (slurp body))]
     (verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
-    (bulk-update/validate-bulk-update-post-params body)
+    (bulk-update/validate-and-queue-bulk-update request-context provider-id body)
     (generate-ingest-response
       headers
       {:status 200

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -6,9 +6,9 @@
             [cmr.message-queue.config :as rmq-conf]))
 
 (defconfig ingest-accept-umm-version
-  "Defines the latest umm version accepted by ingest - it's the latest official version.  
+  "Defines the latest umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"
-  {:default "1.9"}) 
+  {:default "1.9"})
 
 (defconfig ingest-username
   "Ingest database username"
@@ -31,13 +31,25 @@
 
 (defconfig provider-exchange-name
   "The ingest exchange to which provider change messages are published."
-  {:default "cmr_ingest_provider.exchange"})
+  {:default "cmr_ingest.exchange"})
+
+(defconfig provider-queue-name
+  "The queue containing provider events like 'index provider collections'."
+  {:default "cmr_ingest.queue"})
+
+(defconfig provider-queue-listener-count
+  "Number of worker threads to use for the queue listener for the provider queue"
+  {:default 2
+   :type Long})
 
 (defn queue-config
   "Returns the rabbit mq configuration for the ingest application."
   []
   (assoc (rmq-conf/default-config)
-         :exchanges [(provider-exchange-name)]))
+         :queues [(provider-queue-name)]
+         :exchanges [(provider-exchange-name)]
+         :queues-to-exchanges
+         {(provider-queue-name) [(provider-exchange-name)]}))
 
 (defconfig ingest-nrepl-port
   "Port to listen for nREPL connections."

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -30,14 +30,18 @@
     (ingest-password)))
 
 (defconfig provider-exchange-name
+   "The ingest exchange to which provider change messages are published."
+   {:default "cmr_ingest_provider.exchange"})
+
+(defconfig ingest-exchange-name
   "The ingest exchange to which provider change messages are published."
   {:default "cmr_ingest.exchange"})
 
-(defconfig provider-queue-name
+(defconfig ingest-queue-name
   "The queue containing provider events like 'index provider collections'."
   {:default "cmr_ingest.queue"})
 
-(defconfig provider-queue-listener-count
+(defconfig ingest-queue-listener-count
   "Number of worker threads to use for the queue listener for the provider queue"
   {:default 2
    :type Long})
@@ -46,10 +50,10 @@
   "Returns the rabbit mq configuration for the ingest application."
   []
   (assoc (rmq-conf/default-config)
-         :queues [(provider-queue-name)]
-         :exchanges [(provider-exchange-name)]
+         :queues [(ingest-queue-name)]
+         :exchanges [(ingest-exchange-name) (provider-exchange-name)]
          :queues-to-exchanges
-         {(provider-queue-name) [(provider-exchange-name)]}))
+         {(ingest-queue-name) [(ingest-exchange-name)]}))
 
 (defconfig ingest-nrepl-port
   "Port to listen for nREPL connections."

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -28,7 +28,7 @@
   (get-provider-bulk-update-status
     [db provider-id]
     ;; Returns a list of bulk update statuses for the provider
-    (let [statuses (su/query db (su/build (su/select [:task-id :status :status-message :request_json_body]
+    (let [statuses (su/query db (su/build (su/select [:task-id :status :status-message :request-json-body]
                                             (su/from "bulk_update_task_status")
                                             (su/where `(= :provider-id ~provider-id)))))
           statuses (map util/map-keys->kebab-case statuses)]
@@ -45,9 +45,10 @@
   (get-bulk-update-task-collection-status
     [db task-id]
     ;; Get statuses for all collections by task id
-    (su/query db (su/build (su/select [:concept-id :status :status-message]
-                            (su/from "bulk_update_coll_status")
-                            (su/where `(= :task-id ~task-id))))))
+    (map util/map-keys->kebab-case
+      (su/query db (su/build (su/select [:concept-id :status :status-message]
+                              (su/from "bulk_update_coll_status")
+                              (su/where `(= :task-id ~task-id)))))))
 
   (get-bulk-update-collection-status
     [db task-id concept-id]
@@ -134,7 +135,11 @@
   [context task-id]
   (get-bulk-update-task-status (context->db context) task-id))
 
-(defn-timed create-bulk-update-status
+(defn-timed get-bulk-update-collection-statuses-for-task
+  [context task-id]
+  (get-bulk-update-task-collection-status (context->db context) task-id))
+
+(defn-timed create-bulk-update-task
   "Creates all the rows for bulk update status tables - task status and collection
   status. Returns task id"
   [context provider-id json-body concept-ids]
@@ -144,7 +149,6 @@
   "For the task and concept id, update the collection to the given status with the
   given status message"
   [context task-id concept-id status status-message]
-  (def context context)
   (update-bulk-update-collection-status (context->db context) task-id concept-id
     status status-message))
 

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -12,6 +12,13 @@
         exchange-name (config/provider-exchange-name)]
     (queue/publish-message queue-broker exchange-name msg)))
 
+(defn publish-ingest-event
+  "Put an ingest event on the message queue"
+  [context msg]
+  (let [queue-broker (get-in context [:system :queue-broker])
+        exchange-name (config/ingest-exchange-name)]
+    (queue/publish-message queue-broker exchange-name msg)))
+
 (defn trigger-collection-granule-aggregation-cache-refresh
   "Sends a message to trigger a refresh of the collection granule aggregation cache.
    granules-updated-in-last-n indicates a number of seconds back to find granules that were updated.
@@ -47,13 +54,13 @@
   {:action :provider-delete
    :provider-id provider-id})
 
-(defn provider-bulk-update-event
-  [provider-id bulk-update-params]
+(defn ingest-bulk-update-event
+  [task-id bulk-update-params]
   {:action :bulk-update
-   :provider-id provider-id
+   :task-id task-id
    :bulk-update-params bulk-update-params})
 
-(defn provider-collection-bulk-update-event
+(defn ingest-collection-bulk-update-event
   [task-id concept-id bulk-update-params]
   {:action :collection-bulk-update
    :task-id task-id

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -47,3 +47,7 @@
   {:action :provider-delete
    :provider-id provider-id})
 
+(defn provider-bulk-update-event
+  [provider-id]
+  {:action :bulk-update
+   :provider-id provider-id})

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -48,6 +48,14 @@
    :provider-id provider-id})
 
 (defn provider-bulk-update-event
-  [provider-id]
+  [provider-id bulk-update-params]
   {:action :bulk-update
-   :provider-id provider-id})
+   :provider-id provider-id
+   :bulk-update-params bulk-update-params})
+
+(defn provider-collection-bulk-update-event
+  [task-id concept-id bulk-update-params]
+  {:action :collection-bulk-update
+   :task-id task-id
+   :concept-id concept-id
+   :bulk-update-params bulk-update-params})

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -35,14 +35,15 @@
   (get-bulk-update-task-status
     [this task-id]
     (let [task-status (some->> @task-status-atom
-                               (some #(when (= task-id (:task-id %))
+                               (some #(when (= task-id (str (:task-id %)))
                                             %)))]
       (select-keys task-status [:task-id :status :status-message])))
 
   (get-bulk-update-task-collection-status
     [this task-id]
     (some->> @collection-status-atom
-             (filter #(= task-id (:task-id %)))
+             (into [])
+             (filter #(= task-id (str (:task-id %))))
              (map #(select-keys % [:concept-id :status :status-message]))))
 
   (get-bulk-update-collection-status
@@ -56,20 +57,16 @@
   (create-and-save-bulk-update-status
     [this provider-id json-body concept-ids]
     (swap! task-id-atom inc)
-    (let [task-id @task-id-atom
-          task-statuses @task-status-atom
-          collection-statuses @collection-status-atom]
-     (reset! task-status-atom (conj task-statuses
-                                    {:task-id task-id
-                                     :provider-id provider-id
-                                     :request-json-body json-body
-                                     :status "IN_PROGRESS"}))
-     (reset! collection-status-atom (concat collection-statuses
-                                            (map (fn [c]
-                                                  {:task-id task-id
-                                                   :concept-id c
-                                                   :status "PENDING"})
-                                                 concept-ids)))
+    (let [task-id @task-id-atom]
+     (swap! task-status-atom conj {:task-id task-id
+                                   :provider-id provider-id
+                                   :request-json-body json-body
+                                   :status "IN_PROGRESS"})
+     (swap! collection-status-atom concat (map (fn [c]
+                                                {:task-id task-id
+                                                 :concept-id c
+                                                 :status "PENDING"})
+                                               concept-ids))
      task-id))
 
   (update-bulk-update-task-status
@@ -78,21 +75,26 @@
           index (first (keep-indexed #(when (= task-id (:task-id %2))
                                          %1)
                                      task-statuses))]
-      (reset! (:task-status-atom this) (-> task-statuses
+      (swap! (:task-status-atom this) (fn [task-statuses]
+                                       (-> task-statuses
                                            (assoc-in [index :status] status)
-                                           (assoc-in [index :status-message] status-message)))))
+                                           (assoc-in [index :status-message] status-message))))))
+
 
   (update-bulk-update-collection-status
     [this task-id concept-id status status-message]
+    ;; @collection-status-atom is a lazy seq so force into []
     (let [coll-statuses (into [] @collection-status-atom)
           index (first (keep-indexed #(when (and (= concept-id (:concept-id %2))
                                                  (= task-id (:task-id %2)))
                                          %1)
                                      coll-statuses))]
-      (reset! (:collection-status-atom this) (-> coll-statuses
-                                                (assoc-in [index :status] status)
-                                                (assoc-in [index :status-message] status-message)))
-      (let [pending-collections (filter #(and (= task-id (:task-id %))
+      (swap! (:collection-status-atom this) (fn [coll-statuses]
+                                              (-> (into [] coll-statuses)
+                                                  (assoc-in [index :status] status)
+                                                  (assoc-in [index :status-message] status-message))))
+      (let [coll-statuses (into [] @collection-status-atom) ; Need to refresh after change
+            pending-collections (filter #(and (= task-id (:task-id %))
                                               (= "PENDING" (:status %)))
                                         coll-statuses)]
         (when-not (seq pending-collections)
@@ -100,9 +102,10 @@
                 index (first (keep-indexed #(when (= task-id (:task-id %2))
                                                %1)
                                            task-statuses))]
-            (reset! (:task-status-atom this) (-> task-statuses
+            (swap! (:task-status-atom this) (fn [task-statuses]
+                                             (-> task-statuses
                                                  (assoc-in [index :status] status)
-                                                 (assoc-in [index :status-message] status-message))))))))
+                                                 (assoc-in [index :status-message] status-message)))))))))
 
   (reset-bulk-update
     [this]

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -30,24 +30,30 @@
                                    [(format "A find value must be supplied when the update is of type %s"
                                             update-type)]))))
 
-(defn validate-and-queue-bulk-update
-  "Validate the bulk update POST parameters and queueu bulk update"
+(defn validate-and-save-bulk-update
+  "Validate the bulk update POST parameters, save rows to the db for task
+  and collection statuses, and queueu bulk update. Return task id, which comes
+  from the db save."
   [context provider-id json]
   (validate-bulk-update-post-params json)
-  (ingest-events/publish-provider-event context
-    (ingest-events/provider-bulk-update-event provider-id json)))
+  (let [bulk-update-params (json/parse-string json true)
+        {:keys [concept-ids]} bulk-update-params
+        ;; Write db rows - one for overall status, one for each concept id
+        task-id (data-bulk-update/create-bulk-update-task context
+                 provider-id json concept-ids)]
+    ;; Queue the bulk update event
+    (ingest-events/publish-ingest-event context
+      (ingest-events/ingest-bulk-update-event task-id bulk-update-params))
+    task-id))
 
 (defn handle-bulk-update-event
-  "Write to tables and queueu collection bulk update messages"
-  [context provider-id bulk-update-params]
-  (let [body (json/parse-string bulk-update-params true)
-        {:keys [concept-ids]} body
-        task-id (data-bulk-update/create-bulk-update-status context
-                 provider-id bulk-update-params concept-ids)]
+  "For each concept-id, queueu collection bulk update messages"
+  [context task-id bulk-update-params]
+  (let [{:keys [concept-ids]} bulk-update-params]
     (doseq [concept-id concept-ids]
-     (ingest-events/publish-provider-event context
-       (ingest-events/provider-collection-bulk-update-event
-         task-id concept-id body)))))
+     (ingest-events/publish-ingest-event context
+       (ingest-events/ingest-collection-bulk-update-event
+         task-id concept-id bulk-update-params)))))
 
 (defn handle-collection-bulk-update-event
   "Perform update for the given concept id"

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -3,7 +3,8 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [cmr.common.services.errors :as errors]
-   [cmr.common.validations.json-schema :as js]))
+   [cmr.common.validations.json-schema :as js]
+   [cmr.ingest.data.ingest-events :as ingest-events]))
 
 (def bulk-update-schema
   (js/json-string->json-schema (slurp (io/resource "bulk_update_schema.json"))))
@@ -27,3 +28,10 @@
       (errors/throw-service-errors :bad-request
                                    [(format "A find value must be supplied when the update is of type %s"
                                             update-type)]))))
+
+(defn validate-and-queue-bulk-update
+  [context provider-id json]
+  (let [body (json/parse-string json true)]
+    (validate-bulk-update-post-params json)
+    ;(proto-repl.saved-values/save 26)
+    (ingest-events/publish-provider-event context (ingest-events/provider-bulk-update-event provider-id))))

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [cmr.common.services.errors :as errors]
    [cmr.common.validations.json-schema :as js]
+   [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]))
 
 (def bulk-update-schema
@@ -30,8 +31,25 @@
                                             update-type)]))))
 
 (defn validate-and-queue-bulk-update
+  "Validate the bulk update POST parameters and queueu bulk update"
   [context provider-id json]
-  (let [body (json/parse-string json true)]
-    (validate-bulk-update-post-params json)
-    ;(proto-repl.saved-values/save 26)
-    (ingest-events/publish-provider-event context (ingest-events/provider-bulk-update-event provider-id))))
+  (validate-bulk-update-post-params json)
+  (ingest-events/publish-provider-event context
+    (ingest-events/provider-bulk-update-event provider-id json)))
+
+(defn handle-bulk-update-event
+  "Write to tables and queueu collection bulk update messages"
+  [context provider-id bulk-update-params]
+  (let [body (json/parse-string bulk-update-params true)
+        {:keys [concept-ids]} body
+        task-id (data-bulk-update/create-bulk-update-status context
+                 provider-id bulk-update-params concept-ids)]
+    (doseq [concept-id concept-ids]
+     (ingest-events/publish-provider-event context
+       (ingest-events/provider-collection-bulk-update-event
+         task-id concept-id body)))))
+
+(defn handle-collection-bulk-update-event
+  "Perform update for the given concept id"
+  [context task-id concept-id bulk-update-params]
+  (data-bulk-update/update-bulk-update-task-collection-status context task-id concept-id "COMPLETE" nil))

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -11,7 +11,8 @@
 
 (defmethod handle-provider-event :bulk-update
   [context msg]
-  (bulk-update/handle-bulk-update-event context (:provider-id msg) (:bulk-update-params msg)))
+  (bulk-update/handle-bulk-update-event context (:task-id msg)
+    (:bulk-update-params msg)))
 
 (defmethod handle-provider-event :collection-bulk-update
   [context msg]
@@ -26,7 +27,7 @@
   "Subscribe to event messages on various queues"
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
-    (dotimes [n (config/provider-queue-listener-count)]
+    (dotimes [n (config/ingest-queue-listener-count)]
       (queue/subscribe queue-broker
-                       (config/provider-queue-name)
+                       (config/ingest-queue-name)
                        #(handle-provider-event context %)))))

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -1,0 +1,26 @@
+(ns cmr.ingest.services.event-handler
+ (:require
+  [cmr.ingest.config :as config]
+  [cmr.message-queue.services.queue :as queue]))
+
+(defmulti handle-provider-event
+  "Handle the various actions that can be requested for a provider via the provider-queue"
+  (fn [context msg]
+    (keyword (:action msg))))
+
+(defmethod handle-provider-event :bulk-update
+  [context msg]
+  (proto-repl.saved-values/save 25))
+
+;; Default ignores the provider event. There may be provider events we don't care about.
+(defmethod handle-provider-event :default
+  [_ _])
+
+(defn subscribe-to-events
+  "Subscribe to event messages on various queues"
+  [context]
+  (let [queue-broker (get-in context [:system :queue-broker])]
+    (dotimes [n (config/provider-queue-listener-count)]
+      (queue/subscribe queue-broker
+                       (config/provider-queue-name)
+                       #(handle-provider-event context %)))))

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.services.event-handler
  (:require
   [cmr.ingest.config :as config]
+  [cmr.ingest.services.bulk-update-service :as bulk-update]
   [cmr.message-queue.services.queue :as queue]))
 
 (defmulti handle-provider-event
@@ -10,7 +11,12 @@
 
 (defmethod handle-provider-event :bulk-update
   [context msg]
-  (proto-repl.saved-values/save 25))
+  (bulk-update/handle-bulk-update-event context (:provider-id msg) (:bulk-update-params msg)))
+
+(defmethod handle-provider-event :collection-bulk-update
+  [context msg]
+  (bulk-update/handle-collection-bulk-update-event context (:task-id msg)
+    (:concept-id msg) (:bulk-update-params msg)))
 
 ;; Default ignores the provider event. There may be provider events we don't care about.
 (defmethod handle-provider-event :default

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -21,6 +21,7 @@
    [cmr.ingest.api.ingest :as ingest-api]
    [cmr.ingest.api.routes :as routes]
    [cmr.ingest.config :as config]
+   [cmr.ingest.services.event-handler :as event-handler]
    [cmr.ingest.services.humanizer-alias-cache :as humanizer-alias-cache]
    [cmr.ingest.services.jobs :as ingest-jobs]
    [cmr.ingest.services.providers-cache :as pc]
@@ -79,10 +80,14 @@
      (transmit-config/system-with-connections
       sys [:metadata-db :indexer :echo-rest :search :cubby :kms]))))
 
-(def start
+(defn start
   "Performs side effects to initialize the system, acquire resources,
   and start it running. Returns an updated instance of the system."
-  (common-sys/start-fn "ingest" component-order))
+  [system]
+  (let [started-system (common-sys/start system component-order)]
+    (when (:queue-broker system)
+      (event-handler/subscribe-to-events {:system started-system}))
+    started-system))
 
 (def stop
   "Performs side effects to shut down the system and release its

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -145,9 +145,9 @@
   provider."
   [context provider-guid]
   (grant context
-         [{:permissions [:update :delete]
+         [{:permissions [:read :update :delete]
            :user-type :guest}
-          {:permissions [:update :delete]
+          {:permissions [:read :update :delete]
            :user-type :registered}]
          :provider-object-identity
          {:target ingest-management-acl

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -420,7 +420,7 @@
     (let [xml-elem (x/parse-str (:body response))]
       (if-let [errors (seq (cx/strings-at-path xml-elem [:error]))]
         (parse-xml-error-response-elem xml-elem)
-        {:task-id (cx/string-at-path xml-elem [:task-id])}))
+        {:task-id (cx/long-at-path xml-elem [:task-id])}))
     (catch Exception e
       (throw (Exception. (str "Error parsing ingest body: " (pr-str (:body response)) e))))))
 
@@ -468,10 +468,10 @@
       (if-let [errors (seq (cx/strings-at-path xml-elem [:error]))]
         (parse-xml-error-response-elem xml-elem)
         {:tasks (seq (for [task (cx/elements-at-path xml-elem [:tasks :task])]
-                      (util/remove-nil-keys
-                       {:task-id (cx/string-at-path task [:task-id])
-                        :status (cx/string-at-path task [:status])
-                        :status-message (cx/string-at-path task [:status-message])})))}))
+                      {:task-id (cx/long-at-path task [:task-id])
+                       :status (cx/string-at-path task [:status])
+                       :status-message (cx/string-at-path task [:status-message])
+                       :request-json-body (cx/string-at-path task [:request-json-body])}))}))
     (catch Exception e
       (throw (Exception. (str "Error parsing ingest body: " (pr-str (:body response)) e))))))
 
@@ -521,10 +521,9 @@
          :status-message (cx/string-at-path xml-elem [:status-message])
          :collection-statuses
           (seq (for [status (cx/elements-at-path xml-elem [:collection-statuses :collection-status])]
-                (util/remove-nil-keys
-                 {:concept-id (cx/string-at-path status [:concept-id])
-                  :status (cx/string-at-path status [:status])
-                  :status-message (cx/string-at-path status [:status-message])})))}))
+                {:concept-id (cx/string-at-path status [:concept-id])
+                 :status (cx/string-at-path status [:status])
+                 :status-message (cx/string-at-path status [:status-message])}))}))
     (catch Exception e
       (throw (Exception. (str "Error parsing ingest body: " (pr-str (:body response)) e))))))
 
@@ -615,20 +614,20 @@
      [{:provider-guid 'provider-guid1' :provider-id 'PROV1'
        :short-name 'provider short name'}...]"
   ([providers]
-    (setup-providers providers nil))
+   (setup-providers providers nil))
   ([providers options]
-    (let [{:keys [grant-all-search? grant-all-ingest?]}
-           (merge reset-fixture-default-options options)
+   (let [{:keys [grant-all-search? grant-all-ingest?]}
+         (merge reset-fixture-default-options options)
          providers (if (sequential? providers)
                        providers
                        (for [[provider-guid provider-id] providers]
                          {:provider-guid provider-guid
                           :provider-id provider-id}))]
-       (doseq [provider-map providers]
-         (create-provider
-          provider-map
-          {:grant-all-search? grant-all-search?
-           :grant-all-ingest? grant-all-ingest?})))))
+      (doseq [provider-map providers]
+        (create-provider
+         provider-map
+         {:grant-all-search? grant-all-search?
+          :grant-all-ingest? grant-all-ingest?})))))
 
 (defn reset-fixture
   "Resets all the CMR systems then uses the `setup-providers` function to

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
@@ -1,0 +1,26 @@
+(ns cmr.system-int-test.ingest.bulk-update.bulk-update-flow-test
+  "CMR bulk update queueing flow integration tests"
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(deftest bulk-update
+  (let [concept-ids (for [x (range 3)]
+                      (:concept-id (ingest/ingest-concept
+                                     (data-umm-c/collection-concept
+                                       (data-umm-c/collection x {})))))
+        bulk-update-body {:concept-ids concept-ids
+                          :update-type "ADD_TO_EXISTING"
+                          :update-field "SCIENCE_KEYWORDS"
+                          :update-value "X"}
+        response (ingest/parse-bulk-update-body :json
+                   (ingest/bulk-update-collections "PROV1" bulk-update-body
+                     {:accept-format :json :raw? true}))]))
+    ;(proto-repl.saved-values/save 1)))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
@@ -1,6 +1,7 @@
 (ns cmr.system-int-test.ingest.bulk-update.bulk-update-flow-test
-  "CMR bulk update queueing flow integration tests"
+  "CMR bulk update queueing flow integration tests. Endpoint validation is handled"
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
    [cmr.common.util :as util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
@@ -9,18 +10,67 @@
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
+                                           "provguid2" "PROV2"}))
 
 (deftest bulk-update
   (let [concept-ids (for [x (range 3)]
                       (:concept-id (ingest/ingest-concept
                                      (data-umm-c/collection-concept
                                        (data-umm-c/collection x {})))))
+        _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
-                          :update-value "X"}
-        response (ingest/parse-bulk-update-body :json
-                   (ingest/bulk-update-collections "PROV1" bulk-update-body
-                     {:accept-format :json :raw? true}))]))
-    ;(proto-repl.saved-values/save 1)))
+                          :update-value "X"}]
+
+    (testing "Bulk update response"
+      (are3 [accept-format task-id]
+        (let [response (ingest/parse-bulk-update-body accept-format
+                         (ingest/bulk-update-collections "PROV1" bulk-update-body
+                           {:accept-format accept-format :raw? true}))]
+          (is (= task-id (:task-id response))))
+        "JSON" :json 1
+        "XML" :xml 2))
+
+    (testing "Provider status response"
+      ;; Create another bulk update event with PROV2 to make sure we're just
+      ;; getting PROV1 statuses
+      (ingest/bulk-update-collections "PROV2" bulk-update-body)
+
+      (are3 [accept-format]
+        (let [response (ingest/bulk-update-provider-status "PROV1"
+                        {:accept-format accept-format})
+              json-body (json/generate-string bulk-update-body)]
+          (is (= [{:task-id 1,
+                   :status-message nil,
+                   :status "COMPLETE",
+                   :request-json-body json-body}
+                  {:task-id 2,
+                   :status-message nil,
+                   :status "COMPLETE",
+                   :request-json-body json-body}]
+                 (:tasks response))))
+        "JSON" :json
+        "XML" :xml)
+
+     (testing "Provider task status response"
+       (are3 [accept-format]
+         (let [response (ingest/bulk-update-task-status "PROV1" 1
+                         {:accept-format accept-format})]
+           (is (= {:status-message nil,
+                   :status 200,
+                   :task-status "COMPLETE",
+                   ;; TO DO: Remove hardcoded concept ids
+                   :collection-statuses [{:status-message nil,
+                                          :status "COMPLETE",
+                                          :concept-id "C1200000001-PROV1"}
+                                         {:status-message nil,
+                                          :status "COMPLETE",
+                                          :concept-id "C1200000002-PROV1"}
+                                         {:status-message nil,
+                                          :status "COMPLETE",
+                                          :concept-id "C1200000003-PROV1"}]}
+                  response)))
+         "JSON" :json
+         "XML" :xml)))))


### PR DESCRIPTION
Implement ingest queueing for bulk update - this includes adding a new queue and exchange to ingest.

First, create rows in the status tables and get the task id that we can return to the user. Queue a bulk update event that queues individual bulk update events for each concept-id to be updated.

Currently all the bulk update event does is set the status to complete. The actual update is coming in another ticket, this is to get the flow working.

I also replaced all the endpoint dummy data with actual data from the db. I removed tests related to the dummy data and added a new test file testing the overall flow setting statuses to complete.