### PR TITLE
CMR-4379: Allow crawlers to index our collection landing pages

### DIFF
--- a/search-app/resources/public/robots.txt
+++ b/search-app/resources/public/robots.txt
@@ -11,7 +11,6 @@ Disallow: /search/tiles/
 Disallow: /search/reset
 Disallow: /search/community-usage-metrics
 Disallow: /search/humanizers/
-Disallow: /search/concepts/
 Disallow: /search/granules/
 Disallow: /search/collections/
 


### PR DESCRIPTION
under /search/concepts route.

We cannot verify this ticket in SIT or UAT because we only submit our production site for indexing in Google (obviously we don't want to direct science users looking for data to our SIT our UAT environments).

I tested with Google's robots testing tools to verify that removing the one line from robots.txt fixed the problem with loading the landing pages.