### PR TITLE
CMR-4117 Humanizers not showing non-english characters correctly

### DIFF
--- a/transmit-lib/src/cmr/transmit/humanizer.clj
+++ b/transmit-lib/src/cmr/transmit/humanizer.clj
@@ -53,5 +53,9 @@
                  :method :get
                  :raw? raw?
                  :http-options (merge {:headers headers
-                                       :accept :json}
+                                       :accept :json
+                                       ;; :decompress-body false is needed to
+                                       ;; workaround an issue with clj-http.client
+                                       ;; not handling gzip and unicode characters
+                                       :decompress-body false}
                                       http-options)}))))


### PR DESCRIPTION
There's a bug with clj-http.client that brings back non-English characters correctly when decompressing gzip. 

We can't upgrade clj-http at the moment because the newer versions of clj-http cause problems with our parameter parsing, so Chris and I determined this was an acceptable workaround.

I am going to write another ticket to explore other places in our code where this may be occurring. Through normal curl everything is fine.