### PR TITLE
CMR-4036 kibit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ are in place, you will be able to run the following:
 
 `./dev-system/support/build-and-test-ci.sh`
 
+Additionally, if you have an Oracle VM up and running, you can change how
+the tests are run in the REPL by running the following:
+
+```clj
+user=> (reset :db :external)
+...
+user=> (run-all-tests)
+...
+```
+
+Those tests will take much longer to run than when done with the in-memory
+database (~25m vs. ~6m). To switch back to using the in-memory database,
+simply call `(reset :db :in-memory)`.
+
 ## Code structure
 
 The CMR is made up of several small services called microservices. These are

--- a/bootstrap-app/src/cmr/bootstrap/data/virtual_products.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/virtual_products.clj
@@ -1,20 +1,21 @@
 (ns cmr.bootstrap.data.virtual-products
   "Contains functions for bootstrapping virtual products."
-  (:require [clojure.core.async :as async :refer [go >! go-loop <! <!!]]
-            [clojure.string :as str]
-            [cmr.bootstrap.embedded-system-helper :as helper]
-            [cmr.bootstrap.data.util :as data]
-            [cmr.common.log :refer :all]
-            [cmr.common.util :as util]
-            [cmr.common.mime-types :as mime-types]
-            [cmr.common.config :as config :refer [defconfig]]
-            [cmr.metadata-db.data.concepts :as mdb-c]
-            [cmr.metadata-db.data.providers :as mdb-p]
-            [cmr.metadata-db.services.search-service :as search]
-            [cmr.transmit.metadata-db :as mdb]
-            [cmr.umm.umm-core :as umm]
-            [cmr.virtual-product.data.source-to-virtual-mapping :as svm]
-            [cmr.virtual-product.services.virtual-product-service :as vps]))
+  (:require
+   [clojure.core.async :as async :refer [go >! go-loop <! <!!]]
+   [clojure.string :as str]
+   [cmr.bootstrap.data.util :as data]
+   [cmr.bootstrap.embedded-system-helper :as helper]
+   [cmr.common.config :as config :refer [defconfig]]
+   [cmr.common.log :refer :all]
+   [cmr.common.mime-types :as mime-types]
+   [cmr.common.util :as util]
+   [cmr.metadata-db.data.concepts :as mdb-c]
+   [cmr.metadata-db.data.providers :as mdb-p]
+   [cmr.metadata-db.services.search-service :as search]
+   [cmr.transmit.metadata-db :as mdb]
+   [cmr.umm.umm-core :as umm]
+   [cmr.virtual-product.data.source-to-virtual-mapping :as svm]
+   [cmr.virtual-product.services.virtual-product-service :as vps]))
 
 (def channel-name
   "The name (key in system map) for the channel used to coordinate requests."
@@ -52,7 +53,8 @@
   "Returns nil or exactly one concept excluding tombstones by searching metadata-db with the params.
   Throws exception if more than one non-tombstoned concept matches the given params."
   [system params]
-  (let [concepts (->> (search/find-concepts {:system (helper/get-metadata-db system)} params)
+  (let [concepts (->> params
+                      (search/find-concepts {:system (helper/get-metadata-db system)})
                       (filter #(not (:deleted %))))]
     (condp = (count concepts)
       0 nil
@@ -203,7 +205,8 @@
   internals."
   [system provider-id entry-title]
   (info "Bootstrapping virtual products.")
-  (->> (get-source-granule-batch-channel system provider-id entry-title)
+  (->> entry-title
+       (get-source-granule-batch-channel system provider-id)
        (process-source-granule-batches system)))
 
 (defn handle-virtual-product-requests

--- a/bootstrap-app/src/cmr/bootstrap/services/health_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/health_service.clj
@@ -1,17 +1,18 @@
 (ns cmr.bootstrap.services.health-service
   "Contains fuctions to provider health status of the bootstrap app."
-  (:require [cmr.transmit.metadata-db2 :as mdb]
-            [cmr.metadata-db.services.health-service :as hs]
-            [cmr.indexer.services.index-service :as indexer]
-            [cmr.bootstrap.embedded-system-helper :as helper]))
+  (:require
+   [cmr.bootstrap.embedded-system-helper :as helper]
+   [cmr.indexer.services.index-service :as indexer]
+   [cmr.metadata-db.services.health-service :as hs]
+   [cmr.transmit.metadata-db2 :as mdb]))
 
 (defn health
   "Returns the health state of the app."
   [context]
   (let [metadata-db-health (mdb/get-metadata-db-health context)
-        indexer-context (assoc context :system (helper/get-indexer (:system context)))
+        indexer-context (update-in context [:system] helper/get-indexer)
         indexer-health (indexer/health indexer-context)
-        internal-meta-db-context (assoc context :system (helper/get-metadata-db (:system context)))
+        internal-meta-db-context (update-in context [:system] helper/get-metadata-db)
         internal-meta-db-health (hs/health internal-meta-db-context)
         ok? (every? :ok? [metadata-db-health internal-meta-db-health indexer-health])]
     {:ok? ok?

--- a/bootstrap-app/src/cmr/bootstrap/services/replication.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/replication.clj
@@ -103,7 +103,7 @@
           table
           table
           (source-database-link)
-          (.toString (cr/to-sql-time revision-datetime))))
+          (str (cr/to-sql-time revision-datetime))))
 
 (defn- fix-null-replicated-blobs
   "AWS DMS is replicating BLOBs that are over 4K in size as NULL. We need to identify all of them

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -50,7 +50,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   []
-  (let [metadata-db (-> (mdb-system/create-system "metadata-db-in-bootstrap-pool")
+  (let [metadata-db (-> "metadata-db-in-bootstrap-pool"
+                        (mdb-system/create-system)
                         (dissoc :log :web :scheduler :unclustered-scheduler :queue-broker))
         indexer (-> (idx-system/create-system)
                     (dissoc :log :web :queue-broker)

--- a/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
+++ b/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
@@ -2,10 +2,11 @@
   "An implementation of the CMR cache protocol on top of the cubby application. Cubby only supports
   persistence and returning strings so this automatically serializes and deserializes the keys and
   values with EDN. Any key or value serializable to EDN is supported."
-  (:require [cmr.common.cache :as c]
-            [cmr.transmit.cubby :as cubby]
-            [cmr.transmit.config :as config]
-            [clojure.edn :as edn]))
+  (:require
+   [clojure.edn :as edn]
+   [cmr.common.cache :as c]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.cubby :as cubby]))
 
 (defn- serialize
   "Serializes a value for storage in cubby."
@@ -34,11 +35,11 @@
   (get-value
     [this key lookup-fn]
     (let [c-value (c/get-value this key)]
-      (if (not (nil? c-value))
-          c-value
-          (let [value (lookup-fn)]
-            (c/set-value this key value)
-            value))))
+      (if-not (nil? c-value)
+        c-value
+        (let [value (lookup-fn)]
+          (c/set-value this key value)
+          value))))
 
   (reset
     [this]

--- a/common-app-lib/src/cmr/common_app/services/search/datetime_helper.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/datetime_helper.clj
@@ -1,8 +1,9 @@
 (ns cmr.common-app.services.search.datetime-helper
   "Contains helper functions for converting date time string to elastic date time string"
-  (:require [clojure.string :as s]
-            [clj-time.format :as f]
-            [cmr.common.date-time-parser :as p]))
+  (:require
+   [clj-time.format :as f]
+   [clojure.string :as s]
+   [cmr.common.date-time-parser :as p]))
 
 (def earliest-start-date
   "Earliest start date"
@@ -19,7 +20,8 @@
 (defn utc-time->elastic-time
   "Convert utc clj time to elasticsearch time string."
   [tm]
-  (-> (f/unparse (f/formatters :date-time) tm)
+  (-> (f/formatters :date-time)
+      (f/unparse tm)
       (s/replace #"Z" "-0000")))
 
 (defn datetime->string

--- a/common-app-lib/src/cmr/common_app/services/search/messages.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/messages.clj
@@ -28,13 +28,13 @@
 (defn invalid-pattern-opt-setting-msg
   "Creates a message saying which parameters would not allow pattern option setting."
   [params-set]
-  (let [params (reduce (fn [params param] (conj params param)) '() (seq params-set))]
+  (let [params (reduce conj '() (seq params-set))]
     (format "Pattern option setting disallowed on these parameters: %s" params)))
 
 (defn invalid-ignore-case-opt-setting-msg
   "Creates a message saying which parameters would not allow ignore case option setting."
   [params-set]
-  (let [params (reduce (fn [params param] (conj params param)) '() (seq params-set))]
+  (let [params (reduce conj '() (seq params-set))]
     (format "Ignore case option setting disallowed on these parameters: %s" params)))
 
 (defn invalid-settings-for-param

--- a/common-app-lib/src/cmr/common_app/services/search/query_execution.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_execution.clj
@@ -1,12 +1,13 @@
 (ns cmr.common-app.services.search.query-execution
-  (:require [cmr.common-app.services.search.query-model :as qm]
-            [cmr.common-app.services.search.elastic-search-index :as idx]
-            [cmr.common-app.services.search.results-model :as results]
-            [cmr.common-app.services.search.elastic-results-to-query-results :as rc]
-            [cmr.common-app.services.search.complex-to-simple :as c2s]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common-app.services.search.related-item-resolver :as related-item-resolver]
-            [cmr.transmit.config :as tc]))
+  (:require
+   [cmr.common-app.services.search.complex-to-simple :as c2s]
+   [cmr.common-app.services.search.elastic-results-to-query-results :as rc]
+   [cmr.common-app.services.search.elastic-search-index :as idx]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common-app.services.search.related-item-resolver :as related-item-resolver]
+   [cmr.common-app.services.search.results-model :as results]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.transmit.config :as tc]))
 
 (defmulti add-acl-conditions-to-query
   "Adds conditions to the query to enforce ACLs."
@@ -19,8 +20,7 @@
 
 (defmulti query->execution-strategy
   "Returns the execution strategy to use for query execution"
-  (fn [query]
-    (:concept-type query)))
+  :concept-type)
 
 ;; The default query execution strategy is to use elasticsearch
 (defmethod query->execution-strategy :default

--- a/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
@@ -1,13 +1,14 @@
 (ns cmr.common-app.services.search.query-to-elastic
   "Defines protocols and functions to map from a query model to elastic search query"
-  (:require [clojurewerkz.elastisch.query :as q]
-            [clojure.string :as str]
-            [cmr.common-app.services.search.query-model :as qm]
-            [cmr.common-app.services.search.datetime-helper :as h]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.config :as cfg :refer [defconfig]]
-            [cmr.common-app.services.search.query-order-by-expense :as query-expense]
-            [cmr.common-app.services.search.messages :as m]))
+  (:require
+   [clojure.string :as str]
+   [clojurewerkz.elastisch.query :as q]
+   [cmr.common-app.services.search.datetime-helper :as h]
+   [cmr.common-app.services.search.messages :as m]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common-app.services.search.query-order-by-expense :as query-expense]
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.services.errors :as errors]))
 
 (defconfig numeric-range-execution-mode
   "Defines the execution mode to use for numeric ranges in an elasticsearch search"
@@ -80,8 +81,7 @@
 
 (defmulti query->elastic
   "Converts a query model into an elastic search query"
-  (fn [query]
-    (:concept-type query)))
+  :concept-type)
 
 (defmethod query->elastic :default
   [query]
@@ -121,8 +121,7 @@
 
 (defmulti query->sort-params
   "Converts a query into the elastic parameters for sorting results"
-  (fn [query]
-    (:concept-type query)))
+  :concept-type)
 
 (defmethod query->sort-params :default
   [query]

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -194,9 +194,9 @@
   "Create an instance of the metadata-db application."
   [db-component queue-broker]
   (let [sys-with-db (if db-component
-                      (-> (mdb-system/create-system)
-                          (assoc :db db-component
-                                 :scheduler (jobs/create-non-running-scheduler)))
+                      (assoc (mdb-system/create-system)
+                             :db db-component
+                             :scheduler (jobs/create-non-running-scheduler))
                       (mdb-system/create-system))]
     (assoc sys-with-db :queue-broker queue-broker)))
 
@@ -222,15 +222,15 @@
 
 (defmethod create-ingest-app :in-memory
   [db-type queue-broker]
-  (-> (ingest-system/create-system)
-      (assoc :db (ingest-data/create-in-memory-db)
-             :queue-broker queue-broker
-             :scheduler (jobs/create-non-running-scheduler))))
+  (assoc (ingest-system/create-system)
+         :db (ingest-data/create-in-memory-db)
+         :queue-broker queue-broker
+         :scheduler (jobs/create-non-running-scheduler)))
 
 (defmethod create-ingest-app :external
   [db-type queue-broker]
-  (-> (ingest-system/create-system)
-      (assoc :queue-broker queue-broker)))
+  (assoc (ingest-system/create-system)
+         :queue-broker queue-broker))
 
 (defn create-search-app
   "Create an instance of the search application."

--- a/dev-system/src/cmr/dev_system/tests.clj
+++ b/dev-system/src/cmr/dev_system/tests.clj
@@ -31,8 +31,3 @@
                                          integration-test-ns->compare-value
                                          (t/integration-test-namespaces))
            :reset-fn dev-sys-util/reset)))
-
-
-
-
-

--- a/dev-system/src/cmr/dev_system/tests.clj
+++ b/dev-system/src/cmr/dev_system/tests.clj
@@ -6,29 +6,31 @@
 
   { \"keys\": [\"alt+super+a\"], \"command\": \"run_command_in_repl\", \"args\": {\"command\": \"(def all-tests-future (future (cmr.dev-system.tests/run-all-tests {:fail-fast? true :speak? true} )))\", \"refresh_namespaces\": true}},
   "
-  (:require [cmr.common.test.test-runner :as t]
-            [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]))
+  (:require
+   [cmr.common.test.test-runner :as t]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]))
 
 (defn system-integration-test?
   [test-ns]
   (re-find #"system-int-test" test-ns))
 
 (defn integration-test-ns->compare-value
-  "The comparator function to use for sorting integration tests. We want system integration tests
-  to run last."
+  "The comparator function to use for sorting integration tests. We want system integration tests to run last."
   [test-ns]
   (if (system-integration-test? test-ns)
     10
     1))
 
 (defn run-all-tests
-  "Runs all the tests in the cmr. It takes the same options as cmr.common.test-runner/run-all-tests"
+  "Runs all the tests in the cmr. It takes the same options as
+  cmr.common.test-runner/run-all-tests."
   [options]
-  (let [integration-test-namespaces (->> (t/integration-test-namespaces)
-                                         (sort-by integration-test-ns->compare-value))]
-    (t/run-all-tests (assoc options
-                            :integration-test-namespaces integration-test-namespaces
-                            :reset-fn dev-sys-util/reset))))
+  (t/run-all-tests
+    (assoc options
+           :integration-test-namespaces (sort-by
+                                         integration-test-ns->compare-value
+                                         (t/integration-test-namespaces))
+           :reset-fn dev-sys-util/reset)))
 
 
 

--- a/dev-system/support/build.sh
+++ b/dev-system/support/build.sh
@@ -9,10 +9,10 @@
 # CMR_ORACLE_JAR_REPO: Oracle libraries are not available in public maven repositories. We can host
 # them in internal ones for building. If this is set then the maven repo will be updated to use this.
 
-date && echo "Installing all apps" &&
-(cd .. && lein modules do clean, install)
+date && echo "Installing all apps and generating API documentation" &&
+(cd .. && lein modules do clean, install, generate-static)
 if [ $? -ne 0 ] ; then
-  echo "Failed to install apps" >&2
+  echo "Failed to install apps and generate docs" >&2
   exit 1
 fi
 # The library is reinstalled after installing gems so that it will contain the gem code.
@@ -27,23 +27,6 @@ date && echo "Installing orbits gems" &&
 (cd ../orbits-lib && lein install-gems)
 if [ $? -ne 0 ] ; then
   echo "Failed to install gems" >&2
-  exit 1
-fi
-(cd ../search-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate search docs" >&2
-  exit 1
-fi
-date && echo "Generating Ingest API documentation" &&
-(cd ../ingest-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate ingest docs" >&2
-  exit 1
-fi
-date && echo "Generating Access Control API documentation" &&
-(cd ../access-control-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate access control docs" >&2
   exit 1
 fi
 if [ "$CMR_DEV_SYSTEM_DB_TYPE" = "external" ] ; then

--- a/dev-system/support/setup_local_dev.sh
+++ b/dev-system/support/setup_local_dev.sh
@@ -5,10 +5,10 @@
 # Additionally, this script assumes it is being executed in the parent
 # directory of the the dev-system project.
 
-date && echo "Installing all apps" &&
-lein modules do clean, install, clean
+date && echo "Installing all apps and generating API documentation" &&
+lein install-with-content!
 if [ $? -ne 0 ] ; then
-  echo "Failed to install apps" >&2
+  echo "Failed to install apps and generate docs" >&2
   exit 1
 fi
 rm -r dev-system/checkouts
@@ -30,23 +30,4 @@ if [ $? -ne 0 ] ; then
   echo "Failed to install gems" >&2
   exit 1
 fi
-date && echo "Generating Search API documentation" &&
-(cd search-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate search docs" >&2
-  exit 1
-fi
-date && echo "Generating Ingest API documentation" &&
-(cd ingest-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate ingest docs" >&2
-  exit 1
-fi
-date && echo "Generating Access Control API documentation" &&
-(cd access-control-app && lein generate-static)
-if [ $? -ne 0 ] ; then
-  echo "Failed to generate access control docs" >&2
-  exit 1
-fi
-
 

--- a/spatial-lib/src/cmr/spatial/arc.clj
+++ b/spatial-lib/src/cmr/spatial/arc.clj
@@ -1,15 +1,17 @@
 (ns cmr.spatial.arc
-  (:require [cmr.spatial.point :as p]
-            [cmr.spatial.math :refer :all]
-            [primitive-math]
-            [pjstadig.assertions :as pj]
-            [cmr.spatial.vector :as v]
-            [cmr.spatial.mbr :as mbr]
-            [cmr.spatial.conversion :as c]
-            [cmr.spatial.derived :as d]
-            [cmr.common.util :as util]
-            [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
+  (:require
+   [cmr.common.dev.record-pretty-printer :as record-pretty-printer]
+   [cmr.common.util :as util]
+   [cmr.spatial.conversion :as c]
+   [cmr.spatial.derived :as d]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.mbr :as mbr]
+   [cmr.spatial.point :as p]
+   [cmr.spatial.vector :as v]
+   [pjstadig.assertions :as pj]
+   [primitive-math])
   (:import cmr.spatial.point.Point))
+
 (primitive-math/use-primitive-operators)
 
 (def ^:const ^double APPROXIMATION_DELTA
@@ -17,39 +19,28 @@
   0.0000001)
 
 (defrecord GreatCircle
-  [
-    plane-vector
-
-    northernmost-point
-
-    southernmost-point])
-
-
+  [plane-vector
+   northernmost-point
+   southernmost-point])
 
 ;; The arc contains derived information that is cached to prevent recalculating the same
 ;; information over and over again for the same arc. If desired this extra info could be put
 ;; in another record like ArcInfo
 (defrecord Arc
-  [
-   ;; The western most point of the arc
+  [;; The western most point of the arc
    ^Point west-point
    ;; The eastern most point of the arc.
    ^Point east-point
-
    ;; A representation of the great circle the arc lies on.
    ^GreatCircle great-circle
-
    ;; The initial course when following the arc. This is derived from the order of the points passed
    ;; into the arc constructor. It won't necessarily be from west to east or east to west.
    ^double initial-course
-
    ;; The ending course when following the arc.
    ^double ending-course
-
    ;; 1 or 2 bounding rectangles defining the MBR of the arc.
    mbr1
    mbr2])
-
 
 (record-pretty-printer/enable-record-pretty-printing
   GreatCircle
@@ -181,7 +172,7 @@
   (pj/assert (not= point1 point2))
   (pj/assert (not (p/antipodal? point1 point2)))
 
-  (if (< (p/compare-points point1 point2) 0)
+  (if (neg? (p/compare-points point1 point2))
     (arc-from-ordered-points point1 point2 point1 point2)
     (arc-from-ordered-points point1 point2 point2 point1)))
 

--- a/spatial-lib/src/cmr/spatial/geodetic_ring.clj
+++ b/spatial-lib/src/cmr/spatial/geodetic_ring.clj
@@ -1,14 +1,16 @@
 (ns cmr.spatial.geodetic-ring
-  (:require [cmr.spatial.point :as p]
-            [cmr.spatial.math :refer :all]
-            [cmr.common.util :as util]
-            [primitive-math]
-            [cmr.spatial.mbr :as mbr]
-            [cmr.spatial.conversion :as c]
-            [cmr.spatial.arc :as a]
-            [cmr.spatial.derived :as d]
-            [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
+  (:require
+   [cmr.common.dev.record-pretty-printer :as record-pretty-printer]
+   [cmr.common.util :as util]
+   [cmr.spatial.arc :as a]
+   [cmr.spatial.conversion :as c]
+   [cmr.spatial.derived :as d]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.mbr :as mbr]
+   [cmr.spatial.point :as p]
+   [primitive-math])
   (:import cmr.spatial.arc.Arc))
+
 (primitive-math/use-primitive-operators)
 
 (def ^:const ^:private EXTERNAL_POINT_PRECISION
@@ -17,20 +19,17 @@
   4)
 
 (defrecord GeodeticRing
-  [
-   ;; The points that make up the ring. Points must be in counterclockwise order. The last point
+  [;; The points that make up the ring. Points must be in counterclockwise order. The last point
    ;; must match the first point.
    points
-
+   ;;
    ;; Derived fields
-
+   ;;
    ;; A set of the unique points in the ring.
    ;; This should be used as opposed to creating a set from the points many times over which is expensive.
    point-set
-
    ;; The arcs of the ring
    arcs
-
    ;; This attribute contains the rotation direction for the ring. Rotation direction will be one of
    ;; :clockwise, :counter-clockwise, or :none to indicate the point order direction.
    ;; * :clockwise indicates the points are listed in a clockwise order around a center point.
@@ -38,16 +37,12 @@
    ;; * :none indicates the point order is around the earth like a belt.
    ;; Depending on the order it could contain the south or north pole.
    course-rotation-direction
-
    ;; true if ring contains north pole
    contains-north-pole
-
    ;; true if ring contains south pole
    contains-south-pole
-
    ;; the minimum bounding rectangle
    mbr
-
    ;; Three points that are not within the ring. These are used to test if a point is inside or
    ;; outside a ring. We generate multiple external points so that we have a backup if one external
    ;; point is antipodal to a point we're checking is inside a ring.
@@ -201,13 +196,13 @@
                        nil
                        arcs)
             br (if (and contains-north-pole
-                        (not (some p/is-north-pole? (:points ring)))
-                        (not (some a/crosses-north-pole? arcs)))
+                        (not-any? p/is-north-pole? (:points ring))
+                        (not-any? a/crosses-north-pole? arcs))
                  (mbr/mbr -180.0 90.0 180.0 (:south br))
                  br)]
         (if (and contains-south-pole
-                 (not (some p/is-south-pole? (:points ring)))
-                 (not (some a/crosses-south-pole? arcs)))
+                 (not-any? p/is-south-pole? (:points ring))
+                 (not-any? a/crosses-south-pole? arcs))
           (mbr/mbr -180.0 (:north br) 180.0 -90.0)
           br))))
 

--- a/spatial-lib/src/cmr/spatial/line_segment.clj
+++ b/spatial-lib/src/cmr/spatial/line_segment.clj
@@ -1,17 +1,18 @@
 (ns cmr.spatial.line-segment
   "This contains functions for operating on cartesian line segments. These are defined as lines
   that exist in a two dimensional plane."
-  (:require [cmr.spatial.math :refer :all]
-            [primitive-math]
-            [pjstadig.assertions :as pj]
-            [cmr.spatial.mbr :as m]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.messages :as msg]
-            [cmr.common.services.errors :as errors]
-            [cmr.spatial.derived :as d]
-            [cmr.common.util :as util]
-            [clojure.math.combinatorics :as combo]
-            [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
+  (:require
+   [clojure.math.combinatorics :as combo]
+   [cmr.common.dev.record-pretty-printer :as record-pretty-printer]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.util :as util]
+   [cmr.spatial.derived :as d]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.messages :as msg]
+   [cmr.spatial.point :as p]
+   [pjstadig.assertions :as pj]
+   [primitive-math])
   (:import cmr.spatial.point.Point
            cmr.spatial.mbr.Mbr))
 
@@ -22,26 +23,20 @@
 (primitive-math/use-primitive-operators)
 
 (defrecord LineSegment
-  [
-   ^Point point1
+  [^Point point1
    ^Point point2
-
    ;; Derived Fields
-
    ;; true if the line is vertical
    vertical
-
    ;; true if the line is horizontal
    horizontal
-
+   ;;
    ;; Fields from the formula for a line: y = m*x + b
-
+   ;;
    ;; The slope of a line. A vertical line will not have meaningful slope or slope-intercept
    ^Double m
-
    ;; The slope intercept
    ^Double b
-
    ;; The minimum bounding rectangle of the segment
    ^Mbr mbr])
 
@@ -451,7 +446,7 @@
           (> (count intersection-points) 2)
           (errors/internal-error! (str "Found too many intersection points " (pr-str intersection-points)))
 
-          (= (count intersection-points) 0)
+          (zero? (count intersection-points))
           nil ; no intersection at all
 
           (= (count intersection-points) 2)

--- a/spatial-lib/src/cmr/spatial/lr_binary_search.clj
+++ b/spatial-lib/src/cmr/spatial/lr_binary_search.clj
@@ -1,6 +1,6 @@
 (ns cmr.spatial.lr-binary-search
   "Prototype code that finds the largest interior rectangle of a ring."
-  (:require 
+  (:require
     [clojure.math.combinatorics :as combo]
     [cmr.common.log :refer (warn)]
     [cmr.common.services.errors :as errors]
@@ -21,7 +21,7 @@
     [primitive-math])
   (:import
     cmr.spatial.cartesian_ring.CartesianRing
-    cmr.spatial.geodetic_ring.GeodeticRing 
+    cmr.spatial.geodetic_ring.GeodeticRing
     cmr.spatial.mbr.Mbr
     cmr.spatial.polygon.Polygon))
 (primitive-math/use-primitive-operators)
@@ -174,8 +174,7 @@
 
 (defmulti shape->lr-search-points
   "Returns points that may potentially be in the shape to use to search for a LR."
-  (fn [shape]
-    (type shape)))
+  type)
 
 (defmulti polygon->lr-search-points
   (fn [polygon]
@@ -243,7 +242,7 @@
    (let [polygon (d/calculate-derived polygon)
          mbr (relations/mbr polygon)
          initial-lr (or
-                      ;; Find an LR from the center point of the polygon 
+                      ;; Find an LR from the center point of the polygon
                       (even-lr-search polygon (m/center-point mbr))
                       ;; Return the first LR that we can find using a test point
                       (first (filter identity
@@ -265,7 +264,7 @@
         (if not-found-is-error?
           (errors/internal-error! (str "Could not find lr from polygon " (pr-str polygon)))
           (do
-            (warn "Use mbr from one of the points in the polygon because lr is not found " 
+            (warn "Use mbr from one of the points in the polygon because lr is not found "
                   (pr-str polygon))
             (m/point->mbr (-> polygon :rings first :points first))))))))
 

--- a/spatial-lib/src/cmr/spatial/math.clj
+++ b/spatial-lib/src/cmr/spatial/math.clj
@@ -1,6 +1,7 @@
 (ns cmr.spatial.math
-  (:require [primitive-math]
-            [cmr.common.util :as util])
+  (:require
+   [cmr.common.util :as util]
+   [primitive-math])
   (:import net.jafama.StrictFastMath))
 
 (primitive-math/use-primitive-operators)
@@ -59,7 +60,7 @@
 (defn even-long?
   "A copy of the clojure even? function but with long type annotations for primitive math performance."
   [^long l]
-  (= (rem l 2) 0))
+  (zero? (rem l 2)))
 
 (defn odd-long?
   "A copy of the clojure odd? function but with long type annotations for primitive math performance."
@@ -283,9 +284,9 @@
                            m 0.0]
                       (if (or (>= index num-angles) (> (+ index 2) num-angles))
                         m
-                        (recur (+ index 1)
+                        (recur (inc index)
                                (+ m (angle-delta (nth angles index)
-                                                 (nth angles (+ index 1)))))))]
+                                                 (nth angles (inc index)))))))]
     (cond
       (< (abs net) 0.01) :none
       (> net 0.0) :counter-clockwise

--- a/spatial-lib/src/cmr/spatial/ring_relations.clj
+++ b/spatial-lib/src/cmr/spatial/ring_relations.clj
@@ -1,22 +1,23 @@
 (ns cmr.spatial.ring-relations
   "Contains functions on rings that are common to cartesian and geodetic rings."
-  (:require [cmr.spatial.point :as p]
-            [cmr.spatial.math :refer :all]
-            [cmr.common.util :as util]
-            [primitive-math]
-            [cmr.spatial.mbr :as m]
-            [cmr.spatial.conversion :as c]
-            [cmr.spatial.line-segment :as s]
-            [cmr.spatial.arc-line-segment-intersections :as asi]
-            [cmr.spatial.cartesian-ring :as cr]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.geodetic-ring :as gr]
-            [cmr.spatial.line-string :as ls]
-            [clojure.math.combinatorics :as combo])
-  (:import cmr.spatial.cartesian_ring.CartesianRing
-           cmr.spatial.geodetic_ring.GeodeticRing
-           cmr.spatial.point.Point
-           cmr.spatial.mbr.Mbr))
+  (:require
+   [clojure.math.combinatorics :as combo]
+   [cmr.common.util :as util]
+   [cmr.spatial.arc-line-segment-intersections :as asi]
+   [cmr.spatial.cartesian-ring :as cr]
+   [cmr.spatial.conversion :as c]
+   [cmr.spatial.geodetic-ring :as gr]
+   [cmr.spatial.line-segment :as s]
+   [cmr.spatial.line-string :as ls]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.point :as p]
+   [primitive-math])
+  (:import
+   cmr.spatial.cartesian_ring.CartesianRing
+   cmr.spatial.geodetic_ring.GeodeticRing
+   cmr.spatial.point.Point
+   cmr.spatial.mbr.Mbr))
 (primitive-math/use-primitive-operators)
 
 (defn ring
@@ -215,7 +216,7 @@
                                              (= n1 (dec n2))
                                              ;; Reject the last line combined with first line.
                                              (and
-                                               (= n1 0)
+                                               (zero? n1)
                                                (= n2 (dec (count lines)))))))
                                   (combo/combinations (range (count lines)) 2))]
     (mapcat (fn [[n1 n2]]

--- a/spatial-lib/src/cmr/spatial/serialize.clj
+++ b/spatial-lib/src/cmr/spatial/serialize.clj
@@ -11,18 +11,18 @@
     represents one shape in the ords list.
     * type - an integer representing the spatial type (polygon, mbr, etc)
     * size - the number of ordinates in the ords list this shape uses."
-  (:require [cmr.common.services.errors :as errors]
-            [cmr.spatial.geodetic-ring :as gr]
-            [cmr.spatial.ring-relations :as rr]
-            [cmr.spatial.math :refer :all]
-            [cmr.spatial.polygon :as poly]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.line-string :as l]
-            [cmr.spatial.mbr :as m]
-            [cmr.common.util :as u]
-            [cmr.spatial.lr-binary-search :as lr]
-            [clojure.set :as set]))
-
+  (:require
+   [clojure.set :as set]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.util :as u]
+   [cmr.spatial.geodetic-ring :as gr]
+   [cmr.spatial.line-string :as l]
+   [cmr.spatial.lr-binary-search :as lr]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.point :as p]
+   [cmr.spatial.polygon :as poly]
+   [cmr.spatial.ring-relations :as rr]))
 
 ;; Some thoughts about how to store the elasticsearch data in a way that preserves space and accuracy.
 (comment
@@ -49,11 +49,11 @@
   (> (ordinate->stored -180) Integer/MIN_VALUE)
 
   ;; The maximum accuracy we could maintain is 7 digits
-  (= true (maintains-precision? 179.1234567))
-  (= true (maintains-precision? -179.1234567))
+  (true? (maintains-precision? 179.1234567))
+  (true? (maintains-precision? -179.1234567))
 
   ;; Any thing after that loses precision
-  (= false (maintains-precision? 179.12345678)))
+  (false? (maintains-precision? 179.12345678)))
 
 (def ^:const ^double multiplication-factor
   "Ordinates are stored as integers in elasticsearch to maintain space. This is the number used

--- a/spatial-lib/src/cmr/spatial/test/generators.clj
+++ b/spatial-lib/src/cmr/spatial/test/generators.clj
@@ -1,27 +1,27 @@
 (ns cmr.spatial.test.generators
-  (:require [clojure.test.check.generators :as gen]
-            [clojure.string :as str]
-            [cmr.common.test.test-check-ext :as ext-gen :refer [optional]]
-            [pjstadig.assertions :as pj]
-            [primitive-math]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.vector :as v]
-            [cmr.spatial.mbr :as m]
-            [cmr.spatial.geodetic-ring :as gr]
-            [cmr.spatial.ring-relations :as rr]
-            [cmr.spatial.polygon :as poly]
-            [cmr.spatial.line-string :as l]
-            [cmr.spatial.arc :as a]
-            [cmr.spatial.derived :as d]
-            [cmr.spatial.line-segment :as s]
-            [cmr.spatial.arc-line-segment-intersections :as asi]
-            [clojure.math.combinatorics :as combo]))
+  (:require
+   [clojure.math.combinatorics :as combo]
+   [clojure.string :as str]
+   [clojure.test.check.generators :as gen]
+   [cmr.common.test.test-check-ext :as ext-gen :refer [optional]]
+   [cmr.spatial.arc :as a]
+   [cmr.spatial.arc-line-segment-intersections :as asi]
+   [cmr.spatial.derived :as d]
+   [cmr.spatial.geodetic-ring :as gr]
+   [cmr.spatial.line-segment :as s]
+   [cmr.spatial.line-string :as l]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.point :as p]
+   [cmr.spatial.polygon :as poly]
+   [cmr.spatial.ring-relations :as rr]
+   [cmr.spatial.vector :as v]
+   [pjstadig.assertions :as pj]
+   [primitive-math]))
 
 (comment
   ;; If you have trouble reloading this namespace, evaluate the
   ;; following expression:
   (primitive-math/unuse-primitive-operators))
-
 
 (primitive-math/use-primitive-operators)
 
@@ -193,9 +193,8 @@
     ;; Only use this point if it's not already in the ring
     (when-not (some (partial = point) points)
       (loop [pos 1]
-        (if (= pos (count points))
-          ;; We couldn't find a spot to add the point. Return nil
-          nil
+        ;; If we can't find a spot to add the point, return nil
+        (when-not (= pos (count points))
           (if-let [new-ring (insert-point-at ring point pos)]
             (let [new-ring (d/calculate-derived new-ring)
                   self-intersections (rr/self-intersections new-ring)]
@@ -280,7 +279,7 @@
                            diff (- ui li)
                            [li ui] (cond
                                      (> diff 2) [li ui]
-                                     (> ui 0) [(- li (- 3 diff)) ui]
+                                     (pos? ui) [(- li (- 3 diff)) ui]
                                      :else [li (+ ui (- 3 diff))])]
                        (ext-gen/choose-double li ui)))
         lon-gen (if (m/crosses-antimeridian? mbr)

--- a/spatial-lib/src/cmr/spatial/tile.clj
+++ b/spatial-lib/src/cmr/spatial/tile.clj
@@ -16,15 +16,16 @@
   7) Map the densified points back to its original quadrant.
   8) Convert the points from planar coordinates to geodetic coordinates. Convert from radians to
      degrees."
-  (:require [cmr.spatial.math :refer :all]
-            [primitive-math]
-            [cmr.spatial.geodetic-ring :as gr]
-            [cmr.spatial.ring-relations :as rr]
-            [clojure.java.io :as io]
-            [cmr.spatial.derived :as d]
-            [cmr.spatial.relations :as rel]
-            [cmr.spatial.point :as p]
-            [cmr.spatial.line-segment :as s]))
+  (:require
+   [clojure.java.io :as io]
+   [cmr.spatial.derived :as d]
+   [cmr.spatial.geodetic-ring :as gr]
+   [cmr.spatial.line-segment :as s]
+   [cmr.spatial.math :refer :all]
+   [cmr.spatial.point :as p]
+   [cmr.spatial.relations :as rel]
+   [cmr.spatial.ring-relations :as rr]
+   [primitive-math]))
 
 (primitive-math/use-primitive-operators)
 
@@ -100,7 +101,7 @@
   lower-right vertex of the tile as the first vertex."
   [^long h ^long v]
   (let [x-min (* (double (- h (/ NUM_HORIZONTAL_TILES 2))) TILE_SIZE)
-        y-min (* (double (- (/ NUM_VERTICAL_TILES 2) (+ v 1))) TILE_SIZE)
+        y-min (* (double (- (/ NUM_VERTICAL_TILES 2) (inc v))) TILE_SIZE)
         x-max (+ x-min TILE_SIZE)
         y-max (+ y-min TILE_SIZE)]
     [[x-max y-min] [x-max y-max] [x-min y-max] [x-min y-min]]))

--- a/transmit-lib/src/cmr/transmit/echo/rest.clj
+++ b/transmit-lib/src/cmr/transmit/echo/rest.clj
@@ -1,12 +1,13 @@
 (ns cmr.transmit.echo.rest
   "A helper for making echo-rest requests"
-  (:require [clj-http.client :as client]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.services.health-helper :as hh]
-            [cheshire.core :as json]
-            [cmr.transmit.config :as config]
-            [cmr.transmit.connection :as conn]
-            [cmr.common.log :as log :refer (debug info warn error)]))
+  (:require
+   [cheshire.core :as json]
+   [clj-http.client :as client]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.services.health-helper :as hh]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]))
 
 (defn request-options
   [conn]
@@ -37,9 +38,8 @@
          _ (debug (format "Completed ECHO GET Request to %s in [%d] ms" url (- (System/currentTimeMillis) start)))
 
          {:keys [status body headers]} response
-         parsed (if (.startsWith ^String (get headers "Content-Type" "") "application/json")
-                  (json/decode body true)
-                  nil)]
+         parsed (when (.startsWith ^String (get headers "Content-Type" "") "application/json")
+                  (json/decode body true))]
      [status parsed body])))
 
 (defn rest-delete
@@ -64,9 +64,8 @@
          params (merge (post-options conn body-obj) options)
          response (client/post url params)
          {:keys [status body headers]} response
-         parsed (if (.startsWith ^String (get headers "Content-Type" "") "application/json")
-                  (json/decode body true)
-                  nil)]
+         parsed (when (.startsWith ^String (get headers "Content-Type" "") "application/json")
+                  (json/decode body true))]
      [status parsed body])))
 
 

--- a/transmit-lib/src/cmr/transmit/metadata_db2.clj
+++ b/transmit-lib/src/cmr/transmit/metadata_db2.clj
@@ -1,10 +1,11 @@
 (ns cmr.transmit.metadata-db2
   "This contains functions for interacting with the metadata db API. It uses the newer transmit namespace
   style that cubby, concepts, and access control use"
-  (:require [cmr.transmit.connection :as conn]
-            [cmr.transmit.config :as config]
-            [ring.util.codec :as codec]
-            [cmr.transmit.http-helper :as h]))
+  (:require
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]
+   [cmr.transmit.http-helper :as h]
+   [ring.util.codec :as codec]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -103,7 +104,8 @@
   ([context concept-id revision-id]
    (get-concept context concept-id revision-id nil))
   ([context concept-id revision-id {:keys [raw? http-options]}]
-   (-> (h/request context :metadata-db
+   (-> context
+       (h/request :metadata-db
                   {:url-fn #(concept-revision-url % concept-id revision-id)
                    :method :get
                    :raw? raw?
@@ -119,7 +121,8 @@
   ([context concept-id]
    (get-latest-concept context concept-id nil))
   ([context concept-id {:keys [raw? http-options]}]
-   (-> (h/request context :metadata-db
+   (-> context
+       (h/request :metadata-db
                   {:url-fn #(latest-concept-url % concept-id)
                    :method :get
                    :raw? raw?


### PR DESCRIPTION
This work returns to one of several on-going tickets whose focus is cleaning up old code.

Additionally, the following was done:
 * Updated "Testing" section in README to demonstrate usage of `(reset :db :external)`
 * Updated setup scripts to use new top-level alias
 * Updated setup scripts to do documentation generation after install (in the same step)