### PR TITLE
CMR-4152: correct the request log time format to use 24 hour clock.

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -9,7 +9,6 @@
    [ring.adapter.jetty :as jetty])
   (:import
    (java.io ByteArrayInputStream InputStream)
-   (java.util TimeZone)
    (org.eclipse.jetty.server Server NCSARequestLog Connector HttpConnectionFactory)
    (org.eclipse.jetty.server.handler RequestLogHandler)
    (org.eclipse.jetty.servlets.gzip GzipHandler)))
@@ -96,7 +95,7 @@
     (.setRequestLog
       (doto (NCSARequestLog.)
         (.setLogLatency true)
-        (.setLogDateFormat "yyyy-MM-dd hh:mm:ss.SSS")))))
+        (.setLogDateFormat "yyyy-MM-dd HH:mm:ss.SSS")))))
 
 (defn- create-gzip-handler
   "Setup gzip compression for responses.  Compression will be used for any response larger than


### PR DESCRIPTION
This change is going to work as expected in Splunk. It has to...