### PR TITLE
CMR-4292 CMR-4293 CMR-4163

### DIFF
--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -53,7 +53,8 @@
   (common-enabled/validate-write-enabled context "access control")
   (v/validate-acl-save! context acl :create)
   (acl-auth/authorize-acl-action context :create acl)
-  (acl-util/create-acl context acl))
+  (let [acl (acl-util/sync-entry-titles-concept-ids context :create acl)]
+    (acl-util/create-acl context acl)))
 
 (defn update-acl
   "Update the ACL with the given concept-id in Metadata DB. Returns map with concept and revision id of updated acl."
@@ -73,7 +74,8 @@
       (errors/throw-service-error :invalid-data
                                   (format "ACL legacy guid cannot be updated, was [%s] and now [%s]"
                                           existing-legacy-guid legacy-guid)))
-    (let [new-concept (merge (acl-util/acl->base-concept context acl)
+    (let [acl (acl-util/sync-entry-titles-concept-ids context :update acl)
+          new-concept (merge (acl-util/acl->base-concept context acl)
                             {:concept-id concept-id
                               :native-id (:native-id existing-concept)})
           resp (mdb/save-concept context new-concept)]

--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -53,7 +53,7 @@
   (common-enabled/validate-write-enabled context "access control")
   (v/validate-acl-save! context acl :create)
   (acl-auth/authorize-acl-action context :create acl)
-  (let [acl (acl-util/sync-entry-titles-concept-ids context :create acl)]
+  (let [acl (acl-util/sync-entry-titles-concept-ids context acl)]
     (acl-util/create-acl context acl)))
 
 (defn update-acl
@@ -74,7 +74,7 @@
       (errors/throw-service-error :invalid-data
                                   (format "ACL legacy guid cannot be updated, was [%s] and now [%s]"
                                           existing-legacy-guid legacy-guid)))
-    (let [acl (acl-util/sync-entry-titles-concept-ids context :update acl)
+    (let [acl (acl-util/sync-entry-titles-concept-ids context acl)
           new-concept (merge (acl-util/acl->base-concept context acl)
                             {:concept-id concept-id
                               :native-id (:native-id existing-concept)})

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -105,8 +105,10 @@
     (get-acls-by-condition context condition)))
 
 (defn sync-entry-titles-concept-ids
-  "If the ACL is a catalog item acl with a collection identifier that includes concept-ids or
-   entry-titles, return ACL such that both are a union of each list"
+  "If the given ACL is a catalog item acl with a collection identifier that includes concept-ids or
+   entry-titles, return ACL such that both are a unioned with each other for :create action. If action is
+   :update and there are only entry-titles, then sync against entry-titles, otherwise sync against concept-ids.
+   If there are no concept-ids or entry-titles, acl remains unchanged."
   [context action acl]
   (if-let [collection-identifier (get-in acl [:catalog-item-identity :collection-identifier])]
     (let [entry-titles (:entry-titles collection-identifier)

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -106,7 +106,7 @@
 
 (defn sync-entry-titles-concept-ids
   "If the given ACL is a catalog item acl with a collection identifier that includes concept-ids or
-   entry-titles, return the ACL such that both are a unioned with each other."
+   entry-titles, return the ACL such that both are unioned with each other."
   [context acl]
   (if-let [collection-identifier (get-in acl [:catalog-item-identity :collection-identifier])]
     (let [entry-titles (:entry-titles collection-identifier)

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -14,6 +14,7 @@
     [cmr.common-app.services.search.query-model :as qm]
     [cmr.transmit.echo.tokens :as tokens]
     [cmr.transmit.metadata-db2 :as mdb]
+    [cmr.transmit.metadata-db :as mdb1]
     [cmr.common-app.services.search.group-query-conditions :as gc]))
 
 (def acl-provider-id
@@ -102,3 +103,28 @@
                             (qm/string-condition :target target))
                     identity-type-condition)]
     (get-acls-by-condition context condition)))
+
+(defn sync-entry-titles-concept-ids
+  "If the ACL is a catalog item acl with a collection identifier that includes concept-ids or
+   entry-titles, return ACL such that both are a union of each list"
+  [context action acl]
+  (if-let [collection-identifier (get-in acl [:catalog-item-identity :collection-identifier])]
+    (let [entry-titles (:entry-titles collection-identifier)
+          concept-ids (:concept-ids collection-identifier)
+          provider-id (get-in acl [:catalog-item-identity :provider-id])
+          colls-from-entry-titles (when (and (seq entry-titles)
+                                             (or (and (empty? concept-ids)
+                                                      (= action :update))
+                                                 (= action :create)))
+                                    (mdb1/find-concepts context {:provider-id provider-id :entry-title entry-titles} :collection))
+          colls-from-concept-ids (when (seq concept-ids)
+                                   (mdb1/find-concepts context {:provider-id provider-id :concept-id concept-ids} :collection))
+          collections (distinct (concat colls-from-entry-titles colls-from-concept-ids))
+          concept-ids (map :concept-id collections)
+          entry-titles (map #(get-in % [:extra-fields :entry-title]) collections)
+          collection-identifier (-> collection-identifier
+                                    (assoc :entry-titles entry-titles)
+                                    (assoc :concept-ids concept-ids)
+                                    util/remove-nil-keys)]
+      (assoc-in acl [:catalog-item-identity :collection-identifier] collection-identifier))
+    acl))

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -106,18 +106,13 @@
 
 (defn sync-entry-titles-concept-ids
   "If the given ACL is a catalog item acl with a collection identifier that includes concept-ids or
-   entry-titles, return ACL such that both are a unioned with each other for :create action. If action is
-   :update and there are only entry-titles, then sync against entry-titles, otherwise sync against concept-ids.
-   If there are no concept-ids or entry-titles, acl remains unchanged."
-  [context action acl]
+   entry-titles, return the ACL such that both are a unioned with each other."
+  [context acl]
   (if-let [collection-identifier (get-in acl [:catalog-item-identity :collection-identifier])]
     (let [entry-titles (:entry-titles collection-identifier)
           concept-ids (:concept-ids collection-identifier)
           provider-id (get-in acl [:catalog-item-identity :provider-id])
-          colls-from-entry-titles (when (and (seq entry-titles)
-                                             (or (and (empty? concept-ids)
-                                                      (= action :update))
-                                                 (= action :create)))
+          colls-from-entry-titles (when (seq entry-titles)
                                     (mdb1/find-concepts context {:provider-id provider-id :entry-title entry-titles} :collection))
           colls-from-concept-ids (when (seq concept-ids)
                                    (mdb1/find-concepts context {:provider-id provider-id :concept-id concept-ids} :collection))

--- a/access-control-app/src/cmr/access_control/services/event_handler.clj
+++ b/access-control-app/src/cmr/access_control/services/event_handler.clj
@@ -84,10 +84,9 @@
     (doseq [acl-concept (acl-service/get-all-acl-concepts context)
             :let [parsed-acl (acl-service/get-parsed-acl acl-concept)
                   catalog-item-id (:catalog-item-identity parsed-acl)
-                  coll-concept-id (:concept-id collection-concept)
                   concept-ids (get (:collection-identifier catalog-item-id) :concept-ids)]
             :when (and (= (:provider-id collection-concept) (:provider-id catalog-item-id))
-                       (some #{coll-concept-id} concept-ids))]
+                       (some #{concept-id} concept-ids))]
       (if (= 1 (count concept-ids))
         ;; The ACL only references the collection being deleted, and therefore the ACL should be deleted.
         ;; With the addition of concept-ids, this assumes entry-titles and concept-ids are in sync.

--- a/access-control-app/src/cmr/access_control/services/event_handler.clj
+++ b/access-control-app/src/cmr/access_control/services/event_handler.clj
@@ -81,27 +81,27 @@
   [context {:keys [concept-id revision-id]}]
   (let [concept-map (mdb/get-concept context concept-id revision-id)
         collection-concept (acl-matchers/add-acl-enforcement-fields-to-concept concept-map)]
-    (doseq [key-path [:entry-titles :concept-ids]
-            acl-concept (acl-service/get-all-acl-concepts context)
+    (doseq [acl-concept (acl-service/get-all-acl-concepts context)
             :let [parsed-acl (acl-service/get-parsed-acl acl-concept)
                   catalog-item-id (:catalog-item-identity parsed-acl)
-                  value (if (= key-path :entry-titles)
-                          (:EntryTitle collection-concept)
-                          (:concept-id collection-concept))
-                  acl-values (get (:collection-identifier catalog-item-id) key-path)]
+                  coll-concept-id (:concept-id collection-concept)
+                  concept-ids (get (:collection-identifier catalog-item-id) :concept-ids)]
             :when (and (= (:provider-id collection-concept) (:provider-id catalog-item-id))
-                       (some #{value} acl-values))]
-      (if (= 1 (count acl-values))
+                       (some #{coll-concept-id} concept-ids))]
+      (if (= 1 (count concept-ids))
         ;; The ACL only references the collection being deleted, and therefore the ACL should be deleted.
         ;; With the addition of concept-ids, this assumes entry-titles and concept-ids are in sync.
         (acl-service/delete-acl (transmit-config/with-echo-system-token context)
                                 (:concept-id acl-concept))
         ;; Otherwise the ACL references other collections, and will be updated
-        (let [new-acl (update-in parsed-acl
-                                 [:catalog-item-identity :collection-identifier key-path]
-                                 #(remove #{value} %))]
+        (let [new-acl (-> parsed-acl
+                          (assoc-in [:catalog-item-identity :collection-identifier :concept-ids]
+                                    (remove #(= % concept-id) concept-ids))
+                          (update-in [:catalog-item-identity :collection-identifier]
+                                     dissoc :entry-titles))]
           (acl-service/update-acl (transmit-config/with-echo-system-token context)
                                   (:concept-id acl-concept) new-acl))))))
+
 
 (defn subscribe-to-events
   "Subscribe to event messages on various queues"

--- a/metadata-db-app/src/migrations/052_add_coll_ids_catalog_acls.clj
+++ b/metadata-db-app/src/migrations/052_add_coll_ids_catalog_acls.clj
@@ -48,20 +48,4 @@
 (defn down
   "Migrates the database down from version 52."
   []
-  (println "migrations.052-add-coll-ids-catalog-acls down...")
-  (doseq [result (h/query "select * from cmr_acls where acl_identity like 'catalog-item%'")]
-    (println result)
-    (let [{:keys [id metadata deleted]} result
-          deleted (= 1 (long deleted))
-          metadata (-> metadata
-                       (util/gzip-blob->string)
-                       (edn/read-string))
-          metadata (if deleted
-                     metadata
-                     (update-in metadata [:catalog-item-identity :collection-identifier] dissoc :concept-ids))
-          metadata (-> metadata
-                       util/remove-nil-keys
-                       pr-str
-                       util/string->gzip-bytes)
-          result (assoc result :metadata metadata)]
-      (j/update! (config/db) "cmr_acls" result ["id = ?" id]))))
+  (println "migrations.052-add-coll-ids-catalog-acls down..."))

--- a/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
+++ b/metadata-db-app/src/migrations/054_catalog_item_acl_fix.clj
@@ -49,20 +49,4 @@
 (defn down
   "Migrates the database down from version 54."
   []
-  (println "migrations.054-add-coll-ids-catalog-acls down...")
-  (doseq [result (h/query "select * from cmr_acls where acl_identity like 'catalog-item%'")]
-    (println result)
-    (let [{:keys [id metadata deleted]} result
-          deleted (= 1 (long deleted))
-          metadata (-> metadata
-                       (util/gzip-blob->string)
-                       (edn/read-string))
-          metadata (if deleted
-                     metadata
-                     (update-in metadata [:catalog-item-identity :collection-identifier] dissoc :concept-ids))
-          metadata (-> metadata
-                       util/remove-nil-keys
-                       pr-str
-                       util/string->gzip-bytes)
-          result (assoc result :metadata metadata)]
-      (j/update! (config/db) "cmr_acls" result ["id = ?" id]))))
+  (println "migrations.054-add-coll-ids-catalog-acls down..."))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -480,7 +480,7 @@
       (index/wait-until-indexed)
       ;; Verify that those ACLs are NOT found.
       (let [results (:items (ac/search-for-acls (transmit-config/echo-system-token) {:identity_type "catalog_item" :provider "PROV1"}))]
-        (is (= [3] (map :revision_id results)))
+        (is (= [2] (map :revision_id results)))
         (is (= ["coll1/coll2 ACL"] (map :name results)))
         (is (= [(:EntryTitle coll2)]
                (-> (ac/get-acl token (:concept_id (first results)))
@@ -498,7 +498,7 @@
       (index/wait-until-indexed)
       ;; Verify that those ACLs are NOT found.
       (let [results (:items (ac/search-for-acls (transmit-config/echo-system-token) {:identity_type "catalog_item" :provider "PROV2"}))]
-        (is (= [3] (map :revision_id results)))
+        (is (= [2] (map :revision_id results)))
         (is (= ["coll3/coll4 ACL"] (map :name results)))
         (is (= [(:concept-id coll4)]
                (-> (ac/get-acl token (:concept_id (first results)))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -480,7 +480,7 @@
       (index/wait-until-indexed)
       ;; Verify that those ACLs are NOT found.
       (let [results (:items (ac/search-for-acls (transmit-config/echo-system-token) {:identity_type "catalog_item" :provider "PROV1"}))]
-        (is (= [2] (map :revision_id results)))
+        (is (= [3] (map :revision_id results)))
         (is (= ["coll1/coll2 ACL"] (map :name results)))
         (is (= [(:EntryTitle coll2)]
                (-> (ac/get-acl token (:concept_id (first results)))
@@ -498,7 +498,7 @@
       (index/wait-until-indexed)
       ;; Verify that those ACLs are NOT found.
       (let [results (:items (ac/search-for-acls (transmit-config/echo-system-token) {:identity_type "catalog_item" :provider "PROV2"}))]
-        (is (= [2] (map :revision_id results)))
+        (is (= [3] (map :revision_id results)))
         (is (= ["coll3/coll4 ACL"] (map :name results)))
         (is (= [(:concept-id coll4)]
                (-> (ac/get-acl token (:concept_id (first results)))


### PR DESCRIPTION
This PR addresses:
CMR-4292 fixes pump interop, CMR-4293 fixes permitted group ids in collection index, CMR-4163 syncs entry-titles and concept-ids on acl create and update