### PR TITLE
CMR-4152: Remove time zone setting because it did not work correctly …

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -96,7 +96,6 @@
     (.setRequestLog
       (doto (NCSARequestLog.)
         (.setLogLatency true)
-        (.setLogTimeZone (.getID (TimeZone/getDefault)))
         (.setLogDateFormat "yyyy-MM-dd hh:mm:ss.SSS")))))
 
 (defn- create-gzip-handler


### PR DESCRIPTION
…on our NGAP AWS instances.