### PR TITLE
CMR-4013: Added support to metadata-db to save a Variable concept. 

### DIFF
--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -7,7 +7,7 @@
 
 (def concept-types
   "This is the set of the types of concepts in the CMR."
-  #{:collection :granule :tag :tag-association :service :access-group :acl :humanizer})
+  #{:collection :granule :tag :tag-association :variable :service :access-group :acl :humanizer})
 
 (def concept-prefix->concept-type
   "Maps a concept id prefix to the concept type"
@@ -15,6 +15,7 @@
    "G" :granule
    "T" :tag
    "TA" :tag-association
+   "V" :variable
    "S" :service
    "AG" :access-group
    "ACL" :acl
@@ -30,10 +31,10 @@
   "humanizer")
 
 (defn concept-id-validation
-  "Validates both concept-id and collection-concept-id 
+  "Validates both concept-id and collection-concept-id
    and returns errors if it's invalid. Returns nil if valid."
   ([concept-id]
-   ;;validates concept-id  
+   ;;validates concept-id
    ;;use :collection-concept-id in place of param when validating collection-concept-id
    (concept-id-validation :concept-id concept-id))
   ([param concept-id]

--- a/metadata-db-app/README.md
+++ b/metadata-db-app/README.md
@@ -97,13 +97,13 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "native-id": "org.nasa.something.quality/C12-PROV_A42",
     "user-id": "jnorton",
     "format": "applcation/edn",
-    "metadata: {
+    "metadata": {
       "tag-key": "org.nasa.something.quality",
       "originator-id": "jdoe",
       "associated-concept-id": "C12-PROV_A42",
       "revision-id": 1, (optional field),
       "value": "string to be indexed" or "data": "arbitrary JSON <= 32K" (optional fields)
-    }
+    },
     "extra-fields": {
       "tag-key": "org.nasa.something.quality",
       "associated-concept-id": "C12-PROV_A42",
@@ -116,14 +116,28 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
   {
     "concept-type": "humanizer",
     "native-id" : "humanizer",
-    "concept-type" : "humanizer",
     "metadata" : "[{\"type\":\"trim_whitespace\",\"field\":\"platform\",\"order\":-100},{\"type\":\"priority\",\"field\":\"platform\",\"source_value\":\"Aqua\",\"order\":10,\"priority\":10}]",
     "user-id" : "user1",
     "deleted" : false,
     "format" : "application/json"
   }
 
-_Note the absence of provider-id for tags, tag associations and humanizer. These are system level entities and are always assigned the system level provider, CMR._
+#### Variable
+
+  {
+    "concept-type": "variable",
+    "native-id" : "var123",
+    "metadata" : "{ \"Name\": \"totCldH2OStdErr\", \"LongName\": \"totCldH2OStdErrMeasurement\", \"Units\": \"\", \"DataType\": \"float\", \"DimensionsName\": [ \"H2OFunc\", \"H2OPressureLay\", \"MWHingeSurf\", \"Cloud\", \"HingeSurf\", \"H2OPressureLev\", \"AIRSXTrack\", \"StdPressureLay\", \"CH4Func\", \"StdPressureLev\", \"COFunc\", \"O3Func\", \"AIRSTrack\" ], \"Dimensions\": [ \"11\", \"14\", \"7\", \"2\", \"100\", \"15\", \"3\", \"28\", \"10\", \"9\" ], \"ValidRange\": null, \"Scale\": \"1.0\", \"Offset\": \"0.0\", \"FillValue\": \"-9999.0 \", \"VariableType\": \"\", \"ScienceKeywords\": []}",
+    "user-id" : "user1",
+    "deleted" : false,
+    "format" : "application/json",
+    "extra-fields": {
+      "variable-name": "totCldH2OStdErr",
+      "measurement": "totCldH2OStdErrMeasurement"
+    }
+  }
+
+_Note the absence of provider-id for tag, tag association, humanizer and variable. These are system level entities and are always assigned the system level provider, CMR._
 
 ### Sample Tombstone (deleted concept) JSON
 

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/tag_association_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/tag_association_save_test.clj
@@ -1,10 +1,11 @@
 (ns cmr.metadata-db.int-test.concepts.tag-association-save-test
   "Contains integration tests for saving tag associations. Tests saves with various configurations
    including checking for proper error handling."
-  (:require [clojure.test :refer :all]
-            [cmr.common.util :refer (are2)]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer (are2)]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
+   [cmr.metadata-db.int-test.utility :as util]))
 
 
 ;;; fixtures

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/tag_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/tag_save_test.clj
@@ -1,16 +1,11 @@
 (ns cmr.metadata-db.int-test.concepts.tag-save-test
   "Contains integration tests for saving tags. Tests saves with various configurations including
   checking for proper error handling."
-  (:require [clojure.test :refer :all]
-            [clj-http.client :as client]
-            [clj-time.core :as t]
-            [clj-time.format :as f]
-            [clj-time.local :as l]
-            [cmr.common.util :refer (are2)]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.services.messages :as msg]
-            [cmr.metadata-db.services.concept-constraints :as cc]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer (are2)]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
+   [cmr.metadata-db.int-test.utility :as util]))
 
 
 ;;; fixtures

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -1,17 +1,11 @@
 (ns cmr.metadata-db.int-test.concepts.variable-save-test
   "Contains integration tests for saving variables. Tests saves with various configurations including
   checking for proper error handling."
-  (:require [clojure.test :refer :all]
-            [clj-http.client :as client]
-            [clj-time.core :as t]
-            [clj-time.format :as f]
-            [clj-time.local :as l]
-            [cmr.common.util :refer (are2)]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.services.messages :as msg]
-            [cmr.metadata-db.services.concept-constraints :as cc]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]))
-
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer (are2)]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
+   [cmr.metadata-db.int-test.utility :as util]))
 
 ;;; fixtures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -1,0 +1,41 @@
+(ns cmr.metadata-db.int-test.concepts.variable-save-test
+  "Contains integration tests for saving variables. Tests saves with various configurations including
+  checking for proper error handling."
+  (:require [clojure.test :refer :all]
+            [clj-http.client :as client]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clj-time.local :as l]
+            [cmr.common.util :refer (are2)]
+            [cmr.metadata-db.int-test.utility :as util]
+            [cmr.metadata-db.services.messages :as msg]
+            [cmr.metadata-db.services.concept-constraints :as cc]
+            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]))
+
+
+;;; fixtures
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}))
+
+(defmethod c-spec/gen-concept :variable
+  [_ _ uniq-num attributes]
+  (util/variable-concept uniq-num attributes))
+
+;; tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(deftest save-variable-test
+  (c-spec/general-save-concept-test :variable ["CMR"]))
+
+
+(deftest save-variable-specific-test
+  (testing "saving new variables"
+    (are2 [variable exp-status exp-errors]
+          (let [{:keys [status errors]} (util/save-concept variable)]
+            (is (= exp-status status))
+            (is (= (set exp-errors) (set errors))))
+
+          "failure when using non system-level provider"
+          (assoc (util/variable-concept 2) :provider-id "REG_PROV")
+          422
+          ["Variable could not be associated with provider [REG_PROV]. Variables are system level entities."])))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -147,6 +147,35 @@
     [{"type" "trim_whitespace", "field" "platform", "order" -100},
      {"type" "priority", "field" "platform", "source_value" "Aqua", "order" 10, "priority" 10}]))
 
+(def variable-json
+  (json/generate-string
+    { "Name" "totCldH2OStdErr",
+      "LongName" "totCldH2OStdErr",
+      "Units" "",
+      "DataType" "float",
+      "DimensionsName" [
+        "H2OFunc",
+        "H2OPressureLay",
+        "MWHingeSurf",
+        "Cloud",
+        "HingeSurf",
+        "H2OPressureLev",
+        "AIRSXTrack",
+        "StdPressureLay",
+        "CH4Func",
+        "StdPressureLev",
+        "COFunc",
+        "O3Func",
+        "AIRSTrack"
+      ],
+      "Dimensions" [ "11", "14", "7", "2", "100", "15", "3", "28", "10", "9" ],
+      "ValidRange" nil,
+      "Scale" "1.0",
+      "Offset" "0.0",
+      "FillValue" "-9999.0 ",
+      "VariableType" "",
+      "ScienceKeywords" []}))
+
 (def concept-dummy-metadata
   "Index events are now created by MDB when concepts are saved. So the Indexer will attempt
   to look up the metadata for the concepts and parse it. So we need to provide valid
@@ -159,7 +188,8 @@
    :tag-association tag-association-edn
    :access-group group-edn
    :acl acl-edn
-   :humanizer humanizer-json})
+   :humanizer humanizer-json
+   :variable variable-json})
 
 (defn- concept
   "Create a concept map for any concept type. "
@@ -292,6 +322,23 @@
                           attributes)]
     ;; no provider-id should be specified for humanizers
     (dissoc (concept nil :humanizer uniq-num attributes) :provider-id))))
+
+(defn variable-concept
+  "Creates a variabe concept"
+  ([uniq-num]
+   (variable-concept uniq-num {}))
+  ([uniq-num attributes]
+   (let [native-id (str "var-native" uniq-num)
+         extra-fields (merge {:variable-name (str "var" uniq-num)
+                              :measurement (str "measurement" uniq-num)}
+                             (:extra-fields attributes))
+         attributes (merge {:user-id (str "user" uniq-num)
+                            :format "application/json"
+                            :native-id native-id
+                            :extra-fields extra-fields}
+                           (dissoc attributes :extra-fields))]
+     ;; no provider-id should be specified for tags
+     (dissoc (concept nil :variable uniq-num attributes) :provider-id))))
 
 (defn assert-no-errors
   [save-result]
@@ -524,6 +571,10 @@
   (assoc concept :provider-id "CMR"))
 
 (defmethod expected-concept :humanizer
+  [concept]
+  (assoc concept :provider-id "CMR"))
+
+(defmethod expected-concept :variable
   [concept]
   (assoc concept :provider-id "CMR"))
 

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
@@ -40,6 +40,10 @@
   [_ _]
   "cmr_humanizers")
 
+(defmethod get-table-name :variable
+  [_ _]
+  "cmr_variables")
+
 (defmethod get-table-name :default
   [provider concept-type]
   ;; Dont' remove the next line - needed to prevent SQL injection

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -460,7 +460,8 @@
    (j/db-do-commands this "DELETE FROM cmr_tag_associations")
    (j/db-do-commands this "DELETE FROM cmr_groups")
    (j/db-do-commands this "DELETE FROM cmr_acls")
-   (j/db-do-commands this "DELETE FROM cmr_humanizers"))
+   (j/db-do-commands this "DELETE FROM cmr_humanizers")
+   (j/db-do-commands this "DELETE FROM cmr_variables"))
 
   (get-expired-concepts
    [this provider concept-type]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable.clj
@@ -1,0 +1,22 @@
+(ns cmr.metadata-db.data.oracle.concepts.variable
+  "Implements multi-method variations for variables"
+  (:require [cmr.metadata-db.data.oracle.concepts :as c]))
+
+(defmethod c/db-result->concept-map :variable
+  [concept-type db provider-id result]
+  (some-> (c/db-result->concept-map :default db provider-id result)
+          (assoc :concept-type :variable)
+          (assoc :user-id (:user_id result))
+          (assoc-in [:extra-fields :variable-name] (:variable_name result))
+          (assoc-in [:extra-fields :measurement] (:measurement result))))
+
+;; Only "CMR" provider is supported now which is not considered a 'small' provider.
+;; If we ever associate real providers with variables then we will need to add support
+;; for small providers as well.
+(defmethod c/concept->insert-args [:variable false]
+  [concept _]
+  (let [{{:keys [variable-name measurement]} :extra-fields
+         user-id :user-id} concept
+        [cols values] (c/concept->common-insert-args concept)]
+    [(concat cols ["user_id" "variable_name" "measurement"])
+     (concat values [user-id variable-name measurement])]))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable.clj
@@ -1,6 +1,7 @@
 (ns cmr.metadata-db.data.oracle.concepts.variable
   "Implements multi-method variations for variables"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]))
+  (:require
+   [cmr.metadata-db.data.oracle.concepts :as c]))
 
 (defmethod c/db-result->concept-map :variable
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -28,7 +28,8 @@
    :access-group (into common-columns [:provider_id :user_id])
    :service (into common-columns [:provider_id :entry_title :entry_id :delete_time :user_id])
    :acl (into common-columns [:provider_id :user_id :acl_identity])
-   :humanizer (into common-columns [:user_id])})
+   :humanizer (into common-columns [:user_id])
+   :variable (into common-columns [:variable_name :measurement :user_id])})
 
 (def single-table-with-providers-concept-type?
   "The set of concept types that are stored in a single table with a provider column. These concept

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -44,7 +44,8 @@
    :tag 10
    :tag-association 10
    :access-group 10
-   :humanizer 10})
+   :humanizer 10
+   :variable 10})
 
 (defconfig days-to-keep-tombstone
   "Number of days to keep a tombstone before is removed from the database."
@@ -57,7 +58,7 @@
 
 (def system-level-concept-types
   "A set of concept types that only exist on system level provider CMR."
-  #{:tag :tag-association :humanizer})
+  #{:tag :tag-association :humanizer :variable})
 
 ;;; utility methods
 
@@ -72,7 +73,8 @@
       (let [err-msg (case concept-type
                       :tag (msg/tags-only-system-level provider-id)
                       :tag-association (msg/tag-associations-only-system-level provider-id)
-                      :humanizer (msg/humanizers-only-system-level provider-id))]
+                      :humanizer (msg/humanizers-only-system-level provider-id)
+                      :variable (msg/variables-only-system-level provider-id))]
         (errors/throw-service-errors :invalid-data [err-msg])))))
 
 (defn- provider-ids-for-validation

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
@@ -44,7 +44,9 @@
    :service {true #{}
              false #{:entry-id :entry-title}}
    :tag-association {true #{}
-                     false #{:associated-concept-id :associated-revision-id}}})
+                     false #{:associated-concept-id :associated-revision-id}}
+   :variable {true #{}
+             false #{:variable-name :measurement}}})
 
 (defn extra-fields-missing-validation
   "Validates that the concept is provided with extra fields and that all of them are present and not nil."
@@ -172,6 +174,11 @@
                                   concept-id-matches-concept-fields-validation-no-provider
                                   humanizer-native-id-validation)))
 
+(def variable-concept-validation
+  "Builds a function that validates a concept map that has no provider and returns a list of errors"
+  (util/compose-validations (conj base-concept-validations
+                                  concept-id-matches-concept-fields-validation-no-provider
+                                  extra-fields-missing-validation)))
 
 (def validate-concept-default
   "Validates a concept. Throws an error if invalid."
@@ -193,6 +200,10 @@
   "validates a humanizer concept. Throws an error if invalid."
   (util/build-validator :invalid-data humanizer-concept-validation))
 
+(def validate-variable-concept
+  "validates a variable concept. Throws an error if invalid."
+  (util/build-validator :invalid-data variable-concept-validation))
+
 (defmulti validate-concept
   "Validates a concept. Throws an error if invalid."
   (fn [concept]
@@ -213,6 +224,10 @@
 (defmethod validate-concept :humanizer
   [concept]
   (validate-humanizer-concept concept))
+
+(defmethod validate-concept :variable
+  [concept]
+  (validate-variable-concept concept))
 
 (defmethod validate-concept :default
   [concept]

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -98,7 +98,7 @@
       "The Short Name [%s] and Version Id [%s] combined must be unique. The following concepts with the same Short Name and Version Id were found: [%s]."
       (-> concepts first :extra-fields :short-name)
       (-> concepts first :extra-fields :version-id)
-      (str/join ", " (map :concept-id concepts))) 
+      (str/join ", " (map :concept-id concepts)))
     (format
       "The %s [%s] must be unique. The following concepts with the same %s were found: [%s]."
       (str/replace (csk/->Camel_Snake_Case_String field) #"_" " ")
@@ -161,4 +161,8 @@
 
 (defn humanizers-only-system-level [provider-id]
   (format "Humanizer could not be associated with provider [%s]. Humanizer is system level entity."
+          provider-id))
+
+(defn variables-only-system-level [provider-id]
+  (format "Variable could not be associated with provider [%s]. Variables are system level entities."
           provider-id))

--- a/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
@@ -23,7 +23,8 @@
    :service default-supported-find-parameters
    :access-group default-supported-find-parameters
    :acl default-supported-find-parameters
-   :humanizer #{:concept-id :native-id}})
+   :humanizer #{:concept-id :native-id}
+   :variable #{:concept-id :native-id}})
 
 (def granule-supported-parameter-combinations
   "Supported search parameter combination sets for granule find. This does not include flags

--- a/metadata-db-app/src/migrations/048_setup_variables_table.clj
+++ b/metadata-db-app/src/migrations/048_setup_variables_table.clj
@@ -1,0 +1,59 @@
+(ns migrations.048-setup-variables-table
+  (:require [clojure.java.jdbc :as j]
+            [config.migrate-config :as config]
+            [config.mdb-migrate-helper :as h]))
+
+(def ^:private variables-column-sql
+  "id NUMBER,
+  concept_id VARCHAR(255) NOT NULL,
+  native_id VARCHAR(1030) NOT NULL,
+  metadata BLOB NOT NULL,
+  format VARCHAR(255) NOT NULL,
+  revision_id INTEGER DEFAULT 1 NOT NULL,
+  revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+  deleted INTEGER DEFAULT 0 NOT NULL,
+  user_id VARCHAR(30),
+  variable_name VARCHAR(20),
+  measurement VARCHAR(1024),
+  transaction_id INTEGER DEFAULT 0 NOT NULL")
+
+(def ^:private variables-constraint-sql
+  (str "CONSTRAINT variables_pk PRIMARY KEY (id), "
+       ;; Unique constraint on native id and revision id
+       "CONSTRAINT variables_con_rev UNIQUE (native_id, revision_id)
+       USING INDEX (create unique index variables_ucr_i ON cmr_variables (native_id, revision_id)), "
+
+       ;; Unique constraint on concept id and revision id
+       "CONSTRAINT variables_cid_rev UNIQUE (concept_id, revision_id)
+       USING INDEX (create unique index variables_cri ON cmr_variables (concept_id, revision_id))"))
+
+(defn- create-variables-table
+  []
+  (h/sql
+   (format "CREATE TABLE METADATA_DB.cmr_variables (%s, %s)"
+           variables-column-sql variables-constraint-sql)))
+
+
+(defn- create-variables-indices
+  []
+  (h/sql "CREATE INDEX variables_crdi ON cmr_variables (concept_id, revision_id, deleted)"))
+
+(defn- create-variables-sequence
+  []
+  (h/sql "CREATE SEQUENCE cmr_variables_seq"))
+
+(defn up
+  "Migrates the database up to version 48."
+  []
+  (println "migrations.048-setup-variables-table up...")
+  (create-variables-table)
+  (create-variables-indices)
+  (create-variables-sequence))
+
+(defn down
+  "Migrates the database down from version 48."
+  []
+  (println "migrations.048-setup-variables-table down...")
+  (h/sql "DROP SEQUENCE METADATA_DB.cmr_variables_seq")
+  (h/sql "DROP TABLE METADATA_DB.cmr_variables"))

--- a/metadata-db-app/src/migrations/048_setup_variables_table.clj
+++ b/metadata-db-app/src/migrations/048_setup_variables_table.clj
@@ -36,7 +36,9 @@
 
 (defn- create-variables-indices
   []
-  (h/sql "CREATE INDEX variables_crdi ON cmr_variables (concept_id, revision_id, deleted)"))
+  (h/sql "CREATE INDEX variables_crdi ON METADATA_DB.cmr_variables (concept_id, revision_id, deleted)")
+  (h/sql "CREATE INDEX variables_vn ON METADATA_DB.cmr_variables (variable_name)")
+  (h/sql "CREATE INDEX variables_meas ON METADATA_DB.cmr_variables (measurement)"))
 
 (defn- create-variables-sequence
   []

--- a/metadata-db-app/src/migrations/048_setup_variables_table.clj
+++ b/metadata-db-app/src/migrations/048_setup_variables_table.clj
@@ -1,7 +1,6 @@
 (ns migrations.048-setup-variables-table
-  (:require [clojure.java.jdbc :as j]
-            [config.migrate-config :as config]
-            [config.mdb-migrate-helper :as h]))
+  (:require
+   [config.mdb-migrate-helper :as h]))
 
 (def ^:private variables-column-sql
   "id NUMBER,

--- a/metadata-db-app/test/cmr/metadata_db/test/services/concept_service.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/concept_service.clj
@@ -88,19 +88,33 @@
           [(messages/invalid-revision-id concept-id 2 1)]
           (#'cs/validate-concept-revision-id db {:provider-id "PROV1"} concept previous-concept))))))
 
-(deftest validate-system-level-concept-test
+(deftest validate-system-level-tag-concept-test
   (let [tag {:concept-type :tag
              :short-name "TAG1"}
         cmr-provider pv/cmr-provider
         prov1 {:provider-id "PROV1"
-   :short-name "PROV1"
-   :cmr-only true
-   :small false}]
+               :short-name "PROV1"
+               :cmr-only true
+               :small false}]
     (is (= nil (cs/validate-system-level-concept tag cmr-provider)))
     (tu/assert-exception-thrown-with-errors
-      :invalid-data
-      ["Tag could not be associated with provider [PROV1]. Tags are system level entities."]
-      (cs/validate-system-level-concept tag prov1))))
+     :invalid-data
+     ["Tag could not be associated with provider [PROV1]. Tags are system level entities."]
+     (cs/validate-system-level-concept tag prov1))))
+
+(deftest validate-system-level-variable-concept-test
+  (let [variable {:concept-type :variable
+             :variable-name "var123"}
+        cmr-provider pv/cmr-provider
+        prov1 {:provider-id "PROV1"
+               :variable-name "PROV1"
+               :cmr-only true
+               :small false}]
+    (is (= nil (cs/validate-system-level-concept variable cmr-provider)))
+    (tu/assert-exception-thrown-with-errors
+     :invalid-data
+     ["Variable could not be associated with provider [PROV1]. Variables are system level entities."]
+     (cs/validate-system-level-concept variable prov1))))
 
 ;;; Verify that the try-to-save logic is correct.
 (deftest try-to-save-test


### PR DESCRIPTION
Variable concepts are system level concepts and this added db migration to create the CMR_VARIABLES table and added support to save Variable concept in the table. I have added the CREATED_AT column in CMR_VARIABLES table, but didn't add any special handling of it between revisions. It will be added after CMR-4000 is done which is setting up a framework for doing that.
