### PR TITLE
Fixing CMR-4047 - The DataCenter ShortName will no longer allow the >…

### DIFF
--- a/common-lib/src/cmr/common/test/test_check_ext.clj
+++ b/common-lib/src/cmr/common/test/test_check_ext.clj
@@ -53,6 +53,9 @@
           (chuck/pass? reports#))))))
 
 (defmacro qc-and-report-exception-with-seed
+  "This macro re-runs a failed test so that it can capture the information to produce a failed test report.
+   The only difference between this function and the one above is that this one uses a seed value so that
+   the generated values of a UMM record are repeatable."
   [name seed final-reports tests bindings & body]
   `(chuck/report-exception-or-shrunk
     (test-check/quick-check

--- a/umm-spec-lib/resources/json-schemas/umm/v1.9/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/umm/v1.9/umm-cmn-json-schema.json
@@ -45,7 +45,7 @@
         },
         "ShortName": {
           "description": "This is the short name of the data center.",
-           "$ref": "#/definitions/ShortNameType"
+           "$ref": "#/definitions/DataCenterShortNameType"
         },
         "LongName": {
           "description": "This is the long name of the data center.",
@@ -1432,6 +1432,13 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 85
+    },
+    "DataCenterShortNameType": {
+      "description": "The unique name of the data center.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 85,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,84}"
     },
     "PlatformShortNameType": {
       "description": "The unique name of the platform.",

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -347,11 +347,3 @@
 (defn parse-umm-c
   [x]
   (coerce umm-c-schema x))
-
-(comment
-  (coerce umm-c-schema
-          {:EntryTitle "This is a test"
-           :TemporalExtents [{:EndsAtPresentFlag "true"
-                              :SingleDateTimes ["2000-01-01T00:00:00.000Z"]}]
-           :Distributions [{:Fees "123.4"
-                            :Sizes [{:Size "123" :Unit "MB"}]}]}))

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/data_contact.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/data_contact.clj
@@ -159,7 +159,8 @@
  "Generate a contact group in ISO. A contact group is distinguished from a contact person by not
   having an individualName."
  [contact-group]
- [:gmd:pointOfContact
+ (when contact-group
+  [:gmd:pointOfContact
    [:gmd:CI_ResponsibleParty
     [:gmd:organisationName (char-string (:GroupName contact-group))]
     [:gmd:positionName (char-string (:NonDataCenterAffiliation contact-group))]
@@ -167,7 +168,7 @@
     [:gmd:role
      [:gmd:CI_RoleCode
        {:codeList (:ndgc iso/code-lists)
-        :codeListValue "pointOfContact"} "pointOfContact"]]]])
+        :codeListValue "pointOfContact"} "pointOfContact"]]]]))
 
 (defn generate-data-center-contact-groups
  "Generate contact groups in ISO."

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -152,6 +152,12 @@
     (testing (str format " to :umm-json")
       (is (empty? (generate-and-validate-xml :collection :umm-json umm-c-record))))))
 
+;; This test starts with a umm record where the values of the record
+;; are generated with different values every time. This test takes the
+;; UMM record and converts it into another supported format, then converts it back
+;; to UMM and then back to the other format then compares the
+;; expected output with the result of the actual conversions. This test runs a record
+;; through all of the supported formats.
 (deftest roundtrip-generated-collection-records
   (checking "collection round tripping" 100
     [umm-record (gen/no-shrink umm-gen/umm-c-generator)
@@ -170,6 +176,16 @@
       (is (= expected actual)
           (str "Unable to roundtrip with format " metadata-format)))))
 
+;; This test starts with a umm record where the values of the record
+;; are generated with a seed number. When using a seed number you can
+;; regenerate the same random values everytime.  This allows for repeated
+;; testing and to re-create a test that failed with a specific seed number.
+;; While this test specifically tests CMR-4047, it also provides other an example
+;; of how to use the seed numbers from the test failure reports. This test takes the
+;; UMM record and converts it into another supported format, then converts it back
+;; to UMM and then back to the other format then compares the
+;; expected output with the result of the actual conversions. This test runs a record
+;; through all of the supported formats.
 (deftest roundtrip-generated-collection-records-with-seed
   (checking-with-seed "collection round tripping seed" 100 1496683985472
     [umm-record (gen/no-shrink umm-gen/umm-c-generator)


### PR DESCRIPTION
… character to be valid. This fixes the generated tests where the shortname is >.  > also is used in ISO as a separator between the short and long names.