### PR TITLE
CMR-4363: Increase max request size we can accept in Jetty 

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -41,10 +41,10 @@
   ONE_MB)
 
 (def MAX_REQUEST_BODY_SIZE
- "The maximum size of a request to body. This is set to 500KB prevent large requests coming in
-  that cause out of memory exceptions. A large ISO document like AST_L1A can be 120K characters which
-  would take up about 240KB in Java. This value is set to 5 MB."
- (* 5 ONE_MB))
+ "The maximum request body size which the application will accept. This is set to prevent large,
+  invalid requests coming in that cause out of memory exceptions. Requests to save the humanizer
+  report in Cubby can be in the 5 to 10 MB range."
+ (* 50 ONE_MB))
 
 (defn- routes-fn-verify-size
   "Takes the passed in routes function and wraps it with another function that will verify request


### PR DESCRIPTION
from 5MB to 50MB so that large humanizer reports can be saved in cubby.

There is already a test which verifies we can successfully process a body of exactly 50MB and we reject a request with 50MB + 1 byte (cmr.common.test.api.web-server/test-max-post-size).

The only reason we have this limit is so that we can prevent invalid requests from causing OOM errors on our apps. Every app has at least a 1GB heap size so a 50MB request is not likely to cause any problems.