### PR TITLE
CMR-4134 - Added variable validation.

### DIFF
--- a/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
@@ -95,4 +95,5 @@
                 concept-id-validation
                 version-is-not-nil-validation
                 collection-update-validation]
-   :granule []})
+   :granule []
+   :variable []})

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -120,28 +120,30 @@
                                 collection
                                 (when (:validate-keywords? validation-options)
                                   [(keyword-validations context)])))]
-    (if (or (:validate-umm? validation-options) (config/return-umm-spec-validation-errors)
+    (if (or (:validate-umm? validation-options)
+            (config/return-umm-spec-validation-errors)
             (not warn?))
-     (errors/throw-service-errors :invalid-data err-messages)
-     (do
-      (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
-      err-messages))))
+      (errors/throw-service-errors :invalid-data err-messages)
+      (do
+        (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
+        err-messages))))
 
 (defn umm-spec-validate-collection-warnings
- "Validate umm-spec collection validation warnings functions - errors that we want
- to report but we do not want to fail ingest."
- [collection validation-options context]
- (when-let [err-messages (seq (umm-spec-validation/validate-collection-warnings
-                               collection))]
-   (if (or (:validate-umm? validation-options) (config/return-umm-spec-validation-errors))
-     (errors/throw-service-errors :invalid-data err-messages)
-     (do
-      (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
-      err-messages))))
+  "Validate umm-spec collection validation warnings functions - errors that we want
+  to report but we do not want to fail ingest."
+  [collection validation-options context]
+  (when-let [err-messages (seq (umm-spec-validation/validate-collection-warnings
+                                collection))]
+    (if (or (:validate-umm? validation-options)
+            (config/return-umm-spec-validation-errors))
+      (errors/throw-service-errors :invalid-data err-messages)
+      (do
+        (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
+        err-messages))))
 
 (defn validate-granule-umm-spec
   "Validates a UMM granule record using rules defined in UMM Spec with a UMM Spec collection record,
-   updated with platform aliases whoes shortnames don't exist in the platforms."
+  updated with platform aliases whoes shortnames don't exist in the platforms."
   [context collection granule]
   (when-let [errors (seq (umm-spec-validation/validate-granule
                            (humanizer-alias-cache/update-collection-with-aliases
@@ -151,12 +153,59 @@
 
 (defn validate-granule-umm
   "Validates a UMM granule record using rules defined in UMM with a UMM collection record,
-   updated with platform aliases whoes shortnames don't exist in the platforms."
+  updated with platform aliases whoes shortnames don't exist in the platforms."
   [context collection granule]
-    (if-errors-throw :invalid-data (umm-validation/validate-granule
-                                     (humanizer-alias-cache/update-collection-with-aliases
-                                       context collection false)
-                                     granule)))
+  (if-errors-throw :invalid-data (umm-validation/validate-granule
+                                  (humanizer-alias-cache/update-collection-with-aliases
+                                   context collection false)
+                                  granule)))
+
+(defn validate-variable-umm-spec-schema
+  "Validate the variable against the JSON schema and throw errors if
+  configured or return a list of warnings"
+  [variable validation-options]
+  (if-let [err-messages (seq (json-schema/validate-umm-json
+                              (umm-json/umm->json variable)
+                              :variable))]
+    (if (or (:validate-umm? validation-options)
+            (config/return-umm-json-validation-errors))
+      (errors/throw-service-errors :invalid-data err-messages)
+      (do
+        (warn "UMM-Var JSON-Schema Validation Errors: "
+              (pr-str (vec err-messages)))
+        err-messages))))
+
+(defn umm-spec-validate-variable
+  "Validate variable through umm-spec validation functions. If warn? flag is
+  true and umm-spec-validation is off, log warnings and return messages,
+  otherwise throw errors."
+  [variable validation-options context warn?]
+  (when-let [err-messages (seq (umm-spec-validation/validate-variable
+                                variable
+                                (when (:validate-keywords? validation-options)
+                                  [(keyword-validations context)])))]
+    (if (or (:validate-umm? validation-options)
+            (config/return-umm-spec-validation-errors)
+            (not warn?))
+      (errors/throw-service-errors :invalid-data err-messages)
+      (do
+        (warn "UMM-Var UMM Spec Validation Errors: "
+              (pr-str (vec err-messages)))
+        err-messages))))
+
+(defn umm-spec-validate-variable-warnings
+  "Validate umm-spec variable validation warnings functions - errors that we
+  want to report but we do not want to fail ingest."
+  [variable validation-options context]
+  (when-let [err-messages (seq (umm-spec-validation/validate-variable-warnings
+                               variable))]
+    (if (or (:validate-umm? validation-options)
+            (config/return-umm-spec-validation-errors))
+      (errors/throw-service-errors :invalid-data err-messages)
+      (do
+        (warn "UMM-Var UMM Spec Validation Errors: "
+              (pr-str (vec err-messages)))
+       err-messages))))
 
 (defn validate-business-rules
   "Validates the concept against CMR ingest rules."

--- a/ingest-app/test/cmr/ingest/test/validation/business_rule_validation.clj
+++ b/ingest-app/test/cmr/ingest/test/validation/business_rule_validation.clj
@@ -1,0 +1,17 @@
+(ns cmr.ingest.test.validation.business-rule-validation
+  (:require
+   [clojure.test :refer :all]
+   [cmr.ingest.validation.business-rule-validation :as bv]))
+
+(def granule-test-concept {:concept-type :granule})
+(def variable-test-concept {:concept-type :variable})
+
+(deftest business-rules-for-granules
+  (is (= []
+         (bv/business-rule-validations
+          (:concept-type granule-test-concept)))))
+
+(deftest business-rules-for-variables
+  (is (= []
+         (bv/business-rule-validations
+          (:concept-type variable-test-concept)))))


### PR DESCRIPTION
This is part 2 of a three-parter for UMM-Var ingest:

1. Add schema and models for variables (with some placeholders)
2. **Add validation code for variables (with some placeholders)**
3. Add ingest-services and routes for variables

The validators in this change were modeled off of the collection validators and written to use the generated schema. As such, when the UMM-Var schema matures, we should have to change very little (if anything) here.