### PR TITLE
CMR-4330 Use aggregation search to address granule page size issue

### DIFF
--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -278,7 +278,8 @@
                                         :created-at start-date end-date)
                            :result-fields []
                            :aggregations {:collections
-                                          {:terms {:field :collection-concept-id}}}})]
+                                          {:terms {:size 50000
+                                                   :field :collection-concept-id}}}})]
       (qe/execute-query context query))))
 
 (defn get-collections-by-providers

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -78,6 +78,12 @@
     cmr.search.validators.temporal
     cmr.search.validators.validation))
 
+(def query-aggregation-size
+  "Page size for query aggregations. This should be large enough
+  to contain all collections to allow searching for collections
+  from granules."
+  50000)
+
 (defn- sanitize-aql-params
   "When content-type is not set for aql searches, the aql will get mistakenly parsed into params.
   This function removes it, santizes the params and returns the end result."
@@ -278,7 +284,7 @@
                                         :created-at start-date end-date)
                            :result-fields []
                            :aggregations {:collections
-                                          {:terms {:size 50000
+                                          {:terms {:size query-aggregation-size
                                                    :field :collection-concept-id}}}})]
       (qe/execute-query context query))))
 

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -272,11 +272,13 @@
   (when-let [[start-date end-date] (mapv time-format/parse
                                          (string/split (:has-granules-created-at params) #","))]
     (let [query (qm/query {:concept-type :granule
-                           :condition (qm/date-range-condition
-                                       :created-at start-date end-date)
-                           :page-size :unlimited
+                           :page-size 0
                            :result-format :query-specified
-                           :result-fields [:collection-concept-id]})]
+                           :condition (qm/date-range-condition
+                                        :created-at start-date end-date)
+                           :result-fields []
+                           :aggregations {:collections
+                                          {:terms {:field :collection-concept-id}}}})]
       (qe/execute-query context query))))
 
 (defn get-collections-by-providers

--- a/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
@@ -105,7 +105,7 @@
     (testing "Using unsupported or incorrect parameters in conjunction with multi-part-query-params"
       (are [params]
         (let [{:keys [status errors]} (search/find-concepts-with-param-string
-                                        "granule" params)]
+                                        "collection" params)]
           (= [400 [(format "Parameter [%s] was not recognized."
                            (first (string/split params #"=")))]]
              [status errors]))

--- a/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
@@ -105,7 +105,7 @@
     (testing "Using unsupported or incorrect parameters in conjunction with multi-part-query-params"
       (are [params]
         (let [{:keys [status errors]} (search/find-concepts-with-param-string
-                                        "collection" params)]
+                                        "granule" params)]
           (= [400 [(format "Parameter [%s] was not recognized."
                            (first (string/split params #"=")))]]
              [status errors]))


### PR DESCRIPTION
Standard queries were exceeding paging limits because there was the potential to return more than 100k granules within a given temporal range. Because all the initial query needs to get is a list of `collection-concept-ids`, I'm using an aggregation on that field, which allows a page size of 0 for the main query itself which will hopefully side-step this problem.