### PR TITLE
Cmr 3965 umm bulk update

### DIFF
--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -12,6 +12,10 @@
         "UpdateTypeEnum": {
             "type": "string",
             "enum": ["ADD_TO_EXISTING", "CLEAR_FIELD", "CLEAR_ALL_AND_REPLACE", "FIND_AND_REMOVE", "FIND_AND_REPLACE"]
+        },
+        "UpdateFieldEnum": {
+          "type": "string",
+          "enum": ["SCIENCE_KEYWORDS", "LOCATION_KEYWORDS", "DATA_CENTERS", "PLATFORMS", "INSTRUMENTS"]
         }
     },
     "title": "Ingest Bulk Update",
@@ -33,11 +37,10 @@
           "minItems": 1
         },
         "update-type": {
-            "description": "The mime type of the service.",
             "$ref": "#/definitions/UpdateTypeEnum"
         },
         "update-field": {
-          "type": "string"
+          "$ref": "#/definitions/UpdateFieldEnum"
         },
         "update-value": {
           "type": "object"

--- a/ingest-app/src/cmr/ingest/api/ingest.clj
+++ b/ingest-app/src/cmr/ingest/api/ingest.clj
@@ -467,7 +467,7 @@
       :collection-statuses collection-statuses}))))
 
 (def ingest-routes
-  "Defines the routes for ingest, validate, and delete operations"
+  "Defines the routes for ingest, validate, delete, and bulk update operations"
   (set-default-error-format
     :xml
     (context "/providers/:provider-id" [provider-id]

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -55,14 +55,16 @@
    :provider-id provider-id})
 
 (defn ingest-bulk-update-event
-  [task-id bulk-update-params]
+  [provider-id task-id bulk-update-params]
   {:action :bulk-update
+   :provider-id provider-id
    :task-id task-id
    :bulk-update-params bulk-update-params})
 
 (defn ingest-collection-bulk-update-event
-  [task-id concept-id bulk-update-params]
+  [provider-id task-id concept-id bulk-update-params]
   {:action :collection-bulk-update
+   :provider-id provider-id
    :task-id task-id
    :concept-id concept-id
    :bulk-update-params bulk-update-params})

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -6,6 +6,7 @@
    [clojure.string :as string]
    [cmr.common.services.errors :as errors]
    [cmr.common.validations.json-schema :as js]
+   [cmr.ingest.config :as config]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
    [cmr.ingest.services.ingest-service :as ingest-service]
@@ -18,6 +19,10 @@
 
 (def default-exception-message
   "There was an error updating the concept.")
+
+(def update-format
+  "Format to save bulk updates"
+  (str "application/vnd.nasa.cmr.umm+json;version=" (config/ingest-accept-umm-version)))
 
 (defn validate-bulk-update-post-params
   "Validate post body for bulk update. Validate against schema and validation
@@ -77,7 +82,9 @@
         update-field (csk/->PascalCaseKeyword update-field)]
     (-> concept
         (assoc :metadata (field-update/update-concept context concept update-type
-                                                      [update-field] update-value find-value))
+                                                      [update-field] update-value find-value
+                                                      update-format))
+        (assoc :format update-format)
         (update :revision-id inc))))
 
 

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -69,7 +69,7 @@
         update-field (csk/->PascalCaseKeyword update-field)]
     (-> concept
         (assoc :metadata (field-update/update-concept context concept update-type
-                                                      update-field update-value find-value))
+                                                      [update-field] update-value find-value))
         (update :revision-id inc))))
 
 

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -11,13 +11,20 @@
 
 (defmethod handle-provider-event :bulk-update
   [context msg]
-  (bulk-update/handle-bulk-update-event context (:task-id msg)
-    (:bulk-update-params msg)))
+  (bulk-update/handle-bulk-update-event
+   context
+   (:provider-id msg)
+   (:task-id msg)
+   (:bulk-update-params msg)))
 
 (defmethod handle-provider-event :collection-bulk-update
   [context msg]
-  (bulk-update/handle-collection-bulk-update-event context (:task-id msg)
-    (:concept-id msg) (:bulk-update-params msg)))
+  (bulk-update/handle-collection-bulk-update-event
+   context
+   (:provider-id msg)
+   (:task-id msg)
+   (:concept-id msg)
+   (:bulk-update-params msg)))
 
 ;; Default ignores the provider event. There may be provider events we don't care about.
 (defmethod handle-provider-event :default

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -115,7 +115,15 @@
                             :Term "ENVIRONMENTAL IMPACTS"
                             :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
             400
-            ["A find value must be supplied when the update is of type FIND_AND_REPLACE"]))))
+            ["A find value must be supplied when the update is of type FIND_AND_REPLACE"]
+
+            "Invalid update field"
+            {:concept-ids ["C1", "C2", "C3"]
+             :update-field "Science keywords"
+             :update-type "ADD_TO_EXISTING"
+             :update-value {:Category "EARTH SCIENCE"}}
+            400
+            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
 
             ;; Short-name/version currently not supported. Support will be added
             ;; back in with CMR-4129

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -27,16 +27,20 @@
   [index provider]
   (format "C120000000%s-%s" index provider))
 
+(defn- ingest-collection-in-each-format
+  "Ingest a collection in each format and return a list of concept-ids"
+  [attribs]
+  (for [x (range (count collection-formats))
+        :let [format (nth collection-formats x)
+              collection (data-umm-c/collection-concept
+                          (data-umm-c/collection x attribs)
+                          format)]]
+    (:concept-id (ingest/ingest-concept
+                  (assoc collection :concept-id (generate-concept-id x "PROV1"))))))
+
 (deftest bulk-update-science-keywords
   ;; Ingest a collection in each format with science keywords to update
-  (let [concept-ids
-        (for [x (range (count collection-formats))
-              :let [format (nth collection-formats x)
-                    collection (data-umm-c/collection-concept
-                                (data-umm-c/collection x science-keywords-umm)
-                                format)]]
-          (:concept-id (ingest/ingest-concept
-                        (assoc collection :concept-id (generate-concept-id x "PROV1")))))
+  (let [concept-ids (ingest-collection-in-each-format science-keywords-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
                           :update-type "ADD_TO_EXISTING"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -24,7 +24,7 @@
                       :Term "MARINE SEDIMENTS"}]})
 
 (def data-centers-umm
-  {:DataCenters [{:ShortName "NSID"
+  {:DataCenters [{:ShortName "NSID" ;; intentional misspelling for tests
                   :LongName "National Snow and Ice Data Center"
                   :Roles ["ARCHIVER"]
                   :ContactPersons [{:Roles ["Data Center Contact"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -76,6 +76,8 @@
                                  first)]]
         (is (= 2
                (:revision-id (:meta concept))))
+        (is (= "application/vnd.nasa.cmr.umm+json"
+               (:format (:meta concept))))
         (is (= (:ScienceKeywords (:umm concept))
                [{:Category "EARTH SCIENCE"
                  :Term "MARINE SEDIMENTS"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -23,6 +23,17 @@
                       :Topic "OCEANS"
                       :Term "MARINE SEDIMENTS"}]})
 
+(def data-centers-umm
+  {:DataCenters [{:ShortName "NSID"
+                  :LongName "National Snow and Ice Data Center"
+                  :Roles ["ARCHIVER"]
+                  :ContactPersons [{:Roles ["Data Center Contact"]
+                                    :LastName "Smith"}]}
+                 {:ShortName "LPDAAC"
+                  :Roles ["PROCESSOR"]
+                  :ContactPersons [{:Roles ["Data Center Contact"]
+                                    :LastName "Smith"}]}]})
+
 (defn- generate-concept-id
   [index provider]
   (format "C120000000%s-%s" index provider))
@@ -73,3 +84,51 @@
                  :Category "EARTH SCIENCE"
                  :Term "ENVIRONMENTAL IMPACTS"
                  :Topic "HUMAN DIMENSIONS"}])))))
+
+(deftest data-center-bulk-update
+  (let [concept-ids (ingest-collection-in-each-format data-centers-umm)
+        _ (index/wait-until-indexed)]
+    (testing "Invalid data center update"
+      (let [bulk-update-body {:concept-ids concept-ids
+                              :update-type "ADD_TO_EXISTING"
+                              :update-field "DATA_CENTERS"
+                              :update-value {:ShortName "LARC"}}]
+        (ingest/bulk-update-collections "PROV1" bulk-update-body)
+        (index/wait-until-indexed)
+        (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+          (is (= "COMPLETE" (:task-status collection-response)))
+          ;; These error messages all being the same are contingent on the
+          ;; bulk update saving umm-json. If that changes these have to change.
+          (is (every? #(and (= "FAILED" (:status %))
+                            (= "/DataCenters/2 object has missing required properties ([\"Roles\"])"
+                               (:status-message %)))
+                      (:collection-statuses collection-response))))))
+
+    (testing "Data center find and replace"
+      (let [bulk-update-body {:concept-ids concept-ids
+                              :update-type "FIND_AND_REPLACE"
+                              :update-field "DATA_CENTERS"
+                              :find-value {:ShortName "NSID"}
+                              :update-value {:ShortName "NSIDC"
+                                             :Roles ["ORIGINATOR"]}}]
+        (ingest/bulk-update-collections "PROV1" bulk-update-body)
+        (index/wait-until-indexed)
+        (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+          (is (= "COMPLETE" (:task-status collection-response))))
+
+        ;; Check that each concept was updated
+        (doseq [concept-id concept-ids
+                :let [concept (-> (search/find-concepts-umm-json
+                                    :collection {:concept-id concept-id})
+                                  :results
+                                  :items
+                                  first)]]
+         ;; On rev 2, not 3, since previous update failed
+         (is (= 2
+                (:revision-id (:meta concept))))
+         (is (= [{:ShortName "NSIDC"
+                  :Roles ["ORIGINATOR"]}
+                 {:ShortName "LPDAAC"
+                  :Roles ["PROCESSOR"]}]
+                (map #(select-keys % [:Roles :ShortName])
+                     (:DataCenters (:umm concept))))))))))

--- a/umm-spec-lib/src/cmr/umm_spec/util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/util.clj
@@ -112,7 +112,7 @@
   (get-in valid-url-content-types-map [url-content-type type]))
 
 (defn type->url-content-type
-  "Get the URLContentType from the type" 
+  "Get the URLContentType from the type"
   [type]
   (first
     (for [url-content-type (keys valid-url-content-types-map)
@@ -358,11 +358,13 @@
   "Format the ISBN to make it compliant with UMM"
   [isbn]
   (when (some? isbn)
-    (-> isbn
-        str/trim
-        (str/replace "-" "")
-        (str/replace "ISBN" "")
-        (str/replace "ISSN" ""))))
+    (let [isbn (-> isbn
+                   str/trim
+                   (str/replace "-" "")
+                   (str/replace "ISBN" "")
+                   (str/replace "ISSN" ""))]
+      (when (not (str/blank? isbn))
+        isbn))))
 
 (defn truncate
   "Truncate the string if the sanitize option is enabled, otherwise return the original string"

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -14,7 +14,7 @@
                                   :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}]
      (are3 [update-type update-value find-value result]
        (is (= result
-              (field-update/apply-umm-list-update update-type umm [:ScienceKeywords] update-value find-value)))
+              (field-update/apply-update update-type umm [:ScienceKeywords] update-value find-value)))
 
        "Clear and replace"
        :clear-all-and-replace
@@ -93,7 +93,7 @@
     (let [umm {:EntryTitle "Test"}]
      (are3 [update-type update-value find-value result]
        (is (= result
-              (field-update/apply-umm-list-update update-type umm [:ScienceKeywords] update-value find-value)))
+              (field-update/apply-update update-type umm [:ScienceKeywords] update-value find-value)))
 
        "Clear and replace"
        :clear-all-and-replace
@@ -142,7 +142,7 @@
                                           :NumberOfInstruments 0}]}]}]
       (are3 [update-type update-value find-value result]
         (is (= result
-               (field-update/apply-umm-list-update update-type umm [:Platforms] update-value find-value)))
+               (field-update/apply-update update-type umm [:Platforms] update-value find-value)))
 
         "Find and replace short name"
         :find-and-replace
@@ -167,4 +167,109 @@
                       :Instruments [{:ShortName "An Instrument"
                                      :LongName "The Full Name of An Instrument v123.4"
                                      :Technique "Two cans and a string"
-                                     :NumberOfInstruments 0}]}]}))))
+                                     :NumberOfInstruments 0}]}]}))
+  (testing "Instrument updates"
+    (let [umm {:Platforms [{:ShortName "Platform 1"
+                            :LongName "Example Platform Long Name 1"
+                            :Type "Aircraft"
+                            :Instruments [{:ShortName "Inst 1"
+                                           :LongName "Instrument 1"}
+                                          {:ShortName "Inst 2"
+                                           :LongName "Instrument 2"}]}
+                           {:ShortName "Platform 2"
+                            :LongName "Example Platform Long Name 2"
+                            :Type "Aircraft"
+                            :Instruments [{:ShortName "Inst 1"
+                                           :LongName "Instrument 1"}
+                                          {:ShortName "Inst 3"
+                                           :LongName "Instrument 3"}]}]}]
+       (are3 [update-type update-value find-value result]
+         (is (= result
+                (field-update/apply-update update-type umm [:Instruments] update-value find-value)))
+
+         "Add instrument to existing"
+         :add-to-existing
+         {:ShortName "Inst X"}
+         nil
+         {:Platforms [{:ShortName "Platform 1"
+                       :LongName "Example Platform Long Name 1"
+                       :Type "Aircraft"
+                       :Instruments [{:ShortName "Inst 1"
+                                      :LongName "Instrument 1"}
+                                     {:ShortName "Inst 2"
+                                      :LongName "Instrument 2"}
+                                     {:ShortName "Inst X"}]}
+                      {:ShortName "Platform 2"
+                       :LongName "Example Platform Long Name 2"
+                       :Type "Aircraft"
+                       :Instruments [{:ShortName "Inst 1"
+                                      :LongName "Instrument 1"}
+                                     {:ShortName "Inst 3"
+                                      :LongName "Instrument 3"}
+                                     {:ShortName "Inst X"}]}]}
+
+        "Clear all and replace"
+        :clear-all-and-replace
+        {:ShortName "Inst X"}
+        nil
+        {:Platforms [{:ShortName "Platform 1"
+                      :LongName "Example Platform Long Name 1"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst X"}]}
+                     {:ShortName "Platform 2"
+                      :LongName "Example Platform Long Name 2"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst X"}]}]}
+
+        "Find and replace - multiple instances"
+        :find-and-replace
+        {:ShortName "Inst X"}
+        {:ShortName "Inst 1"}
+        {:Platforms [{:ShortName "Platform 1"
+                      :LongName "Example Platform Long Name 1"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst X"
+                                     :LongName "Instrument 1"}
+                                    {:ShortName "Inst 2"
+                                     :LongName "Instrument 2"}]}
+                     {:ShortName "Platform 2"
+                      :LongName "Example Platform Long Name 2"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst X"
+                                     :LongName "Instrument 1"}
+                                    {:ShortName "Inst 3"
+                                     :LongName "Instrument 3"}]}]}
+
+        "Find and replace - multiple instances"
+        :find-and-replace
+        {:ShortName "Inst X"}
+        {:ShortName "Inst 2"}
+        {:Platforms [{:ShortName "Platform 1"
+                      :LongName "Example Platform Long Name 1"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst 1"
+                                     :LongName "Instrument 1"}
+                                    {:ShortName "Inst X"
+                                     :LongName "Instrument 2"}]}
+                     {:ShortName "Platform 2"
+                      :LongName "Example Platform Long Name 2"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "Inst 1"
+                                     :LongName "Instrument 1"}
+                                    {:ShortName "Inst 3"
+                                     :LongName "Instrument 3"}]}]})
+
+       "Find and remove"
+       :find-and-remove
+       nil
+       {:ShortName "Inst 1"}
+       {:Platforms [{:ShortName "Platform 1"
+                     :LongName "Example Platform Long Name 1"
+                     :Type "Aircraft"
+                     :Instruments [{:ShortName "Inst 1"
+                                    :LongName "Instrument 1"}]}
+                    {:ShortName "Platform 2"
+                     :LongName "Example Platform Long Name 2"
+                     :Type "Aircraft"
+                     :Instruments [{:ShortName "Inst 1"
+                                    :LongName "Instrument 1"}]}]}))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -14,7 +14,7 @@
                                   :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}]
      (are3 [update-type update-value find-value result]
        (is (= result
-              (field-update/apply-umm-update update-type umm :ScienceKeywords update-value find-value)))
+              (field-update/apply-umm-list-update update-type umm [:ScienceKeywords] update-value find-value)))
 
        "Clear and replace"
        :clear-all-and-replace
@@ -70,7 +70,11 @@
         :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
                           {:Category "EARTH SCIENCE SERVICES"
                            :Topic "DATA ANALYSIS AND VISUALIZATION"
-                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"
+                           :VariableLevel1 "var 1",
+                           :VariableLevel2 "var 2",
+                           :VariableLevel3 "var 3",
+                           :DetailedVariable "detailed"}]}
 
        "Find and replace, not found"
        :find-and-replace
@@ -89,7 +93,7 @@
     (let [umm {:EntryTitle "Test"}]
      (are3 [update-type update-value find-value result]
        (is (= result
-              (field-update/apply-umm-update update-type umm :ScienceKeywords update-value find-value)))
+              (field-update/apply-umm-list-update update-type umm [:ScienceKeywords] update-value find-value)))
 
        "Clear and replace"
        :clear-all-and-replace
@@ -126,3 +130,41 @@
         :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
        {:Category "EARTH SCIENCE SERVICES"}
        {:EntryTitle "Test"}))))
+
+(deftest platform-instrument-name-updates
+ (testing "Platform name updates"
+   (let [umm {:Platforms [{:ShortName "Platform 1"
+                           :LongName "Example Platform Long Name 1"
+                           :Type "Aircraft"
+                           :Instruments [{:ShortName "An Instrument"
+                                          :LongName "The Full Name of An Instrument v123.4"
+                                          :Technique "Two cans and a string"
+                                          :NumberOfInstruments 0}]}]}]
+      (are3 [update-type update-value find-value result]
+        (is (= result
+               (field-update/apply-umm-list-update update-type umm [:Platforms] update-value find-value)))
+
+        "Find and replace short name"
+        :find-and-replace
+        {:ShortName "A340-600"}
+        {:ShortName "Platform 1"}
+        {:Platforms [{:ShortName "A340-600"
+                      :LongName "Example Platform Long Name 1"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "An Instrument"
+                                     :LongName "The Full Name of An Instrument v123.4"
+                                     :Technique "Two cans and a string"
+                                     :NumberOfInstruments 0}]}]}
+
+        "Find and replace long and short names"
+        :find-and-replace
+        {:ShortName "A340-600"
+         :LongName "Airbus A340-600"}
+        {:ShortName "Platform 1"}
+        {:Platforms [{:ShortName "A340-600"
+                      :LongName "Airbus A340-600"
+                      :Type "Aircraft"
+                      :Instruments [{:ShortName "An Instrument"
+                                     :LongName "The Full Name of An Instrument v123.4"
+                                     :Technique "Two cans and a string"
+                                     :NumberOfInstruments 0}]}]}))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -131,6 +131,48 @@
        {:Category "EARTH SCIENCE SERVICES"}
        {:EntryTitle "Test"}))))
 
+(deftest location-keyword-updates-test
+  (let [umm {:LocationKeywords [{:Category "CONTINENT"
+                                 :Type "ASIA"
+                                 :Subregion1 "WESTERN ASIA"
+                                 :Subregion2 "MIDDLE EAST"
+                                 :Subregion3 "GAZA STRIP"}]}]
+     (are3 [update-type update-value find-value result]
+       (is (= result
+              (field-update/apply-update update-type umm [:LocationKeywords] update-value find-value)))
+
+       "Add to existing"
+       :add-to-existing
+       {:Category "CONTINENT"
+        :Type "EUROPE"}
+       nil
+       {:LocationKeywords [{:Category "CONTINENT"
+                            :Type "ASIA"
+                            :Subregion1 "WESTERN ASIA"
+                            :Subregion2 "MIDDLE EAST"
+                            :Subregion3 "GAZA STRIP"}
+                           {:Category "CONTINENT"
+                            :Type "EUROPE"}]}
+
+       "Clear all and replace"
+       :clear-all-and-replace
+       {:Category "CONTINENT"
+        :Type "EUROPE"}
+       nil
+       {:LocationKeywords [{:Category "CONTINENT"
+                            :Type "EUROPE"}]}
+
+       "Find and replace"
+       :find-and-replace
+       {:Subregion1 "EASTERN ASIA"}
+       {:Subregion1 "WESTERN ASIA"}
+       {:LocationKeywords [{:Category "CONTINENT"
+                            :Type "ASIA"
+                            :Subregion1 "EASTERN ASIA"
+                            :Subregion2 "MIDDLE EAST"
+                            :Subregion3 "GAZA STRIP"}]})))
+
+
 (deftest platform-instrument-name-updates
  (testing "Platform name updates"
    (let [umm {:Platforms [{:ShortName "Platform 1"

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_spec_test_util.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_spec_test_util.clj
@@ -56,7 +56,10 @@
     "ISBN-12345678" "12345678"
 
     "Remove ISSN"
-    "ISSN-12345678" "12345678"))
+    "ISSN-12345678" "12345678"
+
+    "No numbers"
+    "ISBN" nil))
 
 (deftest truncation
   (testing "truncation with sanitize? option"


### PR DESCRIPTION
This is to finish the actual bulk update for all fields required for our objective. 

The decision was recently made that when we do a bulk update to save in umm-json as the new native format, so I have tests based off of that. That's subject to change.

This PR includes:
- Implement additional bulk update fields (had science kws done before)
- Bulk update save in umm-json
- Re-index provider collections after bulk update
- Change replace functionality to merge fields provided, not completely replace
- Update bulk update to handle nested params
- Restrict bulk update to certain fields via enum
- Integration and unit tests for different update scenarios