### PR TITLE
IP Feature - Provide support for an additional test runner

### DIFF
--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -2,16 +2,15 @@
   :description "Provides common utility code for CMR projects."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-lib"
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.2.385"]
-                 [org.ow2.asm/asm "5.1"]
-
-                 [com.taoensso/timbre "4.1.4"]
-
-                 [org.clojure/test.check "0.9.0"]
+  :dependencies [[camel-snake-kebab "0.4.0"]
                  [com.gfredericks/test.chuck "0.2.7"]
+                 [com.taoensso/timbre "4.1.4"]
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.385"]
                  [org.clojure/data.xml "0.0.8"]
-                 [camel-snake-kebab "0.4.0"]
+                 [org.clojure/test.check "0.9.0"]
+                 [org.ow2.asm/asm "5.1"]
+                 [potemkin "1.0.0"]
 
                  ;; Note that we copied some code from this library into in memory cache. Replace that when updating.
                  [org.clojure/core.cache "0.6.5"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-lib"
 
   :dependencies [[camel-snake-kebab "0.4.0"]
+                 [clojusc/ltest "0.2.0-SNAPSHOT"]
                  [com.gfredericks/test.chuck "0.2.7"]
                  [com.taoensso/timbre "4.1.4"]
                  [org.clojure/clojure "1.8.0"]
@@ -10,7 +11,7 @@
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/test.check "0.9.0"]
                  [org.ow2.asm/asm "5.1"]
-                 [potemkin "1.0.0"]
+                 [potemkin "0.4.3"]
 
                  ;; Note that we copied some code from this library into in memory cache. Replace that when updating.
                  [org.clojure/core.cache "0.6.5"]

--- a/common-lib/src/cmr/common/test/runners/default.clj
+++ b/common-lib/src/cmr/common/test/runners/default.clj
@@ -12,35 +12,17 @@
   Note that this functionality was originally provided in the `cmr.common.test.test-runner`
   namespace."
   (:require
+   [clojure.set :as set]
    [clojure.test :as t]
-   [cmr.common.util :as u]
    [cmr.common.dev.util :as du]
-   [clojure.set :as set]))
+   [cmr.common.test.runners.util]
+   [cmr.common.util :as u]
+   [potemkin :refer [import-vars]]))
 
-(defn integration-test-namespaces
-  "The list of integration test namespaces. Anything that contains 'cmr.' and 'int-test' is
-  considered an integration test namespace. This must be a function instead of a var because of its
-  use of all-ns. It must be executed right before test execution to find all test namespaces."
-  []
-  (->> (all-ns)
-       (map str)
-       (filter #(re-find #"cmr\..*int-test" %))
-       vec
-       sort))
-
-(defn unit-test-namespaces
-  "This defines a list of unit test namespaaces. Anything namespace name that contains 'cmr.' and
-  'test' that is not an integration test namespace is considered a unit test namespace. This must be
-  a function instead of a var because of its use of all-ns. It must be executed right before test
-  execution to find all test namespaces."
-  []
-  (->> (all-ns)
-       (map str)
-       (filter #(re-find #"cmr\..*test" %))
-       set
-       (#(set/difference % (set (integration-test-namespaces))))
-       vec
-       sort))
+(import-vars
+  [cmr.common.test.runners.util
+   integration-test-namespaces
+   unit-test-namespaces])
 
 (defn run-tests
   "Runs all the tests matching the list of namespace regular expressions. The tests are run

--- a/common-lib/src/cmr/common/test/runners/ltest.clj
+++ b/common-lib/src/cmr/common/test/runners/ltest.clj
@@ -1,0 +1,38 @@
+(ns cmr.common.test.runners.ltest
+  "This test runner is a CMR adaptor for the ltest Clojure test runner."
+  (:require
+   [clojure.stacktrace :as stack]
+   [clojure.string :as string]
+   [clojure.test :as test]
+   [cmr.common.test.runners.util :as util]
+   [ltest.core :as ltest]
+   [potemkin :refer [import-vars]]))
+
+(import-vars
+  [ltest.core
+   run-test
+   run-tests])
+
+(def unit-test-suite
+  {:name "Unit Tests"
+   :nss (util/unit-test-namespaces)})
+
+(def integration-test-suite
+  {:name "Integration Tests"
+   :nss (util/integration-test-namespaces)})
+
+(def test-suites
+  [unit-test-suite
+   integration-test-suite])
+
+(defn run-unit-tests
+  []
+  (ltest/run-suite unit-test-suite))
+
+(defn run-integration-tests
+  []
+  (ltest/run-suite integration-test-suite))
+
+(defn run-suites
+  []
+  (ltest/run-suites test-suites))

--- a/common-lib/src/cmr/common/test/runners/util.clj
+++ b/common-lib/src/cmr/common/test/runners/util.clj
@@ -1,0 +1,28 @@
+(ns cmr.common.test.runners.util
+  (:require
+   [clojure.set :as set]))
+
+(defn integration-test-namespaces
+  "The list of integration test namespaces. Anything that contains 'cmr.' and 'int-test' is
+  considered an integration test namespace. This must be a function instead of a var because of its
+  use of all-ns. It must be executed right before test execution to find all test namespaces."
+  []
+  (->> (all-ns)
+       (map str)
+       (filter #(re-find #"cmr\..*int-test" %))
+       vec
+       sort))
+
+(defn unit-test-namespaces
+  "This defines a list of unit test namespaaces. Anything namespace name that contains 'cmr.' and
+  'test' that is not an integration test namespace is considered a unit test namespace. This must be
+  a function instead of a var because of its use of all-ns. It must be executed right before test
+  execution to find all test namespaces."
+  []
+  (->> (all-ns)
+       (map str)
+       (filter #(re-find #"cmr\..*test" %))
+       set
+       (#(set/difference % (set (integration-test-namespaces))))
+       vec
+       sort))

--- a/common-lib/src/cmr/common/test/runners/util.clj
+++ b/common-lib/src/cmr/common/test/runners/util.clj
@@ -1,6 +1,7 @@
 (ns cmr.common.test.runners.util
   (:require
-   [clojure.set :as set]))
+   [clojure.set :as set]
+   [clojure.string :as string]))
 
 (defn integration-test-namespaces
   "The list of integration test namespaces. Anything that contains 'cmr.' and 'int-test' is
@@ -26,3 +27,38 @@
        (#(set/difference % (set (integration-test-namespaces))))
        vec
        sort))
+
+(defn union-namespaces
+  "Get a collection of combined unit and integration tests. This function is
+  useful for auditing CMR tests, in particular, comparing with the independent
+  results obtained from calling `(get-all-tests)`."
+  []
+  (set/union (integration-test-namespaces)
+             (unit-test-namespaces)))
+
+(defn- -all-cmr-namespaces
+  "Returns the collection of all CMR namespaces, each as a namespace object."
+  []
+  (filter (fn [x] (string/starts-with? (ns-name x) "cmr")) (all-ns)))
+
+(defn all-cmr-namespaces
+  "Returns the collection of all CMR namespaces, each as a namespace string.
+  This matches the return values of the `integration-test-namespaces` and
+  `unit-test-namespaces` functions."
+  []
+  (filter (fn [x] (string/starts-with? x "cmr")) (map ns-name (all-ns))))
+
+(defn get-all-tests
+  "This function is useful for auditing the CMR tests. Given a collection of
+  namespaces, it will search all of them for tests, returning all discovered
+  tests as vars. If no collection of namespaces is passed as an arg, a list
+  of all namepsace objects whose namepsace names beginn with 'cmr' will be
+  used instead."
+  ([]
+    (get-all-tests (-all-cmr-namespaces)))
+  ([nss]
+    (->> nss
+         (map #(vals (ns-interns %)))
+         (flatten)
+         (map #(-> % meta :test))
+         (remove nil?))))

--- a/common-lib/src/cmr/common/test/test_runner.clj
+++ b/common-lib/src/cmr/common/test/test_runner.clj
@@ -1,0 +1,22 @@
+(ns cmr.common.test.test-runner
+  "DEPRECATED
+
+  This code has moved to `cmr.common.test.runners.default`; please update your
+  text editor's aliases to use the new namespace.
+
+  This namespace is currently maintained for backwards compatibility."
+  (:require
+   [cmr.common.test.runners.default]
+   [potemkin :refer [import-vars]]))
+
+(import-vars
+  [cmr.common.test.runners.default
+   integration-test-namespaces
+   unit-test-namespaces
+   run-tests
+   analyze-results
+   print-results
+   failed-test-result?
+   fail-fast?->test-results-handler
+   last-test-results
+   run-all-tests])

--- a/common-lib/src/cmr/common/test/test_runner.clj
+++ b/common-lib/src/cmr/common/test/test_runner.clj
@@ -7,16 +7,19 @@
   This namespace is currently maintained for backwards compatibility."
   (:require
    [cmr.common.test.runners.default]
+   [cmr.common.test.runners.util]
    [potemkin :refer [import-vars]]))
 
 (import-vars
   [cmr.common.test.runners.default
-   integration-test-namespaces
-   unit-test-namespaces
    run-tests
    analyze-results
    print-results
    failed-test-result?
    fail-fast?->test-results-handler
    last-test-results
-   run-all-tests])
+   run-all-tests]
+
+  [cmr.common.test.runners.util
+   integration-test-namespaces
+   unit-test-namespaces])

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -5,7 +5,8 @@
    [clojure.java.io :as io]
    [clojure.pprint :refer [pp pprint]]
    [clojure.repl :refer :all]
-   [clojure.test :refer [run-all-tests run-tests]]
+   [clojure.string :as string]
+   [clojure.test :refer [*test-out* run-all-tests run-tests]]
    [clojure.tools.namespace.repl :refer [refresh refresh-all]]
    [cmr.access-control.system :as access-control-system]
    [cmr.common.config :as config]
@@ -13,6 +14,9 @@
    [cmr.common.dev.util :as d]
    [cmr.common.jobs :as jobs]
    [cmr.common.log :as log :refer [debug info warn error]]
+   [cmr.common.test.runners.default :as test-runner]
+   [cmr.common.test.runners.ltest :as ltest]
+   [cmr.common.test.runners.util :as runner-util]
    [cmr.common.util :as u]
    [cmr.dev-system.system :as system]
    [cmr.dev-system.tests :as tests]
@@ -235,6 +239,17 @@
   []
   (future
     (tests/run-all-tests {:fail-fast? true :speak? true})))
+
+(defn run-suites
+  "Runs the suites defined by the ltest runner (unit and integration), first
+  setting the log level to `:fatal` to keep the terminal output cleaner. To
+  run with the usual error messages to STDOUT, simply use `ltest/run-suites`
+  directly."
+  ([]
+    (let [orig-log-level @settings/logging-level]
+      (set-logging-level! :fatal)
+      (ltest/run-suites)
+      (set-logging-level! orig-log-level))))
 
 (defn banner
   "Who doesn't like a banner?"


### PR DESCRIPTION
This change adds support for another test runner, without affecting the current/default test runner's behaviour. A convenience function has been provided in dev-system's `user.clj` file, allowing a developer to simple call `(run-suites)` from the REPL in order to use the new test runner (note that unit tests and integration tests are put into separate suites).

These changes also will make it easier to add more (well-behaved`*`)  test runners in the future.

This PR also made the following changes:
 * Moved code from the existing namespace `cmr.common.test.test-runner` to the new, more general `cmr.common.test.runners.default`. To support backwards compatibility, `cmr.common.test.test-runner` was recreated, but with aliases for all the vars it used to have.
 * Moved common test runner functions into `cmr.common.test.runners.util` (notably the functions that locate all the unit and integration tests)
 * Added new functions to `cmr.common.test.runners.util` that will help us audit CMR tests in the future

----
`*` "Well-behaved test runners shouldn't emulate the `clojure.test` API for `run-tests`, but should rather follow the example that the `eftest` and `ltest` test runners provide. In fact, the `ltest` example should be followed, as it sets the default reporter to `clojure.test` (the `ltest` API functions then override the reporter to use its own). The need for this rather awkward and cumbersome approach is due to the manner in which `clojure.test` was originally architected.