### PR TITLE
CMR-4191: Add dummy service facets to V2 facets response

### DIFF
--- a/search-app/src/cmr/search/services/query_execution.clj
+++ b/search-app/src/cmr/search/services/query_execution.clj
@@ -152,10 +152,14 @@
     (common-qe/execute-query context query)))
 
 (defn- merge-facets
-  "Returns the facets by merging the two lists of facets and sort the fields in the correct order."
+  "Returns the facets by merging the two lists of facets and sort the fields in the correct order.
+  If a facet with the same title already exists in others, overwrite that facet with the one
+  provided in facets."
   [facets others]
-  (let [sort-fn (fn [facet] (.indexOf fv2rf/v2-facets-result-field-in-order (:title facet)))]
-    (sort-by sort-fn (concat facets others))))
+  (let [facets-sort-fn (fn [facet] (.indexOf fv2rf/v2-facets-result-field-in-order (:title facet)))
+        facet-titles (set (map :title facets))
+        unique-others (remove #(contains? facet-titles (:title %)) others)]
+    (sort-by facets-sort-fn (concat facets unique-others))))
 
 (defn- merge-search-result-facets
   "Returns search result by merging the base result and the facet results."

--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_helper.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_helper.clj
@@ -16,7 +16,8 @@
    :platform-h "Platforms"
    :instrument-h "Instruments"
    :processing-level-id-h "Processing levels"
-   :science-keywords-h "Keywords"})
+   :science-keywords-h "Keywords"
+   :output-format "Output File Formats"})
 
 (defn terms-facet
   "Construct a terms query to be applied for the given field. Size specifies the number of results

--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_helper.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_helper.clj
@@ -16,8 +16,7 @@
    :platform-h "Platforms"
    :instrument-h "Instruments"
    :processing-level-id-h "Processing levels"
-   :science-keywords-h "Keywords"
-   :output-format "Output File Formats"})
+   :science-keywords-h "Keywords"})
 
 (defn terms-facet
   "Construct a terms query to be applied for the given field. Size specifies the number of results

--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
@@ -45,7 +45,8 @@
 
 (def v2-facets-result-field-in-order
   "Defines the v2 facets result field in order"
-  ["Keywords" "Platforms" "Instruments" "Organizations" "Projects" "Processing levels"])
+  ["Keywords" "Platforms" "Instruments" "Organizations" "Projects" "Processing levels"
+   "Output File Formats" "Reprojections"])
 
 (defn- facet-query
   "Returns the facet query for the given facet field"

--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
@@ -31,8 +31,6 @@
    :data-center :organization.humanized2
    :project :project-sn.humanized2
    :processing-level-id :processing-level-id.humanized2})
-   ;; To add
-   ;  :output-formats :output-formats})
 
 (def facets-v2-params
   "The base search parameters for the v2 facets fields."


### PR DESCRIPTION
This PR is to add example service facets in the V2 facets response to demo how EDSC can expect to retrieve service options from the CMR.

We will perform the actual integration where we can search against UMM-S records with CMR-4086.

The service options facets should only be returned in the SIT environment for now, so by default they will not be returned, but we will override that in the SIT configuration.