### PR TITLE
CMR-3529 Added logging for when the report generator runs as a job.

### DIFF
--- a/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
@@ -175,6 +175,7 @@
 ;; A job for generating the humanizers report
 (defjob HumanizerReportGeneratorJob
   [ctx system]
+  (info "Running scheduled job for generating the humanizer report ...")
   (let [context {:system system}]
     (cache/reset (cache/context->cache context report-cache-key))
     (humanizers-report-csv context)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -1,19 +1,20 @@
 (ns cmr.system-int-test.search.collection-directory-pages-test
   "This tests a running CMR site's directory links at all levels: top-most,
   eosdis, and provider."
-  (:require [clj-http.client :as client]
-            [clojure.test :refer :all]
-            [clojure.string :as string]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.search.site.routes :as r]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.system-int-test.system :as s]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.tag-util :as tags]
-            [cmr.transmit.config :as transmit-config]
-            [cmr.umm-spec.models.umm-common-models :as cm]
-            [cmr.umm-spec.test.expected-conversion :as exp-conv]))
+  (:require
+   [clj-http.client :as client]
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.search.site.routes :as r]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.tag-util :as tags]
+   [cmr.transmit.config :as transmit-config]
+   [cmr.umm-spec.models.umm-common-models :as cm]
+   [cmr.umm-spec.test.expected-conversion :as exp-conv]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants and general utility functions for the tests

--- a/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
@@ -33,7 +33,7 @@
 ;;  curl http://localhost:3003/humanizers/report
 
 (defn- get-cached-report
-  "Gets the value for a given key from the given cache."
+  "Pull the report data from its cache."
   []
   (let [full-url (str (url/search-read-caches-url)
                       "/"


### PR DESCRIPTION
This is important for troubleshooting in production.

I'm not yet convinced that this job is running as expected in AWS deployments. When I hit a deployment URL for the report this morning, it look a long time to get the download data; this should not have happened. The report data should have already been made available in the cache and thus downloaded immediately. It seems that the initial request I made today was what generated the report, indicating that the report did not generate upon post-deployment startup of CMR.

Fortunately, it did cache and my next request was immediate. However, I do have concerns about the job execution and would like to check ElasticSearch after deployments to ensure that it is running as a properly scheduled job.