### PR TITLE
CMR-4369 var concept mime type support

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1984,12 +1984,11 @@ File extension examples:
     curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.iso"
     curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.json"
     curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1/2.echo10"
-    curl -i -H "Accept: version=1.9" \
-      "%CMR-ENDPOINT%/concepts/V100000-PROV1.umm-json"
-    curl -i -H "Accept: version=1.9" \
-      "%CMR-ENDPOINT%/concepts/V100000-PROV1/2.umm-json"
+    curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1.umm_json"
+    curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1/2.umm_json"
+    curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1/2.umm_json_v1_9"
 
-Content type examples:
+MIME-type examples:
 
     curl -i -H 'Accept: application/xml' \
         "%CMR-ENDPOINT%/concepts/G100000-PROV1"
@@ -2015,7 +2014,7 @@ The following extensions and MIME types are supported by the `/concepts/` resour
 
 The following extensions and MIME types are supported by the `/concepts/` resource for the variable concept type:
 
-  * `umm-json`     "application/vnd.nasa.cmr.umm+json;version=1.9"
+  * `umm_json`     "application/vnd.nasa.cmr.umm+json;version=1.9"
 
 ### <a name="search-with-post"></a> Search with POST
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1963,8 +1963,6 @@ Examples of sorting by start_date in descending(Most recent data first) and asce
 
 This allows retrieving the metadata for a single concept. This is only supported for collections, granules, and variables. If no format is specified the native format of the metadata will be returned.
 
-WARNING: Currently for variables, the only `Accept` header value you can pass is `*/*`. As such the format extension is not yet supported for variables.
-
 By concept id
 
     curl -i  "%CMR-ENDPOINT%/concepts/:concept-id"
@@ -1973,18 +1971,32 @@ By concept id and revision id
 
     curl -i "%CMR-ENDPOINT%/concepts/:concept-id/:revision-id"
 
-Examples:
+Plain examples, with and without revision ids:
 
     curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1"
-    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.iso"
-    curl -i -H 'Accept: application/xml' "%CMR-ENDPOINT%/concepts/G100000-PROV1"
-    curl -i -H 'Accept: application/metadata+xml' "%CMR-ENDPOINT%/concepts/G100000-PROV1"
-    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.json"
     curl -i "%CMR-ENDPOINT%/concepts/C100000-PROV1/1"
-    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1/2.echo10"
     curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1"
     curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1/1"
     curl -i "%CMR-ENDPOINT%/concepts/V100000-PROV1/2"
+
+File extension examples:
+
+    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.iso"
+    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1.json"
+    curl -i "%CMR-ENDPOINT%/concepts/G100000-PROV1/2.echo10"
+    curl -i -H "Accept: version=1.9" \
+      "%CMR-ENDPOINT%/concepts/V100000-PROV1.umm-json"
+    curl -i -H "Accept: version=1.9" \
+      "%CMR-ENDPOINT%/concepts/V100000-PROV1/2.umm-json"
+
+Content type examples:
+
+    curl -i -H 'Accept: application/xml' \
+        "%CMR-ENDPOINT%/concepts/G100000-PROV1"
+    curl -i -H 'Accept: application/metadata+xml' \
+        "%CMR-ENDPOINT%/concepts/G100000-PROV1"
+    curl -i -H "Accept: application/vnd.nasa.cmr.umm+json;version=1.9" \
+        "%CMR-ENDPOINT%/concepts/V100000-PROV1"
 
 Note that attempting to retrieve a revision that is a tombstone is an error and will return a 400 status code.
 
@@ -2000,6 +2012,10 @@ The following extensions and MIME types are supported by the `/concepts/` resour
   * `dif`       "application/dif+xml"
   * `dif10`     "application/dif10+xml"
   * `atom`      "application/atom+xml"
+
+The following extensions and MIME types are supported by the `/concepts/` resource for the variable concept type:
+
+  * `umm-json`     "application/vnd.nasa.cmr.umm+json;version=1.9"
 
 ### <a name="search-with-post"></a> Search with POST
 

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -107,7 +107,8 @@
               mt/echo10
               mt/iso19115
               mt/iso-smap}
-   :variable #{mt/any}})
+   :variable #{mt/any
+               mt/umm-json}})
 
 (def find-by-concept-id-concept-types
   #{:collection :granule :variable})


### PR DESCRIPTION
The second phase of the CMR-4369 ticket ended up being less that we had originally planned, mostly because we're going to tackle the metadata-transformer issue we ran into (with versioning the content type) when we add versioning support.

This change simply adds the `mt/umm-json` content type, adds some tests for that, and does a little cleanup.