### PR TITLE
CMR-4132 - Attempt to fix ingest application public root URL again

### DIFF
--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -40,11 +40,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_ACCESS_CONTROL_PUBLIC_PROTOCOL"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "http"})
 
 (defconfig access-control-public-host
@@ -52,11 +49,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_ACCESS_CONTROL_PUBLIC_HOST"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "localhost"})
 
 (defconfig access-control-public-port
@@ -64,19 +58,17 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_ACCESS_CONTROL_PUBLIC_PORT"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default 3011
    :type Long})
 
-(def public-conf
+(defn public-conf
   "Public access-control configuration used for generating proper link URLs in
   dynamic content (templates), generating example requests in documentation,
   and running the access-control service in the development environment for use
   with integration tests."
+  []
   {:protocol (access-control-public-protocol)
    :host (access-control-public-host)
    :port (access-control-public-port)
@@ -104,7 +96,7 @@
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                       common-health/health-cache-key (common-health/create-health-cache)}
 
-             :public-conf public-conf
+             :public-conf (public-conf)
              :relative-root-url (transmit-config/access-control-relative-root-url)
              :scheduler (jobs/create-scheduler
                          `system-holder

--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -31,26 +31,52 @@
   {:default nil
    :parser cfg/maybe-long})
 
-(defconfig access-control-public-protocol
-  "The protocol to use in documentation examples for the access-control application."
-  {:default "http"})
-
-(defconfig access-control-public-host
-  "The host name to use in links returned by the access-control application."
-  {:default "localhost"})
-
-(defconfig access-control-public-port
-  "The port to use in links returned by the access-control application."
-  {:default 3011
-   :type Long})
-
 (defconfig log-level
   "App logging level"
   {:default "info"})
 
-(defn public-conf
-  "Public access-control configuration used for generating example requests in documentation"
-  []
+(defconfig access-control-public-protocol
+  "The protocol to use for public access to the access-control application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_ACCESS_CONTROL_PUBLIC_PROTOCOL"
+  {:default "http"})
+
+(defconfig access-control-public-host
+  "The host name to use for public access to the access-control application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_ACCESS_CONTROL_PUBLIC_HOST"
+  {:default "localhost"})
+
+(defconfig access-control-public-port
+  "The port to use for public access to the access-control application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_ACCESS_CONTROL_PUBLIC_PORT"
+  {:default 3011
+   :type Long})
+
+(def public-conf
+  "Public access-control configuration used for generating proper link URLs in
+  dynamic content (templates), generating example requests in documentation,
+  and running the access-control service in the development environment for use
+  with integration tests."
   {:protocol (access-control-public-protocol)
    :host (access-control-public-host)
    :port (access-control-public-port)
@@ -78,7 +104,7 @@
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                       common-health/health-cache-key (common-health/create-health-cache)}
 
-             :public-conf (public-conf)
+             :public-conf public-conf
              :relative-root-url (transmit-config/access-control-relative-root-url)
              :scheduler (jobs/create-scheduler
                          `system-holder

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -187,11 +187,11 @@
               ;; of templates which (indirectly) make use of/require app
               ;; public-conf data.
               (assoc-in [:apps :search :public-conf]
-                        search-system/public-conf)
+                        (search-system/public-conf))
               (assoc-in [:apps :access-control :public-conf]
-                        access-control-system/public-conf)
+                        (access-control-system/public-conf))
               (assoc-in [:apps :ingest :public-conf]
-                        ingest-system/public-conf))]
+                        (ingest-system/public-conf)))]
     (alter-var-root #'system
                     (constantly
                       (system/start s))))

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -48,11 +48,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_INGEST_PUBLIC_PROTOCOL"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "http"})
 
 (defconfig ingest-public-host
@@ -60,11 +57,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_INGEST_PUBLIC_HOST"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "localhost"})
 
 (defconfig ingest-public-port
@@ -72,19 +66,17 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_INGEST_PUBLIC_PORT"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default 3002
    :type Long})
 
-(def public-conf
+(defn public-conf
   "Public ingest configuration used for generating proper link URLs in dynamic
   content (templates), generating example requests in documentation, and
   running the ingest service in the development environment for use with
   integration tests."
+  []
   {:protocol (ingest-public-protocol)
    :host (ingest-public-host)
    :port (ingest-public-port)
@@ -113,7 +105,7 @@
                        common-health/health-cache-key (common-health/create-health-cache)
                        common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                        humanizer-alias-cache/humanizer-alias-cache-key (humanizer-alias-cache/create-cache)}
-              :public-conf public-conf
+              :public-conf (public-conf)
               :queue-broker (queue-broker/create-queue-broker (config/queue-config))}]
      (transmit-config/system-with-connections
       sys [:metadata-db :indexer :access-control :echo-rest :search :cubby :kms]))))

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -39,17 +39,55 @@
   "Required for jobs"
   (atom nil))
 
-(defconfig public-protocol
-  "The protocol to use in documentation examples for the ingest application."
-  {:default "http"})
-
 (defconfig log-level
   "App logging level"
   {:default "info"})
 
+(defconfig ingest-public-protocol
+  "The protocol to use for public access to the ingest application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_INGEST_PUBLIC_PROTOCOL"
+  {:default "http"})
+
+(defconfig ingest-public-host
+  "The host name to use for public access to the ingest application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_INGEST_PUBLIC_HOST"
+  {:default "localhost"})
+
+(defconfig ingest-public-port
+  "The port to use for public access to the ingest application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_INGEST_PUBLIC_PORT"
+  {:default 3002
+   :type Long})
+
 (def public-conf
-  "Public ingest configuration used for generating example requests in documentation"
-  {:protocol (public-protocol)
+  "Public ingest configuration used for generating proper link URLs in dynamic
+  content (templates), generating example requests in documentation, and
+  running the ingest service in the development environment for use with
+  integration tests."
+  {:protocol (ingest-public-protocol)
+   :host (ingest-public-host)
+   :port (ingest-public-port)
    :relative-root-url (transmit-config/ingest-relative-root-url)})
 
 (defn create-system

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -38,11 +38,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_SEARCH_PUBLIC_PROTOCOL"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "http"})
 
 (defconfig search-public-host
@@ -50,11 +47,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_SEARCH_PUBLIC_HOST"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default "localhost"})
 
 (defconfig search-public-port
@@ -62,11 +56,8 @@
 
   Note: this configuration value is used as-is in local, dev environments
   and is overridden with ENV variables in remote deployments. In both cases,
-  this configuration information is utilized and required.
-
-  The name given after `defconfig` is important and is used when checking for
-  an ENV variable. The ENV variable for this configuration will be:
-  * CMR_SEARCH_PUBLIC_PORT"
+  this configuration information is utilized and required. See `defconfig` for
+  more details."
   {:default 3003
    :type Long})
 
@@ -79,11 +70,12 @@
   "App logging level"
   {:default "info"})
 
-(def public-conf
+(defn public-conf
   "Public search configuration used for generating proper link URLs in dynamic
   content (templates), generating example requests in documentation, and
   running the search service in the development environment for use with
   integration tests."
+  []
   {:protocol (search-public-protocol)
    :host (search-public-host)
    :port (search-public-port)
@@ -128,7 +120,7 @@
                       common-health/health-cache-key (common-health/create-health-cache)
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                       hrs/report-cache-key (hrs/create-report-cache)}
-             :public-conf public-conf
+             :public-conf (public-conf)
              collection-renderer/system-key (collection-renderer/create-collection-renderer)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)
              :scheduler (jobs/create-scheduler

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -34,15 +34,39 @@
 ;; Design based on http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts
 
 (defconfig search-public-protocol
-  "The protocol to use in links returned by the search application."
+  "The protocol to use for public access to the search application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_SEARCH_PUBLIC_PROTOCOL"
   {:default "http"})
 
 (defconfig search-public-host
-  "The host name to use in links returned by the search application."
+  "The host name to use for public access to the search application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_SEARCH_PUBLIC_HOST"
   {:default "localhost"})
 
 (defconfig search-public-port
-  "The port to use in links returned by the search application."
+  "The port to use for public access to the search application.
+
+  Note: this configuration value is used as-is in local, dev environments
+  and is overridden with ENV variables in remote deployments. In both cases,
+  this configuration information is utilized and required.
+
+  The name given after `defconfig` is important and is used when checking for
+  an ENV variable. The ENV variable for this configuration will be:
+  * CMR_SEARCH_PUBLIC_PORT"
   {:default 3003
    :type Long})
 
@@ -55,7 +79,11 @@
   "App logging level"
   {:default "info"})
 
-(def search-public-conf
+(def public-conf
+  "Public search configuration used for generating proper link URLs in dynamic
+  content (templates), generating example requests in documentation, and
+  running the search service in the development environment for use with
+  integration tests."
   {:protocol (search-public-protocol)
    :host (search-public-host)
    :port (search-public-port)
@@ -100,7 +128,7 @@
                       common-health/health-cache-key (common-health/create-health-cache)
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                       hrs/report-cache-key (hrs/create-report-cache)}
-             :public-conf search-public-conf
+             :public-conf public-conf
              collection-renderer/system-key (collection-renderer/create-collection-renderer)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)
              :scheduler (jobs/create-scheduler

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -1,10 +1,20 @@
 (ns cmr.transmit.config
-  "Contains functions for retrieving application connection information from environment variables"
+  "Contains functions for retrieving application connection information from
+  environment variables.
+
+  The data which this namespace provides to CMR apps is used in all deployment
+  environments for sharing configuration values that are transmitted over a
+  private network, containing values that are specifically for service-to-service
+  communications and not values to be accesed or evaluated over public networks.
+
+  On occasion, application will set their publicly-facing configuration values
+  with those that are defined here, but instances such as that are simply
+  where there are values which are the same in both and not expected to change
+  between public and private communications."
   (:require [cmr.common.config :as cfg :refer [defconfig]]
             [cmr.common.util :as util]
             [cmr.transmit.connection :as conn]
             [camel-snake-kebab.core :as csk]))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants for help in testing.


### PR DESCRIPTION
It seems that the last attempt to fix this bug was only a partial success: the ingest application is now using the same public conf set as the other apps and a little bit more configuration data has made it into the base url for the ingest app. Sadly, `cmr.ingest.system/public-conf` did not set the host and port (though it did set the protocol/scheme). Instead of the old value of `null://null:null` we are now getting `http://null:null`. 

In order to address that, there are two steps necessary:

1. the new ingest config data in this PR
1. an update to the ingest config overrides in the configuration service for CMR

With both of those changes, we *should* see this further updated to the full `https://cmr.sit.earthdata.nasa.gov:443` when this gets rolled out to SIT.

Updates:
* Brought access-control, ingest, and search systems into closer parity
* Also, updated dev-system to use the `public-conf`s defined in the respective projects.

In particular, since I am new to this part of the CMR, please examine the following for proper usage and accuracy:
* All three systems are now setting public values for scheme, host, and port
* All of these have new docstrings ~~which attempt to better describe what's going on and what ENV vars will map to them~~
* The `cmr.transmit.config` ns docstring has been updated with more details
