### PR TITLE
CMR-4302: Prevent message queue protocol from being reloaded...

### DIFF
--- a/access-control-app/src/cmr/access_control/services/event_handler.clj
+++ b/access-control-app/src/cmr/access_control/services/event_handler.clj
@@ -3,13 +3,13 @@
   (:require
     [cmr.access-control.config :as config]
     [cmr.access-control.data.access-control-index :as index]
-    [cmr.common.log :refer (debug info warn error)]
-    [cmr.message-queue.services.queue :as queue]
-    [cmr.transmit.metadata-db2 :as mdb]
-    [cmr.umm-spec.acl-matchers :as acl-matchers]
     [cmr.access-control.services.acl-service :as acl-service]
+    [cmr.common.concepts :as concepts]
+    [cmr.common.log :refer (debug info warn error)]
+    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
     [cmr.transmit.config :as transmit-config]
-    [cmr.common.concepts :as concepts]))
+    [cmr.transmit.metadata-db2 :as mdb]
+    [cmr.umm-spec.acl-matchers :as acl-matchers]))
 
 (defmulti handle-provider-event
   "Handle the various messages that are posted to the provider queue.
@@ -107,9 +107,9 @@
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
     (dotimes [n (config/index-queue-listener-count)]
-      (queue/subscribe queue-broker
+      (queue-protocol/subscribe queue-broker
                        (config/provider-queue-name)
                        #(handle-provider-event context %))
-      (queue/subscribe queue-broker
+      (queue-protocol/subscribe queue-broker
                        (config/index-queue-name)
                        #(handle-indexing-event context %)))))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -27,6 +27,7 @@
     [cmr.indexer.data.metrics-fetcher :as metrics-fetcher]
     [cmr.message-queue.config :as qcfg]
     [cmr.message-queue.services.queue :as queue]
+    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
     [cmr.transmit.cubby :as cubby]
     [cmr.transmit.echo.rest :as rest]
     [cmr.transmit.index-set :as tis]
@@ -526,7 +527,7 @@
    :index-set tis/get-index-set-health
    :message-queue (fn [context]
                     (when-let [qb (get-in context [:system :queue-broker])]
-                      (queue/health qb)))})
+                      (queue-protocol/health qb)))})
 
 (defn health
   "Returns the health state of the app."

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -2,7 +2,7 @@
  (:require
   [cmr.ingest.config :as config]
   [cmr.ingest.services.bulk-update-service :as bulk-update]
-  [cmr.message-queue.services.queue :as queue]))
+  [cmr.message-queue.queue.queue-protocol :as queue-protocol]))
 
 (defmulti handle-provider-event
   "Handle the various actions that can be requested for a provider via the provider-queue"
@@ -35,6 +35,6 @@
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
     (dotimes [n (config/ingest-queue-listener-count)]
-      (queue/subscribe queue-broker
-                       (config/ingest-queue-name)
-                       #(handle-provider-event context %)))))
+      (queue-protocol/subscribe queue-broker
+                                (config/ingest-queue-name)
+                                #(handle-provider-event context %)))))

--- a/ingest-app/src/cmr/ingest/services/ingest_service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service.clj
@@ -19,7 +19,7 @@
     [cmr.ingest.services.helper :as h]
     [cmr.ingest.services.messages :as msg]
     [cmr.ingest.validation.validation :as v]
-    [cmr.message-queue.services.queue :as queue]
+    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
     [cmr.oracle.connection :as conn]
     [cmr.transmit.cubby :as cubby]
     [cmr.transmit.echo.rest :as rest]
@@ -48,7 +48,7 @@
   "Resets the queue broker"
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
-    (queue/reset queue-broker))
+    (queue-protocol/reset queue-broker))
   (bulk-update/reset-db context)
   (cache/reset-caches context))
 
@@ -59,7 +59,7 @@
    :metadata-db mdb2/get-metadata-db-health
    :indexer indexer/get-indexer-health
    :cubby cubby/get-cubby-health
-   :message-queue #(queue/health (get-in % [:system :queue-broker]))})
+   :message-queue #(queue-protocol/health (get-in % [:system :queue-broker]))})
 
 (defn health
   "Returns the health state of the app."

--- a/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
@@ -1,0 +1,39 @@
+(ns cmr.message-queue.queue.queue-protocol
+  "Defines the Queue protocol.")
+
+(defprotocol Queue
+  "Functions for working with a message queue"
+
+  (publish-to-queue
+    [this queue-name msg]
+    "Publishes a message on the queue with the given queue name. Returns true if the message was
+    successfully enqueued. Otherwise returns false.")
+
+  (get-queues-bound-to-exchange
+    [this exchange-name]
+    "Returns a sequence of queue names that are bound to the given exchange.")
+
+  (publish-to-exchange
+    [this exchange-name msg]
+    "Publishes a message on the exchange with the given exchange name. Returns true if the message was
+    successfully enqueued. Otherwise returns false.")
+
+  (subscribe
+    [this queue-name handler-fn]
+    "Subscribes to the given queue using the given handler function.
+
+    'handler-fn' is a function that takes a single parameter (the message) and attempts to
+    process it. If the function throws an exception the delivery will be retried.")
+
+  (reset
+    [this]
+    "Reset the broker, deleting any queues and any queued messages")
+
+  (health
+    [this]
+    "Checks to see if the queue is up and functioning properly. Returns a map with the
+    following keys/values:
+    :ok? - set to true if the queue is operational and false if not.
+    :problem (only present when :ok? is false) - a string indicating the problem.
+
+    This function handles exceptions and timeouts internally."))

--- a/message-queue-lib/src/cmr/message_queue/queue/rabbit_mq.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/rabbit_mq.clj
@@ -1,23 +1,25 @@
 (ns cmr.message-queue.queue.rabbit-mq
   "Implements index-queue functionality using rabbit mq"
   (:gen-class)
-  (:require [cmr.common.lifecycle :as lifecycle]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.common.mime-types :as mt]
-            [cmr.message-queue.config :as config]
-            [cmr.common.services.errors :as errors]
-            [cmr.message-queue.services.queue :as queue]
-            [langohr.core :as rmq]
-            [langohr.channel :as lch]
-            [langohr.queue :as lq]
-            [langohr.consumers :as lc]
-            [langohr.confirm :as lcf]
-            [langohr.basic :as lb]
-            [langohr.exchange :as le]
-            [clj-http.client :as client]
-            [cheshire.core :as json]
-            [cmr.common.services.health-helper :as hh]
-            [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
+  (:require
+   [cmr.common.lifecycle :as lifecycle]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.mime-types :as mt]
+   [cmr.message-queue.config :as config]
+   [cmr.common.services.errors :as errors]
+   [cmr.message-queue.queue.queue-protocol :as queue-protocol]
+   [cmr.message-queue.services.queue :as queue]
+   [langohr.core :as rmq]
+   [langohr.channel :as lch]
+   [langohr.queue :as lq]
+   [langohr.consumers :as lc]
+   [langohr.confirm :as lcf]
+   [langohr.basic :as lb]
+   [langohr.exchange :as le]
+   [clj-http.client :as client]
+   [cheshire.core :as json]
+   [cmr.common.services.health-helper :as hh]
+   [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
   (:import java.io.IOException))
 
 (defmacro with-channel
@@ -67,7 +69,7 @@
                       (inc retry-count)
                       wait-q
                       ttl))
-        (queue/publish-to-queue queue-broker wait-q msg)
+        (queue-protocol/publish-to-queue queue-broker wait-q msg)
         (lb/ack ch delivery-tag)))))
 
 (defn- message-handler
@@ -263,7 +265,7 @@
     (assoc this :conn nil))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  queue/Queue
+  queue-protocol/Queue
 
   (publish-to-queue
     [this queue-name msg]

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -18,6 +18,7 @@
    [cmr.common.services.health-helper :as hh]
    [cmr.common.util :as u]
    [cmr.message-queue.config :as config]
+   [cmr.message-queue.queue.queue-protocol :as queue-protocol]
    [cmr.message-queue.services.queue :as queue])
   (:import
    (cmr.message_queue.test ExitException)
@@ -172,7 +173,7 @@
        redrive-policy (str "{\"maxReceiveCount\":\"5\", \"deadLetterTargetArn\": \"" dlq-arn "\"}")
        ;; create the primary queue
        queue-url (.getQueueUrl (.createQueue sqs-client q-name))
-       q-attrs (HashMap. {"RedrivePolicy" redrive-policy 
+       q-attrs (HashMap. {"RedrivePolicy" redrive-policy
                           "VisibilityTimeout" (queue-visibility-timeout q-name)})
        set-queue-attrs-request (doto (SetQueueAttributesRequest.)
                                      (.setAttributes q-attrs)
@@ -294,7 +295,7 @@
     this)
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  queue/Queue
+  queue-protocol/Queue
 
   (publish-to-queue
     [this queue-name msg]
@@ -346,7 +347,7 @@
     [this]
     ;; try to get a list of queues for the first topic (exchange) to test the connection to SNS/SQS
     (try
-      (queue/get-queues-bound-to-exchange this (first exchanges))
+      (queue-protocol/get-queues-bound-to-exchange this (first exchanges))
       {:ok? true}
       (catch Throwable e
         {:ok? false :msg (.getMessage e)}))))

--- a/message-queue-lib/src/cmr/message_queue/services/queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/services/queue.clj
@@ -1,12 +1,13 @@
 (ns cmr.message-queue.services.queue
   "Declares a protocol for creating and interacting with queues and a record that defines
   a queue listener"
-  (:require [cmr.common.lifecycle :as lifecycle]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.util :as util :refer [defn-timed]]
-            [cmr.message-queue.config :as config]
-            [clojail.core :as timeout]))
+  (:require
+   [clojail.core :as timeout]
+   [cmr.common.log :as log :refer [error warn]]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.util :as util :refer [defn-timed]]
+   [cmr.message-queue.config :as config]
+   [cmr.message-queue.queue.queue-protocol :as queue-protocol]))
 
 (defn retry-limit-met?
   "Determine whether or not the given message has met (or exceeded)
@@ -14,43 +15,6 @@
   [msg retry-limit]
   (when-let [retry-count (:retry-count msg)]
     (>= retry-count retry-limit)))
-
-(defprotocol Queue
-  "Functions for working with a message queue"
-
-  (publish-to-queue
-    [this queue-name msg]
-    "Publishes a message on the queue with the given queue name. Returns true if the message was
-    successfully enqueued. Otherwise returns false.")
-
-  (get-queues-bound-to-exchange
-    [this exchange-name]
-    "Returns a sequence of queue names that are bound to the given exchange.")
-
-  (publish-to-exchange
-    [this exchange-name msg]
-    "Publishes a message on the exchange with the given exchange name. Returns true if the message was
-    successfully enqueued. Otherwise returns false.")
-
-  (subscribe
-    [this queue-name handler-fn]
-    "Subscribes to the given queue using the given handler function.
-
-    'handler-fn' is a function that takes a single parameter (the message) and attempts to
-    process it. If the function throws an exception the delivery will be retried.")
-
-  (reset
-    [this]
-    "Reset the broker, deleting any queues and any queued messages")
-
-  (health
-    [this]
-    "Checks to see if the queue is up and functioning properly. Returns a map with the
-    following keys/values:
-    :ok? - set to true if the queue is operational and false if not.
-    :problem (only present when :ok? is false) - a string indicating the problem.
-
-    This function handles exceptions and timeouts internally."))
 
 (defn- try-to-publish
   "Attempts to publish messages to the given exchange.
@@ -63,7 +27,7 @@
   Returns true if the message was successfully enqueued and false otherwise."
   [queue-broker exchange-name msg]
   (when-not (try
-              (publish-to-exchange queue-broker exchange-name msg)
+              (queue-protocol/publish-to-exchange queue-broker exchange-name msg)
               (catch Exception e
                 (error e)
                 false))
@@ -80,7 +44,8 @@
   [queue-broker exchange-name msg]
   (let [start-time (System/currentTimeMillis)]
     (try
-      (timeout/thunk-timeout #(try-to-publish queue-broker exchange-name msg) (config/publish-queue-timeout-ms))
+      (timeout/thunk-timeout #(try-to-publish queue-broker exchange-name msg)
+                             (config/publish-queue-timeout-ms))
       (catch java.util.concurrent.TimeoutException e
         (errors/throw-service-error
           :service-unavailable

--- a/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
@@ -1,10 +1,11 @@
 (ns cmr.metadata-db.data.ingest-events
   "Allows broadcast of ingest events via the message queue"
-  (:require [cmr.metadata-db.config :as config]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.concepts :as cc]
-            [cmr.message-queue.services.queue :as queue]))
+  (:require
+   [cmr.common.concepts :as cc]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.message-queue.services.queue :as queue]
+   [cmr.metadata-db.config :as config]))
 
 (defn publish-event
   "Put an ingest event on the message queue."

--- a/virtual-product-app/src/cmr/virtual_product/services/health_service.clj
+++ b/virtual-product-app/src/cmr/virtual_product/services/health_service.clj
@@ -1,15 +1,16 @@
 (ns cmr.virtual-product.services.health-service
   "Contains fuctions to provider health status of the search app."
-  (:require [cmr.transmit.ingest :as ingest]
-            [cmr.transmit.metadata-db2 :as mdb]
-            [cmr.message-queue.services.queue :as queue]))
+  (:require
+   [cmr.message-queue.queue.queue-protocol :as queue-protocol]
+   [cmr.transmit.ingest :as ingest]
+   [cmr.transmit.metadata-db2 :as mdb]))
 
 (defn health
   "Returns the health state of the app."
   [context]
   (let [ingest-health (ingest/get-ingest-health context)
         metadata-db-health (mdb/get-metadata-db-health context)
-        message-queue-health (queue/health (get-in context [:system :queue-broker]))
+        message-queue-health (queue-protocol/health (get-in context [:system :queue-broker]))
         ok? (every? :ok? [ingest-health metadata-db-health message-queue-health])]
     {:ok? ok?
      :dependencies {:ingest ingest-health


### PR DESCRIPTION
https://nelsonmorris.net/2015/05/18/reloaded-protocol-and-no-implementation-of-method.html provides a good explanation for the errors that we often see with the message queue protocol when we make changes to namespaces in common-lib, and we end up restarting our REPL.

The change is to move the protocol to its own namespace so that it will not get reloaded when other namespaces are updated.

I think we should continue to follow this pattern in the future where protocols go into a namespace with no requires.

