### PR TITLE
CMR-4168 variable deletes

### DIFF
--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -121,7 +121,11 @@
         (PUT "/:variable-id"
              [variable-id :as {:keys [request-context headers body]}]
              (variables/update-variable
-              request-context headers body variable-id))))
+              request-context headers body variable-id))
+        (DELETE "/:variable-id"
+                [variable-id :as {:keys [request-context headers]}]
+                (variables/delete-variable
+                 request-context headers variable-id))))
     ;; Services ingest routes
     (api-core/set-default-error-format
       :xml

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -58,7 +58,7 @@
 (defn delete-variable
   "Deletes the variable with the given variable-key."
   [context headers variable-key]
-  (verify-variable-modification-permission context :delete)
+  (verify-variable-modification-permission context :update)
   (common-enabled/validate-write-enabled context "ingest")
   (api-core/generate-ingest-response
    headers

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -54,3 +54,12 @@
   (api-core/generate-ingest-response
    headers
    (ingest/update-variable context variable-key body)))
+
+(defn delete-variable
+  "Deletes the variable with the given variable-key."
+  [context headers variable-key]
+  (verify-variable-modification-permission context :delete)
+  (common-enabled/validate-write-enabled context "ingest")
+  (api-core/generate-ingest-response
+   headers
+   (ingest/delete-variable context variable-key)))

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -397,6 +397,22 @@
           (dissoc :revision-date :transaction-id)
           (update-in [:revision-id] inc)))))
 
+(defn delete-variable
+  "Deletes a tag with the given concept id"
+  [context variable-key]
+  (let [existing-concept (fetch-variable-concept context variable-key)]
+    (mdb/save-concept
+      context
+      (-> existing-concept
+          ;; Remove fields not allowed when creating a tombstone.
+          (dissoc :metadata :format :provider-id :native-id :transaction-id)
+          (assoc :deleted true
+                 :user-id (context-util/context->user-id
+                           context
+                           msg/token-required-for-variable-modification))
+          (dissoc :revision-date)
+          (update-in [:revision-id] inc)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Service Ingest Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -410,7 +410,7 @@
                  :user-id (context-util/context->user-id
                            context
                            msg/token-required-for-variable-modification))
-          (dissoc :revision-date)
+          (dissoc :revision-date :created-at :extra-fields)
           (update-in [:revision-id] inc)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This adds delete support to UMM-Vars (ingest API).

This is based upon the branch that added update support to UMM-Vars; once that branch is merged, I will rebase this branch so that it's easier to read the diff.