### PR TITLE
CMR-4105: Added logging for tagging requests; Fixed typo.

### DIFF
--- a/metadata-db-app/src/migrations/038_add_indices_to_tag_associations_table.clj
+++ b/metadata-db-app/src/migrations/038_add_indices_to_tag_associations_table.clj
@@ -1,11 +1,12 @@
 (ns migrations.038-add-indices-to-tag-associations-table
-  (:require [config.mdb-migrate-helper :as h]))
+  (:require
+   [config.mdb-migrate-helper :as h]))
 
 (defn up
   []
   (println "migrations.038-add-indices-to-tag-associations-table up...")
   ;; We need the following indices for searching tag associations during tag association validation
-  ;; and disassociate tags.
+  ;; and dissociate tags.
   (h/sql "CREATE INDEX tag_assoc_tkcid ON cmr_tag_associations (tag_key, associated_concept_id)")
   (h/sql "CREATE INDEX tag_assoc_tkcrid ON cmr_tag_associations (tag_key, associated_concept_id, associated_revision_id)"))
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2730,7 +2730,7 @@ Content-Length: 168
 
 #### <a name="tag-disassociation"></a> Tag Disassociation
 
-A tag can be disassociated from collections through either a JSON query or a list of collection concept revisions similar to tag association requests. Tag disassociation by query only supports tag disassociation of the latest revision of collections. Tag disassociation by collections supports tag disassociation from any specified collection revisions. The tag disassociation response looks the same as tag association response. It normally returns status code 200 with a response of a list of individual tag disassociation responses, one for each tag association attempted to delete. Each tag disassociation response has a `tagged_item` field and either a `tag_association` field with the tag association concept id and revision id when the tag disassociation succeeded or an `errors` or `warnings` field with detailed message when the tag disassociation failed or inapplicable. The `tagged_item` field is the collection concept id and the optional revision id that is used to identify the collection during tag disassociation. Here is a sample tag disassociation request and its response:
+A tag can be dissociated from collections through either a JSON query or a list of collection concept revisions similar to tag association requests. Tag disassociation by query only supports tag disassociation of the latest revision of collections. Tag disassociation by collections supports tag disassociation from any specified collection revisions. The tag disassociation response looks the same as tag association response. It normally returns status code 200 with a response of a list of individual tag disassociation responses, one for each tag association attempted to delete. Each tag disassociation response has a `tagged_item` field and either a `tag_association` field with the tag association concept id and revision id when the tag disassociation succeeded or an `errors` or `warnings` field with detailed message when the tag disassociation failed or inapplicable. The `tagged_item` field is the collection concept id and the optional revision id that is used to identify the collection during tag disassociation. Here is a sample tag disassociation request and its response:
 
 ```
 curl -XDELETE -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR-ENDPOINT%/tags/edsc.in_modaps/associations -d \
@@ -2787,7 +2787,7 @@ Status code 422 is returned when:
 
 #### <a name="disassociating-collections-with-a-tag-by-query"></a> Disassociating a Tag from Collections by query
 
-Tags can be disassociated from collections by sending a DELETE request with a JSON query for collections to `%CMR-ENDPOINT%/tags/<tag-key>/associations/by_query` where `tag-key` is the tag key of the tag. All collections found in the query will be _removed_ from the current set of associated collections.
+Tags can be dissociated from collections by sending a DELETE request with a JSON query for collections to `%CMR-ENDPOINT%/tags/<tag-key>/associations/by_query` where `tag-key` is the tag key of the tag. All collections found in the query will be _removed_ from the current set of associated collections.
 
 
 ```
@@ -2824,7 +2824,7 @@ Content-Length: 168
 
 #### <a name="disassociating-collections-with-a-tag-by-concept-ids"></a> Disassociating a Tag from Collections by collection concept ids
 
-Tags can be disassociated from collections by sending a DELETE request with a JSON array of collection concept-ids to `%CMR-ENDPOINT%/tags/<tag-key>/associations/by_query` where `tag-key` is the tag key of the tag. All collections found in the query will be _removed_ from the current set of associated collections.
+Tags can be dissociated from collections by sending a DELETE request with a JSON array of collection concept-ids to `%CMR-ENDPOINT%/tags/<tag-key>/associations/by_query` where `tag-key` is the tag key of the tag. All collections found in the query will be _removed_ from the current set of associated collections.
 
 
 ```

--- a/search-app/src/cmr/search/api/tags_api.clj
+++ b/search-app/src/cmr/search/api/tags_api.clj
@@ -4,10 +4,11 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [cmr.acl.core :as acl]
+   [cmr.common-app.api.enabled :as common-enabled]
+   [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
-   [cmr.common-app.api.enabled :as common-enabled]
    [cmr.search.services.tagging-service :as tagging-service]
    [compojure.core :refer :all]
    [compojure.route :as route]))
@@ -78,15 +79,19 @@
   (verify-tag-modification-permission context :update)
   (common-enabled/validate-write-enabled context "search")
   (validate-tag-content-type headers)
+  (info (format "Tagging [%s] on collections: %s by client: %s."
+                tag-key body (:client-id context)))
   (tag-api-response (tagging-service/associate-tag-to-collections context tag-key body)))
 
-(defn disassociate-tag-to-collections
-  "Disassociate the tag to a list of collections."
+(defn dissociate-tag-to-collections
+  "Dissociate the tag to a list of collections."
   [context headers body tag-key]
   (verify-tag-modification-permission context :update)
   (common-enabled/validate-write-enabled context "search")
   (validate-tag-content-type headers)
-  (tag-api-response (tagging-service/disassociate-tag-to-collections context tag-key body)))
+  (info (format "Dissociating tag [%s] from collections: %s by client: %s."
+                tag-key body (:client-id context)))
+  (tag-api-response (tagging-service/dissociate-tag-to-collections context tag-key body)))
 
 (defn associate-tag-by-query
   "Processes a request to associate a tag."
@@ -94,15 +99,19 @@
   (verify-tag-modification-permission context :update)
   (common-enabled/validate-write-enabled context "search")
   (validate-tag-content-type headers)
+  (info (format "Tagging [%s] on collections by query: %s by client: %s."
+                tag-key body (:client-id context)))
   (tag-api-response (tagging-service/associate-tag-by-query context tag-key body)))
 
-(defn disassociate-tag-by-query
-  "Processes a request to disassociate a tag."
+(defn dissociate-tag-by-query
+  "Processes a request to dissociate a tag."
   [context headers body tag-key]
   (verify-tag-modification-permission context :update)
   (common-enabled/validate-write-enabled context "search")
   (validate-tag-content-type headers)
-  (tag-api-response (tagging-service/disassociate-tag-by-query context tag-key body)))
+  (info (format "Dissociating tag [%s] from collections by query: %s by client: %s."
+                tag-key body (:client-id context)))
+  (tag-api-response (tagging-service/dissociate-tag-by-query context tag-key body)))
 
 (defn search-for-tags
   [context params]
@@ -140,9 +149,9 @@
           (associate-tag-to-collections
             request-context headers (slurp body) (str/lower-case tag-key)))
 
-        ;; Disassociate a tag with a list of collections
+        ;; Dissociate a tag with a list of collections
         (DELETE "/" {:keys [request-context headers body]}
-          (disassociate-tag-to-collections
+          (dissociate-tag-to-collections
             request-context headers (slurp body) (str/lower-case tag-key)))
 
         (context "/by_query" []
@@ -151,7 +160,7 @@
             (associate-tag-by-query
               request-context headers (slurp body) (str/lower-case tag-key)))
 
-          ;; Disassociate a tag with collections
+          ;; Dissociate a tag with collections
           (DELETE "/" {:keys [request-context headers body]}
-            (disassociate-tag-by-query
+            (dissociate-tag-by-query
               request-context headers (slurp body) (str/lower-case tag-key))))))))

--- a/search-app/src/cmr/search/services/tagging_service.clj
+++ b/search-app/src/cmr/search/services/tagging_service.clj
@@ -286,8 +286,8 @@
   [context tag-key tag-associations-json]
   (link-tag-to-collections context tag-key tag-associations-json :insert))
 
-(defn disassociate-tag-to-collections
-  "Disassociates a tag from the given list of tag associations in json."
+(defn dissociate-tag-to-collections
+  "Dissociates a tag from the given list of tag associations in json."
   [context tag-key tag-associations-json]
   (link-tag-to-collections context tag-key tag-associations-json :delete))
 
@@ -296,8 +296,8 @@
   [context tag-key json-query]
   (update-tag-associations-with-query context tag-key json-query :insert))
 
-(defn disassociate-tag-by-query
-  "Disassociates a tag from collections that are the result of a JSON query"
+(defn dissociate-tag-by-query
+  "Dissociates a tag from collections that are the result of a JSON query"
   [context tag-key json-query]
   (update-tag-associations-with-query context tag-key json-query :delete))
 

--- a/system-int-test/src/cmr/system_int_test/utils/tag_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/tag_util.clj
@@ -113,27 +113,27 @@
   ([token tag-key coll-concept-ids options]
    (associate-tag :concept-ids token tag-key coll-concept-ids options)))
 
-(defn- disassociate-tag
-  "Disassociates a tag with collections found with a JSON query"
+(defn- dissociate-tag
+  "Dissociates a tag with collections found with a JSON query"
   [association-type token tag-key condition options]
   (let [options (merge {:raw? true :token token} options)
-        response (tt/disassociate-tag association-type (s/context) tag-key condition options)]
+        response (tt/dissociate-tag association-type (s/context) tag-key condition options)]
     (index/wait-until-indexed)
     (process-response response)))
 
-(defn disassociate-by-query
-  "Disassociates a tag with collections found with a JSON query"
+(defn dissociate-by-query
+  "Dissociates a tag with collections found with a JSON query"
   ([token tag-key condition]
-   (disassociate-by-query token tag-key condition nil))
+   (dissociate-by-query token tag-key condition nil))
   ([token tag-key condition options]
-   (disassociate-tag :query token tag-key {:condition condition} options)))
+   (dissociate-tag :query token tag-key {:condition condition} options)))
 
-(defn disassociate-by-concept-ids
-  "Disassociates a tag with collections by collection concept ids"
+(defn dissociate-by-concept-ids
+  "Dissociates a tag with collections by collection concept ids"
   ([token tag-key coll-concept-ids]
-   (disassociate-by-concept-ids token tag-key coll-concept-ids nil))
+   (dissociate-by-concept-ids token tag-key coll-concept-ids nil))
   ([token tag-key coll-concept-ids options]
-   (disassociate-tag :concept-ids token tag-key coll-concept-ids options)))
+   (dissociate-tag :concept-ids token tag-key coll-concept-ids options)))
 
 (defn save-tag
   "A helper function for creating or updating tags for search tests. If the tag does not have a

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
@@ -771,10 +771,10 @@
                  tag1-colls)]
 
       (index/wait-until-indexed)
-      ;; disassociate tag1 from coll2 and not send indexing events
+      ;; dissociate tag1 from coll2 and not send indexing events
       (dev-sys-util/eval-in-dev-sys
         `(cmr.metadata-db.config/set-publish-messages! false))
-      (tags/disassociate-by-query user1-token tag-key {:concept_id (:concept-id coll2)})
+      (tags/dissociate-by-query user1-token tag-key {:concept_id (:concept-id coll2)})
       (dev-sys-util/eval-in-dev-sys
         `(cmr.metadata-db.config/set-publish-messages! true))
 

--- a/system-int-test/test/cmr/system_int_test/search/tagging/collection_revisions_tag_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/collection_revisions_tag_search_test.clj
@@ -1,14 +1,15 @@
 (ns cmr.system-int-test.search.tagging.collection-revisions-tag-search-test
   "This tests searching for collection revisions by tag parameters"
-  (:require [clojure.test :refer :all]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.search-util :as search]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.system-int-test.utils.tag-util :as tags]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.system-int-test.data2.collection :as dc]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.system-int-test.system :as s]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.tag-util :as tags]))
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
@@ -141,8 +142,8 @@
       (assert-collection-refs-found [coll1-1 coll2-1 coll2-2]
                                     {:tag-data {"tag1" "ice"} :all-revisions true})
 
-      ;; disassociate tag
-      (tags/disassociate-by-concept-ids token "tag1" [{:concept-id (:concept-id coll2-1)
+      ;; dissociate tag
+      (tags/dissociate-by-concept-ids token "tag1" [{:concept-id (:concept-id coll2-1)
                                                        :revision-id (:revision-id coll2-1)}
                                                       {:concept-id (:concept-id coll1-3)
                                                        :revision-id (:revision-id coll1-3)}])
@@ -150,4 +151,3 @@
       (assert-collection-refs-found [] {:tag-data {"tag1" "snow"}})
       (assert-collection-refs-found [coll1-1 coll2-2]
                                     {:tag-data {"tag1" "ice"} :all-revisions true}))))
-

--- a/system-int-test/test/cmr/system_int_test/search/tagging/enable_disable_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/enable_disable_test.clj
@@ -105,11 +105,11 @@
         (is (= 200 (:status response)))))
 
     (testing "dissociate by query works before disable"
-      (let [response (tags/disassociate-by-query token tag1-key {:provider "PROV1"})]
+      (let [response (tags/dissociate-by-query token tag1-key {:provider "PROV1"})]
         (is (= 200 (:status response)))))
 
-    (testing "disassociate tag with collection works before disable"
-      (let [response (tags/disassociate-by-concept-ids
+    (testing "dissociate tag with collection works before disable"
+      (let [response (tags/dissociate-by-concept-ids
                                token
                                tag1-key
                                [{:concept-id (:concept-id tag-collection)}])]
@@ -123,11 +123,11 @@
         (is (= 503 (:status response)))))
 
     (testing "dissociate by query fails after disable"
-      (let [response (tags/disassociate-by-query token tag1-key {:provider "PROV1"})]
+      (let [response (tags/dissociate-by-query token tag1-key {:provider "PROV1"})]
         (is (= 503 (:status response)))))
 
-    (testing "disassociate tag with collection fails after disable"
-      (let [response (tags/disassociate-by-concept-ids
+    (testing "dissociate tag with collection fails after disable"
+      (let [response (tags/dissociate-by-concept-ids
                                token
                                tag1-key
                                [{:concept-id (:concept-id tag-collection)}])]
@@ -141,11 +141,11 @@
         (is (= 200 (:status response)))))
 
     (testing "dissociate by query works after re-enable"
-      (let [response (tags/disassociate-by-query token tag2-key {:provider "PROV1"})]
+      (let [response (tags/dissociate-by-query token tag2-key {:provider "PROV1"})]
         (is (= 200 (:status response)))))
 
-    (testing "disassociate tag with collection works after re-enable"
-      (let [response (tags/disassociate-by-concept-ids
+    (testing "dissociate tag with collection works after re-enable"
+      (let [response (tags/dissociate-by-concept-ids
                                token
                                tag2-key
                                [{:concept-id (:concept-id tag-collection)}])]

--- a/system-int-test/test/cmr/system_int_test/search/tagging/tag_acl_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/tag_acl_test.clj
@@ -119,15 +119,15 @@
       (let [tag (uniq-tag)
             {:keys [concept-id revision-id]} (tags/create-tag all-user tag)]
         (testing "Success"
-          (is (= 200 (:status (tags/disassociate-by-query update-user (:tag-key tag) {:provider "foo"}))))
-          (is (= 200 (:status (tags/disassociate-by-query all-user (:tag-key tag) {:provider "foo"})))))
+          (is (= 200 (:status (tags/dissociate-by-query update-user (:tag-key tag) {:provider "foo"}))))
+          (is (= 200 (:status (tags/dissociate-by-query all-user (:tag-key tag) {:provider "foo"})))))
 
         (testing "Failure Cases"
           (are
             [token]
             (= {:status 401
                 :errors ["You do not have permission to update a tag."]}
-               (tags/disassociate-by-query token (:tag-key tag) {:provider "foo"}))
+               (tags/dissociate-by-query token (:tag-key tag) {:provider "foo"}))
 
             nil
             guest-token

--- a/system-int-test/test/cmr/system_int_test/search/tagging/tag_association_collection_revisions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/tag_association_collection_revisions_test.clj
@@ -1,18 +1,16 @@
 (ns cmr.system-int-test.search.tagging.tag-association-collection-revisions-test
   "This tests associating tags with collection revisions."
-  (:require [clojure.test :refer :all]
-            [clojure.string :as str]
-            [cmr.common.util :refer [are2] :as util]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.search-util :as search]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.system-int-test.utils.metadata-db-util :as mdb]
-            [cmr.system-int-test.utils.tag-util :as tags]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.system-int-test.data2.collection :as dc]
-            [cmr.transmit.tag :as tt]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.system-int-test.system :as s]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer [are2] :as util]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.tag-util :as tags]))
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"}
@@ -201,7 +199,7 @@
     (index/wait-until-indexed)
 
     (testing "successful case"
-      (let [response (tags/disassociate-by-concept-ids
+      (let [response (tags/dissociate-by-concept-ids
                        token tag-key [{:concept-id (:concept-id coll2-1)
                                        :revision-id (:revision-id coll2-1)}
                                       {:concept-id (:concept-id coll3)}])]
@@ -214,16 +212,16 @@
           response)))
 
     (testing "revision-id must be an integer"
-      (let [{:keys [status errors]} (tags/disassociate-by-concept-ids
+      (let [{:keys [status errors]} (tags/dissociate-by-concept-ids
                                       token tag-key
                                       [{:concept-id (:concept-id coll1-1)
                                         :revision-id "1"}])
             expected-msg "/0/revision_id instance type (string) does not match any allowed primitive type (allowed: [\"integer\"])"]
         (is (= [400 [expected-msg]] [status errors]))))
 
-    (testing "disassociate tag of a non-existent collection revision"
+    (testing "dissociate tag of a non-existent collection revision"
       (let [concept-id (:concept-id coll1-1)
-            response (tags/disassociate-by-concept-ids
+            response (tags/dissociate-by-concept-ids
                        token tag-key
                        [{:concept-id concept-id
                          :revision-id 5}])]
@@ -233,10 +231,10 @@
                              concept-id)]}}
           response)))
 
-    (testing "disassociate tag of an invisible collection revision"
+    (testing "dissociate tag of an invisible collection revision"
       (let [concept-id (:concept-id coll4)
             revision-id (:revision-id coll4)
-            response (tags/disassociate-by-concept-ids
+            response (tags/dissociate-by-concept-ids
                        token tag-key
                        [{:concept-id concept-id
                          :revision-id revision-id}])]
@@ -246,10 +244,10 @@
                              concept-id revision-id)]}}
           response)))
 
-    (testing "disassociate tag of a tombstoned revision is invalid"
+    (testing "dissociate tag of a tombstoned revision is invalid"
       (let [concept-id (:concept-id coll1-2-tombstone)
             revision-id (:revision-id coll1-2-tombstone)
-            response (tags/disassociate-by-concept-ids
+            response (tags/dissociate-by-concept-ids
                        token tag-key
                        [{:concept-id concept-id
                          :revision-id revision-id}])
@@ -260,8 +258,8 @@
           {[concept-id revision-id] {:errors [expected-msg]}}
           response)))
 
-    (testing "disassociate tag of collection that already has collection revision tagging"
-      (let [response (tags/disassociate-by-concept-ids
+    (testing "dissociate tag of collection that already has collection revision tagging"
+      (let [response (tags/dissociate-by-concept-ids
                        token tag-key [{:concept-id (:concept-id coll1-3)}])
             expected-msg (format "Tag [%s] is not associated with collection [%s]."
                                  tag-key (:concept-id coll1-3))]
@@ -269,10 +267,10 @@
           {[(:concept-id coll1-3)] {:warnings [expected-msg]}}
           response)))
 
-    (testing "disassociate tag of individual collection revision that already has been tagged at the collection level"
+    (testing "dissociate tag of individual collection revision that already has been tagged at the collection level"
       (let [concept-id (:concept-id coll3)
             revision-id (:revision-id coll3)
-            response (tags/disassociate-by-concept-ids
+            response (tags/dissociate-by-concept-ids
                        token tag-key
                        [{:concept-id concept-id
                          :revision-id revision-id}])
@@ -283,10 +281,10 @@
           {[concept-id revision-id] {:warnings [expected-msg]}}
           response)))
 
-    (testing "disassociate tag of collection revisions mixed response"
+    (testing "dissociate tag of collection revisions mixed response"
       (let [concept-id (:concept-id coll1-1)
             revision-id (:revision-id coll1-1)
-            response (tags/disassociate-by-concept-ids
+            response (tags/dissociate-by-concept-ids
                        token tag-key
                        [{:concept-id concept-id :revision-id 5}
                         {:concept-id concept-id :revision-id revision-id}])]
@@ -297,7 +295,7 @@
            [concept-id revision-id] {:concept-id "TA1200000005-CMR" :revision-id 2}}
           response)))))
 
-(deftest associate-disassociate-tag-with-collection-revisions-test
+(deftest associate-dissociate-tag-with-collection-revisions-test
   ;; Grant all collections in PROV1
   (e/grant-registered-users (s/context) (e/coll-catalog-item-id "PROV1"))
   (let [coll1-1 (d/ingest "PROV1" (dc/collection {:entry-title "et1"}))
@@ -343,13 +341,13 @@
     (assert-tag-association token [coll1-1 coll1-2 coll1-3 coll2-2] "tag1" {:all-revisions true})
     (assert-tag-association token [coll1-3 coll2-1] "tag2" {:all-revisions true})
 
-    ;; disassociate tag1 from coll1-2 and coll2-2
-    (tags/disassociate-by-concept-ids token "tag1" [{:concept-id (:concept-id coll1-2)
+    ;; dissociate tag1 from coll1-2 and coll2-2
+    (tags/dissociate-by-concept-ids token "tag1" [{:concept-id (:concept-id coll1-2)
                                                      :revision-id (:revision-id coll1-2)}
                                                     {:concept-id (:concept-id coll2-2)
                                                      :revision-id (:revision-id coll2-2)}])
-    ;; disassociate tag2 from coll1-3
-    (tags/disassociate-by-concept-ids token "tag2" [{:concept-id (:concept-id coll1-3)
+    ;; dissociate tag2 from coll1-3
+    (tags/dissociate-by-concept-ids token "tag2" [{:concept-id (:concept-id coll1-3)
                                                      :revision-id (:revision-id coll1-3)}])
     (index/wait-until-indexed)
     ;; verify association, latest revision

--- a/transmit-lib/src/cmr/transmit/tag.clj
+++ b/transmit-lib/src/cmr/transmit/tag.clj
@@ -1,10 +1,11 @@
 (ns cmr.transmit.tag
   "This contains functions for interacting with the tagging API."
-  (:require [cmr.transmit.connection :as conn]
-            [cmr.transmit.config :as config]
-            [ring.util.codec :as codec]
-            [cmr.transmit.http-helper :as h]
-            [cheshire.core :as json]))
+  (:require
+   [cheshire.core :as json]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]
+   [cmr.transmit.http-helper :as h]
+   [ring.util.codec :as codec]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -72,8 +73,8 @@
                                        :accept :json}
                                       http-options)}))))
 
-(defn disassociate-tag
-  "Sends a request to disassociate the tag with collections based on the given association type.
+(defn dissociate-tag
+  "Sends a request to dissociate the tag with collections based on the given association type.
   Valid association type are :query and :concept-ids.
   Valid options are
   * :raw? - set to true to indicate the raw response should be returned. See
@@ -82,7 +83,7 @@
   be used.
   * http-options - Other http-options to be sent to clj-http."
   ([association-type context concept-id content]
-   (disassociate-tag context concept-id content nil))
+   (dissociate-tag context concept-id content nil))
   ([association-type context concept-id content {:keys [raw? token http-options]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]


### PR DESCRIPTION
This PR has no real code change except added logging and fixed typos. The logging is added so that we can monitor tagging request better.