### PR TITLE
CMR-4226: Add logging to verify distinct collection-ids

### DIFF
--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -250,6 +250,11 @@
                           (assoc :echo-collection-id collections-with-new-granules)
                           (dissoc :has-granules-created-at)
                           lp/process-legacy-psa)]
+    
+    (info (format "Found %d collections. Were they distinct? - %s"
+                  (count collections-with-new-granules)
+                  (distinct? collections-with-new-granules)))
+
     (find-concepts-by-parameters ctx path-w-extension search-params headers body)))
 
 (defn- granule-parent-collection-query?


### PR DESCRIPTION
In order to help troubleshoot an issue with searching collections by granules that were added within a date-range, I'd like to add some logging to make debugging other environments easier.