### PR TITLE
IP sprint cleanup

### DIFF
--- a/collection-renderer-lib/resources/collection_preview/bootstrap.rb
+++ b/collection-renderer-lib/resources/collection_preview/bootstrap.rb
@@ -28,7 +28,7 @@ include CmrMetadataPreview::OptionsHelper
 include CmrMetadataPreview::CmrMetadataPreviewHelper
 
 
-## Thesee need to work but they don't need to return real URLs.
+## These need to work but they don't need to return real URLs.
 def url_for(options)
   "http://example.com"
 end

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -63,11 +63,11 @@
                (println (slurp "resources/text/banner.txt"))
                (println (slurp "resources/text/loading.txt")))}
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
-             "-Dclojure.compiler.direct-linking=true"
-             ;; Enable logging in jetty.
-             "-Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog"
-             "-Dorg.eclipse.jetty.LEVEL=INFO"
-             "-Dorg.eclipse.jetty.websocket.LEVEL=INFO"]
+             "-Dclojure.compiler.direct-linking=true"]
+             ;; Uncomment to enable logging in jetty.
+             ; "-Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog"
+             ; "-Dorg.eclipse.jetty.LEVEL=INFO"
+             ; "-Dorg.eclipse.jetty.websocket.LEVEL=INFO"]
   :profiles {
     :dev-dependencies {:dependencies [[ring-mock "0.1.5"]
                                       [org.clojure/tools.namespace "0.2.11"]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -12,7 +12,7 @@
    [cmr.umm-spec.umm-to-xml-mappings.iso-shared.distributions-related-url :as sdru]
    [cmr.umm-spec.umm-to-xml-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.umm-to-xml-mappings.iso-shared.platform :as platform]
-   [cmr.umm-spec.umm-to-xml-mappings.iso-shared.project :as project]
+   [cmr.umm-spec.umm-to-xml-mappings.iso-shared.project-element :as project]
    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.additional-attribute :as aa]
    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.data-contact :as data-contact]
    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.metadata-association :as ma]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_shared/project_element.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_shared/project_element.clj
@@ -1,4 +1,4 @@
-(ns cmr.umm-spec.umm-to-xml-mappings.iso-shared.project
+(ns cmr.umm-spec.umm-to-xml-mappings.iso-shared.project-element
   "Functions for generating ISO-19115 and ISO-SMAP XML elements from UMM project records."
   (:require
     [cmr.common.xml.gen :refer :all]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
@@ -9,7 +9,7 @@
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.distributions-related-url :as sdru]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.platform :as platform]
-    [cmr.umm-spec.umm-to-xml-mappings.iso-shared.project :as project]
+    [cmr.umm-spec.umm-to-xml-mappings.iso-shared.project-element :as project]
     [cmr.umm-spec.umm-to-xml-mappings.iso-smap.data-contact :as data-contact]
     [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.tiling-system :as tiling]
     [cmr.umm-spec.util :as su :refer [with-default char-string]]))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -17,7 +17,7 @@
    [cmr.umm-spec.util :as su :refer [char-string]]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
-   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project :as project]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.additional-attribute :as aa]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as data-contact]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.distributions-related-url :as dru]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/project_element.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/project_element.clj
@@ -1,4 +1,4 @@
-(ns cmr.umm-spec.xml-to-umm-mappings.iso-shared.project
+(ns cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element
  "Functions to parse Projects from ISO 19115-2 and SMAP"
  (:require
   [clojure.string :as string]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -10,7 +10,7 @@
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
-   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project :as project]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.data-contact :as data-contact]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.distributions-related-url :as dru]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.spatial :as spatial]


### PR DESCRIPTION
1. Remove Jetty debug logging by default
2. Improve REPL startup time by preventing JRuby runtime startup from blocking (one minute 20 seconds for me)
3. Fix warnings from lein modules tasks due to project.clj named files that are not Leiningen project files.