### PR TITLE
CMR-4285 Incorrect results on Find&Replace of Science Keywords when not all levels of hierarchy are specified in Find term

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -503,8 +503,8 @@ The following update types are supported:
 
   * Add to existing - the update value is added to the existing list. An update value is required.
   * Clear all and replace - clear the list and replace with the update value.
-  * Find and update - replace any instance in the list that matches the find value with the update value.
-  * Find and replace - merge update value into any instance in the list that matches the find value.
+  * Find and replace - replace any instance in the list that matches the find value with the update value.
+  * Find and update - merge update value into any instance in the list that matches the find value.
   * Find and remove - remove any instance from the list that matches the find value.
 
 Update types that include a find will match on the fields supplied. For example, for a science keyword update with a find value of {"Category": "EARTH SCIENCES"}, any science keyword with a category of "EARTH SCIENCES" will be considered a match regardless of the values of the science keyword topic, term, etc.

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -503,7 +503,8 @@ The following update types are supported:
 
   * Add to existing - the update value is added to the existing list. An update value is required.
   * Clear all and replace - clear the list and replace with the update value.
-  * Find and replace - replace any instance in the list that matches the find value with the update value.
+  * Find and update - replace any instance in the list that matches the find value with the update value.
+  * Find and replace - merge update value into any instance in the list that matches the find value.
   * Find and remove - remove any instance from the list that matches the find value.
 
 Update types that include a find will match on the fields supplied. For example, for a science keyword update with a find value of {"Category": "EARTH SCIENCES"}, any science keyword with a category of "EARTH SCIENCES" will be considered a match regardless of the values of the science keyword topic, term, etc.
@@ -519,10 +520,10 @@ Bulk update can be initiated by sending an HTTP POST request to `%CMR-ENDPOINT%/
 The POST request takes the following parameters:
 
   * Concept-ids (required) - a list of concept ids to update
-  * Update type (required) - choose from the enumeration: ADD_TO_EXISTING, CLEAR_ALL_AND_REPLACE, FIND_AND_REPLACE, FIND_AND_REMOVE
+  * Update type (required) - choose from the enumeration: ADD_TO_EXISTING, CLEAR_ALL_AND_REPLACE, FIND_AND_REPLACE, FIND_AND_REMOVE, FIND_AND_UPDATE
   * Update field (required) - choose from the enumeration: SCIENCE_KEYWORDS, LOCATION_KEYWORDS, DATA_CENTERS, PLATFORMS, INSTRUMENTS
-  * Update value (required when update type is ADD_TO_EXISTING, CLEAR_ALL_AND_REPLACE, FIND_AND_REPLACE) - UMM-JSON representation of the update to make
-  * Find value (required when update type is FIND_AND_REPLACE or FIND_AND_REMOVE) - UMM-JSON representation of the data to find
+  * Update value (required when update type is ADD_TO_EXISTING, CLEAR_ALL_AND_REPLACE, FIND_AND_REPLACE, FIND_AND_UPDATE) - UMM-JSON representation of the update to make
+  * Find value (required when update type is FIND_AND_REPLACE, FIND_AND_UPDATE or  FIND_AND_REMOVE) - UMM-JSON representation of the data to find
 
 The return value includes a status code indicating that the bulk update was successfully initiated, any errors if not successful, and on success a task-id that can be used for querying the bulk update status. The bulk update will be run asynchronously and the status of the overall bulk update task as well as the status of individual collection updates can be queried using the task id.
 

--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -11,7 +11,7 @@
         },
         "UpdateTypeEnum": {
             "type": "string",
-            "enum": ["ADD_TO_EXISTING", "CLEAR_FIELD", "CLEAR_ALL_AND_REPLACE", "FIND_AND_REMOVE", "FIND_AND_REPLACE"]
+            "enum": ["ADD_TO_EXISTING", "CLEAR_FIELD", "CLEAR_ALL_AND_REPLACE", "FIND_AND_REMOVE", "FIND_AND_REPLACE", "FIND_AND_UPDATE"]
         },
         "UpdateFieldEnum": {
           "type": "string",

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -46,7 +46,8 @@
                                    [(format "An update value must be supplied when the update is of type %s"
                                             update-type)]))
     (when (and (or (= "FIND_AND_REPLACE" update-type)
-                   (= "FIND_AND_REMOVE" update-type))
+                   (= "FIND_AND_REMOVE" update-type)
+                   (= "FIND_AND_UPDATE" update-type))
                (nil? find-value))
       (errors/throw-service-errors :bad-request
                                    [(format "A find value must be supplied when the update is of type %s"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -97,7 +97,7 @@
              :update-field "SCIENCE_KEYWORDS"
              :update-type "REPLACE"}
             400
-            ["/update-type instance value (\"REPLACE\") not found in enum (possible values: [\"ADD_TO_EXISTING\",\"CLEAR_FIELD\",\"CLEAR_ALL_AND_REPLACE\",\"FIND_AND_REMOVE\",\"FIND_AND_REPLACE\"])"]
+            ["/update-type instance value (\"REPLACE\") not found in enum (possible values: [\"ADD_TO_EXISTING\",\"CLEAR_FIELD\",\"CLEAR_ALL_AND_REPLACE\",\"FIND_AND_REMOVE\",\"FIND_AND_REPLACE\",\"FIND_AND_UPDATE\"])"]
 
             "Missing update value"
             {:concept-ids ["C1", "C2", "C3"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -34,7 +34,7 @@
                   :ContactPersons [{:Roles ["Data Center Contact"]
                                     :LastName "Smith"}]}]})
 
-(def update-replace-keywords-umm
+(def find-replace-keywords-umm
   {:ScienceKeywords [{:Category "EARTH SCIENCE"
                       :Topic "ATMOSPHERE"
                       :Term "AIR QUALITY"
@@ -147,7 +147,7 @@
                      (:DataCenters (:umm concept))))))))))
 
 (deftest bulk-update-replace-test
-  (let [concept-ids (ingest-collection-in-each-format replace-keywords-umm)
+  (let [concept-ids (ingest-collection-in-each-format find-replace-keywords-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
                           :update-type "FIND_AND_REPLACE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -106,9 +106,9 @@
                                (:status-message %)))
                       (:collection-statuses collection-response))))))
 
-    (testing "Data center find and replace"
+    (testing "Data center find and update"
       (let [bulk-update-body {:concept-ids concept-ids
-                              :update-type "FIND_AND_REPLACE"
+                              :update-type "FIND_AND_UPDATE"
                               :update-field "DATA_CENTERS"
                               :find-value {:ShortName "NSID"}
                               :update-value {:ShortName "NSIDC"

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -43,6 +43,19 @@
   (if (seq (get-in umm update-field))
     (let [update-value (util/remove-nil-keys update-value)]
       ;; For each entry in update-field, if we find it using the find params,
+      ;; completely replace with update value
+      (update-in umm update-field #(map (fn [x]
+                                          (if (value-matches? find-value x)
+                                            update-value
+                                            x))
+                                        %)))
+    umm))
+
+(defmethod apply-umm-list-update :find-and-update
+  [update-type umm update-field update-value find-value]
+  (if (seq (get-in umm update-field))
+    (let [update-value (util/remove-nil-keys update-value)]
+      ;; For each entry in update-field, if we find it using the find params,
       ;; update only the fields supplied in update-value with nils removed
       (update-in umm update-field #(map (fn [x]
                                           (if (value-matches? find-value x)

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -208,7 +208,7 @@
        :find-and-replace
        {:Subregion1 "EASTERN ASIA"}
        {:Subregion1 "WESTERN ASIA"}
-       {:LocationKeywords [{:Subregion1 "WESTERN ASIA"}]})))
+       {:LocationKeywords [{:Subregion1 "EASTERN ASIA"}]})))
 
 (deftest platform-instrument-name-updates
  (testing "Platform name updates"
@@ -259,7 +259,8 @@
         {:ShortName "A340-600"
          :LongName "Airbus A340-600"}
         {:ShortName "Platform 1"}
-        {:Platforms [{:ShortName "Airbus A340-600""}]}))
+        {:Platforms [{:ShortName "A340-600"
+                      :LongName "Airbus A340-600"}]}))
 
   (testing "Instrument updates"
     (let [umm {:Platforms [{:ShortName "Platform 1"

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -60,8 +60,8 @@
                            :VariableLevel1 "var 1" :VariableLevel2 "var 2"
                            :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}
 
-       "Find and replace"
-       :find-and-replace
+       "Find and update"
+       :find-and-update
        {:Category "EARTH SCIENCE SERVICES"
         :Topic "DATA ANALYSIS AND VISUALIZATION"
         :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
@@ -75,6 +75,31 @@
                            :VariableLevel2 "var 2",
                            :VariableLevel3 "var 3",
                            :DetailedVariable "detailed"}]}
+
+       "Find and update, not found"
+       :find-and-update
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "Topic"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES" :Topic "topic" :Term "term"
+                           :VariableLevel1 "var 1" :VariableLevel2 "var 2"
+                           :VariableLevel3 "var 3" :DetailedVariable "detailed"}]}
+
+       "Find and replace"
+       :find-and-replace
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"
+        :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}
+                          {:Category "EARTH SCIENCE SERVICES"
+                           :Topic "DATA ANALYSIS AND VISUALIZATION"
+                           :Term "GEOGRAPHIC INFORMATION SYSTEMS"}]}
 
        "Find and replace, not found"
        :find-and-replace
@@ -123,6 +148,14 @@
        {:Category "EARTH SCIENCE SERVICES"}
        {:EntryTitle "Test"}
 
+       "Find and update"
+       :find-and-update
+       {:Category "EARTH SCIENCE SERVICES"
+        :Topic "DATA ANALYSIS AND VISUALIZATION"
+        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       {:Category "EARTH SCIENCE SERVICES"}
+       {:EntryTitle "Test"}
+
        "Find and replace"
        :find-and-replace
        {:Category "EARTH SCIENCE SERVICES"
@@ -162,16 +195,20 @@
        {:LocationKeywords [{:Category "CONTINENT"
                             :Type "EUROPE"}]}
 
-       "Find and replace"
-       :find-and-replace
+       "Find and update"
+       :find-and-update
        {:Subregion1 "EASTERN ASIA"}
        {:Subregion1 "WESTERN ASIA"}
        {:LocationKeywords [{:Category "CONTINENT"
                             :Type "ASIA"
                             :Subregion1 "EASTERN ASIA"
                             :Subregion2 "MIDDLE EAST"
-                            :Subregion3 "GAZA STRIP"}]})))
-
+                            :Subregion3 "GAZA STRIP"}]}
+       "Find and replace"
+       :find-and-replace
+       {:Subregion1 "EASTERN ASIA"}
+       {:Subregion1 "WESTERN ASIA"}
+       {:LocationKeywords [{:Subregion1 "WESTERN ASIA"}]})))
 
 (deftest platform-instrument-name-updates
  (testing "Platform name updates"
@@ -186,8 +223,8 @@
         (is (= result
                (field-update/apply-update update-type umm [:Platforms] update-value find-value)))
 
-        "Find and replace short name"
-        :find-and-replace
+        "Find and update short name"
+        :find-and-update
         {:ShortName "A340-600"}
         {:ShortName "Platform 1"}
         {:Platforms [{:ShortName "A340-600"
@@ -198,8 +235,8 @@
                                      :Technique "Two cans and a string"
                                      :NumberOfInstruments 0}]}]}
 
-        "Find and replace long and short names"
-        :find-and-replace
+        "Find and update long and short names"
+        :find-and-update
         {:ShortName "A340-600"
          :LongName "Airbus A340-600"}
         {:ShortName "Platform 1"}
@@ -209,7 +246,21 @@
                       :Instruments [{:ShortName "An Instrument"
                                      :LongName "The Full Name of An Instrument v123.4"
                                      :Technique "Two cans and a string"
-                                     :NumberOfInstruments 0}]}]}))
+                                     :NumberOfInstruments 0}]}]}
+
+        "Find and replace short name"
+        :find-and-replace
+        {:ShortName "A340-600"}
+        {:ShortName "Platform 1"}
+        {:Platforms [{:ShortName "A340-600"}]}
+
+        "Find and replace long and short names"
+        :find-and-replace
+        {:ShortName "A340-600"
+         :LongName "Airbus A340-600"}
+        {:ShortName "Platform 1"}
+        {:Platforms [{:ShortName "Airbus A340-600""}]}))
+
   (testing "Instrument updates"
     (let [umm {:Platforms [{:ShortName "Platform 1"
                             :LongName "Example Platform Long Name 1"
@@ -263,8 +314,8 @@
                       :Type "Aircraft"
                       :Instruments [{:ShortName "Inst X"}]}]}
 
-        "Find and replace - multiple instances"
-        :find-and-replace
+        "Find and update - multiple instances"
+        :find-and-update
         {:ShortName "Inst X"}
         {:ShortName "Inst 1"}
         {:Platforms [{:ShortName "Platform 1"
@@ -282,8 +333,8 @@
                                     {:ShortName "Inst 3"
                                      :LongName "Instrument 3"}]}]}
 
-        "Find and replace - multiple instances"
-        :find-and-replace
+        "Find and update - multiple instances"
+        :find-and-update
         {:ShortName "Inst X"}
         {:ShortName "Inst 2"}
         {:Platforms [{:ShortName "Platform 1"
@@ -301,17 +352,52 @@
                                     {:ShortName "Inst 3"
                                      :LongName "Instrument 3"}]}]})
 
-       "Find and remove"
-       :find-and-remove
-       nil
-       {:ShortName "Inst 1"}
-       {:Platforms [{:ShortName "Platform 1"
-                     :LongName "Example Platform Long Name 1"
-                     :Type "Aircraft"
-                     :Instruments [{:ShortName "Inst 1"
-                                    :LongName "Instrument 1"}]}
-                    {:ShortName "Platform 2"
-                     :LongName "Example Platform Long Name 2"
-                     :Type "Aircraft"
-                     :Instruments [{:ShortName "Inst 1"
-                                    :LongName "Instrument 1"}]}]}))))
+      "Find and replace - multiple instances"
+      :find-and-replace
+      {:ShortName "Inst X"}
+      {:ShortName "Inst 1"}
+      {:Platforms [{:ShortName "Platform 1"
+                    :LongName "Example Platform Long Name 1"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"}
+                                  {:ShortName "Inst 2"
+                                   :LongName "Instrument 2"}]}
+                   {:ShortName "Platform 2"
+                    :LongName "Example Platform Long Name 2"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"}
+                                  {:ShortName "Inst 3"
+                                   :LongName "Instrument 3"}]}]}
+
+      "Find and replace - multiple instances"
+      :find-and-replace
+      {:ShortName "Inst X"}
+      {:ShortName "Inst 2"}
+      {:Platforms [{:ShortName "Platform 1"
+                    :LongName "Example Platform Long Name 1"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"
+                                   :LongName "Instrument 1"}
+                                  {:ShortName "Inst 2"}]}
+                   {:ShortName "Platform 2"
+                    :LongName "Example Platform Long Name 2"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"
+                                   :LongName "Instrument 1"}
+                                  {:ShortName "Inst 3"
+                                   :LongName "Instrument 3"}]}]}
+
+      "Find and remove"
+      :find-and-remove
+      nil
+      {:ShortName "Inst 1"}
+      {:Platforms [{:ShortName "Platform 1"
+                    :LongName "Example Platform Long Name 1"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"
+                                   :LongName "Instrument 1"}]}
+                   {:ShortName "Platform 2"
+                    :LongName "Example Platform Long Name 2"
+                    :Type "Aircraft"
+                    :Instruments [{:ShortName "Inst 1"
+                                   :LongName "Instrument 1"}]}]}))))


### PR DESCRIPTION
This PR alters bulk update.

It moves the current implementation of find-and-replace to find-and-update
It changes find-and-replace to completely replace matched values with the update value instead of merging the original value and the updated value