### PR TITLE
Cmr 4230 - Sort by version

### DIFF
--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -190,7 +190,7 @@
 (defnestedmapping temporal-mapping
   "Defines mappings for TemporalExtents."
   {:start-date m/date-field-mapping
-   :end-date m/date-field-mapping}) 
+   :end-date m/date-field-mapping})
 
 (def spatial-coverage-fields
   "Defines the sets of fields shared by collections and granules for indexing spatial data."
@@ -267,6 +267,7 @@
           :short-name.lowercase  m/string-field-mapping
           :version-id            (m/stored m/string-field-mapping)
           :version-id.lowercase  m/string-field-mapping
+          :parsed-version-id.lowercase m/string-field-mapping
 
           ;; Stored to allow retrieval for implementing granule acls
           :access-value                   (m/stored m/float-field-mapping)
@@ -330,15 +331,15 @@
           ;; centers, distribution centers, processing centers, and
           ;; originating centers.
           :data-centers data-center-hierarchical-mapping
-         
+
           ;; nested mapping containing all the temporal ranges within a collection.
           :temporals temporal-mapping
 
-          ;; nested mapping for limit_to_granules case. 
+          ;; nested mapping for limit_to_granules case.
           ;; it either contains [{:start-date granule-start-date :end-date granule-end-date}]
           ;; or when there're no granules, contains all the temporal ranges within the collection
-          :limit-to-granules-temporals temporal-mapping         
- 
+          :limit-to-granules-temporals temporal-mapping
+
           ;; Facet fields
           ;; We can run aggregations on the above science keywords as a
           ;; nested document. However the counts that come back are counts
@@ -507,7 +508,7 @@
 
      ;; granule temporal search is not nested but it shares the same code
      ;; with the collection temporal search which is nested. So we need
-     ;; a nested index structure even though for granules it's just using one 
+     ;; a nested index structure even though for granules it's just using one
      ;; start-date, end-date.
      :temporals temporal-mapping
      :size (m/stored m/float-field-mapping)

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection.clj
@@ -16,6 +16,9 @@
     "Leading 0's version"
     "006" "6"
 
+    "Leading and trailing 0's"
+    "010" "10"
+
     "String version"
     "Not provided" "Not provided"
 

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection.clj
@@ -1,0 +1,23 @@
+(ns cmr.indexer.test.data.concepts.collection
+  "Functions for testing cmr.indexer.data.concepts.collection namespace"
+  (:require
+    [clojure.test :refer :all]
+    [cmr.common.util :as util :refer [are3]]
+    [cmr.indexer.data.concepts.collection :as collection-indexer]))
+
+(deftest parse-version-id
+  (are3 [version-id parsed-version-id]
+    (is (= parsed-version-id
+           (#'collection-indexer/parse-version-id version-id)))
+
+    "Regular integer version"
+    "15" "15"
+
+    "Leading 0's version"
+    "006" "6"
+
+    "String version"
+    "Not provided" "Not provided"
+
+    "Nil version"
+    nil nil))

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -262,7 +262,7 @@
 (defmethod q2e/concept-type->sort-key-map :collection
   [_]
   {:short-name :short-name.lowercase
-   :version-id :version-id.lowercase
+   :version-id :parsed-version-id.lowercase ; Use parsed for sorting
    :entry-title :entry-title.lowercase
    :entry-id :entry-id.lowercase
    :provider :provider-id.lowercase
@@ -321,7 +321,7 @@
   "This defines the sub sort fields for a latest revision collection search. Short name and version id
    are included for better relevancy with search results where all the other sort keys were identical."
   [{(q2e/query-field->elastic-field :short-name :collection) {:order "asc"}}
-   {(q2e/query-field->elastic-field :version-id :collection) {:order "desc"}}
+   {(q2e/query-field->elastic-field :parsed-version-id.lowercase :collection) {:order "desc"}}
    {(q2e/query-field->elastic-field :concept-seq-id :collection) {:order "asc"}}
    {(q2e/query-field->elastic-field :revision-id :collection) {:order "desc"}}])
 

--- a/search-relevancy-test/src/search_relevancy_test/relevancy_test.clj
+++ b/search-relevancy-test/src/search_relevancy_test/relevancy_test.clj
@@ -81,4 +81,5 @@
    (relevancy-test args nil))
   ([args search-params]
    (test-setup)
-   (run-anomaly-tests args search-params)))
+   (run-anomaly-tests args search-params)
+   nil)) ; Return nil so the return value is not printed to the REPL

--- a/search-relevancy-test/src/search_relevancy_test/result_logger.clj
+++ b/search-relevancy-test/src/search_relevancy_test/result_logger.clj
@@ -109,7 +109,7 @@
         log-history (core/get-argument-value args "-log-history")
         log-history (if (some? log-history)
                       (Boolean/parseBoolean log-history)
-                      true)]
+                      false)]
     (when log-history
       (write-test-run-to-csv test-run-history-csv results run-description))
     (write-test-run-to-csv local-test-run-csv results run-description)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
@@ -903,3 +903,29 @@
          "||" [0]
          "48AND" [48]
          "OR" [49])))
+
+;; Test that the same collection short-name with different versions comes back
+;; in descending order by version, even if the versions are in different formats
+;; i.e. 001 vs 2
+(deftest version-sort
+  (let [coll-v1 (d/ingest-umm-spec-collection
+                  "PROV1"
+                  (data-umm-c/collection
+                           {:EntryTitle "MODIS/Terra Total Precipitable Water Aerosol 5-Min L2 Swath 1km and 5km V001",
+                            :ShortName "MOD05_L2",
+                            :Version "001"}))
+        coll-v2 (d/ingest-umm-spec-collection
+                  "PROV1"
+                  (data-umm-c/collection
+                           {:EntryTitle "MODIS/Terra Total Precipitable Water Aerosol 5-Min L2 Swath 1km and 5km V002",
+                            :ShortName "MOD05_L2",
+                            :Version "2"}))
+        coll-v3 (d/ingest-umm-spec-collection
+                  "PROV1"
+                  (data-umm-c/collection
+                           {:EntryTitle "MODIS/Terra Total Precipitable Water Aerosol 5-Min L2 Swath 1km and 5km V003",
+                            :ShortName "MOD05_L2",
+                            :Version "003"}))
+        _ (index/wait-until-indexed)
+        refs (search/find-refs :collection {:keyword "MOD05_L2"})]
+     (is (d/refs-match-order? [coll-v3 coll-v2 coll-v1] refs))))


### PR DESCRIPTION
We are already sorting by version for keyword search, but have run across an issue in a few cases where the version formats are mismatched (i.e. 5 vs 006) which would result in the versions not sorting correctly. I added a parsed-version-id that tries to parse to int to normalize the versions if possible.