### PR TITLE
CMR-4045 Fix additional attribute validation for collections

### DIFF
--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
@@ -23,7 +23,8 @@
          :Description (or Description "Generated")
          :DataType DataType
          :ParameterRangeBegin (aa/gen-value DataType ParameterRangeBegin)
-         :ParameterRangeEnd (aa/gen-value DataType ParameterRangeEnd)})
+         :ParameterRangeEnd (aa/gen-value DataType ParameterRangeEnd)
+         :Value Value})
       (umm-cmn/map->AdditionalAttributeType
         {:Name Name
          :Group Group

--- a/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_validation_core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_validation_core.clj
@@ -44,7 +44,7 @@
   ([collection additional-validations]
    (validation-errors->path-errors
     (v/validate (cons vc/collection-validations additional-validations)
-                 collection))))
+                (aa/add-parsed-values collection)))))
 
 (defn validate-collection-warnings
   "Validates the UMM record against the list of warnings - issues that we want
@@ -54,7 +54,7 @@
   ([collection additional-validations]
    (validation-errors->path-errors
     (v/validate (cons vc/collection-validation-warnings additional-validations)
-                 collection))))
+                (aa/add-parsed-values collection)))))
 
 (defn validate-granule
   "Validates the umm record returning a list of error maps containing a path through the


### PR DESCRIPTION
The additional attribute parsed values were not being added for collection validation (they were being added for granule parent validation) so the parsed values were always nil and certain validations were not running because of that.