### PR TITLE
CMR-4330 - -> _

### DIFF
--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -115,7 +115,7 @@
    a granule search.
 
   This could be generalized to support parameters that require multiple queries"
-  #{:has-granules-created-at})
+  #{:has_granules_created_at})
 
 (defn- concept-type-path-w-extension->concept-type
   "Parses the concept type and extension (\"granules.echo10\") into the concept type"
@@ -255,7 +255,7 @@
         collection-ids (get-bucket-values-from-aggregation collections-with-new-granules-search :collections)
         search-params (-> params
                           (assoc :echo-collection-id collection-ids)
-                          (dissoc :has-granules-created-at)
+                          (dissoc :has_granules_created_at)
                           lp/process-legacy-psa)]
 
     (if (empty? collection-ids)

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -115,7 +115,7 @@
    a granule search.
 
   This could be generalized to support parameters that require multiple queries"
-  #{:has_granules_created_at})
+  #{:has_granules_created_at :has-granules-created-at})
 
 (defn- concept-type-path-w-extension->concept-type
   "Parses the concept type and extension (\"granules.echo10\") into the concept type"
@@ -256,6 +256,7 @@
         search-params (-> params
                           (assoc :echo-collection-id collection-ids)
                           (dissoc :has_granules_created_at)
+                          (dissoc :has-granules-created-at)
                           lp/process-legacy-psa)]
 
     (if (empty? collection-ids)

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -276,7 +276,7 @@
    Supports CMR Harvesting."
   [context params]
   (when-let [[start-date end-date] (mapv time-format/parse
-                                         (string/split (:has-granules-created-at params) #","))]
+                                         (string/split (:has_granules_created_at params) #","))]
     (let [query (qm/query {:concept-type :granule
                            :page-size 0
                            :result-format :query-specified

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -276,7 +276,8 @@
    Supports CMR Harvesting."
   [context params]
   (when-let [[start-date end-date] (mapv time-format/parse
-                                         (string/split (:has_granules_created_at params) #","))]
+                                         (string/split (or (:has_granules_created_at params)
+                                                           (:has-granules-created-at params)) #","))]
     (let [query (qm/query {:concept-type :granule
                            :page-size 0
                            :result-format :query-specified

--- a/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
@@ -90,7 +90,7 @@
                                "collection"
                                "has_granules_created_at=2014-01-01T10:00:00Z,2016-02-01T10:00:00Z")
             none-found (client/get (str "http://localhost:3003/collections"
-                                        "?has_granules_created_at=2017-02-01T10:00:00Z,2016-02-01T10:00:00Z"))]
+                                        "?has-granules-created-at=2017-02-01T10:00:00Z,2016-02-01T10:00:00Z"))]
         (d/refs-match? [regular-collection] range-references)
         (and (= (:body none-found) "")
              (= (get (:headers none-found) "CMR-Hits") 0))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_with_new_granule_search_test.clj
@@ -86,14 +86,11 @@
 
     (index/wait-until-indexed)
     (testing "Old and deleted collections should not be found."
-      (let [references (search/find-concepts-with-param-string
-                         "collection"
-                         "has-granules-created-at=2014-01-01T10:00:00Z")
-            range-references (search/find-concepts-with-param-string
+      (let [range-references (search/find-concepts-with-param-string
                                "collection"
-                               "has-granules-created-at=2014-01-01T10:00:00Z,2016-02-01T10:00:00Z")
+                               "has_granules_created_at=2014-01-01T10:00:00Z,2016-02-01T10:00:00Z")
             none-found (client/get (str "http://localhost:3003/collections"
-                                        "?has-granules-created-at=2017-02-01T10:00:00Z,2016-02-01T10:00:00Z"))]
+                                        "?has_granules_created_at=2017-02-01T10:00:00Z,2016-02-01T10:00:00Z"))]
         (d/refs-match? [regular-collection] range-references)
         (and (= (:body none-found) "")
              (= (get (:headers none-found) "CMR-Hits") 0))))
@@ -109,4 +106,4 @@
           (= [400 [(format "Parameter [%s] was not recognized."
                            (first (string/split params #"=")))]]
              [status errors]))
-        "birthday=2011-01-01T00:00:00Z&has-granules-created-at=2014-01-01T10:00:00Z"))))
+        "birthday=2011-01-01T00:00:00Z&has_granules_created_at=2014-01-01T10:00:00Z"))))


### PR DESCRIPTION
I forgot to do this in my last PR. This just changes the `has-granules-created-at` parameter to be `has_granules_created_at`, which is what it should have been in the first place