### PR TITLE
CMR-4145: create variable association in metadata-db

### DIFF
--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -7,7 +7,8 @@
 
 (def concept-types
   "This is the set of the types of concepts in the CMR."
-  #{:collection :granule :tag :tag-association :variable :service :access-group :acl :humanizer})
+  #{:collection :granule :tag :tag-association :variable :variable-association
+    :service :access-group :acl :humanizer})
 
 (def concept-prefix->concept-type
   "Maps a concept id prefix to the concept type"
@@ -16,6 +17,7 @@
    "T" :tag
    "TA" :tag-association
    "V" :variable
+   "VA" :variable-association
    "S" :service
    "AG" :access-group
    "ACL" :acl

--- a/metadata-db-app/README.md
+++ b/metadata-db-app/README.md
@@ -82,7 +82,7 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "concept-type": "tag",
     "native-id": "org.nasa.something.quality",
     "user-id": "jnorton",
-    "format": "applcation/edn",
+    "format": "application/edn",
     "metadata: {
       "tag-key": "org.nasa.something.quality",
       "description": "A good tag",
@@ -96,7 +96,7 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "concept-type": "tag-association",
     "native-id": "org.nasa.something.quality/C12-PROV_A42",
     "user-id": "jnorton",
-    "format": "applcation/edn",
+    "format": "application/edn",
     "metadata": {
       "tag-key": "org.nasa.something.quality",
       "originator-id": "jdoe",
@@ -134,6 +134,27 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "extra-fields": {
       "variable-name": "totCldH2OStdErr",
       "measurement": "totCldH2OStdErrMeasurement"
+    }
+  }
+
+#### Variable Association
+
+  {
+    "concept-type": "variable-association",
+    "native-id": "totCldH2OStdErr/C12-PROV_A42",
+    "user-id": "user1",
+    "format": "application/edn",
+    "metadata": {
+      "variable-name": "totCldH2OStdErr",
+      "originator-id": "jdoe",
+      "associated-concept-id": "C12-PROV_A42",
+      "revision-id": 1, (optional field),
+      "value": "string to be indexed" or "data": "arbitrary JSON <= 32K" (optional fields)
+    },
+    "extra-fields": {
+      "variable-name": "totCldH2OStdErr",
+      "associated-concept-id": "C12-PROV_A42",
+      "associated-revision-id": 1
     }
   }
 

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_association_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_association_save_test.clj
@@ -1,0 +1,40 @@
+(ns cmr.metadata-db.int-test.concepts.variable-association-save-test
+  "Contains integration tests for saving variable associations. Tests saves with various
+   configurations including checking for proper error handling."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer (are2)]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
+   [cmr.metadata-db.int-test.utility :as util]))
+
+(use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}))
+
+(defmethod c-spec/gen-concept :variable-association
+  [_ _ uniq-num attributes]
+  (let [concept-attributes (or (:concept-attributes attributes) {})
+        concept (util/create-and-save-collection "REG_PROV" uniq-num 1 concept-attributes)
+        variable-attributes (or (:variable-attributes attributes) {})
+        variable (util/create-and-save-variable uniq-num 1 variable-attributes)
+        attributes (dissoc attributes :concept-attributes :variable-attributes)]
+    (util/variable-association-concept concept variable uniq-num attributes)))
+
+;; tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(deftest save-variable-association-test
+  (c-spec/general-save-concept-test :variable-association ["CMR"]))
+
+(deftest save-variable-association-specific-test
+  (testing "saving new variable associations"
+    (are2 [variable-association exp-status exp-errors]
+          (let [variable-collection (util/create-and-save-collection "REG_PROV" 1)
+                variable (util/create-and-save-variable 1)
+                {:keys [status errors]} (util/save-concept variable-association)]
+
+            (is (= exp-status status))
+            (is (= (set exp-errors) (set errors))))
+
+          "failure when using non system-level provider"
+          (assoc (util/variable-association-concept variable-collection variable 2) :provider-id "REG_PROV")
+          422
+          [(str "Variable association could not be associated with provider [REG_PROV]. "
+                "Variable associations are system level entities.")])))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
@@ -44,6 +44,10 @@
   [_ _]
   "cmr_variables")
 
+(defmethod get-table-name :variable-association
+  [_ _]
+  "cmr_variable_associations")
+
 (defmethod get-table-name :default
   [provider concept-type]
   ;; Dont' remove the next line - needed to prevent SQL injection

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -467,7 +467,8 @@
    (j/db-do-commands this "DELETE FROM cmr_groups")
    (j/db-do-commands this "DELETE FROM cmr_acls")
    (j/db-do-commands this "DELETE FROM cmr_humanizers")
-   (j/db-do-commands this "DELETE FROM cmr_variables"))
+   (j/db-do-commands this "DELETE FROM cmr_variables")
+   (j/db-do-commands this "DELETE FROM cmr_variable_associations"))
 
   (get-expired-concepts
    [this provider concept-type]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/collection.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/collection.clj
@@ -1,12 +1,11 @@
 (ns cmr.metadata-db.data.oracle.concepts.collection
   "Implements multi-method variations for collections"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [clj-time.coerce :as cr]
-            [cmr.oracle.connection :as oracle]
-            [cmr.metadata-db.data.concepts :as concepts]))
+  (:require
+   [clj-time.coerce :as cr]
+   [cmr.common.date-time-parser :as p]
+   [cmr.metadata-db.data.concepts :as concepts]
+   [cmr.metadata-db.data.oracle.concepts :as c]
+   [cmr.oracle.connection :as oracle]))
 
 (defmethod c/db-result->concept-map :collection
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/granule.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/granule.clj
@@ -1,11 +1,10 @@
 (ns cmr.metadata-db.data.oracle.concepts.granule
   "Implements multi-method variations for granules"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [cmr.oracle.connection :as oracle]
-            [clj-time.coerce :as cr]))
+  (:require
+   [clj-time.coerce :as cr]
+   [cmr.common.date-time-parser :as p]
+   [cmr.metadata-db.data.oracle.concepts :as c]
+   [cmr.oracle.connection :as oracle]))
 
 (defmethod c/db-result->concept-map :granule
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/group.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/group.clj
@@ -1,12 +1,7 @@
 (ns cmr.metadata-db.data.oracle.concepts.group
   "Implements multi-method variations for groups"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [clj-time.coerce :as cr]
-            [cmr.oracle.connection :as oracle]
-            [cmr.metadata-db.data.concepts :as concepts]))
+  (:require
+   [cmr.metadata-db.data.oracle.concepts :as c]))
 
 (defmethod c/db-result->concept-map :access-group
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/service.clj
@@ -1,12 +1,11 @@
 (ns cmr.metadata-db.data.oracle.concepts.service
   "Implements multi-method variations for services"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [clj-time.coerce :as cr]
-            [cmr.oracle.connection :as oracle]
-            [cmr.metadata-db.data.concepts :as concepts]))
+  (:require
+   [clj-time.coerce :as cr]
+   [cmr.common.date-time-parser :as p]
+   [cmr.metadata-db.data.concepts :as concepts]
+   [cmr.metadata-db.data.oracle.concepts :as c]
+   [cmr.oracle.connection :as oracle]))
 
 (defmethod c/db-result->concept-map :service
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/tag.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/tag.clj
@@ -1,13 +1,9 @@
 (ns cmr.metadata-db.data.oracle.concepts.tag
   "Implements multi-method variations for tags"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [clj-time.coerce :as cr]
-            [cmr.oracle.connection :as oracle]
-            [cmr.metadata-db.data.concepts :as concepts]
-            [cmr.metadata-db.data.ingest-events :as ingest-events]))
+  (:require
+   [cmr.metadata-db.data.concepts :as concepts]
+   [cmr.metadata-db.data.ingest-events :as ingest-events]
+   [cmr.metadata-db.data.oracle.concepts :as c]))
 
 (defmethod c/db-result->concept-map :tag
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/tag_association.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/tag_association.clj
@@ -1,20 +1,16 @@
 (ns cmr.metadata-db.data.oracle.concepts.tag-association
-  "Implements multi-method variations for tags"
-  (:require [cmr.metadata-db.data.oracle.concepts :as c]
-            [cmr.metadata-db.data.oracle.concept-tables :as tables]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.date-time-parser :as p]
-            [clj-time.coerce :as cr]
-            [cmr.oracle.connection :as oracle]
-            [cmr.metadata-db.data.concepts :as concepts]))
+  "Implements multi-method variations for tag associations"
+  (:require
+   [cmr.metadata-db.data.oracle.concepts :as c]))
 
 (defmethod c/db-result->concept-map :tag-association
   [concept-type db provider-id result]
   (some-> (c/db-result->concept-map :default db provider-id result)
           (assoc :concept-type :tag-association)
           (assoc-in [:extra-fields :associated-concept-id] (:associated_concept_id result))
-          (assoc-in [:extra-fields :associated-revision-id] (when-let [ari (:associated_revision_id result)]
-                                                              (long ari)))
+          (assoc-in [:extra-fields :associated-revision-id]
+                    (when-let [ari (:associated_revision_id result)]
+                      (long ari)))
           (assoc-in [:extra-fields :tag-key] (:tag_key result))
           (assoc :user-id (:user_id result))))
 

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable_association.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable_association.clj
@@ -1,0 +1,29 @@
+(ns cmr.metadata-db.data.oracle.concepts.variable-association
+  "Implements multi-method variations for variables"
+  (:require
+   [cmr.metadata-db.data.concepts :as concepts]
+   [cmr.metadata-db.data.oracle.concept-tables :as tables]
+   [cmr.metadata-db.data.oracle.concepts :as c]
+   [cmr.oracle.connection :as oracle]))
+
+(defmethod c/db-result->concept-map :variable-association
+  [concept-type db provider-id result]
+  (some-> (c/db-result->concept-map :default db provider-id result)
+          (assoc :concept-type :variable-association)
+          (assoc-in [:extra-fields :associated-concept-id] (:associated_concept_id result))
+          (assoc-in [:extra-fields :associated-revision-id]
+                    (when-let [ari (:associated_revision_id result)]
+                      (long ari)))
+          (assoc-in [:extra-fields :variable-name] (:variable_name result))
+          (assoc :user-id (:user_id result))))
+
+;; Only "CMR" provider is supported now which is not considered a 'small' provider. If we
+;; ever associate real providers with variable-associatons then we will need to add support
+;; for small providers as well.
+(defmethod c/concept->insert-args [:variable-association false]
+  [concept _]
+  (let [{{:keys [associated-concept-id associated-revision-id variable-name]} :extra-fields
+         :keys [user-id]} concept
+        [cols values] (c/concept->common-insert-args concept)]
+    [(concat cols ["associated_concept_id" "associated_revision_id" "variable_name" "user_id"])
+     (concat values [associated-concept-id associated-revision-id variable-name user-id])]))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable_association.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/variable_association.clj
@@ -1,10 +1,7 @@
 (ns cmr.metadata-db.data.oracle.concepts.variable-association
   "Implements multi-method variations for variables"
   (:require
-   [cmr.metadata-db.data.concepts :as concepts]
-   [cmr.metadata-db.data.oracle.concept-tables :as tables]
-   [cmr.metadata-db.data.oracle.concepts :as c]
-   [cmr.oracle.connection :as oracle]))
+   [cmr.metadata-db.data.oracle.concepts :as c]))
 
 (defmethod c/db-result->concept-map :variable-association
   [concept-type db provider-id result]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -25,12 +25,16 @@
                      [:provider_id :entry_title :entry_id :short_name :version_id :delete_time
                       :user_id])
    :tag (into common-columns [:user_id])
-   :tag-association (into common-columns [:associated_concept_id :associated_revision_id :tag_key :user_id])
+   :tag-association (into common-columns
+                          [:associated_concept_id :associated_revision_id :tag_key :user_id])
    :access-group (into common-columns [:provider_id :user_id])
    :service (into common-columns [:provider_id :entry_title :entry_id :delete_time :user_id])
    :acl (into common-columns [:provider_id :user_id :acl_identity])
    :humanizer (into common-columns [:user_id])
-   :variable (into common-columns [:variable_name :measurement :user_id])})
+   :variable (into common-columns [:variable_name :measurement :user_id])
+   :variable-association (into common-columns
+                               [:associated_concept_id :associated_revision_id
+                                :variable-name :user_id])})
 
 (def single-table-with-providers-concept-type?
   "The set of concept types that are stored in a single table with a provider column. These concept

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -118,25 +118,34 @@
          :invalid-data (msg/granule-collection-cannot-change coll-concept-id parent-concept-id))
         (assoc concept :concept-id concept-id)))))
 
-(defmulti set-or-generate-created-at
-  "Get the existing created-at value for the given concept and set it or set it to the 
-  current datetime if it has never been saved."
-  (fn [db provider concept & previous-revision]
-    (:concept-type concept)))
-
-(defmethod set-or-generate-created-at :collection
-  [db provider concept & previous-revision]
+(defn- set-or-generate-created-at-for-concept
+  "Set the created-at of the given concept to the value of its previous revision if exists;
+   otherwise, set it to the current datetime."
+  [db provider concept]
   (let [{:keys [concept-id concept-type]} concept
-        previous-revision (first previous-revision)
-        existing-created-at (:created-at (or previous-revision
-                                             (c/get-concept db concept-type provider concept-id)))
+        existing-created-at (:created-at
+                             (c/get-concept db concept-type provider concept-id))
         created-at (if existing-created-at existing-created-at (time-keeper/now))]
     (assoc concept :created-at created-at)))
 
+(defmulti set-or-generate-created-at
+  "Get the existing created-at value for the given concept and set it or set it to the
+  current datetime if it has never been saved."
+  (fn [db provider concept]
+    (:concept-type concept)))
+
+(defmethod set-or-generate-created-at :collection
+  [db provider concept]
+  (set-or-generate-created-at-for-concept db provider concept))
+
+(defmethod set-or-generate-created-at :variable
+  [db provider concept]
+  (set-or-generate-created-at-for-concept db provider concept))
+
 (defmethod set-or-generate-created-at :default
-  [_db _provider concept & _previous-revision]
+  [_db _provider concept]
   concept)
-  
+
 (defn- set-or-generate-revision-id
   "Get the next available revision id from the DB for the given concept or
   one if the concept has never been saved."
@@ -315,9 +324,11 @@
     (let [concepts (apply concat
                           (for [[provider-id concept-type-tuples-map] split-tuples-map
                                 [concept-type tuples] concept-type-tuples-map]
-                            (let [provider (provider-service/get-provider-by-id context provider-id true)]
+                            (let [provider (provider-service/get-provider-by-id
+                                            context provider-id true)]
                               ;; Retrieve the concepts for this type and provider id.
-                              (if (and (> parallel-chunk-size 0) (< parallel-chunk-size (count tuples)))
+                              (if (and (> parallel-chunk-size 0)
+                                       (< parallel-chunk-size (count tuples)))
                                 ;; retrieving chunks in parallel for faster read performance
                                 (apply concat
                                        (cutil/pmap-n-all
@@ -358,9 +369,11 @@
     (let [concepts (apply concat
                           (for [[provider-id concept-type-concept-id-map] split-concept-ids-map
                                 [concept-type cids] concept-type-concept-id-map]
-                            (let [provider (provider-service/get-provider-by-id context provider-id true)]
+                            (let [provider (provider-service/get-provider-by-id
+                                            context provider-id true)]
                               ;; Retrieve the concepts for this type and provider id.
-                              (if (and (> parallel-chunk-size 0) (< parallel-chunk-size (count cids)))
+                              (if (and (> parallel-chunk-size 0)
+                                       (< parallel-chunk-size (count cids)))
                                 ;; retrieving chunks in parallel for faster read performance
                                 (apply concat
                                        (cutil/pmap-n-all
@@ -458,7 +471,7 @@
         concept (assoc concept :provider-id provider-id)
         provider (provider-service/get-provider-by-id context provider-id true)
         _ (validate-system-level-concept concept provider)
-        concept (->> concept 
+        concept (->> concept
                      (set-or-generate-concept-id db provider)
                      (set-or-generate-created-at db provider))]
     (validate-concept-revision-id db provider concept)

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -45,7 +45,8 @@
    :tag-association 10
    :access-group 10
    :humanizer 10
-   :variable 10})
+   :variable 10
+   :variable-association 10})
 
 (defconfig days-to-keep-tombstone
   "Number of days to keep a tombstone before is removed from the database."
@@ -58,7 +59,7 @@
 
 (def system-level-concept-types
   "A set of concept types that only exist on system level provider CMR."
-  #{:tag :tag-association :humanizer :variable})
+  #{:tag :tag-association :humanizer :variable :variable-association})
 
 ;;; utility methods
 
@@ -74,7 +75,9 @@
                       :tag (msg/tags-only-system-level provider-id)
                       :tag-association (msg/tag-associations-only-system-level provider-id)
                       :humanizer (msg/humanizers-only-system-level provider-id)
-                      :variable (msg/variables-only-system-level provider-id))]
+                      :variable (msg/variables-only-system-level provider-id)
+                      :variable-association (msg/variable-associations-only-system-level
+                                             provider-id))]
         (errors/throw-service-errors :invalid-data [err-msg])))))
 
 (defn- provider-ids-for-validation

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
@@ -46,7 +46,9 @@
    :tag-association {true #{}
                      false #{:associated-concept-id :associated-revision-id}}
    :variable {true #{}
-             false #{:variable-name :measurement}}})
+              false #{:variable-name :measurement}}
+   :variable-association {true #{}
+                          false #{:associated-concept-id :associated-revision-id}}})
 
 (defn extra-fields-missing-validation
   "Validates that the concept is provided with extra fields and that all of them are present and not nil."
@@ -156,7 +158,7 @@
   (util/compose-validations (conj base-concept-validations
                                   concept-id-matches-concept-fields-validation-no-provider)))
 
-(def tag-association-concept-validation
+(def association-concept-validation
   "Builds a function that validats a tag association concept map that has no provider and returns
   a list of errors"
   (util/compose-validations (conj base-concept-validations
@@ -188,9 +190,9 @@
   "validates a tag concept. Throws an error if invalid."
   (util/build-validator :invalid-data tag-concept-validation))
 
-(def validate-tag-association-concept
+(def validate-association-concept
   "Validates a tag association concept. Throws an error if invalid."
-  (util/build-validator :invalid-data tag-association-concept-validation))
+  (util/build-validator :invalid-data association-concept-validation))
 
 (def validate-concept-group
   "Validates a group concept. Throws and error if invalid."
@@ -215,7 +217,7 @@
 
 (defmethod validate-concept :tag-association
   [concept]
-  (validate-tag-association-concept concept))
+  (validate-association-concept concept))
 
 (defmethod validate-concept :access-group
   [concept]
@@ -228,6 +230,10 @@
 (defmethod validate-concept :variable
   [concept]
   (validate-variable-concept concept))
+
+(defmethod validate-concept :variable-association
+  [concept]
+  (validate-association-concept concept))
 
 (defmethod validate-concept :default
   [concept]

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -166,3 +166,8 @@
 (defn variables-only-system-level [provider-id]
   (format "Variable could not be associated with provider [%s]. Variables are system level entities."
           provider-id))
+
+(defn variable-associations-only-system-level [provider-id]
+  (format (str "Variable association could not be associated with provider [%s]. "
+               "Variable associations are system level entities.")
+          provider-id))

--- a/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
@@ -24,7 +24,9 @@
    :access-group default-supported-find-parameters
    :acl default-supported-find-parameters
    :humanizer #{:concept-id :native-id}
-   :variable #{:concept-id :native-id}})
+   :variable #{:concept-id :native-id}
+   :variable-association #{:concept-id :native-id :associated-concept-id :associated-revision-id
+                           :variable-name}})
 
 (def granule-supported-parameter-combinations
   "Supported search parameter combination sets for granule find. This does not include flags

--- a/metadata-db-app/src/migrations/050_setup_variable_associations_table.clj
+++ b/metadata-db-app/src/migrations/050_setup_variable_associations_table.clj
@@ -1,0 +1,60 @@
+(ns migrations.050-setup-variable-associations-table
+  (:require
+   [config.mdb-migrate-helper :as h]))
+
+(def ^:private variable-assocs-column-sql
+  "id NUMBER,
+  concept_id VARCHAR(255) NOT NULL,
+  native_id VARCHAR(1500) NOT NULL,
+  metadata BLOB NOT NULL,
+  format VARCHAR(255) NOT NULL,
+  revision_id INTEGER DEFAULT 1 NOT NULL,
+  associated_concept_id VARCHAR(255) NOT NULL,
+  associated_revision_id INTEGER NULL,
+  revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+  deleted INTEGER DEFAULT 0 NOT NULL,
+  variable_name varchar(20) NOT NULL,
+  user_id VARCHAR(30),
+  transaction_id NUMBER DEFAULT 0 NOT NULL")
+
+(def ^:private variable-assocs-constraint-sql
+  (str "CONSTRAINT v_assoc_pk PRIMARY KEY (id), "
+        ;; Unique constraint on native id and revision id
+        "CONSTRAINT v_assoc_con_rev UNIQUE (native_id, revision_id)
+         USING INDEX (create unique index v_assoc_ucr_i ON cmr_variable_associations (native_id, revision_id)), "
+
+        ;; Unique constraint on concept id and revision id
+        "CONSTRAINT v_assoc_cid_rev UNIQUE (concept_id, revision_id)
+         USING INDEX (create unique index v_assoc_cri ON cmr_variable_associations (concept_id, revision_id))"))
+
+(defn- create-variable-associations-table
+  []
+  (h/sql (format "CREATE TABLE METADATA_DB.cmr_variable_associations (%s, %s)"
+                 variable-assocs-column-sql variable-assocs-constraint-sql)))
+
+(defn- create-variable-associations-indices
+  []
+  (h/sql "CREATE INDEX v_assoc_crdi ON cmr_variable_associations (concept_id, revision_id, deleted)")
+  (h/sql "CREATE INDEX v_assoc_acari ON cmr_variable_associations (associated_concept_id, associated_revision_id)")
+  (h/sql "CREATE INDEX v_assoc_vnri ON cmr_variable_associations (variable_name, revision_id)")
+  (h/sql "CREATE INDEX v_assoc_vncid ON cmr_variable_associations (variable_name, associated_concept_id)")
+  (h/sql "CREATE INDEX v_assoc_vncrid ON cmr_variable_associations (variable_name, associated_concept_id, associated_revision_id)"))
+
+(defn- create-variable-associations-sequence
+  []
+  (h/sql "CREATE SEQUENCE cmr_variable_associations_seq"))
+
+(defn up
+  "Migrates the database up to version 50."
+  []
+  (println "migrations.050-setup-variable-associations-table up...")
+  (create-variable-associations-table)
+  (create-variable-associations-indices)
+  (create-variable-associations-sequence))
+
+(defn down
+  "Migrates the database down from version 50."
+  []
+  (println "migrations.050-setup-variable-associations-table down...")
+  (h/sql "DROP SEQUENCE METADATA_DB.cmr_variable_associations_seq")
+  (h/sql "DROP TABLE METADATA_DB.cmr_variable_associations"))


### PR DESCRIPTION
This is part 1 of a four-parter for creating variable associations with collections:

1. Add creating variable association concept in metadata-db
2. Add search of variables in metadata-db
3. Add search of variable associations in metadata-db
4. Add variable associations endpoint in search-app