### PR TITLE
CMR-4285 removes dupes after find and replace and find and update

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -39,6 +39,21 @@
                   :ContactPersons [{:Roles ["Data Center Contact"]
                                     :LastName "Smith"}]}]})
 
+(def find-update-keywords-umm
+  {:ScienceKeywords [{:Category "EARTH SCIENCE"
+                      :Topic "ATMOSPHERE"
+                      :Term "AIR QUALITY"
+                      :VariableLevel1 "CARBON MONOXIDE"}
+                     {:Category "EARTH SCIENCE"
+                      :Topic "ATMOSPHERE"
+                      :Term "AIR QUALITY"
+                      :VariableLevel1 "CARBON MONOXIDE"}
+                     {:Category "EARTH SCIENCE"
+                      :Topic "ATMOSPHERE"
+                      :Term "CLOUDS"
+                      :VariableLevel1 "CLOUD MICROPHYSICS"
+                      :VariableLevel2 "CLOUD LIQUID WATER/ICE"}]})
+
 (def find-replace-keywords-umm
   {:ScienceKeywords [{:Category "EARTH SCIENCE"
                       :Topic "ATMOSPHERE"
@@ -199,4 +214,42 @@
                 :Topic "ATMOSPHERE"
                 :Term "AIR QUALITY"
                 :VariableLevel1 "EMISSIONS"}]
+              (:ScienceKeywords (:umm concept)))))))
+
+(deftest bulk-update-update-test
+  (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)
+        _ (index/wait-until-indexed)
+        bulk-update-body {:concept-ids concept-ids
+                          :update-type "FIND_AND_UPDATE"
+                          :update-field "SCIENCE_KEYWORDS"
+                          :find-value {:Topic "ATMOSPHERE"}
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "ATMOSPHERE"
+                                         :Term "AIR QUALITY"
+                                         :VariableLevel1 "EMISSIONS"}}
+        task-id (:task-id (ingest/bulk-update-collections "PROV1" bulk-update-body))]
+      (index/wait-until-indexed)
+      (let [collection-response (ingest/bulk-update-task-status "PROV1" task-id)]
+        (is (= "COMPLETE" (:task-status collection-response))))
+
+      ;; Check that each concept was updated
+      (doseq [concept-id concept-ids
+              :let [concept (-> (search/find-concepts-umm-json :collection
+                                                               {:concept-id concept-id})
+                                :results
+                                :items
+                                first)]]
+       (is (= 2
+              (:revision-id (:meta concept))))
+       (is (= "application/vnd.nasa.cmr.umm+json"
+              (:format (:meta concept))))
+       (is (= [{:Category "EARTH SCIENCE",
+                :Topic "ATMOSPHERE",
+                :Term "AIR QUALITY",
+                :VariableLevel1 "EMISSIONS"}
+               {:Category "EARTH SCIENCE",
+                :Topic "ATMOSPHERE",
+                :Term "AIR QUALITY",
+                :VariableLevel1 "EMISSIONS",
+                :VariableLevel2 "CLOUD LIQUID WATER/ICE"}]
               (:ScienceKeywords (:umm concept)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -195,12 +195,8 @@
               (:revision-id (:meta concept))))
        (is (= "application/vnd.nasa.cmr.umm+json"
               (:format (:meta concept))))
-       (is (= (:ScienceKeywords (:umm concept))
-              [{:Category "EARTH SCIENCE"
+       (is (= [{:Category "EARTH SCIENCE"
                 :Topic "ATMOSPHERE"
                 :Term "AIR QUALITY"
-                :VariableLevel1 "EMISSIONS"}
-               {:Category "EARTH SCIENCE"
-                :Topic "ATMOSPHERE"
-                :Term "AIR QUALITY"
-                :VariableLevel1 "EMISSIONS"}])))))
+                :VariableLevel1 "EMISSIONS"}]
+              (:ScienceKeywords (:umm concept)))))))

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -45,11 +45,11 @@
     (let [update-value (util/remove-nil-keys update-value)]
       ;; For each entry in update-field, if we find it using the find params,
       ;; completely replace with update value
-      (update-in umm update-field #(map (fn [x]
-                                          (if (value-matches? find-value x)
-                                            update-value
-                                            x))
-                                        %)))
+      (update-in umm update-field #(distinct (map (fn [x]
+                                                    (if (value-matches? find-value x)
+                                                      update-value
+                                                      x))
+                                                  %))))
     umm))
 
 (defmethod apply-umm-list-update :find-and-update
@@ -58,11 +58,11 @@
     (let [update-value (util/remove-nil-keys update-value)]
       ;; For each entry in update-field, if we find it using the find params,
       ;; update only the fields supplied in update-value with nils removed
-      (update-in umm update-field #(map (fn [x]
-                                          (if (value-matches? find-value x)
-                                            (merge x update-value)
-                                            x))
-                                        %)))
+      (update-in umm update-field #(distinct (map (fn [x]
+                                                    (if (value-matches? find-value x)
+                                                      (merge x update-value)
+                                                      x))
+                                                  %))))
     umm))
 
 (defn apply-update


### PR DESCRIPTION
This PR purpose is to fix find-and-replace and find-and-update to no longer leave duplicates in the umm it updates.