### PR TITLE
CMR-4145: Added search of variables and variable associations in metadata-db

### DIFF
--- a/metadata-db-app/README.md
+++ b/metadata-db-app/README.md
@@ -326,8 +326,8 @@ Supported combinations of concept type and parameters:
   * collections with any combination of concept-id, provider-id, entry-id, entry-title, short-name, version-id and native-id
   * granules with provider-id, granule-ur
   * granules with provider-id, native-id
-  * tags, tag associations or humanizers with concept-id or native-id
-  * tag associations with associated-concept-id, associated-revision-id
+  * tags, tag associations, variables, variable associations or humanizers with concept-id or native-id
+  * tag associations or variable associations with associated-concept-id, associated-revision-id
 
 ```
 curl "http://localhost:3001/concepts/search/collections?provider-id=PROV1&short-name=s&version-id=1"

--- a/metadata-db-app/README.md
+++ b/metadata-db-app/README.md
@@ -83,11 +83,7 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "native-id": "org.nasa.something.quality",
     "user-id": "jnorton",
     "format": "application/edn",
-    "metadata: {
-      "tag-key": "org.nasa.something.quality",
-      "description": "A good tag",
-      "originator-id": "jnorton"
-    }
+    "metadata": "{:tag-key \"org.nasa.something.ozone\", :description \"A very good tag\", :originator-id \"jnorton\"}"
   }
 
 #### Tag Association
@@ -97,19 +93,15 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
     "native-id": "org.nasa.something.quality/C12-PROV_A42",
     "user-id": "jnorton",
     "format": "application/edn",
-    "metadata": {
-      "tag-key": "org.nasa.something.quality",
-      "originator-id": "jdoe",
-      "associated-concept-id": "C12-PROV_A42",
-      "revision-id": 1, (optional field),
-      "value": "string to be indexed" or "data": "arbitrary JSON <= 32K" (optional fields)
-    },
+    "metadata": "{:tag-key \"org.nasa.something.ozone\", :associated-concept-id \"C120000000-PROV1\", :revision-id 1, :value \"string to be indexed\"}",
     "extra-fields": {
       "tag-key": "org.nasa.something.quality",
       "associated-concept-id": "C12-PROV_A42",
       "associated-revision-id": 1
     }
   }
+
+The tag association metadata can have "value": "string to be indexed" or "data": "arbitrary JSON <= 32K" (optional fields)
 
 #### Humanizer
 
@@ -125,35 +117,29 @@ The provider-id can be "CMR" (for system level groups) or another provider id.
 #### Variable
 
   {
-    "concept-type": "variable",
-    "native-id" : "var123",
-    "metadata" : "{ \"Name\": \"totCldH2OStdErr\", \"LongName\": \"totCldH2OStdErrMeasurement\", \"Units\": \"\", \"DataType\": \"float\", \"DimensionsName\": [ \"H2OFunc\", \"H2OPressureLay\", \"MWHingeSurf\", \"Cloud\", \"HingeSurf\", \"H2OPressureLev\", \"AIRSXTrack\", \"StdPressureLay\", \"CH4Func\", \"StdPressureLev\", \"COFunc\", \"O3Func\", \"AIRSTrack\" ], \"Dimensions\": [ \"11\", \"14\", \"7\", \"2\", \"100\", \"15\", \"3\", \"28\", \"10\", \"9\" ], \"ValidRange\": null, \"Scale\": \"1.0\", \"Offset\": \"0.0\", \"FillValue\": \"-9999.0 \", \"VariableType\": \"\", \"ScienceKeywords\": []}",
-    "user-id" : "user1",
-    "deleted" : false,
-    "format" : "application/json",
-    "extra-fields": {
-      "variable-name": "totCldH2OStdErr",
-      "measurement": "totCldH2OStdErrMeasurement"
-    }
+  "concept-type": "variable",
+  "native-id": "totcldh2ostderr",
+  "metadata": "{ :name \"totCldH2OStdErr\", :long-name \"totCldH2OStdErrMeasurement\", :units \"\", :data-type \"float\", :dimensions-name [ \"H2OFunc\", \"H2OPressureLay\", \"MWHingeSurf\", \"Cloud\", \"HingeSurf\", \"H2OPressureLev\", \"AIRSXTrack\", \"StdPressureLay\", \"CH4Func\", \"StdPressureLev\", \"COFunc\", \"O3Func\", \"AIRSTrack\" ], :dimensions [ \"11\", \"14\", \"7\", \"2\", \"100\", \"15\", \"3\", \"28\", \"10\", \"9\" ], :valid-range null, :scale \"1.0\", :offset \"0.0\", :fill-value \"-9999.0 \", :variable-type \"\", :science-keywords [] :originator-id \"user1\"}",
+  "user-id": "user1",
+  "deleted": false,
+  "format": "application/edn",
+  "extra-fields": {
+    "variable-name": "totCldH2OStdErr",
+    "measurement": "totCldH2OStdErrMeasurement"
   }
+}
 
 #### Variable Association
 
   {
     "concept-type": "variable-association",
-    "native-id": "totCldH2OStdErr/C12-PROV_A42",
+    "native-id": "totCldH2OStdErr/C1200000005-PROV1",
     "user-id": "user1",
     "format": "application/edn",
-    "metadata": {
-      "variable-name": "totCldH2OStdErr",
-      "originator-id": "jdoe",
-      "associated-concept-id": "C12-PROV_A42",
-      "revision-id": 1, (optional field),
-      "value": "string to be indexed" or "data": "arbitrary JSON <= 32K" (optional fields)
-    },
+    "metadata": "{:variable-name \"totCldH2OStdErr\", :originator-id \"user1\", :associated-concept-id \"C1200000005-PROV1\", :associated-revision-id 1, :data {:description \"Needs more work\"}}",
     "extra-fields": {
       "variable-name": "totCldH2OStdErr",
-      "associated-concept-id": "C12-PROV_A42",
+      "associated-concept-id": "C1200000005-PROV1",
       "associated-revision-id": 1
     }
   }

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/search_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/search_test.clj
@@ -472,7 +472,75 @@
               "everything"
               5 {})))))
 
-(comment
- (util/find-concepts
-  :access-group
-  {:provider-id "REG_PROV" :native-id "native-id 1"}))
+(deftest find-variables
+  (let [variable1 (util/create-and-save-variable 1 3)
+        variable2 (util/create-and-save-variable 2 2)]
+    (testing "find latest revsions"
+      (are2 [variables params]
+        (= (set variables)
+           (set (->> (util/find-latest-concepts :variable params)
+                     :concepts
+                     (map #(dissoc % :provider-id :revision-date :transaction-id :created-at)))))
+
+        "with metadata"
+        [variable1 variable2]
+        {}
+
+        "exclude metadata"
+        [(dissoc variable1 :metadata) (dissoc variable2 :metadata)]
+        {:exclude-metadata true}))
+
+    (testing "find all revisions"
+      (let [num-of-variables (-> (util/find-concepts :variable {})
+                                 :concepts
+                                 count)]
+        (is (= 5 num-of-variables))))))
+
+(deftest find-variables-with-invalid-parameters
+  (testing "extra parameters"
+    (is (= {:status 400
+            :errors ["Finding concept type [variable] with parameters [provider-id] is not supported."]}
+           (util/find-concepts :variable {:provider-id "REG_PROV"})))))
+
+(deftest find-variable-associations
+  (let [coll1 (save-collection "REG_PROV" 1 {:extra-fields {:entry-id "entry-1"
+                                                            :entry-title "et1"
+                                                            :version-id "v1"
+                                                            :short-name "s1"}})
+        coll2 (save-collection "REG_PROV" 2 {:extra-fields {:entry-id "entry-2"
+                                                            :entry-title "et2"
+                                                            :version-id "v1"
+                                                            :short-name "s2"}})
+        associated-variable (util/create-and-save-variable 1)
+        var-association1 (util/create-and-save-variable-association coll1 associated-variable 1 3)
+        var-association2 (util/create-and-save-variable-association coll2 associated-variable 2 2)]
+    (testing "find latest revisions"
+      (are2 [variable-associations params]
+        (= (set variable-associations)
+           (set (->> (util/find-latest-concepts :variable-association params)
+                     :concepts
+                     (map #(dissoc % :provider-id :revision-date :transaction-id)))))
+
+        "by associated-concept-id"
+        [var-association1]
+        {:associated-concept-id "C1200000000-REG_PROV"}
+
+        "with metadata"
+        [var-association1 var-association2]
+        {}
+
+        "exclude metadata"
+        [(dissoc var-association1 :metadata) (dissoc var-association2 :metadata)]
+        {:exclude-metadata true}))
+
+    (testing "find all revisions"
+      (let [num-of-variable-associations (-> (util/find-concepts :variable-association {})
+                                             :concepts
+                                             count)]
+        (is (= 5 num-of-variable-associations))))))
+
+(deftest find-variable-associations-with-invalid-parameters
+  (testing "extra parameters"
+    (is (= {:status 400
+            :errors ["Finding concept type [variable-association] with parameters [provider-id] is not supported."]}
+           (util/find-concepts :variable-association {:provider-id "REG_PROV"})))))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -572,9 +572,9 @@
   "Modifies a concept for comparison with a retrieved concept."
   (fn [concept]
     (let [{:keys [concept-type]} concept]
-      (if (concept-service/system-level-concept-types concept-type)
+      (if (contains? concept-service/system-level-concept-types concept-type)
         ;; system level concept
-        :system
+        :system-level-concept
         concept-type))))
 
 (defmethod expected-concept :granule
@@ -590,7 +590,7 @@
     concept
     (assoc concept :provider-id "CMR")))
 
-(defmethod expected-concept :system
+(defmethod expected-concept :system-level-concept
   [concept]
   (assoc concept :provider-id "CMR"))
 
@@ -731,6 +731,19 @@
              (assert-no-errors (save-concept concept)))
          {:keys [concept-id revision-id]} (save-concept concept)]
      (assoc concept :concept-id concept-id :revision-id revision-id))))
+
+(defn create-and-save-variable-association
+  "Creates, saves, and returns a variable association concept with its data from metadata-db"
+  ([concept variable uniq-num]
+   (create-and-save-variable-association concept variable uniq-num 1))
+  ([concept variable uniq-num num-revisions]
+   (create-and-save-variable-association concept variable uniq-num num-revisions {}))
+  ([concept variable uniq-num num-revisions attributes]
+   (let [concept (variable-association-concept concept variable uniq-num attributes)
+          _ (dotimes [n (dec num-revisions)]
+              (assert-no-errors (save-concept concept)))
+          {:keys [concept-id revision-id]} (save-concept concept)]
+      (assoc concept :concept-id concept-id :revision-id revision-id))))
 
 ;;; providers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -34,7 +34,7 @@
    :variable (into common-columns [:variable_name :measurement :user_id])
    :variable-association (into common-columns
                                [:associated_concept_id :associated_revision_id
-                                :variable-name :user_id])})
+                                :variable_name :user_id])})
 
 (def single-table-with-providers-concept-type?
   "The set of concept types that are stored in a single table with a provider column. These concept

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -31,6 +31,8 @@
    [cmr.metadata-db.data.oracle.concepts.service]
    [cmr.metadata-db.data.oracle.concepts.tag-association]
    [cmr.metadata-db.data.oracle.concepts.tag]
+   [cmr.metadata-db.data.oracle.concepts.variable-association]
+   [cmr.metadata-db.data.oracle.concepts.variable]
    [cmr.metadata-db.data.oracle.concepts]
    [cmr.metadata-db.data.oracle.providers]
    [cmr.metadata-db.data.oracle.search]))

--- a/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
@@ -114,7 +114,8 @@
   [context params]
   (validate-find-params params)
   (cond
-    (contains? #{:tag :tag-association :acl :humanizer} (:concept-type params))
+    (contains? #{:tag :tag-association :acl :humanizer :variable :variable-association}
+               (:concept-type params))
     (find-cmr-concepts context params)
 
     (= :access-group (:concept-type params))


### PR DESCRIPTION
This is part 2 and part 3 of a four-parter for creating variable associations with collections:

1. Add creating variable association concept in metadata-db
2. Add search of variables in metadata-db
3. Add search of variable associations in metadata-db
4. Add variable associations endpoint in search-app
