### PR TITLE
CMR-4343: Refactor dispatching logic in bootstrap-app

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -88,28 +88,28 @@ HTTP/1.1 200 OK
 
 ### Bulk copy provider FIX_PROV1 and all it's collections and granules to the metadata db
 
-    curl -v -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1"}' http://localhost:3006/bulk_migration/providers
+    curl -i -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1"}' http://localhost:3006/bulk_migration/providers
 
 For the echo-reverb test fixture data, the following curl can be used to check metadata db
 to make sure the new data is available:
 
-    curl -v http://localhost:3001/concepts/G1000000033-FIX_PROV1
+    curl -i http://localhost:3001/concepts/G1000000033-FIX_PROV1
 
 This should return the granule including the echo-10 xml.
 
 ### Copy a single collection's granules
 
-    curl -v -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1", "collection_id": "C1000000073-FIX_PROV1"}' http://localhost:3006/bulk_migration/collections
+    curl -i -XPOST -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1", "collection_id": "C1000000073-FIX_PROV1"}' http://localhost:3006/bulk_migration/collections
 
 ### Bulk index a provider
 
-  	curl -v -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1"}' http://localhost:3006/bulk_index/providers
+    curl -i -XPOST -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1"}' http://localhost:3006/bulk_index/providers
 
 NOTE from CMR-1908 that when reindexing a provider the collections are not reindexed in the all revisions index. The workaround here is to use the indexer endpoint for reindexing collections.
 
 ### Bulk index a single collection
 
-  	curl -v -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1", "collection_id":"C123-FIX_PROV1"}' http://localhost:3006/bulk_index/collections
+    curl -i -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1", "collection_id":"C123-FIX_PROV1"}' http://localhost:3006/bulk_index/collections
 
 ### Bulk index concepts by concept-id - for indexing multiple specific items
 
@@ -118,17 +118,17 @@ NOTE from CMR-1908 that when reindexing a provider the collections are not reind
 
 ### Bulk index concepts newer than a given date-time
 
-    curl -v XPOST http://localhost:3006/bulk_index/after_date_time?date_time=2015-02-02T10:00:00Z"
+    curl -i -XPOST http://localhost:3006/bulk_index/after_date_time?date_time=2015-02-02T10:00:00Z"
 
 ### Bulk index all system concepts (tags/acls/access-groups)
 
-    curl -v XPOST http://localhost:3006/bulk_index/system_concepts
+    curl -i -XPOST http://localhost:3006/bulk_index/system_concepts
 
 ### Initialize Virtual Products
 
 Virtual collections contain granules derived from a source collection. Only granules specified in the source collections in the virtual product app configuration will be considered. Virtual granules will only be created in the configured destination virtual collections if they already exist. To initialize virtual granules from existing source granules, use the following command:
 
-    curl -v -XPOST http://localhost:3006/virtual_products?provider-id=PROV1&entry-title=et1
+    curl -i -XPOST http://localhost:3006/virtual_products?provider-id=PROV1&entry-title=et1
 
 Note that provider-id and entry-title are required.
 
@@ -138,17 +138,17 @@ This endpoint should only be using in an AWS environment where the Database Migr
 is being used to replicate changes from another database to this environment. This will index any
 concepts that have been replicated since the last replication run.
 
-    curl -v -XPOST http://localhost:3006/index_recently_replicated
+    curl -i -XPOST http://localhost:3006/index_recently_replicated
 
 ### Run database migration
 
 Migrate database to the latest schema version:
 
-    curl -v -XPOST -H "Echo-Token: XXXX" http://localhost:3006/db-migrate
+    curl -i -XPOST -H "Echo-Token: XXXX" http://localhost:3006/db-migrate
 
 Migrate database to a specific schema version (e.g. 3):
 
-    curl -v -XPOST -H "Echo-Token: XXXX" http://localhost:3006/db-migrate?version=3
+    curl -i -XPOST -H "Echo-Token: XXXX" http://localhost:3006/db-migrate?version=3
 
 ### Check application health
 
@@ -290,4 +290,4 @@ Example un-healthy response body:
 
 ## License
 
-Copyright © 2014 NASA
+Copyright © 2014-2017 NASA

--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -41,7 +41,8 @@
      :body {:message (str "Processing collection " collection-id "for provider " provider-id)}}))
 
 (defn- migrate-provider
-  "Copy a single provider's data from catalog-rest to metadata db (including collections and granules)"
+  "Copy a single provider's data from catalog-rest to metadata db (including collections and
+  granules)."
   [context provider-id-map params]
   (let [provider-id (get provider-id-map "provider_id")
         synchronous (synchronous? params)]
@@ -57,7 +58,8 @@
         result (bs/index-provider context provider-id synchronous start-index)
         msg (if synchronous
               result
-              (str "Processing provider " provider-id " for bulk indexing from start index " start-index))]
+              (str "Processing provider " provider-id " for bulk indexing from start index "
+                   start-index))]
     {:status 202
      :body {:message msg}}))
 
@@ -126,7 +128,8 @@
         concept-type (keyword (get request-details-map "concept_type"))
         concept-ids (get request-details-map "concept_ids")
         synchronous (synchronous? params)
-        result (bs/delete-concepts-from-index-by-id context synchronous provider-id concept-type concept-ids)
+        result (bs/delete-concepts-from-index-by-id context synchronous provider-id concept-type
+                                                    concept-ids)
         msg (if synchronous
               (str "Processed " result "conccepts for bulk deletion from indexes.")
               (str "Processing concepts for bulk deletion from indexes."))]
@@ -204,20 +207,18 @@
         (DELETE "/concepts" {:keys [request-context body params]}
           (bulk-delete-concepts-from-index-by-id request-context body params)))
 
-
       (context "/rebalancing_collections/:concept-id" [concept-id]
+        ;; Start rebalancing
+        (POST "/start" {:keys [request-context params]}
+          (start-rebalance-collection request-context concept-id params))
 
-       ;; Start rebalancing
-       (POST "/start" {:keys [request-context params]}
-         (start-rebalance-collection request-context concept-id params))
+        ;; Get counts of rebalancing data
+        (GET "/status" {:keys [request-context]}
+          (rebalance-status request-context concept-id))
 
-       ;; Get counts of rebalancing data
-       (GET "/status" {:keys [request-context]}
-         (rebalance-status request-context concept-id))
-
-       ;; Complete reindexing
-       (POST "/finalize" {:keys [request-context]}
-         (finalize-rebalance-collection request-context concept-id)))
+        ;; Complete reindexing
+        (POST "/finalize" {:keys [request-context]}
+          (finalize-rebalance-collection request-context concept-id)))
 
       (context "/virtual_products" []
         (POST "/" {:keys [request-context params]}

--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -64,7 +64,7 @@
         provider-id (get provider-id-map "provider_id")
         start-index (Long/parseLong (get params :start_index "0"))
         result (bs/index-provider context dispatcher provider-id start-index)
-        msg (if
+        msg (if (synchronous? params)
               result
               (str "Processing provider " provider-id " for bulk indexing from start index "
                    start-index))]
@@ -78,7 +78,7 @@
         date-time (:date_time params)]
     (if-let [date-time-value (date-time-parser/try-parse-datetime date-time)]
       (let [result (bs/index-data-later-than-date-time context dispatcher date-time-value)
-            msg (if
+            msg (if (synchronous? params)
                   (:message result)
                   (str "Processing data after " date-time " for bulk indexing"))]
         {:status 202
@@ -93,7 +93,7 @@
         provider-id (get provider-id-collection-map "provider_id")
         collection-id (get provider-id-collection-map "collection_id")
         result (bs/index-collection context dispatcher provider-id collection-id)
-        msg (if
+        msg (if (synchronous? params)
               result
               (str "Processing collection " collection-id " for bulk indexing."))]
     {:status 202

--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -21,7 +21,6 @@
     [cmr.oracle.connection :as oc]
     [cmr.transmit.config :as transmit-config]))
 
-
 (def ^:private elastic-http-try-count->wait-before-retry-time
   "A map of of the previous number of tries to communicate with Elasticsearch over http to the amount
   of time to wait before retrying an http request. Will stop retrying if the number of requests

--- a/bootstrap-app/src/cmr/bootstrap/data/migration_utils.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/migration_utils.clj
@@ -2,7 +2,6 @@
   "Contains utility functions for database migrations"
   (:require [cmr.metadata-db.data.oracle.concept-tables :as tables]))
 
-
 (defn catalog-rest-user
   [system]
   (get-in system [:catalog-rest-user]))

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -1,12 +1,9 @@
 (ns cmr.bootstrap.services.bootstrap-service
   "Provides methods to insert migration requets on the approriate channels."
   (:require
-    [clojure.core.async :as async :refer [go >!]]
-    [cmr.bootstrap.config :as cfg]
     [cmr.bootstrap.data.bulk-index :as bulk]
-    [cmr.bootstrap.data.bulk-migration :as bm]
     [cmr.bootstrap.data.rebalance-util :as rebalance-util]
-    [cmr.bootstrap.data.virtual-products :as vp]
+    [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
     [cmr.common.cache :as cache]
     [cmr.common.concepts :as concepts]
     [cmr.common.log :refer (debug info warn error)]
@@ -27,32 +24,17 @@
    :delete-concepts-from-index-by-id :core-async-dispatcher
    :bootstrap-virtual-products :core-async-dispatcher})
 
-(defn- get-dispatcher
-  "Returns the correct dispatcher to use based on the system configuration and the request."
-  [context synchronous request-type]
-  (if synchronous
-    (get-in context [:system :synchronous-dispatcher])
-    (get-in context [:system (request-type->dispatcher request-type)])))
-
 (defn migrate-provider
   "Copy all the data for a provider (including collections and graunules) from catalog rest
   to the metadata db without blocking."
-  [context provider-id synchronous]
-  (if synchronous
-    (bm/copy-provider (:system context) provider-id)
-    (let [channel (get-in context [:system :provider-db-channel])]
-      (info "Adding provider" provider-id "to provider channel")
-      (go (>! channel provider-id)))))
+  [context dispatcher provider-id]
+  (dispatch-protocol/migrate-provider dispatcher context provider-id))
 
 (defn migrate-collection
   "Copy all the data for a given collection (including graunules) from catalog rest
   to the metadata db without blocking."
-  [context provider-id collection-id synchronous]
-  (if synchronous
-    (bm/copy-single-collection (:system context) provider-id collection-id)
-    (let [channel (get-in context [:system :collection-db-channel])]
-      (info "Adding collection"  collection-id "for provider" provider-id "to collection channel")
-      (go (>! channel {:collection-id collection-id :provider-id provider-id})))))
+  [context dispatcher provider-id collection-id]
+  (dispatch-protocol/migrate-collection dispatcher context provider-id collection-id))
 
 (defn- get-provider
   "Returns the metadata db provider that matches the given provider id. Throws exception if
@@ -63,7 +45,18 @@
     (errors/throw-service-errors :bad-request
                               [(format "Provider: [%s] does not exist in the system" provider-id)])))
 
-(defn validate-collection
+(defn index-provider
+  "Bulk index all the collections and granules for a provider."
+  [context dispatcher provider-id start-index]
+  (get-provider context provider-id)
+  (dispatch-protocol/index-provider dispatcher context provider-id start-index))
+
+(defn index-data-later-than-date-time
+  "Bulk index all the concepts with a revision date later than the given date-time."
+  [context dispatcher date-time]
+  (dispatch-protocol/index-data-later-than-date-time dispatcher context date-time))
+
+(defn- validate-collection
   "Validates to be bulk_indexed collection exists in cmr else an exception is thrown."
   [context provider-id collection-id]
   (let [provider (get-provider context provider-id)]
@@ -71,82 +64,34 @@
       (errors/throw-service-errors :bad-request
                                 [(format "Collection [%s] does not exist." collection-id)]))))
 
-(defn index-provider
-  "Bulk index all the collections and granules for a provider."
-  [context provider-id synchronous start-index]
-  (get-provider context provider-id)
-  (if synchronous
-    (bulk/index-provider (:system context) provider-id start-index)
-    (let [channel (get-in context [:system :provider-index-channel])]
-      (info "Adding provider" provider-id "to provider index channel")
-      (go (>! channel {:provider-id provider-id
-                       :start-index start-index})))))
-
-(defn index-data-later-than-date-time
-  "Bulk index all the concepts with a revision date later than the given date-time."
-  [context date-time synchronous]
-  (if synchronous
-    (bulk/index-data-later-than-date-time (:system context) date-time)
-    (let [channel (get-in context [:system :data-index-channel])]
-      (info "Adding date-time" date-time "to data index channel.")
-      (go (>! channel {:date-time date-time})))))
-
 (defn index-collection
   "Bulk index all the granules in a collection"
-  ([context provider-id collection-id synchronous]
-   (index-collection context provider-id collection-id synchronous nil))
-  ([context provider-id collection-id synchronous options]
+  ([context dispatcher provider-id collection-id]
+   (index-collection context dispatcher provider-id collection-id nil))
+  ([context dispatcher provider-id collection-id options]
    (validate-collection context provider-id collection-id)
-   (if synchronous
-     (bulk/index-granules-for-collection (:system context) provider-id collection-id options)
-     (let [channel (get-in context [:system :collection-index-channel])]
-       (info "Adding collection" collection-id "to collection index channel")
-       (go (>! channel (merge options
-                              {:provider-id provider-id
-                               :collection-id collection-id})))))))
+   (dispatch-protocol/index-collection dispatcher context provider-id collection-id options)))
 
 (defn index-system-concepts
   "Bulk index all the tags, acls, and access-groups."
-  [context synchronous start-index]
-  (if synchronous
-    (bulk/index-system-concepts (:system context) start-index)
-    (let [channel (get-in context [:system :system-concept-channel])]
-      (info "Adding bulk index request to system concepts channel.")
-      (go (>! channel {:start-index start-index})))))
+  [context dispatcher start-index]
+  (dispatch-protocol/index-system-concepts dispatcher context start-index))
 
 (defn index-concepts-by-id
   "Bulk index the concepts given by the concept-ids"
-  [context synchronous provider-id concept-type concept-ids]
-  (if synchronous
-    (bulk/index-concepts-by-id (:system context) provider-id concept-type concept-ids)
-    (let [channel (get-in context [:system :concept-id-channel])]
-      (info "Adding bulk index request to concept-id channel.")
-      (go (>! channel {:provider-id provider-id
-                       :concept-type concept-type
-                       :request :index
-                       :concept-ids concept-ids})))))
+  [context dispatcher provider-id concept-type concept-ids]
+  (dispatch-protocol/index-concepts-by-id dispatcher context provider-id concept-type concept-ids))
 
 (defn delete-concepts-from-index-by-id
   "Bulk delete the concepts given by the concept-ids from the indexes"
-  [context synchronous provider-id concept-type concept-ids]
-  (if synchronous
-    (bulk/delete-concepts-by-id (:system context) provider-id concept-type concept-ids)
-    (let [channel (get-in context [:system :concept-id-channel])]
-      (info "Adding bulk delete reqeust to concept-id channel.")
-      (go (>! channel {:provider-id provider-id
-                       :concept-type concept-type
-                       :request :delete
-                       :concept-ids concept-ids})))))
+  [context dispatcher provider-id concept-type concept-ids]
+  (dispatch-protocol/delete-concepts-from-index-by-id dispatcher context provider-id concept-type
+                                                      concept-ids))
 
 (defn bootstrap-virtual-products
   "Initializes virtual products."
-  [context synchronous provider-id entry-title]
-  (if synchronous
-    (vp/bootstrap-virtual-products (:system context) provider-id entry-title)
-    (go
-      (info "Adding message to virtual products channel.")
-      (-> context :system (get vp/channel-name) (>! {:provider-id provider-id
-                                                     :entry-title entry-title})))))
+  [context dispatcher provider-id entry-title]
+  (dispatch-protocol/bootstrap-virtual-products dispatcher context provider-id entry-title))
 
 (defn- wait-until-index-set-hash-cache-times-out
   "Waits until the indexer's index set cache hash codes times out so that all of the indexer's will
@@ -160,7 +105,7 @@
 (defn start-rebalance-collection
   "Kicks off collection rebalancing. Will run synchronously if synchronous is true. Throws exceptions
   from failures to change the index set."
-  [context concept-id synchronous]
+  [context dispatcher concept-id]
   (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
   ;; This will throw an exception if the collection is already rebalancing
   (index-set/add-rebalancing-collection context indexer-index-set/index-set-id concept-id)
@@ -178,9 +123,10 @@
   (let [provider-id (:provider-id (concepts/parse-concept-id concept-id))]
     ;; queue the collection for reindexing into the new index
     (index-collection
-     context provider-id concept-id synchronous
+     context dispatcher provider-id concept-id
      {:target-index-key (keyword concept-id)
-      :completion-message (format "Completed reindex of [%s] for rebalancing granule indexes." concept-id)})))
+      :completion-message (format "Completed reindex of [%s] for rebalancing granule indexes."
+                                  concept-id)})))
 
 (defn finalize-rebalance-collection
   "Finalizes collection rebalancing."

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/core_async_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/core_async_dispatch.clj
@@ -1,5 +1,5 @@
-(ns cmr.bootstrap.services.bootstrap-service
-  "Provides methods to insert migration requets on the approriate channels."
+(ns cmr.bootstrap.services.dispatch.core-async-dispatch
+  "Provides methods to insert migration requets on the appropriate channels."
   (:require
     [clojure.core.async :as async :refer [go >!]]
     [cmr.bootstrap.config :as cfg]
@@ -14,25 +14,6 @@
     [cmr.indexer.data.index-set :as indexer-index-set]
     [cmr.indexer.system :as indexer-system]
     [cmr.transmit.index-set :as index-set]))
-
-(def request-type->dispatcher
-  "A map of request types to which dispatcher to use for asynchronous requests."
-  {:migrate-provider :core-async-dispatcher
-   :migrate-collection :core-async-dispatcher
-   :index-provider :core-async-dispatcher
-   :index-data-later-than-date-time :core-async-dispatcher
-   :index-collection :core-async-dispatcher
-   :index-system-concepts :core-async-dispatcher
-   :index-concepts-by-id :core-async-dispatcher
-   :delete-concepts-from-index-by-id :core-async-dispatcher
-   :bootstrap-virtual-products :core-async-dispatcher})
-
-(defn- get-dispatcher
-  "Returns the correct dispatcher to use based on the system configuration and the request."
-  [context synchronous request-type]
-  (if synchronous
-    (get-in context [:system :synchronous-dispatcher])
-    (get-in context [:system (request-type->dispatcher request-type)])))
 
 (defn migrate-provider
   "Copy all the data for a provider (including collections and graunules) from catalog rest
@@ -205,6 +186,8 @@
 
   ;; Remove all granules from small collections for this collection.
   (rebalance-util/delete-collection-granules-from-small-collections context concept-id))
+
+
 
 (defn rebalance-status
   "Returns a map of counts of granules in the collection in metadata db, the small collections index,

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/core_async_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/core_async_dispatch.clj
@@ -1,196 +1,143 @@
 (ns cmr.bootstrap.services.dispatch.core-async-dispatch
   "Provides methods to insert migration requets on the appropriate channels."
   (:require
-    [clojure.core.async :as async :refer [go >!]]
-    [cmr.bootstrap.config :as cfg]
-    [cmr.bootstrap.data.bulk-index :as bulk]
-    [cmr.bootstrap.data.bulk-migration :as bm]
-    [cmr.bootstrap.data.rebalance-util :as rebalance-util]
-    [cmr.bootstrap.data.virtual-products :as vp]
-    [cmr.common.cache :as cache]
-    [cmr.common.concepts :as concepts]
-    [cmr.common.log :refer (debug info warn error)]
-    [cmr.common.services.errors :as errors]
-    [cmr.indexer.data.index-set :as indexer-index-set]
-    [cmr.indexer.system :as indexer-system]
-    [cmr.transmit.index-set :as index-set]))
+    [clojure.core.async :as async :refer [>!]]
+    [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
+    [cmr.common.log :refer [info]]))
 
 (defn migrate-provider
   "Copy all the data for a provider (including collections and graunules) from catalog rest
   to the metadata db without blocking."
-  [context provider-id synchronous]
-  (if synchronous
-    (bm/copy-provider (:system context) provider-id)
-    (let [channel (get-in context [:system :provider-db-channel])]
-      (info "Adding provider" provider-id "to provider channel")
-      (go (>! channel provider-id)))))
+  [this context provider-id]
+  (let [channel (:provider-db-channel this)]
+    (info "Adding provider" provider-id "to provider channel")
+    (async/go (>! channel provider-id))))
 
 (defn migrate-collection
   "Copy all the data for a given collection (including graunules) from catalog rest
   to the metadata db without blocking."
-  [context provider-id collection-id synchronous]
-  (if synchronous
-    (bm/copy-single-collection (:system context) provider-id collection-id)
-    (let [channel (get-in context [:system :collection-db-channel])]
-      (info "Adding collection"  collection-id "for provider" provider-id "to collection channel")
-      (go (>! channel {:collection-id collection-id :provider-id provider-id})))))
-
-(defn- get-provider
-  "Returns the metadata db provider that matches the given provider id. Throws exception if
-  no matching provider is found."
-  [context provider-id]
-  (if-let [provider (bulk/get-provider-by-id context provider-id)]
-    provider
-    (errors/throw-service-errors :bad-request
-                              [(format "Provider: [%s] does not exist in the system" provider-id)])))
-
-(defn validate-collection
-  "Validates to be bulk_indexed collection exists in cmr else an exception is thrown."
-  [context provider-id collection-id]
-  (let [provider (get-provider context provider-id)]
-    (when-not (bulk/get-collection context provider collection-id)
-      (errors/throw-service-errors :bad-request
-                                [(format "Collection [%s] does not exist." collection-id)]))))
+  [this context provider-id collection-id]
+  (let [channel (:collection-db-channel this)]
+    (info "Adding collection"  collection-id "for provider" provider-id "to collection channel")
+    (async/go (>! channel {:collection-id collection-id :provider-id provider-id}))))
 
 (defn index-provider
   "Bulk index all the collections and granules for a provider."
-  [context provider-id synchronous start-index]
-  (get-provider context provider-id)
-  (if synchronous
-    (bulk/index-provider (:system context) provider-id start-index)
-    (let [channel (get-in context [:system :provider-index-channel])]
-      (info "Adding provider" provider-id "to provider index channel")
-      (go (>! channel {:provider-id provider-id
-                       :start-index start-index})))))
+  [this context provider-id start-index]
+  (let [channel (:provider-index-channel this)]
+    (info "Adding provider" provider-id "to provider index channel")
+    (async/go (>! channel {:provider-id provider-id
+                           :start-index start-index}))))
 
 (defn index-data-later-than-date-time
   "Bulk index all the concepts with a revision date later than the given date-time."
-  [context date-time synchronous]
-  (if synchronous
-    (bulk/index-data-later-than-date-time (:system context) date-time)
-    (let [channel (get-in context [:system :data-index-channel])]
-      (info "Adding date-time" date-time "to data index channel.")
-      (go (>! channel {:date-time date-time})))))
+  [this context date-time]
+  (let [channel (:data-index-channel this)]
+    (info "Adding date-time" date-time "to data index channel.")
+    (async/go (>! channel {:date-time date-time}))))
 
 (defn index-collection
   "Bulk index all the granules in a collection"
-  ([context provider-id collection-id synchronous]
-   (index-collection context provider-id collection-id synchronous nil))
-  ([context provider-id collection-id synchronous options]
-   (validate-collection context provider-id collection-id)
-   (if synchronous
-     (bulk/index-granules-for-collection (:system context) provider-id collection-id options)
-     (let [channel (get-in context [:system :collection-index-channel])]
-       (info "Adding collection" collection-id "to collection index channel")
-       (go (>! channel (merge options
-                              {:provider-id provider-id
-                               :collection-id collection-id})))))))
+  [this context provider-id collection-id options]
+  (let [channel (:collection-index-channel this)]
+    (info "Adding collection" collection-id "to collection index channel")
+    (async/go (>! channel (merge options
+                                 {:provider-id provider-id
+                                  :collection-id collection-id})))))
 
 (defn index-system-concepts
   "Bulk index all the tags, acls, and access-groups."
-  [context synchronous start-index]
-  (if synchronous
-    (bulk/index-system-concepts (:system context) start-index)
-    (let [channel (get-in context [:system :system-concept-channel])]
-      (info "Adding bulk index request to system concepts channel.")
-      (go (>! channel {:start-index start-index})))))
+  [this context start-index]
+  (let [channel (:system-concept-channel this)]
+    (info "Adding bulk index request to system concepts channel.")
+    (async/go (>! channel {:start-index start-index}))))
 
 (defn index-concepts-by-id
   "Bulk index the concepts given by the concept-ids"
-  [context synchronous provider-id concept-type concept-ids]
-  (if synchronous
-    (bulk/index-concepts-by-id (:system context) provider-id concept-type concept-ids)
-    (let [channel (get-in context [:system :concept-id-channel])]
-      (info "Adding bulk index request to concept-id channel.")
-      (go (>! channel {:provider-id provider-id
-                       :concept-type concept-type
-                       :request :index
-                       :concept-ids concept-ids})))))
+  [this context provider-id concept-type concept-ids]
+  (let [channel (:concept-id-channel this)]
+    (info "Adding bulk index request to concept-id channel.")
+    (async/go (>! channel {:provider-id provider-id
+                           :concept-type concept-type
+                           :request :index
+                           :concept-ids concept-ids}))))
 
 (defn delete-concepts-from-index-by-id
   "Bulk delete the concepts given by the concept-ids from the indexes"
-  [context synchronous provider-id concept-type concept-ids]
-  (if synchronous
-    (bulk/delete-concepts-by-id (:system context) provider-id concept-type concept-ids)
-    (let [channel (get-in context [:system :concept-id-channel])]
-      (info "Adding bulk delete reqeust to concept-id channel.")
-      (go (>! channel {:provider-id provider-id
-                       :concept-type concept-type
-                       :request :delete
-                       :concept-ids concept-ids})))))
+  [this context provider-id concept-type concept-ids]
+  (let [channel (:concept-id-channel this)]
+    (info "Adding bulk delete reqeust to concept-id channel.")
+    (async/go (>! channel {:provider-id provider-id
+                           :concept-type concept-type
+                           :request :delete
+                           :concept-ids concept-ids}))))
 
 (defn bootstrap-virtual-products
   "Initializes virtual products."
-  [context synchronous provider-id entry-title]
-  (if synchronous
-    (vp/bootstrap-virtual-products (:system context) provider-id entry-title)
-    (go
-      (info "Adding message to virtual products channel.")
-      (-> context :system (get vp/channel-name) (>! {:provider-id provider-id
-                                                     :entry-title entry-title})))))
+  [this context provider-id entry-title]
+  (let [channel (:virtual-product-channel this)]
+    (info "Adding message to virtual products channel.")
+    (async/go (>! channel {:provider-id provider-id
+                           :entry-title entry-title}))))
 
-(defn- wait-until-index-set-hash-cache-times-out
-  "Waits until the indexer's index set cache hash codes times out so that all of the indexer's will
-   be using the same cached data."
+(defrecord CoreAsyncDispatcher
+  [;; Channel for requesting full provider migration
+   provider-db-channel
+   ;; Channel for requesting single collection/granules migration.
+   ;; Takes maps, e.g., {:collection-id collection-id :provider-id provider-id}
+   collection-db-channel
+   ;; Channel for requesting full provider indexing - collections/granules
+   provider-index-channel
+   ;; Channel for processing collections to index.
+   collection-index-channel
+   ;; Channel for processing data newer than a given date-time.
+   data-index-channel
+   ;; Channel for processing bulk index requests for system concepts (tags, acls, access-groups)
+   system-concept-channel
+   ;; channel for processing bulk index requests by concept-id
+   concept-id-channel
+   ;; channel for bootstrapping virtual products
+   virtual-product-channel])
+
+(def dispatch-behavior
+  "Map of protocol definitions to the implementations of that protocol for the
+  dispatcher."
+  {:migrate-provider migrate-provider
+   :migrate-collection migrate-collection
+   :index-provider index-provider
+   :index-data-later-than-date-time index-data-later-than-date-time
+   :index-collection index-collection
+   :index-system-concepts index-system-concepts
+   :index-concepts-by-id index-concepts-by-id
+   :delete-concepts-from-index-by-id delete-concepts-from-index-by-id
+   :bootstrap-virtual-products bootstrap-virtual-products})
+
+(extend CoreAsyncDispatcher
+        dispatch-protocol/Dispatch
+        dispatch-behavior)
+
+(defn- create-default-channels
+  "Creates channels needed for all bootstrapping work and returns as a map of channel name to
+  channel."
   []
-  ;; Wait 3 seconds beyond the time that the indexer set cache consistency setting.
-  (let [sleep-secs (+ 3 (indexer-system/index-set-cache-consistent-timeout-seconds))]
-    (info "Waiting" sleep-secs "seconds so indexer index set hashes will timeout.")
-    (Thread/sleep (* 1000 sleep-secs))))
+  {:provider-db-channel (async/chan 10)
+   :collection-db-channel (async/chan 100)
+   :provider-index-channel (async/chan 10)
+   :collection-index-channel (async/chan 100)
+   :data-index-channel (async/chan 10)
+   :system-concept-channel (async/chan 10)
+   :concept-id-channel (async/chan 10)
+   :virtual-product-channel (async/chan)})
 
-(defn start-rebalance-collection
-  "Kicks off collection rebalancing. Will run synchronously if synchronous is true. Throws exceptions
-  from failures to change the index set."
-  [context concept-id synchronous]
-  (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
-  ;; This will throw an exception if the collection is already rebalancing
-  (index-set/add-rebalancing-collection context indexer-index-set/index-set-id concept-id)
-
-  ;; Clear the cache so that the newest index set data will be used.
-  ;; This clears embedded caches so the indexer cache in this bootstrap app will be cleared.
-  (cache/reset-caches context)
-
-  ;; We must wait here so that any new granules coming in will start to pick up the new index set
-  ;; and be indexed into both the old and the new. Then we can safely reindex everything and know
-  ;; we haven't missed a granule. There would be a race condition otherwise where a new granule
-  ;; came in and was indexed only to the old collection but after we started reindexing the collection.
-  (wait-until-index-set-hash-cache-times-out)
-
-  (let [provider-id (:provider-id (concepts/parse-concept-id concept-id))]
-    ;; queue the collection for reindexing into the new index
-    (index-collection
-     context provider-id concept-id synchronous
-     {:target-index-key (keyword concept-id)
-      :completion-message (format "Completed reindex of [%s] for rebalancing granule indexes." concept-id)})))
-
-(defn finalize-rebalance-collection
-  "Finalizes collection rebalancing."
-  [context concept-id]
-  (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
-  ;; This will throw an exception if the collection is not rebalancing
-  (index-set/finalize-rebalancing-collection context indexer-index-set/index-set-id concept-id)
-  ;; Clear the cache so that the newest index set data will be used.
-  ;; This clears embedded caches so the indexer cache in this bootstrap app will be cleared.
-  (cache/reset-caches context)
-
-  ;; There is a race condition as noted here: https://wiki.earthdata.nasa.gov/display/CMR/Rebalancing+Collection+Indexes+Approach
-  ;; "There's a period of time during which the different indexer applications may be processing
-  ;; granules for this very collection and may have already decided which index its going to. It's
-  ;; possible that the indexer will index a granule into small collections after the bootstrap has
-  ;; issued the delete. The next step to verify should identify if the race conditions has occurred. "
-  ;; The sleep here decreases the probability of the race condition giving time for
-  ;; indexer to finish indexing any granule currently being processed.
-  ;; This doesn't remove the race condition. We still have steps in the overall process to detect it
-  ;; and resolve it. (manual fixes if necessary)
-  (wait-until-index-set-hash-cache-times-out)
-
-  ;; Remove all granules from small collections for this collection.
-  (rebalance-util/delete-collection-granules-from-small-collections context concept-id))
-
-
-
-(defn rebalance-status
-  "Returns a map of counts of granules in the collection in metadata db, the small collections index,
-   and in the separate collection index if it exists."
-  [context concept-id]
-  (rebalance-util/rebalancing-collection-counts context concept-id))
+(defn create-core-async-dispatcher
+  "Creates a new core async dispatcher."
+  []
+  (let [channels (create-default-channels)]
+    (->CoreAsyncDispatcher (:provider-db-channel channels)
+                           (:collection-db-channel channels)
+                           (:provider-index-channel channels)
+                           (:collection-index-channel channels)
+                           (:data-index-channel channels)
+                           (:system-concept-channel channels)
+                           (:concept-id-channel channels)
+                           (:virtual-product-channel channels))))

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/dispatch_protocol.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/dispatch_protocol.clj
@@ -1,0 +1,43 @@
+(ns cmr.bootstrap.services.dispatch.dispatch-protocol
+  "Defines the Bootstrap dispatch protocol.")
+
+(defprotocol Dispatch
+  "Functions for handling the dispatch of bootstrap requests."
+
+  (migrate-provider
+   [this context provider-id]
+   "Copy all the data for a provider (including collections and graunules) from catalog rest
+   to the metadata db without blocking.")
+
+  (migrate-collection
+   [this context provider-id collection-id]
+   "Copy all the data for a given collection (including graunules) from catalog rest
+   to the metadata db without blocking.")
+
+  (index-provider
+   [this context provider-id start-index]
+   "Bulk index all the collections and granules for a provider.")
+
+  (index-data-later-than-date-time
+   [this context date-time]
+   "Bulk index all the concepts with a revision date later than the given date-time.")
+
+  (index-collection
+   [this context provider-id collection-id options]
+   "Bulk index all the granules in a collection")
+
+  (index-system-concepts
+   [this context start-index]
+   "Bulk index all the tags, acls, and access-groups.")
+
+  (index-concepts-by-id
+   [this context provider-id concept-type concept-ids]
+   "Bulk index the concepts given by the concept-ids")
+
+  (delete-concepts-from-index-by-id
+   [this context provider-id concept-type concept-ids]
+   "Bulk delete the concepts given by the concept-ids from the indexes")
+
+  (bootstrap-virtual-products
+   [this context provider-id entry-title]
+   "Initializes virtual products for the given provider and entry title."))

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/synchronous_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/synchronous_dispatch.clj
@@ -53,8 +53,7 @@
   [this context provider-id entry-title]
   (virtual-products/bootstrap-virtual-products (:system context) provider-id entry-title))
 
-(defrecord SynchronousDispatcher
-  [system])
+(defrecord SynchronousDispatcher [])
 
 (def dispatch-behavior
   "Map of protocol definitions to the implementations of that protocol for the synchronous

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/synchronous_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/synchronous_dispatch.clj
@@ -1,0 +1,74 @@
+(ns cmr.bootstrap.services.dispatch.synchronous-dispatch
+  "Functions implementing the dispatch protocol to support synchronous calls."
+  (:require
+   [cmr.bootstrap.data.bulk-index :as bulk-index]
+   [cmr.bootstrap.data.bulk-migration :as bulk-migration]
+   [cmr.bootstrap.data.virtual-products :as virtual-products]
+   [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]))
+
+(defn- migrate-provider
+  "Copy all the data for a provider (including collections and graunules) from catalog rest
+  to the metadata db without blocking."
+  [this context provider-id]
+  (bulk-migration/copy-provider (:system context) provider-id))
+
+(defn- migrate-collection
+  "Copy all the data for a given collection (including graunules) from catalog rest
+  to the metadata db without blocking."
+  [this context provider-id collection-id]
+  (bulk-migration/copy-single-collection (:system context) provider-id collection-id))
+
+(defn- index-provider
+  "Bulk index all the collections and granules for a provider."
+  [this context provider-id start-index]
+  (bulk-index/index-provider (:system context) provider-id start-index))
+
+(defn- index-data-later-than-date-time
+  "Bulk index all the concepts with a revision date later than the given date-time."
+  [this context date-time]
+  (bulk-index/index-data-later-than-date-time (:system context) date-time))
+
+(defn- index-collection
+  "Bulk index all the granules in a collection"
+  [this context provider-id collection-id options]
+  (bulk-index/index-granules-for-collection (:system context) provider-id collection-id options))
+
+(defn- index-system-concepts
+  "Bulk index all the tags, acls, and access-groups."
+  [this context start-index]
+  (bulk-index/index-system-concepts (:system context) start-index))
+
+(defn- index-concepts-by-id
+  "Bulk index the concepts given by the concept-ids"
+  [this context provider-id concept-type concept-ids]
+  (bulk-index/index-concepts-by-id (:system context) provider-id concept-type concept-ids))
+
+(defn- delete-concepts-from-index-by-id
+  "Bulk delete the concepts given by the concept-ids from the indexes"
+  [this context provider-id concept-type concept-ids]
+  (bulk-index/delete-concepts-by-id (:system context) provider-id concept-type concept-ids))
+
+(defn- bootstrap-virtual-products
+  "Initializes virtual products for the given provider and entry title."
+  [this context provider-id entry-title]
+  (virtual-products/bootstrap-virtual-products (:system context) provider-id entry-title))
+
+(defrecord SynchronousDispatcher
+  [system])
+
+(def dispatch-behavior
+  "Map of protocol definitions to the implementations of that protocol for the synchronous
+  dispatcher."
+  {:migrate-provider migrate-provider
+   :migrate-collection migrate-collection
+   :index-provider index-provider
+   :index-data-later-than-date-time index-data-later-than-date-time
+   :index-collection index-collection
+   :index-system-concepts index-system-concepts
+   :index-concepts-by-id index-concepts-by-id
+   :delete-concepts-from-index-by-id delete-concepts-from-index-by-id
+   :bootstrap-virtual-products bootstrap-virtual-products})
+
+(extend SynchronousDispatcher
+        dispatch-protocol/Dispatch
+        dispatch-behavior)

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -3,7 +3,7 @@
   represented as a map of components. Design based on
   http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts."
   (:require
-   [clojure.core.async :as ca :refer [chan]]
+   [clojure.core.async :refer [chan]]
    [cmr.access-control.system :as ac-system]
    [cmr.acl.core :as acl]
    [cmr.bootstrap.api.routes :as routes]

--- a/bootstrap-app/src/cmr/db.clj
+++ b/bootstrap-app/src/cmr/db.clj
@@ -4,10 +4,10 @@
    [cmr.bootstrap.config :as bootstrap-config]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.oracle.config :as oracle-config]
-   [cmr.oracle.sql-utils :as su])
+   [cmr.oracle.sql-utils :as su]
    [cmr.oracle.user :as o]
    [config.migrate-config :as mc]
-   [drift.execute :as drift]
+   [drift.execute :as drift])
   (:gen-class))
 
 (defn create-user

--- a/bootstrap-app/src/cmr/db.clj
+++ b/bootstrap-app/src/cmr/db.clj
@@ -1,12 +1,13 @@
 (ns cmr.db
   "Entry point for the db related operations. Defines a main method that accepts arguments."
-  (:require [cmr.common.log :refer (debug info warn error)]
-            [drift.execute :as drift]
-            [cmr.oracle.user :as o]
-            [cmr.oracle.config :as oracle-config]
-            [cmr.bootstrap.config :as bootstrap-config]
-            [config.migrate-config :as mc]
-            [cmr.oracle.sql-utils :as su])
+  (:require
+   [cmr.bootstrap.config :as bootstrap-config]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.oracle.config :as oracle-config]
+   [cmr.oracle.sql-utils :as su])
+   [cmr.oracle.user :as o]
+   [config.migrate-config :as mc]
+   [drift.execute :as drift]
   (:gen-class))
 
 (defn create-user

--- a/bootstrap-app/src/config/migrate_config.clj
+++ b/bootstrap-app/src/config/migrate_config.clj
@@ -1,11 +1,12 @@
 (ns config.migrate-config
   "Provides the configuration for Drift migrations."
-  (:require [drift.builder :refer [incremental-migration-number-generator]]
-            [clojure.java.jdbc :as j]
-            [cmr.oracle.connection :as oracle]
-            [cmr.common.lifecycle :as lifecycle]
-            [cmr.oracle.config :as oracle-config]
-            [cmr.bootstrap.config :as bootstrap-config])
+  (:require
+   [clojure.java.jdbc :as j]
+   [cmr.bootstrap.config :as bootstrap-config]
+   [cmr.common.lifecycle :as lifecycle]
+   [cmr.oracle.config :as oracle-config]
+   [cmr.oracle.connection :as oracle]
+   [drift.builder :as drift-builder])
   (import java.sql.SQLException))
 
 (def bootstrap-db-atom (atom nil))
@@ -15,7 +16,8 @@
   []
   (when-not @bootstrap-db-atom
     (reset! bootstrap-db-atom (lifecycle/start
-                                (oracle/create-db (bootstrap-config/db-spec "bootstrap-migrations")) nil)))
+                                (oracle/create-db (bootstrap-config/db-spec "bootstrap-migrations"))
+                                nil)))
   @bootstrap-db-atom)
 
 (defn- maybe-create-schema-table
@@ -44,10 +46,10 @@
   {:directory "src/cmr/bootstrap/migrations/"
    :ns-content "\n  (:require [clojure.java.jdbc :as j]\n            [config.migrate-config :as config])"
    :namespace-prefix "cmr.bootstrap.migrations"
-   :migration-number-generator incremental-migration-number-generator
+   :migration-number-generator drift-builder/incremental-migration-number-generator
    :init maybe-create-schema-table
    :current-version current-db-version
-   :update-version update-db-version })
+   :update-version update-db-version})
 
 (defn migrate-config []
   "Drift migrate configuration used by lein migrate.

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -22,7 +22,7 @@ To do so, perform the following:
 As noted above, you will need to create a `profiles.clj` in the `dev-system`
 directory. This will provide configuration/authentication information required
 by CMR for a local, in-memory "deployment". You will need to contact a core
-CMR developmer for the appropriate values for each key in `profiles.clj`.
+CMR developer for the appropriate values for each key in `profiles.clj`.
 
 ## Security of `dev-system`
 


### PR DESCRIPTION
This is the first of a few pull requests for CMR-4343. There is no change in functionality as a result of this PR.

Currently we use core.async channels for queueing up work for the bootstrap application. Unfortunately this does not allow for scaling up because the queue is local to a single instance.

My goal for CMR-4343 is to at a minimum change our bulk indexing of providers to put messages on a message queue so that operations can spin up additional bootstrap instances whenever they need to reindex all the granules in the system.

So back to this PR - the purpose of this was to refactor the way we handle dispatching bootstrap work to make it easy to add a new implementation (the message queue) without worrying about breaking existing functionality.

Our integration tests always request synchronous requests for bulk indexing since there are timing issues if trying to use core.async.

I temporarily modified all of the bootstrap endpoint calls in system-int-test to use asynchronous requests and added sleeps after making the requests in order to test the core.async implementation after the refactor. All of the tests passed (but took a really long time).