### PR TITLE
CMR-4350 fine tune var perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Those tests will take much longer to run than when done with the in-memory
 database (~25m vs. ~6m). To switch back to using the in-memory database,
 simply call `(reset :db :in-memory)`.
 
+There is also a different, optional test runner you can use. For more details
+see the docstring for `run-suites` in `dev-system/dev/user.clj` for usage
+instructions.
+
 ## Code structure
 
 The CMR is made up of several small services called microservices. These are

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -203,7 +203,7 @@
   "Creates a function that will call f with it's arguments. If f returns any
   errors then it will throw a service error of the type given.
 
-  DEPRECATED: we should use the validations namespace"
+  DEPRECATED: we should use the validations namespace."
   [error-type f]
   (fn [& args]
     (when-let [errors (apply f args)]
@@ -211,10 +211,12 @@
         (errors/throw-service-errors error-type errors)))))
 
 (defn apply-validations
-  "Applies the arguments to each validation concatenating all errors and
-  returning them
+  "Given a list of validation functions, applies the arguments to each
+  validation, concatenating all errors and returning them. As such, validation
+  functions are expected to only return a list; if the list is empty, it is
+  understood that no errors occurred.
 
-  DEPRECATED: we should use the validations namespace"
+  DEPRECATED: we should use the validations namespace."
   [validations & args]
   (reduce (fn [errors validation]
             (if-let [new-errors (apply validation args)]
@@ -225,9 +227,9 @@
 
 (defn compose-validations
   "Creates a function that will compose together a list of validation functions
-  into a single function that will perform all validations together
+  into a single function that will perform all validations together.
 
-  DEPRECATED: we should use the validations namespace"
+  DEPRECATED: we should use the validations namespace."
   [validation-fns]
   (partial apply-validations validation-fns))
 

--- a/common-lib/src/cmr/common/validations/core.clj
+++ b/common-lib/src/cmr/common/validations/core.clj
@@ -9,7 +9,8 @@
   seq-of-validations."
   (:require [clojure.string :as str]
             [camel-snake-kebab.core :as csk]
-            [cmr.common.services.errors :as errors]))
+            [cmr.common.services.errors :as errors]
+            [cmr.common.validations.messages :as msg]))
 
 (comment
 
@@ -116,15 +117,11 @@
   (fn [field-path value]
     (validate validation field-path (prefn value))))
 
-(defn required-msg
-  []
-  "%s is required.")
-
 (defn required
   "Validates that the value is not nil"
   [field-path value]
   (when (nil? value)
-    {field-path [(required-msg)]}))
+    {field-path [(msg/required)]}))
 
 (defn every
   "Validate a validation against every item in a sequence. The field path will
@@ -135,29 +132,17 @@
                        (validate validation (conj field-path idx) value))]
       (apply merge-with concat error-maps))))
 
-(defn integer-msg
-  [value]
-  (format "%%s must be an integer but was [%s]." value))
-
 (defn integer
   "Validates that the value is an integer"
   [field-path value]
   (when (and value (not (integer? value)))
-    {field-path [(integer-msg value)]}))
-
-(defn number-msg
-  [value]
-  (format "%%s must be a number but was [%s]." value))
+    {field-path [(msg/integer value)]}))
 
 (defn number
   "Validates the value is a number"
   [field-path value]
   (when (and value (not (number? value)))
-    {field-path [(number-msg value)]}))
-
-(defn within-range-msg
-  [minv maxv value]
-  (format "%%s must be within [%s] and [%s] but was [%s]." minv maxv value))
+    {field-path [(msg/number value)]}))
 
 (defn within-range
   "Creates a validator within a specified range"
@@ -165,13 +150,7 @@
   (fn [field-path value]
     (when (and value (or (neg? (compare value minv))
                          (pos? (compare value maxv))))
-      {field-path [(within-range-msg minv maxv value)]})))
-
-(defn field-cannot-be-changed-msg
-  [existing-value new-value]
-  (format
-    "%%s cannot be modified. Attempted to change existing value [%s] to [%s]"
-    existing-value new-value))
+      {field-path [(msg/within-range minv maxv value)]})))
 
 (defn field-cannot-be-changed
   "Validation that a field in a object has not been modified. Accepts optional
@@ -188,7 +167,7 @@
        (when (and (not skip-validation?)
                   (not= existing-value new-value))
          {(conj field-path field)
-          [(field-cannot-be-changed-msg existing-value new-value)]})))))
+          [(msg/field-cannot-be-changed existing-value new-value)]})))))
 
 (defn when-present
   "Validation-transformer: Returns a validation which only runs validations

--- a/common-lib/src/cmr/common/validations/messages.clj
+++ b/common-lib/src/cmr/common/validations/messages.clj
@@ -1,0 +1,23 @@
+(ns cmr.common.validations.messages)
+
+(defn required
+  []
+  "%s is required.")
+
+(defn integer
+  [value]
+  (format "%%s must be an integer but was [%s]." value))
+
+(defn number
+  [value]
+  (format "%%s must be a number but was [%s]." value))
+
+(defn within-range
+  [minv maxv value]
+  (format "%%s must be within [%s] and [%s] but was [%s]." minv maxv value))
+
+(defn field-cannot-be-changed
+  [existing-value new-value]
+  (format
+    "%%s cannot be modified. Attempted to change existing value [%s] to [%s]"
+    existing-value new-value))

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -17,6 +17,17 @@ To do so, perform the following:
 4. Configure `profiles.clj` (see below)
 3. Run the local setup script: `dev-system/support/setup_local_dev.sh`
 
+## Running Tests
+
+There are several ways in which you can run tests with dev-system. The
+top-level CMR `README.md` offers some instructions on this point, including
+switching between `:in-memory` mode (the default) and `:external` (see the
+section "Testing CMR" in that README for more details).
+
+Furthermore, there is a second (and optional) test runner you can use for
+running suites, test namespaces, and individual test functions. See the
+docstring for `run-suites` in `dev/user.clj` for usage information.
+
 ## Setting up profiles.clj
 
 As noted above, you will need to create a `profiles.clj` in the `dev-system`

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
@@ -55,7 +55,7 @@
             _ (Thread/sleep 10)
             {second-revision-id :revision-id} (util/save-concept initial-collection)
             _ (Thread/sleep 10)
-            {tombstone-revision-id :revision-id} (util/delete-concept concept-id)
+            {tombstone-revision-id :revision-id} (util/save-concept {:deleted true :concept-id concept-id})
             _ (Thread/sleep 10)
             {final-revision-id :revision-id} (util/save-concept initial-collection)
             [initial-revision

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/collection_save_test.clj
@@ -39,14 +39,6 @@
           coll2 (util/collection-concept "SMAL_PROV2" 2 {:native-id "foo"})]
       (c-spec/save-distinct-concepts-test coll1 coll2))))
 
-(defn- created-at-same?
-  "Returns true if the `created-at` for the given concept revisions are the same
-  and none of them are nil"
-  [& concepts]
-  (let [created-ats (map :created-at concepts)]
-    (and (apply = created-ats)
-         (not-any? nil? created-ats))))
-
 (deftest save-collection-created-at-test
   (testing "Save collection multiple times gets same created-at"
     (doseq [provider-id ["REG_PROV" "SMAL_PROV1"]]
@@ -63,7 +55,7 @@
             _ (Thread/sleep 10)
             {second-revision-id :revision-id} (util/save-concept initial-collection)
             _ (Thread/sleep 10)
-            {tombstone-revision-id :revision-id} (util/save-concept {:deleted true :concept-id concept-id})
+            {tombstone-revision-id :revision-id} (util/delete-concept concept-id)
             _ (Thread/sleep 10)
             {final-revision-id :revision-id} (util/save-concept initial-collection)
             [initial-revision
@@ -74,7 +66,7 @@
                                     second-revision-id
                                     tombstone-revision-id
                                     final-revision-id])]
-        (is (created-at-same? initial-revision second-revision tombstone final-revision))))))
+        (is (util/created-at-same? initial-revision second-revision tombstone final-revision))))))
 
 (deftest save-collection-post-commit-constraint-violations
   (testing "duplicate entry titles"

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -7,10 +7,13 @@
    [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
    [cmr.metadata-db.int-test.utility :as util]))
 
+(def provider-id "REG_PROV")
+
 ;;; fixtures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}))
+(use-fixtures :each (util/reset-database-fixture
+                     {:provider-id provider-id :small false}))
 
 (defmethod c-spec/gen-concept :variable
   [_ provider-id uniq-num attributes]
@@ -19,8 +22,43 @@
 ;; tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (deftest save-variable-test
-  (c-spec/general-save-concept-test :variable ["REG_PROV"]))
+  (c-spec/general-save-concept-test :variable [provider-id]))
 
 (deftest save-variable-with-missing-required-parameters-test
   (c-spec/save-test-with-missing-required-parameters
-    :variable ["REG_PROV"] [:concept-type :provider-id :native-id :extra-fields]))
+    :variable [provider-id] [:concept-type :provider-id :native-id :extra-fields]))
+
+(deftest save-variable-created-at-test
+  (testing "Save variable multiple times gets same created-at"
+    (let [initial-var (util/variable-concept provider-id 2)
+          ;; 1) Save a variable
+          ;; 2) Then wait for a small period of time before saving it again
+          ;; 3) Then wait again and save a tombstone.
+          ;; 4) Finally, wait a bit and save a new (non-tombstone) revision.
+          ;;
+          ;; All should have the same `created-at` value.
+          ;;
+          ;; Note - Originally planned to use the time-keeper functionality
+          ;; for this, but metdata-db tests don't have access to the control
+          ;; api that would allow this to work in CI.
+          {concept-id :concept-id
+           initial-revision-id :revision-id} (util/save-concept initial-var)
+          _ (Thread/sleep 100)
+          {second-revision-id :revision-id} (util/save-concept initial-var)
+          _ (Thread/sleep 100)
+          {tombstone-revision-id :revision-id} (util/delete-concept
+                                                concept-id)
+          _ (Thread/sleep 100)
+          {final-revision-id :revision-id} (util/save-concept initial-var)
+          [initial-revision
+           second-revision
+           tombstone
+           final-revision] (mapv #(:concept (util/get-concept-by-id-and-revision concept-id %))
+                                 [initial-revision-id
+                                  second-revision-id
+                                  tombstone-revision-id
+                                  final-revision-id])]
+      (is (util/created-at-same? initial-revision
+                                 second-revision
+                                 tombstone
+                                 final-revision)))))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -815,6 +815,14 @@
                              :headers {transmit-config/token-header (transmit-config/echo-system-token)}
                              :connection-manager (conn-mgr)})))
 
+(defn created-at-same?
+  "Returns true if the `created-at` for the given concept revisions are the same
+  and none of them are nil"
+  [& concepts]
+  (let [created-ats (map :created-at concepts)]
+    (and (apply = created-ats)
+         (not-any? nil? created-ats))))
+
 ;;; fixtures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn reset-database-fixture

--- a/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
@@ -20,7 +20,6 @@
     "Finds the latest concepts by the given provider and parameters.
     :concept-type must present in the parameters."))
 
-
 (defprotocol ConceptsStore
   "Functions for saving and retrieving concepts"
 

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -111,6 +111,10 @@
   [_ {:keys [provider-id]} base-clause]
   (add-provider-clause provider-id base-clause))
 
+(defmethod by-provider :variable
+  [_ {:keys [provider-id]} base-clause]
+  (add-provider-clause provider-id base-clause))
+
 (defmethod by-provider :default
   [_ {:keys [provider-id small]} base-clause]
   (if small

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -204,3 +204,17 @@
           transaction-id
           this-revision-id
           this-transaction-id))
+
+(defn pvn-equality-failure
+  [new-concept old-concept]
+   (format (str "Revision [%d] of concept [%s] has the same provider [%s] "
+                "and variable name [%s] but different native id [%s] than "
+                "the new concept [%s] with revision [%d] and native id [%s].")
+           (:revision-id old-concept)
+           (:concept-id old-concept)
+           (:provider-id old-concept)
+           (get-in old-concept [:extra-fields :variable-name])
+           (:native-id old-concept)
+           (:concept-id new-concept)
+           (:revision-id new-concept)
+           (:native-id new-concept)))

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -26,7 +26,9 @@
     expected-id received-id concept-id))
 
 (defn concept-id-and-revision-id-conflict [concept-id revision-id]
-  (format "Conflict with existing concept-id [%s] and revision-id [%s]" concept-id revision-id))
+  (format "Conflict with existing concept-id [%s] and revision-id [%s]"
+          concept-id
+          revision-id))
 
 (defn missing-concept-type []
   "Concept must include concept-type.")
@@ -135,11 +137,12 @@
 (defn provider-with-short-name-exists [provider]
   (let [{:keys [provider-id short-name]} provider]
     (format "Provider with short name [%s] already exists. Its provider id is [%s]."
-            short-name provider-id)))
+            short-name
+            provider-id)))
 
 (defn granule-collection-cannot-change [old-concept-id new-concept-id]
   (format "Granule's parent collection cannot be changed, was [%s], now [%s]."
-          old-concept-id, new-concept-id))
+          old-concept-id new-concept-id))
 
 (defn field-too-long [value limit]
   (format "%%s [%s] exceeds %d characters" value limit))
@@ -175,3 +178,29 @@
   (format (str "Variable association could not be associated with provider [%s]. "
                "Variable associations are system level entities.")
           provider-id))
+
+(defn concept-not-found [provider-id field-name field-value]
+  (format "Unable to find saved concept for provider [%s] and %s [%s]"
+          provider-id
+          field-name
+          field-value))
+
+(defn concept-higher-transaction-id
+  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
+  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
+               "which is higher than revision [%d] with transaction-id [%d].")
+          revision-id
+          concept-id
+          transaction-id
+          this-revision-id
+          this-transaction-id))
+
+(defn concept-lower-transaction-id
+  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
+  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
+               "which is lower than revision [%d] with transaction-id [%d].")
+          revision-id
+          concept-id
+          transaction-id
+          this-revision-id
+          this-transaction-id))

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -108,6 +108,37 @@
       (str/replace (csk/->snake_case_string field) #"_" " ")
       (str/join ", " (map :concept-id concepts)))))
 
+(defn concept-higher-transaction-id
+  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
+  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
+               "which is higher than revision [%d] with transaction-id [%d].")
+          revision-id
+          concept-id
+          transaction-id
+          this-revision-id
+          this-transaction-id))
+
+(defn concept-lower-transaction-id
+  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
+  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
+               "which is lower than revision [%d] with transaction-id [%d].")
+          revision-id
+          concept-id
+          transaction-id
+          this-revision-id
+          this-transaction-id))
+
+(defn pvn-equality-failure
+  [concept]
+  (format (str "The provider id [%s] and variable name [%s] combined must be "
+               "unique for a given native-id [%s]. The following concept "
+               "with the same provider id, variable name and native-id was "
+               "found: [%s].")
+          (:provider-id concept)
+          (get-in concept [:extra-fields :variable-name])
+          (:native-id concept)
+          (:concept-id concept)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Provider Messages
 
@@ -184,37 +215,3 @@
           provider-id
           field-name
           field-value))
-
-(defn concept-higher-transaction-id
-  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
-  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
-               "which is higher than revision [%d] with transaction-id [%d].")
-          revision-id
-          concept-id
-          transaction-id
-          this-revision-id
-          this-transaction-id))
-
-(defn concept-lower-transaction-id
-  [revision-id concept-id transaction-id this-revision-id this-transaction-id]
-  (format (str "Revision [%d] of concept [%s] has transaction-id [%d] "
-               "which is lower than revision [%d] with transaction-id [%d].")
-          revision-id
-          concept-id
-          transaction-id
-          this-revision-id
-          this-transaction-id))
-
-(defn pvn-equality-failure
-  [new-concept old-concept]
-   (format (str "Revision [%d] of concept [%s] has the same provider [%s] "
-                "and variable name [%s] but different native id [%s] than "
-                "the new concept [%s] with revision [%d] and native id [%s].")
-           (:revision-id old-concept)
-           (:concept-id old-concept)
-           (:provider-id old-concept)
-           (get-in old-concept [:extra-fields :variable-name])
-           (:native-id old-concept)
-           (:concept-id new-concept)
-           (:revision-id new-concept)
-           (:native-id new-concept)))

--- a/metadata-db-app/src/migrations/062_add_variable_constraint.clj
+++ b/metadata-db-app/src/migrations/062_add_variable_constraint.clj
@@ -1,0 +1,54 @@
+(ns migrations.062-add-variable-constraint
+  (:require
+   [config.mdb-migrate-helper :as h]))
+
+(def ^:private table-name "cmr_variables")
+(def ^:private table (format "METADATA_DB.%s" table-name))
+(def ^:private new-constraint-name "variables_con_n_r_p")
+(def ^:private new-index-name "variables_idx_n_r_p")
+(def ^:private old-constraint-name "variables_con_rev")
+(def ^:private old-index-name "variables_ucr_i")
+
+(defn- add-variable-constraint
+  []
+  (h/sql
+   (format (str "ALTER TABLE %s "
+                "ADD CONSTRAINT %s "
+                "UNIQUE (native_id, revision_id, provider_id) "
+                "USING INDEX (CREATE UNIQUE INDEX %s ON %s "
+                "(native_id, revision_id, provider_id))")
+           table new-constraint-name new-index-name table-name)))
+
+(defn- drop-constraint
+  [constraint-name]
+  (h/sql
+    (format "ALTER TABLE %s DROP CONSTRAINT %s" table constraint-name)))
+
+(defn- drop-index
+  [index-name]
+  (h/sql
+    (format "DROP INDEX %s" index-name)))
+
+(defn- re-add-old-variable-constraint
+  []
+  (h/sql
+   (format (str "ALTER TABLE %s "
+                "ADD CONSTRAINT %s "
+                "UNIQUE (native_id, revision_id) "
+                "USING INDEX (CREATE UNIQUE INDEX %s ON %s "
+                "(native_id, revision_id))")
+           table old-constraint-name old-index-name table-name)))
+
+(defn up
+  "Migrates the database up to version 61."
+  []
+  (println "migrations.062-add-variable-constraint up...")
+  (drop-constraint old-constraint-name)
+  (add-variable-constraint))
+
+(defn down
+  "Migrates the database down from version 61."
+  []
+  (println "migrations.062-add-variable-constraint down...")
+  (drop-constraint new-constraint-name)
+  (re-add-old-variable-constraint))

--- a/search-app/test/cmr/search/test/services/tagging/tag_validation.clj
+++ b/search-app/test/cmr/search/test/services/tagging/tag_validation.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [cmr.search.services.tagging.tag-validation :as tv]
             [cmr.common.validations.core :as v]
+            [cmr.common.validations.messages :as v-msg]
             [cmr.search.services.tagging.tagging-service-messages :as msg]))
 
 (def update-tag-validations (var-get #'tv/update-tag-validations))
@@ -23,14 +24,14 @@
                     :description "anything"}}))
 
     (testing "tag-key can't change"
-      (is (= {[:tag-key] [(v/field-cannot-be-changed-msg "current" "update")]}
+      (is (= {[:tag-key] [(v-msg/field-cannot-be-changed "current" "update")]}
              (v/validate
                update-tag-validations
                {:tag-key "update"
                 :existing {:tag-key "current"}}))))
 
     (testing "Originator id can't change"
-      (is (= {[:originator-id] [(v/field-cannot-be-changed-msg "current" "update")]}
+      (is (= {[:originator-id] [(v-msg/field-cannot-be-changed "current" "update")]}
              (v/validate
                update-tag-validations
                {:tag-key "foo" :originator-id "update"

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -1,5 +1,7 @@
 (ns cmr.system-int-test.ingest.collection-ingest-test
-  "CMR collection ingest integration tests"
+  "CMR collection ingest integration tests.
+
+  For collection permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [clj-http.client :as client]
    [clj-time.core :as t]

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -1,5 +1,7 @@
 (ns cmr.system-int-test.ingest.granule-ingest-test
-  "CMR granule ingest integration tests"
+  "CMR granule ingest integration tests.
+
+  For granule permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [cheshire.core :as json]
    [clojure.edn :as edn]

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
@@ -1,5 +1,7 @@
 (ns cmr.system-int-test.ingest.variable-ingest-test
-  "CMR variable ingest integration tests."
+  "CMR variable ingest integration tests.
+
+  For variable permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [clj-http.client :as client]
    [clj-time.core :as t]


### PR DESCRIPTION
The primary purpose of the changes in this PR is to add a constraint that will improve fine-grained permissions on variables. In particular, we previously had no check in place for attempting to create a variable with the same variable name and provider id but different native-id from one that already exists in the db.

Additionally, this PR has:

* made updates for better organization of various messages into the proper namespace(s)
* added another variable integration test
* updated testing sections of a couple README files
