### PR TITLE
Cmr 3965 umm update

### DIFF
--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -40,13 +40,11 @@
           "type": "string"
         },
         "update-value": {
-          "type": "string"
+          "type": "object"
         },
         "find-value": {
-          "type": "string"
+          "type": "object"
         }
     },
-    "required": ["update-type", "update-field"],
-    "oneOf": [{"required": ["concept-ids"]},
-              {"required": ["collection-ids"]}]
+    "required": ["update-type", "update-field", "concept-ids"]
 }

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -165,6 +165,11 @@
   (update-bulk-update-collection-status (context->db context) task-id concept-id
     status status-message))
 
+(defn reset-db
+  "Clear bulk update db"
+  [context]
+  (reset-bulk-update (context->db context)))
+
 (comment
   (reset-bulk-update (context->db context))
   (def db (context->db context)))

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -114,7 +114,8 @@
   (reset-bulk-update
     [this]
     (reset! task-status-atom [])
-    (reset! collection-status-atom []))
+    (reset! collection-status-atom [])
+    (reset! task-id-atom 0))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   lifecycle/Lifecycle

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -1,12 +1,17 @@
 (ns cmr.ingest.services.bulk-update-service
   (:require
+   [camel-snake-kebab.core :as csk]
    [cheshire.core :as json]
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [cmr.common.services.errors :as errors]
    [cmr.common.validations.json-schema :as js]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
-   [cmr.transmit.metadata-db2 :as mdb2]))
+   [cmr.ingest.services.ingest-service :as ingest-service]
+   [cmr.transmit.metadata-db :as mdb]
+   [cmr.transmit.metadata-db2 :as mdb2]
+   [cmr.umm-spec.field-update :as field-update]))
 
 (def bulk-update-schema
   (js/json-string->json-schema (slurp (io/resource "bulk_update_schema.json"))))
@@ -56,16 +61,56 @@
        (ingest-events/ingest-collection-bulk-update-event
          task-id concept-id bulk-update-params)))))
 
+(defn- update-collection
+  "Perform the update on the collection"
+  [context concept bulk-update-params]
+  (let [{:keys [update-type update-field find-value update-value]} bulk-update-params
+        update-type (csk/->kebab-case-keyword update-type)
+        update-field (csk/->PascalCaseKeyword update-field)]
+    (field-update/update-concept context concept update-type update-field
+                                 update-value find-value)))
+
+
+(defn- update-and-save-collection
+  "Make collection updates, go through ingest validation. Attempt save to
+  metadata db. If validation or save errors are thrown, they will be caught and
+  handled in handle-collection-bulk-update-event. If warnings were returned,
+  return a warning string."
+  [context concept bulk-update-params]
+  (let [updated-metadata (update-collection context concept bulk-update-params)
+        concept (-> concept
+                    (assoc :metadata updated-metadata)
+                    (update :revision-id inc))
+        ;; If errors are caught, an error will be thrown and logged to the DB
+        ;; If we get warnings back, validation was successful, but will still
+        ;; log warnings
+        {:keys [concept warnings]} (ingest-service/validate-and-prepare-collection
+                                     context concept nil)]
+    (mdb/save-concept context concept)
+    (when (seq warnings)
+      (str "Collection was updated successfully, but translating the collection "
+           "to UMM-C had the following issues: "
+           (str/join "; " warnings)))))
+
 (defn handle-collection-bulk-update-event
   "Perform update for the given concept id. Log an error status of the concept
   cannot be found."
   [context task-id concept-id bulk-update-params]
   (try
     (if-let [concept (mdb2/get-latest-concept context concept-id)]
-      (data-bulk-update/update-bulk-update-task-collection-status context task-id
-        concept-id "COMPLETE" nil)
+      (let [success-status-message (update-and-save-collection context concept bulk-update-params)]
+        (data-bulk-update/update-bulk-update-task-collection-status context task-id
+          concept-id "COMPLETE" success-status-message))
       (data-bulk-update/update-bulk-update-task-collection-status context task-id
         concept-id "FAILED" (format "Concept-id [%s] is not valid." concept-id)))
+    (catch clojure.lang.ExceptionInfo ex-info
+      (if (= :conflict (:type (.getData ex-info)))
+        ;; Concurrent update - re-queue concept update
+        (ingest-events/publish-ingest-event context
+          (ingest-events/ingest-collection-bulk-update-event
+            task-id concept-id bulk-update-params))
+        (data-bulk-update/update-bulk-update-task-collection-status
+          context task-id concept-id "FAILED" (.getMessage ex-info))))
     (catch Exception e
       (let [message (.getMessage e)
             concept-id-message (re-find #"Concept-id.*is not valid." message)]

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -96,7 +96,7 @@
          (string/join "; " warnings))))
 
 (defn handle-collection-bulk-update-event
-  "Perform update for the given concept id. Log an error status of the concept
+  "Perform update for the given concept id. Log an error status if the concept
   cannot be found."
   [context task-id concept-id bulk-update-params]
   (try
@@ -110,9 +110,11 @@
     (catch clojure.lang.ExceptionInfo ex-info
       (if (= :conflict (:type (.getData ex-info)))
         ;; Concurrent update - re-queue concept update
-        (ingest-events/publish-ingest-event context
-          (ingest-events/ingest-collection-bulk-update-event
-            task-id concept-id bulk-update-params))
+        (ingest-events/publish-ingest-event
+         context
+         (ingest-events/ingest-collection-bulk-update-event task-id
+                                                            concept-id
+                                                            bulk-update-params))
         (data-bulk-update/update-bulk-update-task-collection-status
           context task-id concept-id "FAILED" (.getMessage ex-info))))
     (catch Exception e

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -9,6 +9,7 @@
     [cmr.common.services.messages :as cmsg]
     [cmr.common.util :as util :refer [defn-timed]]
     [cmr.ingest.config :as config]
+    [cmr.ingest.data.bulk-update :as bulk-update]
     [cmr.ingest.data.ingest-events :as ingest-events]
     [cmr.ingest.data.provider-acl-hash :as pah]
     [cmr.ingest.services.helper :as h]
@@ -222,6 +223,7 @@
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
     (queue/reset queue-broker))
+  (bulk-update/reset-db context)
   (cache/reset-caches context))
 
 (def health-check-fns

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -15,7 +15,10 @@
   {:concept-ids ["C1", "C2", "C3"]
    :update-type "ADD_TO_EXISTING"
    :update-field "SCIENCE_KEYWORDS"
-   :update-value "X"})
+   :update-value {:Category "EARTH SCIENCE"
+                  :Topic "HUMAN DIMENSIONS"
+                  :Term "ENVIRONMENTAL IMPACTS"
+                  :VariableLevel1 "HEAVY METALS CONCENTRATION"}})
 
 (defn- grant-permissions-create-token
   "Test setup to create read/update ingest permissions for bulk update and
@@ -63,13 +66,11 @@
               (is (= status-code status))
               (is (= error-messages errors)))
 
-            "Missing collection identifiers"
+            "Missing concept-ids"
             {:update-field "SCIENCE_KEYWORDS"
              :update-type "ADD_TO_EXISTING"}
             400
-            ["instance failed to match exactly one schema (matched 0 out of 2)"
-             "object has missing required properties ([\"concept-ids\"])"
-             "object has missing required properties ([\"collection-ids\"])"]
+            ["object has missing required properties ([\"concept-ids\"])"]
 
             "0 concept-ids"
             {:concept-ids []
@@ -78,26 +79,6 @@
             400
             ["/concept-ids array is too short: must have at least 1 elements but instance has 0 elements"]
 
-            "0 collection ids"
-            {:collection-ids []
-             :update-field "SCIENCE_KEYWORDS"
-             :update-type "ADD_TO_EXISTING"}
-            400
-            ["/collection-ids array is too short: must have at least 1 elements but instance has 0 elements"]
-
-            "Missing short-name"
-            {:collection-ids [{:version "V1"}]
-             :update-field "SCIENCE_KEYWORDS"
-             :update-type "ADD_TO_EXISTING"}
-            400
-            ["/collection-ids/0 object has missing required properties ([\"short-name\"])"]
-
-            "Missing version"
-            {:collection-ids [{:short-name "ABC"}]
-             :update-field "SCIENCE_KEYWORDS"
-             :update-type "ADD_TO_EXISTING"}
-            400
-            ["/collection-ids/0 object has missing required properties ([\"version\"])"]
 
             "Missing update field"
             {:concept-ids ["C1", "C2", "C3"]
@@ -129,9 +110,44 @@
             {:concept-ids ["C1", "C2", "C3"]
              :update-field "SCIENCE_KEYWORDS"
              :update-type "FIND_AND_REPLACE"
-             :update-value "X"}
+             :update-value {:Category "EARTH SCIENCE"
+                            :Topic "HUMAN DIMENSIONS"
+                            :Term "ENVIRONMENTAL IMPACTS"
+                            :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
             400
             ["A find value must be supplied when the update is of type FIND_AND_REPLACE"]))))
+
+            ;; Short-name/version currently not supported. Support will be added
+            ;; back in with CMR-4129
+
+            ; "Missing collection identifiers"
+            ; {:update-field "SCIENCE_KEYWORDS"
+            ;  :update-type "ADD_TO_EXISTING"}
+            ; 400
+            ; ["instance failed to match exactly one schema (matched 0 out of 2)"
+            ;  "object has missing required properties ([\"concept-ids\"])"
+            ;  "object has missing required properties ([\"collection-ids\"])"]
+            ;
+            ; "0 collection ids"
+            ; {:collection-ids []
+            ;  :update-field "SCIENCE_KEYWORDS"
+            ;  :update-type "ADD_TO_EXISTING"}
+            ; 400
+            ; ["/collection-ids array is too short: must have at least 1 elements but instance has 0 elements"]
+            ;
+            ; "Missing short-name"
+            ; {:collection-ids [{:version "V1"}]
+            ;  :update-field "SCIENCE_KEYWORDS"
+            ;  :update-type "ADD_TO_EXISTING"}
+            ; 400
+            ; ["/collection-ids/0 object has missing required properties ([\"short-name\"])"]
+            ;
+            ; "Missing version"
+            ; {:collection-ids [{:short-name "ABC"}]
+            ;  :update-field "SCIENCE_KEYWORDS"
+            ;  :update-type "ADD_TO_EXISTING"}
+            ; 400
+            ; ["/collection-ids/0 object has missing required properties ([\"version\"])"]))))
 
 (deftest bulk-update-status-endpoint-validation
   (testing "Invalid provider"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
@@ -30,7 +30,10 @@
         bulk-update-body {:concept-ids concept-ids
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
-                          :update-value "X"}
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "HUMAN DIMENSIONS"
+                                         :Term "ENVIRONMENTAL IMPACTS"
+                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         json-body (json/generate-string bulk-update-body)]
 
     (testing "Bulk update response"
@@ -88,7 +91,10 @@
   (let [bulk-update-body {:concept-ids ["C1200000100-PROV1" "C111"]
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
-                          :update-value "X"}
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "HUMAN DIMENSIONS"
+                                         :Term "ENVIRONMENTAL IMPACTS"
+                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         json-body (json/generate-string bulk-update-body)
         {:keys [task-id]} (ingest/bulk-update-collections "PROV1" bulk-update-body)
         _ (qb-side-api/wait-for-terminal-states)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -1,0 +1,73 @@
+(ns cmr.system-int-test.ingest.bulk-update.bulk-update-test
+  "CMR bulk update. Test the actual update "
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(def collection-formats
+  "Formats to test bulk update"
+  [:dif :dif10 :echo10 :iso19115 :iso-smap :umm-json])
+
+(defn- generate-concept-id
+  [index provider]
+  (format "C120000000%s-%s" index provider))
+
+(deftest bulk-update-science-keywords
+  ;; Ingest a collection in each format with science keywords to update
+  (let [concept-ids (for [x (range (count collection-formats))
+                          :let [format (nth collection-formats x)]]
+                      (:concept-id (ingest/ingest-concept
+                                     (assoc
+                                       (data-umm-c/collection-concept
+                                         (data-umm-c/collection
+                                           x
+                                           {:ScienceKeywords
+                                             [{:Category "EARTH SCIENCE"
+                                               :Topic "OCEANS"
+                                               :Term "MARINE SEDIMENTS"}]})
+                                         format)
+                                       :concept-id
+                                       (generate-concept-id x "PROV1")))))
+        _ (index/wait-until-indexed)
+        bulk-update-body {:concept-ids concept-ids
+                          :update-type "ADD_TO_EXISTING"
+                          :update-field "SCIENCE_KEYWORDS"
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "HUMAN DIMENSIONS"
+                                         :Term "ENVIRONMENTAL IMPACTS"
+                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}]
+       ;; Kick off bulk update
+       (ingest/bulk-update-collections "PROV1" bulk-update-body)
+       ;; Wait for queueing/indexing to catch up
+       (index/wait-until-indexed)
+       (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+         (def collection-response collection-response)
+         (is (= "COMPLETE" (:task-status collection-response))))
+
+       ;; Check that each concept was updated
+       (doseq [concept-id concept-ids
+               :let [concept (-> (search/find-concepts-umm-json
+                                   :collection {:concept-id concept-id})
+                                 :results
+                                 :items
+                                 first)]]
+        (is (= 2
+              (:revision-id (:meta concept))))
+        (is (= (:ScienceKeywords (:umm concept))
+               [{:Category "EARTH SCIENCE"
+                 :Term "MARINE SEDIMENTS"
+                 :Topic "OCEANS"}
+                {:VariableLevel1 "HEAVY METALS CONCENTRATION"
+                 :Category "EARTH SCIENCE"
+                 :Term "ENVIRONMENTAL IMPACTS"
+                 :Topic "HUMAN DIMENSIONS"}])))))

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -1,0 +1,50 @@
+(ns cmr.umm-spec.field-update
+ "Functions to apply an update of a particular type to a field-translation"
+ (:require
+  [cmr.umm-spec.umm-spec-core :as spec-core]))
+
+(defn- value-matches?
+  "Return true if the value is a match on find value."
+  [find-value value]
+  (= (select-keys value (keys find-value))
+     find-value))
+
+(defmulti apply-umm-update
+  "Apply the umm update by type"
+  (fn [update-type umm update-field update-value find-value]
+    update-type))
+
+(defmethod apply-umm-update :add-to-existing
+  [update-type umm update-field update-value find-value]
+  (update umm update-field #(conj % update-value)))
+
+(defmethod apply-umm-update :clear-all-and-replace
+  [update-type umm update-field update-value find-value]
+  (assoc umm update-field [update-value]))
+
+(defmethod apply-umm-update :find-and-remove
+  [update-type umm update-field update-value find-value]
+  (if (seq (get umm update-field))
+    (update umm update-field #(remove (fn [x]
+                                        (value-matches? find-value x))
+                                      %))
+    umm))
+
+(defmethod apply-umm-update :find-and-replace
+  [update-type umm update-field update-value find-value]
+  (if (seq (get umm update-field))
+    (update umm update-field #(map (fn [x]
+                                     (if (value-matches? find-value x)
+                                       update-value
+                                       x))
+                                   %))
+    umm))
+
+(defn update-concept
+  "Apply an update to a raw concept. Convert to UMM, apply the update, and
+  convert back to native format."
+  [context concept update-type update-field update-value find-value]
+  (let [{:keys [format metadata concept-type]} concept
+        umm (spec-core/parse-metadata context concept-type format metadata {:sanitize? false})
+        umm (apply-umm-update update-type umm update-field update-value find-value)]
+    (spec-core/generate-metadata context umm (:format concept))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -1,0 +1,128 @@
+(ns cmr.umm-spec.test.field-update
+ "Unit tests for UMM field update functionality"
+ (:require
+  [clojure.test :refer :all]
+  [cmr.common.util :refer [are3]]
+  [cmr.umm-spec.field-update :as field-update]))
+
+(deftest science-keyword-field-updates
+  (testing "Existing science keywords"
+    (let [umm {:EntryTitle "Test"
+               :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                                 {:Category "EARTH SCIENCE SERVICES" :Topic "topic" :Term "term"
+                                  :VariableLevel1 "var 1" :VariableLevel2 "var 2"
+                                  :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}]
+     (are3 [update-type update-value find-value result]
+       (is (= result
+              (field-update/apply-umm-update update-type umm :ScienceKeywords update-value find-value)))
+
+       "Clear and replace"
+       :clear-all-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       nil
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+
+       "Add to existing"
+       :add-to-existing
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       nil
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES" :Topic "topic" :Term "term"
+                           :VariableLevel1 "var 1" :VariableLevel2 "var 2"
+                           :VariableLevel3 "var 3" :DetailedVariable "detailed"}
+                          {:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+
+       "Find and remove"
+       :find-and-remove
+       nil
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}]}
+
+       "Find and remove, not found"
+       :find-and-remove
+       nil
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "Topic"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES" :Topic "topic" :Term "term"
+                           :VariableLevel1 "var 1" :VariableLevel2 "var 2"
+                           :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}
+
+       "Find and replace"
+       :find-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+
+       "Find and replace, not found"
+       :find-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "Topic"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES" :Topic "topic" :Term "term"
+                           :VariableLevel1 "var 1" :VariableLevel2 "var 2"
+                           :VariableLevel3 "var 3" :DetailedVariable "detailed"}]})))
+
+  (testing "No science keywords"
+    (let [umm {:EntryTitle "Test"}]
+     (are3 [update-type update-value find-value result]
+       (is (= result
+              (field-update/apply-umm-update update-type umm :ScienceKeywords update-value find-value)))
+
+       "Clear and replace"
+       :clear-all-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       nil
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+
+       "Add to existing"
+       :add-to-existing
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       nil
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+
+       "Find and remove"
+       :find-and-remove
+       nil
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"}
+
+       "Find and replace"
+       :find-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"}))))


### PR DESCRIPTION
This is another part of CMR-3965. Put in the framework to bulk update collections through umm conversion, save to metadata db, and report errors. This is not going to handle every bulk update case, but right now focusing on science keywords as that is the main use case and goal of this PI. I will have another PR coming for this ticket with more fields to bulk update.

