### PR TITLE
CMR-4240 metadata db variable save provider

### DIFF
--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
@@ -1,7 +1,7 @@
 (ns cmr.metadata-db.int-test.concepts.collection-save-test
   "Contains integration tests for saving collections. Tests saves with various configurations including
   checking for proper error handling."
-  (:require 
+  (:require
    [clj-time.format :as time-format]
    [clojure.test :refer :all]
    [cmr.common.date-time-parser :as common-parser]
@@ -10,7 +10,6 @@
    [cmr.metadata-db.int-test.utility :as util]
    [cmr.metadata-db.services.concept-constraints :as cc]
    [cmr.metadata-db.services.messages :as msg]))
-
 
 ;;; fixtures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -49,7 +48,7 @@
          (not-any? nil? created-ats))))
 
 (deftest save-collection-created-at-test
-  (testing "Save collection multiple times gets same created-at" 
+  (testing "Save collection multiple times gets same created-at"
     (doseq [provider-id ["REG_PROV" "SMAL_PROV1"]]
       (let [initial-collection (util/collection-concept provider-id 2)
             ;; Save a collection, then wait for a small period of time before saving it
@@ -67,16 +66,16 @@
             {tombstone-revision-id :revision-id} (util/save-concept {:deleted true :concept-id concept-id})
             _ (Thread/sleep 10)
             {final-revision-id :revision-id} (util/save-concept initial-collection)
-            [initial-revision 
-             second-revision 
-             tombstone 
+            [initial-revision
+             second-revision
+             tombstone
              final-revision] (mapv #(:concept (util/get-concept-by-id-and-revision concept-id %))
-                                   [initial-revision-id 
-                                    second-revision-id 
-                                    tombstone-revision-id 
+                                   [initial-revision-id
+                                    second-revision-id
+                                    tombstone-revision-id
                                     final-revision-id])]
         (is (created-at-same? initial-revision second-revision tombstone final-revision))))))
-               
+
 (deftest save-collection-post-commit-constraint-violations
   (testing "duplicate entry titles"
     (doseq [provider-id ["REG_PROV" "SMAL_PROV1"]]

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/granule_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/granule_save_test.clj
@@ -1,19 +1,19 @@
 (ns cmr.metadata-db.int-test.concepts.granule-save-test
   "Contains integration tests for saving granules. Tests saves with various configurations including
   checking for proper error handling."
-  (:require [clojure.test :refer :all]
-            [clj-http.client :as client]
-            [clj-time.core :as t]
-            [clj-time.format :as f]
-            [clj-time.local :as l]
-            [cmr.common.log :refer (info)]
-            [cmr.common-app.test.side-api :as side]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.services.messages :as msg]
-            [cmr.metadata-db.services.concept-constraints :as cc]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec])
+  (:require
+   [clojure.test :refer :all]
+   [clj-http.client :as client]
+   [clj-time.core :as t]
+   [clj-time.format :as f]
+   [clj-time.local :as l]
+   [cmr.common.log :refer (info)]
+   [cmr.common-app.test.side-api :as side]
+   [cmr.metadata-db.int-test.utility :as util]
+   [cmr.metadata-db.services.messages :as msg]
+   [cmr.metadata-db.services.concept-constraints :as cc]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec])
   (:import java.io.FileNotFoundException))
-
 
 ;;; fixtures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -49,10 +49,6 @@
       (util/verify-concept-was-saved gran1)
       (util/verify-concept-was-saved gran2)
       (is (not= gran1-concept-id gran2-concept-id)))))
-
-(deftest missing-required-parameters
-  (c-spec/save-test-with-missing-required-parameters
-    :granule ["REG_PROV" "SMAL_PROV1"] [:concept-type :provider-id :native-id :extra-fields]))
 
 (deftest save-granule-post-commit-constraint-violations
   (testing "duplicate granule URs"

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -13,22 +13,14 @@
 (use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}))
 
 (defmethod c-spec/gen-concept :variable
-  [_ _ uniq-num attributes]
-  (util/variable-concept uniq-num attributes))
+  [_ provider-id uniq-num attributes]
+  (util/variable-concept provider-id uniq-num attributes))
 
 ;; tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (deftest save-variable-test
-  (c-spec/general-save-concept-test :variable ["CMR"]))
+  (c-spec/general-save-concept-test :variable ["REG_PROV"]))
 
-(deftest save-variable-specific-test
-  (testing "saving new variables"
-    (are3 [variable exp-status exp-errors]
-          (let [{:keys [status errors]} (util/save-concept variable)]
-            (is (= exp-status status))
-            (is (= (set exp-errors) (set errors))))
-
-          "failure when using non system-level provider"
-          (assoc (util/variable-concept 2) :provider-id "REG_PROV")
-          422
-          ["Variable could not be associated with provider [REG_PROV]. Variables are system level entities."])))
+(deftest save-variable-with-missing-required-parameters-test
+  (c-spec/save-test-with-missing-required-parameters
+    :variable ["REG_PROV"] [:concept-type :provider-id :native-id :extra-fields]))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -299,9 +299,9 @@
 
 (defn variable-concept
   "Creates a variabe concept"
-  ([uniq-num]
-   (variable-concept uniq-num {}))
-  ([uniq-num attributes]
+  ([provider-id uniq-num]
+   (variable-concept provider-id uniq-num {}))
+  ([provider-id uniq-num attributes]
    (let [native-id (str "var-native" uniq-num)
          extra-fields (merge {:variable-name (str "var" uniq-num)
                               :measurement (str "measurement" uniq-num)}
@@ -311,8 +311,7 @@
                             :native-id native-id
                             :extra-fields extra-fields}
                            (dissoc attributes :extra-fields))]
-     ;; no provider-id should be specified for variables
-     (dissoc (concept nil :variable uniq-num attributes) :provider-id))))
+     (concept provider-id :variable uniq-num attributes))))
 
 (defn variable-association-concept
   "Creates a variable association concept"

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -60,7 +60,7 @@
 
 (def system-level-concept-types
   "A set of concept types that only exist on system level provider CMR."
-  #{:tag :tag-association :humanizer :service :variable :variable-association})
+  #{:tag :tag-association :humanizer :service :variable-association})
 
 ;;; utility methods
 
@@ -77,7 +77,6 @@
                       :tag-association (msg/tag-associations-only-system-level provider-id)
                       :humanizer (msg/humanizers-only-system-level provider-id)
                       :service (msg/services-only-system-level provider-id)
-                      :variable (msg/variables-only-system-level provider-id)
                       :variable-association (msg/variable-associations-only-system-level
                                              provider-id))]
         (errors/throw-service-errors :invalid-data [err-msg])))))

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
@@ -52,7 +52,8 @@
                           false #{:associated-concept-id :associated-revision-id}}})
 
 (defn extra-fields-missing-validation
-  "Validates that the concept is provided with extra fields and that all of them are present and not nil."
+  "Validates that the concept is provided with extra fields and that all of them are present
+  and not nil."
   [concept]
   (if-let [extra-fields (util/remove-nil-keys (:extra-fields concept))]
     (map #(msg/missing-extra-field %)
@@ -177,12 +178,6 @@
                                   concept-id-matches-concept-fields-validation-no-provider
                                   humanizer-native-id-validation)))
 
-(def variable-concept-validation
-  "Builds a function that validates a concept map that has no provider and returns a list of errors"
-  (util/compose-validations (conj base-concept-validations
-                                  concept-id-matches-concept-fields-validation-no-provider
-                                  extra-fields-missing-validation)))
-
 (def service-concept-validation
   "Builds a function that validates a concept map that has no provider and returns a list of errors"
   (util/compose-validations (conj base-concept-validations
@@ -209,10 +204,6 @@
   "validates a humanizer concept. Throws an error if invalid."
   (util/build-validator :invalid-data humanizer-concept-validation))
 
-(def validate-variable-concept
-  "validates a variable concept. Throws an error if invalid."
-  (util/build-validator :invalid-data variable-concept-validation))
-
 (def validate-service-concept
   "validates a service concept. Throws an error if invalid."
   (util/build-validator :invalid-data service-concept-validation))
@@ -237,10 +228,6 @@
 (defmethod validate-concept :humanizer
   [concept]
   (validate-humanizer-concept concept))
-
-(defmethod validate-concept :variable
-  [concept]
-  (validate-variable-concept concept))
 
 (defmethod validate-concept :variable-association
   [concept]


### PR DESCRIPTION
ON HOLD:

Not ready for review -- I discovered other areas that I need to address (failing tests in search, etc.) before this is ready.

Tasks for this PR:
* Updated the metadata-db concept service to remove variables from the system-level concept types
* Removed variables from the extended concept validations (mirroring the validations that collections and granules do)
* Updated the metadata-db testing utility to create testing variable concepts with a provider id
* Removed variable-specific test that was created for non-provider-id variables
* Updated remaining variables test and add a new one