### PR TITLE
CMR-4152: Set request log format to log timestamps the same way

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -9,6 +9,7 @@
    [ring.adapter.jetty :as jetty])
   (:import
    (java.io ByteArrayInputStream InputStream)
+   (java.util TimeZone)
    (org.eclipse.jetty.server Server NCSARequestLog Connector HttpConnectionFactory)
    (org.eclipse.jetty.server.handler RequestLogHandler)
    (org.eclipse.jetty.servlets.gzip GzipHandler)))
@@ -94,7 +95,9 @@
     (.setHandler existing-handler)
     (.setRequestLog
       (doto (NCSARequestLog.)
-        (.setLogLatency true)))))
+        (.setLogLatency true)
+        (.setLogTimeZone (.getID (TimeZone/getDefault)))
+        (.setLogDateFormat "yyyy-MM-dd hh:mm:ss.SSS")))))
 
 (defn- create-gzip-handler
   "Setup gzip compression for responses.  Compression will be used for any response larger than


### PR DESCRIPTION
Set request log format to log timestamps the same way as our debug log. See if that addresses Splunk issue of combining distinct entries into a single event. In any case we've wanted to make this change even if it does not resolve the Splunk issue.