### PR TITLE
CMR-4214: Add JSON schema validation to variable ingest API

### DIFF
--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -18,10 +18,10 @@
   POST body. Writes rows to tables and returns task id"
   [provider-id request]
   (let [{:keys [body headers request-context]} request
-        body (string/trim (slurp body))]
+        content (api-core/read-body! body)]
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
-    (let [task-id (bulk-update/validate-and-save-bulk-update request-context provider-id body)]
+    (let [task-id (bulk-update/validate-and-save-bulk-update request-context provider-id content)]
       (api-core/generate-ingest-response
         headers
         {:status 200

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -20,7 +20,7 @@
 (defn validate-collection
   [provider-id native-id request]
   (let [{:keys [body content-type params headers request-context]} request
-        concept (api-core/body->concept :collection provider-id native-id body content-type headers)
+        concept (api-core/body->concept! :collection provider-id native-id body content-type headers)
         validation-options (get-validation-options headers)]
     (api-core/verify-provider-exists request-context provider-id)
     (info (format "Validating Collection %s from client %s"
@@ -40,7 +40,7 @@
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
-    (let [concept (api-core/body->concept :collection provider-id native-id body content-type headers)
+    (let [concept (api-core/body->concept! :collection provider-id native-id body content-type headers)
           validation-options (get-validation-options headers)
           save-collection-result (ingest/save-collection
                                   request-context

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -193,16 +193,23 @@
     (assoc concept :concept-id concept-id)
     concept))
 
+(defn metadata->concept
+  "Create a metadata concept from the given metadata"
+  [concept-type metadata content-type headers]
+  (-> {:metadata metadata
+       :format (mt/keep-version content-type)
+       :native-id (:name metadata)
+       :concept-type concept-type}
+      (set-concept-id headers)
+      (set-revision-id headers)))
+
 (defn body->concept
-  "Create a metadata concept from the given request body."
+  "Create a metadata concept from the given request body.
+   This function has the side effect of emptying the request body.
+   Don't try to read the body again after calling this function."
   ([concept-type body content-type headers]
    (let [metadata (string/trim (slurp body))]
-     (-> {:metadata metadata
-          :format (mt/keep-version content-type)
-          :native-id (:name metadata)
-          :concept-type concept-type}
-         (set-concept-id headers)
-         (set-revision-id headers))))
+     (metadata->concept concept-type metadata content-type headers)))
   ([concept-type native-id body content-type headers]
    (assoc (body->concept concept-type body content-type headers)
           :native-id native-id))

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -193,6 +193,13 @@
     (assoc concept :concept-id concept-id)
     concept))
 
+(defn read-body!
+  "Returns the body content string by slurping the request body.
+  This function has the side effect of emptying the request body.
+  Don't try to read the body again after calling this function."
+  [body]
+  (string/trim (slurp body)))
+
 (defn metadata->concept
   "Create a metadata concept from the given metadata"
   [concept-type metadata content-type headers]
@@ -203,18 +210,18 @@
       (set-concept-id headers)
       (set-revision-id headers)))
 
-(defn body->concept
+(defn body->concept!
   "Create a metadata concept from the given request body.
-   This function has the side effect of emptying the request body.
-   Don't try to read the body again after calling this function."
+  This function has the side effect of emptying the request body.
+  Don't try to read the body again after calling this function."
   ([concept-type body content-type headers]
-   (let [metadata (string/trim (slurp body))]
+   (let [metadata (read-body! body)]
      (metadata->concept concept-type metadata content-type headers)))
   ([concept-type native-id body content-type headers]
-   (assoc (body->concept concept-type body content-type headers)
+   (assoc (body->concept! concept-type body content-type headers)
           :native-id native-id))
   ([concept-type provider-id native-id body content-type headers]
-   (assoc (body->concept concept-type native-id body content-type headers)
+   (assoc (body->concept! concept-type native-id body content-type headers)
           :provider-id provider-id)))
 
 (defn concept->loggable-string

--- a/ingest-app/src/cmr/ingest/api/granules.clj
+++ b/ingest-app/src/cmr/ingest/api/granules.clj
@@ -21,7 +21,7 @@
 (defmethod validate-granule :default
   [provider-id native-id {:keys [body content-type headers request-context]}]
   (api-core/verify-provider-exists request-context provider-id)
-  (let [concept (api-core/body->concept :granule provider-id native-id body content-type headers)]
+  (let [concept (api-core/body->concept! :granule provider-id native-id body content-type headers)]
     (info (format "Validating granule %s from client %s"
                   (api-core/concept->loggable-string concept) (:client-id request-context)))
     (ingest/validate-granule request-context concept)
@@ -63,7 +63,7 @@
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
-    (let [concept (api-core/body->concept :granule provider-id native-id body content-type headers)]
+    (let [concept (api-core/body->concept! :granule provider-id native-id body content-type headers)]
       (info (format "Ingesting granule %s from client %s"
                     (api-core/concept->loggable-string concept) (:client-id request-context)))
       (api-core/generate-ingest-response headers (ingest/save-granule request-context concept)))))

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -116,12 +116,11 @@
       :xml
       (context "/variables" []
         (POST "/"
-              {:keys [request-context headers body]}
-              (variables/create-variable request-context headers body))
+              request
+              (variables/create-variable request))
         (PUT "/:variable-id"
-             [variable-id :as {:keys [request-context headers body]}]
-             (variables/update-variable
-              request-context headers body variable-id))
+             [variable-id :as request]
+             (variables/update-variable variable-id request))
         (DELETE "/:variable-id"
                 [variable-id :as {:keys [request-context headers]}]
                 (variables/delete-variable

--- a/ingest-app/src/cmr/ingest/api/services.clj
+++ b/ingest-app/src/cmr/ingest/api/services.clj
@@ -42,7 +42,7 @@
   (verify-service-modification-permission context :update)
   (common-enabled/validate-write-enabled context "ingest")
   (validate-service-content-type headers)
-  (let [metadata (string/trim (slurp body))]
+  (let [metadata (api-core/read-body! body)]
     (api-core/generate-ingest-response
      headers
      (ingest/create-service context metadata))))
@@ -53,7 +53,7 @@
   (verify-service-modification-permission context :update)
   (common-enabled/validate-write-enabled context "ingest")
   (validate-service-content-type headers)
-  (let [metadata (string/trim (slurp body))]
+  (let [metadata (api-core/read-body! body)]
     (api-core/generate-ingest-response
      headers
      (ingest/update-service context service-key metadata))))

--- a/ingest-app/src/cmr/ingest/api/services.clj
+++ b/ingest-app/src/cmr/ingest/api/services.clj
@@ -2,6 +2,7 @@
   "Service ingest functions in support of the ingest API."
   (:require
    [cheshire.core :as json]
+   [clojure.string :as string]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common.log :refer [debug info warn error]]
@@ -41,9 +42,10 @@
   (verify-service-modification-permission context :update)
   (common-enabled/validate-write-enabled context "ingest")
   (validate-service-content-type headers)
-  (api-core/generate-ingest-response
-   headers
-   (ingest/create-service context body)))
+  (let [metadata (string/trim (slurp body))]
+    (api-core/generate-ingest-response
+     headers
+     (ingest/create-service context metadata))))
 
 (defn update-service
   "Processes a request to update a service."
@@ -51,6 +53,7 @@
   (verify-service-modification-permission context :update)
   (common-enabled/validate-write-enabled context "ingest")
   (validate-service-content-type headers)
-  (api-core/generate-ingest-response
-   headers
-   (ingest/update-service context service-key body)))
+  (let [metadata (string/trim (slurp body))]
+    (api-core/generate-ingest-response
+     headers
+     (ingest/update-service context service-key metadata))))

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -45,7 +45,7 @@
              inherits this limitation from the real system."
   [request]
   (let [{:keys [body content-type headers request-context]} request
-        metadata (string/trim (slurp body))]
+        metadata (api-core/read-body! body)]
     (verify-variable-modification-permission request-context :update)
     (common-enabled/validate-write-enabled request-context "ingest")
     (validate-variable-metadata content-type headers metadata)
@@ -57,7 +57,7 @@
   "Processes a request to update a variable."
   [variable-key request]
   (let [{:keys [body content-type headers request-context]} request
-        metadata (string/trim (slurp body))]
+        metadata (api-core/read-body! body)]
     (verify-variable-modification-permission request-context :update)
     (common-enabled/validate-write-enabled request-context "ingest")
     (validate-variable-metadata content-type headers metadata)

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -25,11 +25,6 @@
       :unauthorized
       (format "You do not have permission to %s a variable." (name permission-type)))))
 
-(defn- validate-variable-content-type
-  "Validates that content type sent with a variable is JSON"
-  [headers]
-  (mt/extract-header-mime-type #{mt/json} headers "content-type" true))
-
 (defn- validate-variable-metadata
   "Validate variable metadata, throws error if the metadata is not a valid against the
    UMM variable JSON schema."

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -2,6 +2,7 @@
   "Variable ingest functions in support of the ingest API."
   (:require
    [cheshire.core :as json]
+   [clojure.string :as string]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common.log :refer [debug info warn error]]
@@ -9,7 +10,8 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
-   [cmr.ingest.services.ingest-service :as ingest]))
+   [cmr.ingest.services.ingest-service :as ingest]
+   [cmr.ingest.validation.validation :as v]))
 
 (defn- verify-variable-modification-permission
   "Verifies the current user has been granted permission to modify variables in
@@ -28,6 +30,15 @@
   [headers]
   (mt/extract-header-mime-type #{mt/json} headers "content-type" true))
 
+(defn- validate-variable-metadata
+  "Validate variable metadata, throws error if the metadata is not a valid against the
+   UMM variable JSON schema."
+  [content-type headers metadata]
+  (let [concept (api-core/metadata->concept :variable metadata content-type headers)
+        concept (update-in concept [:format] ingest/fix-ingest-concept-format)]
+    (v/validate-concept-request concept)
+    (v/validate-concept-metadata concept)))
+
 (defn create-variable
   "Processes a create variable request.
 
@@ -37,23 +48,27 @@
              permission in the system for any ingest; only 'update' is
              allowed for ingest operations. The mock ACL system (rightly)
              inherits this limitation from the real system."
-  [context headers body]
-  (verify-variable-modification-permission context :update)
-  (common-enabled/validate-write-enabled context "ingest")
-  (validate-variable-content-type headers)
-  (api-core/generate-ingest-response
-   headers
-   (ingest/create-variable context body)))
+  [request]
+  (let [{:keys [body content-type headers request-context]} request
+        metadata (string/trim (slurp body))]
+    (verify-variable-modification-permission request-context :update)
+    (common-enabled/validate-write-enabled request-context "ingest")
+    (validate-variable-metadata content-type headers metadata)
+    (api-core/generate-ingest-response
+     headers
+     (ingest/create-variable request-context metadata))))
 
 (defn update-variable
   "Processes a request to update a variable."
-  [context headers body variable-key]
-  (verify-variable-modification-permission context :update)
-  (common-enabled/validate-write-enabled context "ingest")
-  (validate-variable-content-type headers)
-  (api-core/generate-ingest-response
-   headers
-   (ingest/update-variable context variable-key body)))
+  [variable-key request]
+  (let [{:keys [body content-type headers request-context]} request
+        metadata (string/trim (slurp body))]
+    (verify-variable-modification-permission request-context :update)
+    (common-enabled/validate-write-enabled request-context "ingest")
+    (validate-variable-metadata content-type headers metadata)
+    (api-core/generate-ingest-response
+     headers
+     (ingest/update-variable request-context variable-key metadata))))
 
 (defn delete-variable
   "Deletes the variable with the given variable-key."

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -94,19 +94,13 @@
           {:keys [revision-id]} (mdb/save-concept context concept)]
       {:concept-id concept-id, :revision-id revision-id})))
 
-(defmulti concept-json->concept
-  "Converts the concept in JSON format to a standard Clojure data structure. It
-  is expected that this function will be used to parse a request's body."
-  type)
-
-(defmethod concept-json->concept java.io.ByteArrayInputStream
-  [data]
-  (concept-json->concept (slurp data)))
-
-(defmethod concept-json->concept java.lang.String
-  [data]
+(defn- concept-json->concept
+  "Returns the concept for the given concept JSON string.
+   This is a temporary function and will be replaced by the UMM parse-metadata function once
+   UMM-Var and UMM-Service are fully supported in UMM-Spec."
+  [json-str]
   (util/map-keys->kebab-case
-   (json/parse-string data true)))
+   (json/parse-string json-str true)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Collection Service Functions

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -96,8 +96,8 @@
 
 (defn- concept-json->concept
   "Returns the concept for the given concept JSON string.
-   This is a temporary function and will be replaced by the UMM parse-metadata function once
-   UMM-Var and UMM-Service are fully supported in UMM-Spec."
+  This is a temporary function and will be replaced by the UMM parse-metadata function once
+  UMM-Var and UMM-Service are fully supported in UMM-Spec."
   [json-str]
   (util/map-keys->kebab-case
    (json/parse-string json-str true)))

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -35,7 +35,7 @@
 ;;; General Support/Utility Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- fix-ingest-concept-format
+(defn fix-ingest-concept-format
   "Fixes formats"
   [fmt]
   (if (or

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -43,7 +43,7 @@
   "Validates the metadata length is not unreasonable."
   [concept]
   (when (<= (count (:metadata concept)) 4)
-    (errors/throw-service-error :bad-request "XML content is too short.")))
+    (errors/throw-service-error :bad-request "Request content is too short.")))
 
 (defn validate-concept-request
   "Validates the initial request to ingest a concept."

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -22,7 +22,8 @@
 (def ^:private
   valid-concept-mime-types
   {:collection #{mt/echo10 mt/iso-smap mt/iso19115 mt/dif mt/dif10 mt/umm-json}
-   :granule    #{mt/echo10 mt/iso-smap}})
+   :granule #{mt/echo10 mt/iso-smap}
+   :variable #{mt/umm-json}})
 
 
 (defn- validate-format

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -44,16 +44,16 @@
    :LongName "A long UMM-Var name"
    :Units "m"
    :DataType "float32"
-   :DimensionsName ["H2OFunc"
-                    "H2OPressureLay"
-                    "MWHingeSurf"
-                    "Cloud"]
-   :Dimensions ["11" "14" "7" "2"]
-   :ValidRange []
-   :Scale 1.0
-   :Offset 0.0
-   :FillValue -9999.0
-   :VariableType "SCIENCE_VARIABLE"})
+   :DimensionsName "H2OFunc"
+   :Dimensions "11"
+   :ValidRange {}
+   :Scale "1.0"
+   :Offset "0.0"
+   :FillValue "-9999.0"
+   :VariableType "SCIENCE_VARIABLE"
+   :ScienceKeywords [{:Category "sk-A"
+                       :Topic "sk-B"
+                       :Term "sk-C"}]})
 
 (defn make-variable
   "Makes a valid variable based on the given input"
@@ -65,7 +65,6 @@
    (merge
     sample-variable
     {:Name (str "Name" index)
-     :Version (str "V" index)
      :LongName (str "Long UMM-Var name " index)}
     attrs)))
 
@@ -74,7 +73,10 @@
   ([token variable]
    (create-variable token variable nil))
   ([token variable options]
-   (let [options (merge {:raw? true :token token} options)]
+   (let [options (merge {:raw? true
+                         :token token
+                         :http-options {:content-type "application/vnd.nasa.cmr.umm+json"}}
+                        options)]
      (ingest-util/parse-map-response
       (transmit-variable/create-variable (s/context) variable options)))))
 
@@ -90,7 +92,10 @@
   ([token variable-name variable]
    (update-variable token variable-name variable nil))
   ([token variable-name variable options]
-   (let [options (merge {:raw? true :token token} options)]
+   (let [options (merge {:raw? true
+                         :token token
+                         :http-options {:content-type "application/vnd.nasa.cmr.umm+json"}}
+                        options)]
      (ingest-util/parse-map-response
       (transmit-variable/update-variable (s/context) variable-name variable options)))))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -166,13 +166,13 @@
           response (ingest/ingest-concept concept-with-empty-body
                                           {:accept-format :json :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (is (re-find #"XML content is too short." (first errors)))))
+      (is (re-find #"Request content is too short." (first errors)))))
   (testing "xml response"
     (let [concept-with-empty-body  (assoc (data-umm-c/collection-concept {}) :metadata "")
           response (ingest/ingest-concept concept-with-empty-body
                                           {:accept-format :xml :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"XML content is too short." (first errors))))))
+      (is (re-find #"Request content is too short." (first errors))))))
 
 ;; Verify that XML is returned for ingest errros when the headers aren't set
 (deftest collection-ingest-with-errors-no-accept-header-test
@@ -181,7 +181,7 @@
           response (ingest/ingest-concept concept-with-empty-body
                                           {:raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"XML content is too short." (first errors))))))
+      (is (re-find #"Request content is too short." (first errors))))))
 
 ;; Verify that the accept header works with deletions
 (deftest delete-collection-with-accept-header-test
@@ -344,7 +344,7 @@
         {:keys [status errors]} (ingest/ingest-concept concept-with-empty-body)]
     (index/wait-until-indexed)
     (is (= status 400))
-    (is (re-find #"XML content is too short." (first errors)))))
+    (is (re-find #"Request content is too short." (first errors)))))
 
 ;; Verify old DeleteTime concept results in 400 error.
 (deftest old-delete-time-collection-ingest-test

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -123,7 +123,7 @@
         {:keys [status errors]} (ingest/ingest-concept granule-with-empty-body)]
     (index/wait-until-indexed)
     (is (= 400 status))
-    (is (re-find #"XML content is too short." (first errors)))))
+    (is (re-find #"Request content is too short." (first errors)))))
 
 ;; Verify that the accept header works
 (deftest granule-ingest-accept-header-response-test

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
@@ -241,7 +241,7 @@
     (testing "empty request body"
       (let [{:keys [status errors]} (ingest-variable token "")]
         (is (= status 400))
-        (is (re-find #"XML content is too short." (first errors)))))
+        (is (re-find #"Request content is too short." (first errors)))))
 
     (testing "invalid JSON request body"
       (let [{:keys [status errors]} (ingest-variable token "This is not a valid JSON string")]


### PR DESCRIPTION
This added JSON schema validation to variable ingest API. Since we are moving the variable ingest API to provider routes and the create and update routes will be combined as documented in CMR-4239, I left the code refactoring that I want to do out of this PR. This simply added the ability to validate against UMM-Var JSON schema without touching the existing structure of the code.

I also filed CMR-4301 for adding the similar validation for services ingest API rather than just fixing it in this PR, as the UMM-Services schema is still in flux.

The existing UMM-Var schema clearly needs some work as it does not match the sample JSON that is provided by Simon. I have brought that to Simon's attention and it will be addressed separately. For now, I just updated our sample JSON to match the existing schema. 