### PR TITLE
CMR-4169: Require the services namespace to ensure services multi-methods are loaded

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -28,6 +28,7 @@
    [cmr.metadata-db.data.oracle.concepts.granule]
    [cmr.metadata-db.data.oracle.concepts.group]
    [cmr.metadata-db.data.oracle.concepts.humanizer]
+   [cmr.metadata-db.data.oracle.concepts.service]
    [cmr.metadata-db.data.oracle.concepts.tag-association]
    [cmr.metadata-db.data.oracle.concepts.tag]
    [cmr.metadata-db.data.oracle.concepts.variable-association]


### PR DESCRIPTION
This ticket failed verification in UAT. We will need to backport to 1.75.x.