### PR TITLE
CMR-4336 Bulk index tests failing when saving ACLs and using Oracle

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -171,7 +171,7 @@
   [context group-permissions object-identity-type object-identity]
   (let [cmr-acl (if (= object-identity-type :catalog_item_identity)
                   (util/map-keys->snake_case {:group_permissions group-permissions
-                                              object-identity-type (util/remove-nil-keys (merge {:name (str "NAME" (java.util.UUID/randomUUID))}
+                                              object-identity-type (util/remove-nil-keys (merge {:name (str (java.util.UUID/randomUUID))}
                                                                                                 object-identity))})
                   {:group_permissions group-permissions
                    object-identity-type object-identity})

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -653,8 +653,7 @@
          small (if (some? small) small (get options :small false))
          grant-all-search? (get options :grant-all-search? true)
          grant-all-ingest? (get options :grant-all-ingest? true)
-         grant-all-access-control (get options :grant-all-access-control? true)]
-
+         grant-all-access-control? (get options :grant-all-access-control? true)]
      (create-mdb-provider {:provider-id provider-id
                            :short-name short-name
                            :cmr-only cmr-only
@@ -673,7 +672,7 @@
      (when grant-all-ingest?
        (echo-util/grant-all-ingest (s/context) provider-id))
 
-     (when grant-all-access-control
+     (when grant-all-access-control?
        (echo-util/grant-system-group-permissions-to-all (s/context))
        (echo-util/grant-provider-group-permissions-to-all (s/context) provider-id)))))
 
@@ -692,7 +691,7 @@
   ([providers]
    (setup-providers providers nil))
   ([providers options]
-   (let [{:keys [grant-all-search? grant-all-ingest?]}
+   (let [{:keys [grant-all-search? grant-all-ingest? grant-all-access-control?]}
          (merge reset-fixture-default-options options)
          providers (if (sequential? providers)
                        providers
@@ -703,7 +702,8 @@
         (create-provider
          provider-map
          {:grant-all-search? grant-all-search?
-          :grant-all-ingest? grant-all-ingest?})))))
+          :grant-all-ingest? grant-all-ingest?
+          :grant-all-access-control? grant-all-access-control?})))))
 
 (defn reset-fixture
   "Resets all the CMR systems then uses the `setup-providers` function to

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -678,7 +678,8 @@
 
 (def reset-fixture-default-options
   {:grant-all-search? true
-   :grant-all-ingest? true})
+   :grant-all-ingest? true
+   :grant-all-access-control? true})
 
 (defn setup-providers
   "Creates the given providers in CMR. Providers can be passed in

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
@@ -249,14 +249,12 @@
           "Granules"
           :granule [gran2])
 
-
-        ;; Commented out until ACLs and groups are supported in the index by concept-id API
         ; ;; ACLs
         (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
               items (:items response)]
           (search-results-match? items [acl2]))
 
-        ; ;; ;; Groups
+        ;; Groups
         (let [response (ac/search-for-groups (u/conn-context) {})
               ;; Need to filter out admin group created by fixture
               items (filter #(not (= "mock-admin-group-guid" (:legacy_guid %))) (:items response))]

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
@@ -27,7 +27,6 @@
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1"}) {:grant-all-access-control? false}]))
-                       ; tags/grant-all-tag-fixture]))
 
 (defn- save-collection
   "Saves a collection concept"

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
@@ -26,8 +26,8 @@
     [cmr.umm.echo10.echo10-core :as echo10]))
 
 (use-fixtures :each (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"})
-                       tags/grant-all-tag-fixture]))
+                      [(ingest/reset-fixture {"provguid1" "PROV1"}) {:grant-all-access-control? false}]))
+                       ; tags/grant-all-tag-fixture]))
 
 (defn- save-collection
   "Saves a collection concept"
@@ -153,25 +153,24 @@
         exp-items (set (map #(dissoc % :status) expected))]
     (is (= exp-items search-items))))
 
-;; CMR-4336 - ACLs commented out throughout the test
 (deftest index-system-concepts-test
   (s/only-with-real-database
    ;; Disable message publishing so items are not indexed as part of the initial save.
    (dev-sys-util/eval-in-dev-sys `(cmr.metadata-db.config/set-publish-messages! false))
    (let [
-        ;  acl1 (save-acl 1
-        ;                 {:extra-fields {:acl-identity "system:token"
-        ;                                 :target-provider-id "PROV1"}}
-        ;                 "TOKEN")
-        ;  acl2 (save-acl 2
-        ;                 {:extra-fields {:acl-identity "system:group"
-        ;                                 :target-provider-id "PROV1"}}
-        ;                 "GROUP")
-        ;  acl3 (save-acl 3
-        ;                 {:extra-fields {:acl-identity "system:user"
-        ;                                 :target-provider-id "PROV1"}}
-        ;                 "USER")
-        ;  _ (delete-concept acl3)
+         acl1 (save-acl 1
+                        {:extra-fields {:acl-identity "system:token"
+                                        :target-provider-id "PROV1"}}
+                        "TOKEN")
+         acl2 (save-acl 2
+                        {:extra-fields {:acl-identity "system:group"
+                                        :target-provider-id "PROV1"}}
+                        "GROUP")
+         acl3 (save-acl 3
+                        {:extra-fields {:acl-identity "system:user"
+                                        :target-provider-id "PROV1"}}
+                        "USER")
+         _ (delete-concept acl3)
          group1 (save-group 1 {})
          group2 (save-group 2 {})
          group3 (save-group 3 {})
@@ -186,9 +185,9 @@
      (index/wait-until-indexed)
 
      ;; ACLs
-     ;  (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
-     ;        items (:items response)]
-     ;    (search-results-match? items [acl1 acl2]))
+     (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
+           items (:items response)]
+       (search-results-match? items [acl1 acl2]))
 
      ;; Groups
      (let [response (ac/search-for-groups (u/conn-context) {})
@@ -221,24 +220,22 @@
           gran2 (save-granule 2 coll2 {})
           tag1 (save-tag 1)
           tag2 (save-tag 2 {})
-          ; acl1 (save-acl 1
-          ;                {:extra-fields {:acl-identity "system:token"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "TOKEN")
-          ; acl2 (save-acl 2
-          ;                {:extra-fields {:acl-identity "system:group"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "GROUP")
+          acl1 (save-acl 1
+                         {:extra-fields {:acl-identity "system:token"
+                                         :target-provider-id "PROV1"}}
+                         "TOKEN")
+          acl2 (save-acl 2
+                         {:extra-fields {:acl-identity "system:group"
+                                         :target-provider-id "PROV1"}}
+                         "GROUP")
           group1 (save-group 1)
           group2 (save-group 2 {})]
 
       (bootstrap/bulk-index-concepts "PROV1" :collection colls)
       (bootstrap/bulk-index-concepts "PROV1" :granule [(:concept-id gran2)])
       (bootstrap/bulk-index-concepts "PROV1" :tag [(:concept-id tag1)])
-
-      ;; Commented out until ACLs and groups are supported in the index by concept-id API
-      ; (bootstrap/bulk-index-concepts "CMR" :access-group [(:concept-id group2)])
-      ; (bootstrap/bulk-index-concepts "CMR" :acl [(:concept-id acl2)])
+      (bootstrap/bulk-index-concepts "CMR" :access-group [(:concept-id group2)])
+      (bootstrap/bulk-index-concepts "CMR" :acl [(:concept-id acl2)])
 
       (index/wait-until-indexed)
 
@@ -256,15 +253,15 @@
 
         ;; Commented out until ACLs and groups are supported in the index by concept-id API
         ; ;; ACLs
-        ; (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
-        ;       items (:items response)]
-        ;   (search-results-match? items [acl2]))
+        (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
+              items (:items response)]
+          (search-results-match? items [acl2]))
 
         ; ;; ;; Groups
-        ; (let [response (ac/search-for-groups (u/conn-context) {})
-        ;       ;; Need to filter out admin group created by fixture
-        ;       items (filter #(not (= "mock-admin-group-guid" (:legacy_guid %))) (:items response))]
-        ;   (search-results-match? items [group2]))
+        (let [response (ac/search-for-groups (u/conn-context) {})
+              ;; Need to filter out admin group created by fixture
+              items (filter #(not (= "mock-admin-group-guid" (:legacy_guid %))) (:items response))]
+          (search-results-match? items [group2]))
 
         (are3 [expected-tags]
           (let [result-tags (update
@@ -293,14 +290,14 @@
           gran5 (save-granule 5 coll3)
           tag1 (save-tag 1)
           tag2 (save-tag 2 {})
-          ; acl1 (save-acl 1
-          ;                {:extra-fields {:acl-identity "system:token"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "TOKEN")
-          ; acl2 (save-acl 2
-          ;                {:extra-fields {:acl-identity "system:group"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "GROUP")
+          acl1 (save-acl 1
+                         {:extra-fields {:acl-identity "system:token"
+                                         :target-provider-id "PROV1"}}
+                         "TOKEN")
+          acl2 (save-acl 2
+                         {:extra-fields {:acl-identity "system:group"
+                                         :target-provider-id "PROV1"}}
+                         "GROUP")
           group1 (save-group 1)
           group2 (save-group 2 {})]
 
@@ -312,10 +309,8 @@
       (bootstrap/bulk-delete-concepts "PROV1" :collection (map :concept-id [coll1]))
       (bootstrap/bulk-delete-concepts "PROV1" :granule (map :concept-id [gran1 gran3 gran4]))
       (bootstrap/bulk-delete-concepts "PROV1" :tag [(:concept-id tag1)])
-
-      ;; Commented out until ACLs and groups are supported in the delete by concept-id API
-      ; (bootstrap/bulk-index-concepts "CMR" :access-group [(:concept-id group2)])
-      ; (bootstrap/bulk-index-concepts "CMR" :acl [(:concept-id acl2)])
+      (bootstrap/bulk-index-concepts "CMR" :access-group [(:concept-id group2)])
+      (bootstrap/bulk-index-concepts "CMR" :acl [(:concept-id acl2)])
 
       (index/wait-until-indexed)
 
@@ -352,16 +347,16 @@
           gran2 (save-granule 2 coll2 {:revision-date "3016-01-01T10:00:00Z"})
           tag1 (save-tag 1)
           tag2 (save-tag 2 {:revision-date "3016-01-01T10:00:00Z"})
-          ; acl1 (save-acl 1
-          ;                {:revision-date "2000-01-01T09:59:40Z"
-          ;                 :extra-fields {:acl-identity "system:token"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "TOKEN")
-          ; acl2 (save-acl 2
-          ;                {:revision-date "3016-01-01T09:59:41Z"
-          ;                 :extra-fields {:acl-identity "system:group"
-          ;                                :target-provider-id "PROV1"}}
-          ;                "GROUP")
+          acl1 (save-acl 1
+                         {:revision-date "2000-01-01T09:59:40Z"
+                          :extra-fields {:acl-identity "system:token"
+                                         :target-provider-id "PROV1"}}
+                         "TOKEN")
+          acl2 (save-acl 2
+                         {:revision-date "3016-01-01T09:59:41Z"
+                          :extra-fields {:acl-identity "system:group"
+                                         :target-provider-id "PROV1"}}
+                         "GROUP")
           group1 (save-group 1)
           group2 (save-group 2 {:revision-date "3016-01-01T10:00:00Z"})]
 
@@ -379,9 +374,9 @@
           :granule [gran2])
 
         ;; ACLs
-        ; (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
-        ;       items (:items response)]
-        ;   (search-results-match? items [acl2]))
+        (let [response (ac/search-for-acls (u/conn-context) {} {:token (tc/echo-system-token)})
+              items (:items response)]
+          (search-results-match? items [acl2]))
 
         ;; Groups
         (let [response (ac/search-for-groups (u/conn-context) {})


### PR DESCRIPTION
This PR fixes bulk index tests that were trying to save acls, while in external db mode