### PR TITLE
CMR-4043 ACL search by user should not return ACLs for which the user has no permissions

### DIFF
--- a/access-control-app/int_test/cmr/access_control/int_test/acl_search_test.clj
+++ b/access-control-app/int_test/cmr/access_control/int_test/acl_search_test.clj
@@ -523,6 +523,10 @@
         acl-group2 (u/ingest-acl admin-token (assoc (u/provider-acl "OPTION_ASSIGNMENT")
                                               :group_permissions
                                               [{:group_id (:concept_id group2) :permissions ["create"]}]))
+        ;; Added for CMR-4043
+        acl-registered-no-perm (u/ingest-acl admin-token (assoc (u/provider-acl "AUDIT_REPORT")
+                                                          :group_permissions
+                                                          [{:user_type "registered" :permissions []}]))
         ;; No user should match this acl since group3 has no members
         acl-group3 (u/ingest-acl admin-token (assoc (u/catalog-item-acl "All Granules")
                                               :group_permissions

--- a/access-control-app/src/cmr/access_control/services/acl_search_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_search_service.clj
@@ -224,10 +224,15 @@
   [context concept-type param value options]
   ;; reject non-existent users
   (groups/validate-members-exist context [value])
-
   (let [groups (->> (auth-util/get-sids context value)
                     (map name))]
-    (cp/string-parameter->condition concept-type :permitted-group groups options)))
+    (gc/and
+     (gc/or
+      (nf/parse-nested-condition :group-permission {:permission "create"} false false)
+      (nf/parse-nested-condition :group-permission {:permission "read"} false false)
+      (nf/parse-nested-condition :group-permission {:permission "update"} false false)
+      (nf/parse-nested-condition :group-permission {:permission "delete"} false false))
+     (cp/string-parameter->condition concept-type :permitted-group groups options))))
 
 (defmethod cp/parameter->condition :legacy-guid
   [context concept-type param value options]

--- a/access-control-app/src/cmr/access_control/services/acl_search_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_search_service.clj
@@ -231,7 +231,8 @@
       (nf/parse-nested-condition :group-permission {:permission "create"} false false)
       (nf/parse-nested-condition :group-permission {:permission "read"} false false)
       (nf/parse-nested-condition :group-permission {:permission "update"} false false)
-      (nf/parse-nested-condition :group-permission {:permission "delete"} false false))
+      (nf/parse-nested-condition :group-permission {:permission "delete"} false false)
+      (nf/parse-nested-condition :group-permission {:permission "order"} false false))
      (cp/string-parameter->condition concept-type :permitted-group groups options))))
 
 (defmethod cp/parameter->condition :legacy-guid


### PR DESCRIPTION
This pull request fixes ACL search by permitted user.  Originally it was returning ACLs with empty permission vectors.  This behavior is undesired.