### PR TITLE
CMR-4252 CMR Failing to properly report collection_ids for LARC_ASDC Selected Collections Granule ACLs.

### DIFF
--- a/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
+++ b/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
@@ -1,0 +1,67 @@
+(ns migrations.054-catalog-item-acl-fix
+  (:require [clojure.java.jdbc :as j]
+            [clojure.edn :as edn]
+            [cmr.common.util :as util]
+            [config.migrate-config :as config]
+            [config.mdb-migrate-helper :as h]
+            [cmr.metadata-db.data.oracle.providers :as providers]
+            [clojure.string :as string]))
+
+(defn- get-concept-ids
+  "For a given provider and entry-titles in collection-identifier, returns list of collection concept ids"
+  [provider-id collection-identifier]
+  (when-let [entry-titles (get collection-identifier :entry-titles)]
+    (let [provider (-> (h/get-provider provider-id)
+                       providers/dbresult->provider)
+          t (h/get-provider-collection-tablename provider)]
+      (for [entry-title entry-titles
+            :let [result (j/query (config/db) [(format "select distinct concept_id from metadata_db.%s where entry_title = ?" t)
+                                               entry-title])]]
+          (:concept_id (first result))))))
+
+(defn up
+  "Migrates the database up to version 54."
+  []
+  (println "migrations.054-add-coll-ids-catalog-acls up...")
+  (doseq [result (h/query "select * from cmr_acls where acl_identity like 'catalog-item%'")]
+    (println result)
+    (let [{:keys [id metadata deleted]} result
+          deleted (= 1 (long deleted))
+          metadata (-> metadata
+                       (util/gzip-blob->string)
+                       (edn/read-string))
+          {{:keys [collection-identifier collection-applicable granule-applicable provider-id]} :catalog-item-identity} metadata
+          concept-ids (if (or collection-applicable granule-applicable)
+                        (get-concept-ids provider-id collection-identifier)
+                        nil)
+          metadata (if deleted
+                     metadata
+                     (if (seq concept-ids)
+                       (assoc-in metadata [:catalog-item-identity :collection-identifier :concept-ids] concept-ids)
+                       metadata))
+          metadata (-> metadata
+                       pr-str
+                       util/string->gzip-bytes)
+          result (assoc result :metadata metadata)]
+      (j/update! (config/db) "cmr_acls" result ["id = ?" id]))))
+
+(defn down
+  "Migrates the database down from version 54."
+  []
+  (println "migrations.054-add-coll-ids-catalog-acls down...")
+  (doseq [result (h/query "select * from cmr_acls where acl_identity like 'catalog-item%'")]
+    (println result)
+    (let [{:keys [id metadata deleted]} result
+          deleted (= 1 (long deleted))
+          metadata (-> metadata
+                       (util/gzip-blob->string)
+                       (edn/read-string))
+          metadata (if deleted
+                     metadata
+                     (update-in metadata [:catalog-item-identity :collection-identifier] dissoc :concept-ids))
+          metadata (-> metadata
+                       util/remove-nil-keys
+                       pr-str
+                       util/string->gzip-bytes)
+          result (assoc result :metadata metadata)]
+      (j/update! (config/db) "cmr_acls" result ["id = ?" id]))))

--- a/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
+++ b/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
@@ -1,11 +1,12 @@
 (ns migrations.054-catalog-item-acl-fix
-  (:require [clojure.java.jdbc :as j]
-            [clojure.edn :as edn]
-            [cmr.common.util :as util]
-            [config.migrate-config :as config]
-            [config.mdb-migrate-helper :as h]
-            [cmr.metadata-db.data.oracle.providers :as providers]
-            [clojure.string :as string]))
+  (:require
+   [clojure.java.jdbc :as j]
+   [clojure.edn :as edn]
+   [cmr.common.util :as util]
+   [config.migrate-config :as config]
+   [config.mdb-migrate-helper :as h]
+   [cmr.metadata-db.data.oracle.providers :as providers]
+   [clojure.string :as string]))
 
 (defn- get-concept-ids
   "For a given provider and entry-titles in collection-identifier, returns list of collection concept ids"

--- a/metadata-db-app/src/migrations/055_remove_provider_services_tables.clj
+++ b/metadata-db-app/src/migrations/055_remove_provider_services_tables.clj
@@ -1,4 +1,4 @@
-(ns migrations.054-remove-provider-services-tables
+(ns migrations.055-remove-provider-services-tables
   (:require
     [config.mdb-migrate-helper :as h]
     [config.migrate-config :as config]))
@@ -16,9 +16,9 @@
   (format "%s_SERVICES_SEQ" provider))
 
 (defn up
-  "Migrates the database up to version 54."
+  "Migrates the database up to version 55."
   []
-  (println "migrations.054-remove-provider-services-tables up...")
+  (println "migrations.055-remove-provider-services-tables up...")
   (doseq [provider (conj (map :provider-id (h/get-regular-providers)) "SMALL_PROV")
           :let [table-name (get-services-table-name provider)
                 sequence-name (get-services-sequence-name provider)]]
@@ -55,9 +55,9 @@
    provider provider provider provider provider provider provider provider))
 
 (defn down
-  "Migrates the database down from version 54."
+  "Migrates the database down from version 55."
   []
-  (println "migrations.054-remove-provider-services-tables down...")
+  (println "migrations.055-remove-provider-services-tables down...")
   (doseq [provider (conj (map :provider-id (h/get-regular-providers)) "SMALL_PROV")
           :let [sequence-name (get-services-sequence-name provider)]]
     (h/sql (create-service-table-for-provider-sql provider))

--- a/metadata-db-app/src/migrations/056_setup_services_table.clj
+++ b/metadata-db-app/src/migrations/056_setup_services_table.clj
@@ -1,13 +1,13 @@
-(ns migrations.055-setup-services-table
+(ns migrations.056-setup-services-table
   (:require
    [config.mdb-migrate-helper :as h]))
 
 (def ^:private services-column-sql
   "id NUMBER,
-  concept_id VARCHAR(255) NOT NULL,
+  concept_id VARCHAR(256) NOT NULL,
   native_id VARCHAR(1030) NOT NULL,
   metadata BLOB NOT NULL,
-  format VARCHAR(255) NOT NULL,
+  format VARCHAR(256) NOT NULL,
   revision_id INTEGER DEFAULT 1 NOT NULL,
   revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
@@ -45,16 +45,16 @@
   (h/sql "CREATE SEQUENCE cmr_services_seq"))
 
 (defn up
-  "Migrates the database up to version 55."
+  "Migrates the database up to version 56."
   []
-  (println "migrations.055-setup-services-table up...")
+  (println "migrations.056-setup-services-table up...")
   (create-services-table)
   (create-services-indices)
   (create-services-sequence))
 
 (defn down
-  "Migrates the database down from version 55."
+  "Migrates the database down from version 56."
   []
-  (println "migrations.055-setup-services-table down...")
+  (println "migrations.056-setup-services-table down...")
   (h/sql "DROP SEQUENCE METADATA_DB.cmr_services_seq")
   (h/sql "DROP TABLE METADATA_DB.cmr_services"))

--- a/metadata-db-app/src/migrations/056_setup_services_table.clj
+++ b/metadata-db-app/src/migrations/056_setup_services_table.clj
@@ -4,10 +4,10 @@
 
 (def ^:private services-column-sql
   "id NUMBER,
-  concept_id VARCHAR(256) NOT NULL,
+  concept_id VARCHAR(255) NOT NULL,
   native_id VARCHAR(1030) NOT NULL,
   metadata BLOB NOT NULL,
-  format VARCHAR(256) NOT NULL,
+  format VARCHAR(255) NOT NULL,
   revision_id INTEGER DEFAULT 1 NOT NULL,
   revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,

--- a/metadata-db-app/src/migrations/057_update_variable_name_length.clj
+++ b/metadata-db-app/src/migrations/057_update_variable_name_length.clj
@@ -1,17 +1,17 @@
-(ns migrations.056-update-variable-name-length
+(ns migrations.057-update-variable-name-length
   (:require
    [config.mdb-migrate-helper :as h]))
 
 (defn up
-  "Migrates the database up to version 56."
+  "Migrates the database up to version 57."
   []
-  (println "migrations.056-update-variable-name-length up...")
+  (println "migrations.057-update-variable-name-length up...")
   (h/sql "alter table METADATA_DB.cmr_variables modify variable_name VARCHAR(80) NOT NULL"))
 
 
 (defn down
-  "Migrates the database down from version 56."
+  "Migrates the database down from version 57."
   []
-  (println "migrations.056-update-variable-name-length down...")
+  (println "migrations.057-update-variable-name-length down...")
   ;; We don't want to roll back the length change
   (h/sql "alter table METADATA_DB.cmr_variables modify variable_name VARCHAR(80) NULL"))


### PR DESCRIPTION
This PR is to fix catalog item acls with granule-applicable true but collection-applicable false, before these were being skipped in the dbmigrations 53 and 52.  Also reorders dbmigrations. 