### PR TITLE
CMR-4386: Use a small buffer when verifying request body sizes

### DIFF
--- a/common-lib/test/cmr/common/test/api/web_server.clj
+++ b/common-lib/test/cmr/common/test/api/web_server.clj
@@ -114,3 +114,24 @@
    (with-progress-reporting
     (bench
      (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)})))))
+
+
+(comment
+ (require '[criterium.core :refer [with-progress-reporting bench quick-bench]])
+
+ (def test-fn
+   (#'s/routes-fn-verify-size (constantly nil)))
+
+ ; Large example
+ (time (let [lots-of-bytes (.getBytes (str/join (repeat (dec s/MAX_REQUEST_BODY_SIZE) "0")))]
+         (test-fn {:body (java.io.ByteArrayInputStream. lots-of-bytes)})))
+
+
+ (time (let [small-bytes (.getBytes (str/join (repeat (* 5000 1024) "0")))]
+         (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)})))
+
+ (time (do (str/join (repeat s/ONE_MB "0")) nil))
+
+ ; Small example
+ (time (let [small-bytes (.getBytes (str/join (repeat 10 "0")))]
+         (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)}))))

--- a/common-lib/test/cmr/common/test/api/web_server.clj
+++ b/common-lib/test/cmr/common/test/api/web_server.clj
@@ -100,17 +100,17 @@
  (require '[criterium.core :refer [with-progress-reporting bench quick-bench]])
 
  (def test-fn
-   (#'s/routes-fn-verify-size (constantly nil)))
+   (#'s/wrap-request-body-size-validation (constantly nil)))
 
  ; Large example
  (let [lots-of-bytes (.getBytes (str/join (repeat (dec s/MAX_REQUEST_BODY_SIZE) "0")))]
    (with-progress-reporting
-    (bench
+    (quick-bench
      (test-fn {:body (java.io.ByteArrayInputStream. lots-of-bytes)}))))
 
 
  ; Small example
  (let [small-bytes (.getBytes (str/join (repeat 10 "0")))]
    (with-progress-reporting
-    (bench
+    (quick-bench
      (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)})))))

--- a/common-lib/test/cmr/common/test/api/web_server.clj
+++ b/common-lib/test/cmr/common/test/api/web_server.clj
@@ -114,24 +114,3 @@
    (with-progress-reporting
     (bench
      (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)})))))
-
-
-(comment
- (require '[criterium.core :refer [with-progress-reporting bench quick-bench]])
-
- (def test-fn
-   (#'s/routes-fn-verify-size (constantly nil)))
-
- ; Large example
- (time (let [lots-of-bytes (.getBytes (str/join (repeat (dec s/MAX_REQUEST_BODY_SIZE) "0")))]
-         (test-fn {:body (java.io.ByteArrayInputStream. lots-of-bytes)})))
-
-
- (time (let [small-bytes (.getBytes (str/join (repeat (* 5000 1024) "0")))]
-         (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)})))
-
- (time (do (str/join (repeat s/ONE_MB "0")) nil))
-
- ; Small example
- (time (let [small-bytes (.getBytes (str/join (repeat 10 "0")))]
-         (test-fn {:body (java.io.ByteArrayInputStream. small-bytes)}))))


### PR DESCRIPTION
Every request submitted to any CMR application was causing a 50MB buffer to be allocated in order to validate the size of the request body was less than 50MB.

(We recently increased the max request body size from 5MB to 50MB in SIT and UAT, but that change has not made it to production). So in production we are allocating a 5MB buffer on every request.

We started seeing Java heap space errors for some apps in SIT in UAT, which can easily happen when many requests are actively validating the size of the request body in parallel.

This change is to use buffers of 512 bytes to validate the request body. If a request is larger than 512 bytes we will continue allocating additional buffers until we've read the entire body or hit 50MB and we reject the request.

I've done some performance testing which indicates this code change if faster for all request bodies 50KB or smaller. Almost all of our requests have request bodies smaller than 50KB.

Larger requests take longer to validate with the smaller buffers, but even a 50MB request would complete in under 5 seconds vs. 2 seconds previously.

I want to rerun some of the performance numbers, because I realized my test setup was artificially increasing the times. I will post them in the ticket when complete.

