### PR TITLE
CMR-4220: Back out the search using the new index created by CMR-4103;

### DIFF
--- a/search-app/src/cmr/search/data/complex_to_simple_converters/temporal.clj
+++ b/search-app/src/cmr/search/data/complex_to_simple_converters/temporal.clj
@@ -16,10 +16,9 @@
   so that it will be easier to convert into elastic json"
   [temporal]
   (let [{:keys [start-date end-date exclusive? limit-to-granules]} temporal
-        [start-date-field end-date-field] 
-          (if limit-to-granules
-            [:limit-to-granules-temporals.start-date :limit-to-granules-temporals.end-date]
-            [:temporals.start-date :temporals.end-date])
+        [start-date-field end-date-field] (if limit-to-granules
+                                            [:granule-start-date :granule-end-date]
+                                            [:start-date :end-date])
         conditions (if end-date
                      [(cqm/map->DateRangeCondition {:field start-date-field
                                                     :end-date end-date
@@ -31,13 +30,10 @@
                      [(gc/or-conds [(cqm/map->MissingCondition {:field end-date-field})
                                     (cqm/map->DateRangeCondition {:field end-date-field
                                                                   :start-date start-date
-                                                                  :exclusive? exclusive?})])])
-        and-conditions (gc/and-conds (concat
-                                       [(cqm/map->ExistCondition {:field start-date-field})]
-                                       conditions))]
-    (if limit-to-granules
-      (cqm/nested-condition :limit-to-granules-temporals and-conditions) 
-      (cqm/nested-condition :temporals and-conditions))))
+                                                                  :exclusive? exclusive?})])])]
+    (gc/and-conds (concat
+                    [(cqm/map->ExistCondition {:field start-date-field})]
+                    conditions)))) 
 
 (defn current-end-date
   "Returns the current end datetime for a given year and attributes of a periodic temporal condition"

--- a/system-int-test/test/cmr/system_int_test/search/collection_temporal_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_temporal_search_test.clj
@@ -145,11 +145,12 @@
       [coll7] {"temporal[]" "1997-05-03T00:00:00Z,1997-05-06T00:00:00Z"
                            "options[temporal][limit_to_granules]" true}
 
-      "coll7 is not returned when searching with a temporal range that's within the gap of the collection's temporal ranges"
-      [] {"temporal[]" "1997-05-03T00:00:00Z,1997-05-04T00:00:00Z"}
+      ;; coll7 is returned in the following two tests because of CMR-4220. Once CMR-4284 is fixed, remove it.
+      "coll7 is returned when searching with a temporal range that's within the gap of the collection's temporal ranges"
+      [coll7] {"temporal[]" "1997-05-03T00:00:00Z,1997-05-04T00:00:00Z"}
 
-      "coll7 is not returned when searching with a temporal range that's within the gap of the collection's temporal ranges limit-to-granules case"
-      [] {"temporal[]" "1997-05-03T00:00:00Z,1997-05-04T00:00:00Z"
+      "coll7 is returned when searching with a temporal range that's within the gap of the collection's temporal ranges limit-to-granules case"
+      [coll7] {"temporal[]" "1997-05-03T00:00:00Z,1997-05-04T00:00:00Z"
                            "options[temporal][limit_to_granules]" true})))
 
 (deftest search-by-temporal-limit-to-granules-updates-are-handled-by-partial-refresh
@@ -297,8 +298,9 @@
         "search by temporal_end"
         [coll1 coll2 coll3 coll4 coll6 coll7 coll9 coll10 coll11 coll12 coll13 coll14] {"temporal[]" "/2010-12-12T12:00:00Z"}
 
+        ;; coll14 is returned in the following one test because of CMR-4220. Once CMR-4284 is fixed, remove it.
         "search by temporal_range that falls into the gap of the collection temporal ranges"
-        [] {"temporal[]" "1960-05-03T00:00:00Z, 1960-05-04T00:00:00Z"}
+        [coll14] {"temporal[]" "1960-05-03T00:00:00Z, 1960-05-04T00:00:00Z"}
  
         "search by temporal_range that intersects with the collection temporal ranges"
         [coll14] {"temporal[]" "1960-05-03T00:00:00Z, 1960-05-06T00:00:00Z"}


### PR DESCRIPTION
CMR-4103 added nested index for granule and collection search. In order to make it work, we need to re-index all the granules, which takes a long time.  So we need to break this into two parts and fix them in two different sprints.:

1. Add nested index.
2. Modify the search to make use of the new index.

CMR-4220 addresses the first part, CMR-4284 will address the second part.