### PR TITLE
CMR-4090 Deployment fixes for landing pages directory

### DIFF
--- a/search-app/resources/templates/search-eosdis-directory-links.html
+++ b/search-app/resources/templates/search-eosdis-directory-links.html
@@ -9,16 +9,16 @@
 <p>
   Listed here are all the EOSDIS providers linked to pages that list the
   collection landing pages. Note that the number of collections for each
-  provider is given in parentheses after the provider name.
+  provider is given in parentheses after the provider ID.
 </p>
 
 <ul>
   {% for provider in providers %}
   <li>
     {% if provider.collections-count = 0 %}
-      {{ provider.name }}
+      {{ provider.id }}
     {% else %}
-      <a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a>
+      <a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.id }}</a>
     {% endif %} ({{ provider.collections-count }})</li>
   {% endfor %}
 </ul>

--- a/search-app/resources/templates/search-eosdis-directory-links.html
+++ b/search-app/resources/templates/search-eosdis-directory-links.html
@@ -14,7 +14,12 @@
 
 <ul>
   {% for provider in providers %}
-  <li><a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a> ({{ provider.collections-count }})</li>
+  <li>
+    {% if provider.collections-count = 0 %}
+      {{ provider.name }}
+    {% else %}
+      <a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a>
+    {% endif %} ({{ provider.collections-count }})</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/search-app/resources/templates/search-eosdis-directory-links.html
+++ b/search-app/resources/templates/search-eosdis-directory-links.html
@@ -5,9 +5,16 @@
 {% block main-content %}
 <h2 class="cover-heading">Directory of Collections Landing Pages</h2>
 <h3 class="cover-heading">EOSDIS</h3>
+
+<p>
+  Listed here are all the EOSDIS providers linked to pages that list the
+  collection landing pages. Note that the number of collections for each
+  provider is given in parentheses after the provider name.
+</p>
+
 <ul>
   {% for provider in providers %}
-  <li><a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a></li>
+  <li><a href="{{ base-url }}site/collections/directory/{{ provider.id }}/{{ provider.tag }}">{{ provider.name }}</a> ({{ provider.collections-count }})</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -32,11 +32,11 @@
   "Get the collection data associated with a provider and tag."
   [context tag provider-id]
   (->> {:tag-key tag
-                 :provider provider-id
-                 :result-format {:format :umm-json-results}}
-        (query-svc/make-concepts-query context :collection)
-        (query-exec/execute-query context)
-        :items))
+        :provider provider-id
+        :result-format {:format :umm-json-results}}
+       (query-svc/make-concepts-query context :collection)
+       (query-exec/execute-query context)
+       :items))
 
 (defn provider-data
   "Create a provider data structure suitable for template iteration to
@@ -46,20 +46,19 @@
   that is used on the destination page."
   [context tag data]
   (let [provider-id (:provider-id data)
-        provider-name provider-id
         collections (collection-data context tag provider-id)]
     {:id provider-id
-     :name provider-name
      :tag tag
      :collections collections
      :collections-count (count collections)}))
 
 (defn providers-data
-  "Given a list of provider maps"
+  "Given a list of provider maps, create the nested data structure needed
+  for rendering providers in a template."
   [context tag providers]
   (->> providers
        (map (partial provider-data context tag))
-       (sort-by :name)))
+       (sort-by :id)))
 
 (defn get-doi
   "Extract the DOI information from a collection item."
@@ -156,8 +155,7 @@
   ([context provider-id tag filter-fn]
    (merge
     (base-page context)
-    {:provider-name provider-id
-     :provider-id provider-id
+    {:provider-id provider-id
      :tag-name (get-tag-short-name tag)
      :links (filter filter-fn
                     (make-links
@@ -177,6 +175,4 @@
    tag
    #(string/includes?
      (str %)
-     ;; XXX is this the right URL to check? this might only include links that
-     ;; are part of the current app ...?
      (config/application-public-root-url context))))

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -100,11 +100,6 @@
   [item]
   (get-in item [:umm "ShortName"]))
 
-(defn make-text
-  "Create the `text` part of a landing page link."
-  [item]
-  (format "%s (%s)" (get-entry-title item) (get-short-name item)))
-
 (defn make-link
   "Given a single item from a query's collections, generate an appropriate
   landing page link.
@@ -112,7 +107,7 @@
   A generated link has the form `{:href ... :text ...}`."
   [cmr-base-url item]
   {:href (make-href cmr-base-url item)
-   :text (make-text item)})
+   :text (get-entry-title item)})
 
 (defn make-links
   "Given a collection from an elastic search query, generate landing page

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -34,10 +34,17 @@
 
   Note that the given tag will be used to filter provider collections data
   that is used on the destination page."
-  [tag provider-data]
-  {:id (:provider-id provider-data)
-   :name (:provider-id provider-data)
+  [tag data]
+  {:id (:provider-id data)
+   :name (:provider-id data)
    :tag tag})
+
+(defn providers-data
+  "Given a list of provider maps"
+  [tag providers]
+  (->> providers
+       (map (partial provider-data tag))
+       (sort-by :name)))
 
 (defn get-doi
   "Extract the DOI information from a collection item."
@@ -129,7 +136,7 @@
   (let [providers (mdb/get-providers context)]
     (merge
       (base-page context)
-      {:providers (map (partial provider-data "gov.nasa.eosdis") providers)})))
+      {:providers (providers-data "gov.nasa.eosdis" providers)})))
 
 (defn get-provider-tag-landing-links
   "Generate the data necessary to render EOSDIS landing page links."

--- a/search-app/test/cmr/search/test/site/data.clj
+++ b/search-app/test/cmr/search/test/site/data.clj
@@ -76,24 +76,19 @@
     (is (= "s3"
            (data/get-short-name coll-data-1)))))
 
-(deftest make-text
-  (testing "with an entry title and short name"
-    (is (= "coll3 (s3)"
-           (data/make-text coll-data-1)))))
-
 (deftest make-link
   (testing "with an entry title and short name"
     (is (= {:href "http://cmr.test.host/concepts/C1200000003-PROV1.html"
-            :text "coll3 (s3)"}
+            :text "coll3"}
            (data/make-link cmr-base-url coll-data-1))))
   (testing "with an entry title, short name, and doi"
     (is (= {:href "http://dx.doi.org/doi6"
-            :text "coll3 (s3)"}
+            :text "coll3"}
            (data/make-link cmr-base-url coll-data-2)))))
 
 (deftest make-links
   (let [coll [coll-data-1 coll-data-2]]
     (is (= [{:href "http://cmr.test.host/concepts/C1200000003-PROV1.html"
-             :text "coll3 (s3)"}
-            {:href "http://dx.doi.org/doi6", :text "coll3 (s3)"}]
+             :text "coll3"}
+            {:href "http://dx.doi.org/doi6", :text "coll3"}]
            (data/make-links cmr-base-url coll)))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -152,10 +152,12 @@
     (setup-collections)
     (f)))
 
+;; Note tha the fixtures are created out of order such that sorting can be
+;; checked.
 (use-fixtures :once (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"
-                                              "provguid2" "PROV2"
-                                              "provguid3" "PROV3"})
+                      [(ingest/reset-fixture {"provguid3" "PROV3"
+                                              "provguid1" "PROV1"
+                                              "provguid2" "PROV2"})
                        tags/grant-all-tag-fixture
                        collections-fixture]))
 

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -63,34 +63,34 @@
   (let [url (format "%sconcepts" base-url)]
     (and
       (string/includes? body (format "%s/%s" url "C1200000015-PROV1.html"))
-      (string/includes? body "Collection Item 2 (s2)")
+      (string/includes? body "Collection Item 2")
       (string/includes? body (format "%s/%s" url "C1200000016-PROV1.html"))
-      (string/includes? body "Collection Item 3 (s3)"))))
+      (string/includes? body "Collection Item 3"))))
 
 (defn expected-provider2-level-links?
   [body]
   (let [url (format "%sconcepts" base-url)]
     (and
       (string/includes? body (format "%s/%s" url "C1200000018-PROV2.html"))
-      (string/includes? body "Collection Item 2 (s2)")
+      (string/includes? body "Collection Item 2")
       (string/includes? body (format "%s/%s" url "C1200000019-PROV2.html"))
-      (string/includes? body "Collection Item 3 (s3)"))))
+      (string/includes? body "Collection Item 3"))))
 
 (defn expected-provider3-level-links?
   [body]
   (let [url "http://dx.doi.org"]
     (and
       (string/includes? body (format "%s/%s" url "doi5"))
-      (string/includes? body "Collection Item 5 (s5)")
+      (string/includes? body "Collection Item 5")
       (string/includes? body (format "%s/%s" url "doi6"))
-      (string/includes? body "Collection Item 6 (s6)"))))
+      (string/includes? body "Collection Item 6"))))
 
 (defn expected-provider1-col1-link?
   [body]
   (let [url (format "%sconcepts" base-url)]
     (and
       (string/includes? body (format "%s/%s" url "C1200000014-PROV1.html"))
-      (string/includes? body "Collection Item 1 (s1)"))))
+      (string/includes? body "Collection Item 1"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Functions for creating testing data

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -54,7 +54,9 @@
     (and
       (string/includes? body (format "%s/%s/%s" url "PROV1" tag))
       (string/includes? body (format "%s/%s/%s" url "PROV2" tag))
-      (string/includes? body (format "%s/%s/%s" url "PROV3" tag)))))
+      (string/includes? body (format "%s/%s/%s" url "PROV3" tag))
+      (not (string/includes? body (format "%s/%s/%s" url "PROV4" tag)))
+      (string/includes? body "PROV4"))))
 
 (defn expected-provider1-level-links?
   [body]
@@ -152,7 +154,8 @@
 ;; Note tha the fixtures are created out of order such that sorting can be
 ;; checked.
 (use-fixtures :once (join-fixtures
-                      [(ingest/reset-fixture {"provguid3" "PROV3"
+                      [(ingest/reset-fixture {"provguid4" "PROV4"
+                                              "provguid3" "PROV3"
                                               "provguid1" "PROV1"
                                               "provguid2" "PROV2"})
                        tags/grant-all-tag-fixture

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -62,18 +62,18 @@
   [body]
   (let [url (format "%sconcepts" base-url)]
     (and
-      (string/includes? body (format "%s/%s" url "C1200000015-PROV1.html"))
+      (string/includes? body (format "%s/%s" url "C1200000019-PROV1.html"))
       (string/includes? body "Collection Item 2")
-      (string/includes? body (format "%s/%s" url "C1200000016-PROV1.html"))
+      (string/includes? body (format "%s/%s" url "C1200000020-PROV1.html"))
       (string/includes? body "Collection Item 3"))))
 
 (defn expected-provider2-level-links?
   [body]
   (let [url (format "%sconcepts" base-url)]
     (and
-      (string/includes? body (format "%s/%s" url "C1200000018-PROV2.html"))
+      (string/includes? body (format "%s/%s" url "C1200000022-PROV2.html"))
       (string/includes? body "Collection Item 2")
-      (string/includes? body (format "%s/%s" url "C1200000019-PROV2.html"))
+      (string/includes? body (format "%s/%s" url "C1200000023-PROV2.html"))
       (string/includes? body "Collection Item 3"))))
 
 (defn expected-provider3-level-links?


### PR DESCRIPTION
@chris-durbin provided some feedback after the initial deployment of the landing pages and sitemap features. Changes include:
* Alphabetical listing of providers
* Providers with no landing pages aren't linked
* All providers get a parenthetical count of landing pages after their link

Note that this branch is part 1 of 2; the second branch will include UX fixes for layout.