### PR TITLE
CMR-4196: Needed to submit sitemap to Google for indexing

### DIFF
--- a/common-app-lib/resources/templates/structure.html
+++ b/common-app-lib/resources/templates/structure.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="5kcma5msOSY2RixJaI2JfwUp6Ev_Lh5IVQHCUDnMG3k" />
     <title>{% block title %}{% endblock %}</title>
 
     {% block head-pre-css %}


### PR DESCRIPTION
This is needed in order to manually submit our sitemap file for indexing. I'm only making this change on the current production release since this needs to be there for just https://cmr.earthdata.nasa.gov/search and only for a one-time verification. I've tested locally this change does not break the main page and the verification is present where needed.