### PR TITLE
CMR-4343: Change provider bootstrapping to use message queue

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -52,5 +52,8 @@
   (assoc (queue-config/default-config)
          :queues [(bootstrap-provider-queue-name)]
          :exchanges [(bootstrap-provider-exchange-name)]
+         :queues-to-policies {(bootstrap-provider-queue-name) {:max-tries 1
+                                                               ;; 6 hours visibility timeout
+                                                               :visibility-timeout-secs 21600}}
          :queues-to-exchanges
          {(bootstrap-provider-queue-name) [(bootstrap-provider-exchange-name)]}))

--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -1,8 +1,10 @@
 (ns cmr.bootstrap.config
   "Contains functions to retrieve metadata db specific configuration"
-  (:require [cmr.common.config :as cfg :refer [defconfig]]
-            [cmr.oracle.config :as oracle-config]
-            [cmr.oracle.connection :as conn]))
+  (:require
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.message-queue.config :as queue-config]
+   [cmr.oracle.config :as oracle-config]
+   [cmr.oracle.connection :as conn]))
 
 (defconfig bootstrap-username
   "Defines the bootstrap database username."
@@ -27,3 +29,28 @@
   "Port to listen for nREPL connections"
   {:default nil
    :parser cfg/maybe-long})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Message queue configuration
+
+(defconfig bootstrap-provider-exchange-name
+   "The bootstrap exchange to which provider bootstrap messages are published."
+   {:default "cmr-bootstrap-provider-exchange"})
+
+(defconfig bootstrap-provider-queue-name
+  "The queue containing bootstrap provider events."
+  {:default "cmr-bootstrap-provider-queue"})
+
+(defconfig bootstrap-provider-queue-listener-count
+  "Number of worker threads to use for the queue listener for the bootstrap provider queue"
+  {:default 1
+   :type Long})
+
+(defn queue-config
+  "Returns the queue configuration for the bootstrap application."
+  []
+  (assoc (queue-config/default-config)
+         :queues [(bootstrap-provider-queue-name)]
+         :exchanges [(bootstrap-provider-exchange-name)]
+         :queues-to-exchanges
+         {(bootstrap-provider-queue-name) [(bootstrap-provider-exchange-name)]}))

--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -53,7 +53,7 @@
          :queues [(bootstrap-provider-queue-name)]
          :exchanges [(bootstrap-provider-exchange-name)]
          :queues-to-policies {(bootstrap-provider-queue-name) {:max-tries 1
-                                                               ;; 6 hours visibility timeout
-                                                               :visibility-timeout-secs 21600}}
-         :queues-to-exchanges
-         {(bootstrap-provider-queue-name) [(bootstrap-provider-exchange-name)]}))
+                                                               ;; max 12 hours visibility timeout
+                                                               :visibility-timeout-secs 43200}}
+         :queues-to-exchanges {(bootstrap-provider-queue-name)
+                               [(bootstrap-provider-exchange-name)]}))

--- a/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
@@ -7,8 +7,8 @@
 
 (defn publish-bootstrap-event
   "Put a bootstrap event on the message queue."
-  [dispatcher msg]
-  (let [queue-broker (:queue-broker dispatcher)
+  [context msg]
+  (let [queue-broker (get-in context [:system :queue-broker])
         exchange-name (config/bootstrap-provider-exchange-name)]
     (info "Publishing bootstrap message: " msg)
     (queue/publish-message queue-broker exchange-name msg)))

--- a/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
@@ -1,0 +1,21 @@
+(ns cmr.bootstrap.data.message-queue
+  "Broadcast of bootstrap actions via the message queue"
+  (:require
+   [cmr.bootstrap.config :as config]
+   [cmr.common.log :refer [info]]
+   [cmr.message-queue.services.queue :as queue]))
+
+(defn publish-bootstrap-event
+  "Put a bootstrap event on the message queue."
+  [dispatcher msg]
+  (let [queue-broker (:queue-broker dispatcher)
+        exchange-name (config/bootstrap-provider-exchange-name)]
+    (info "Publishing bootstrap message: " msg)
+    (queue/publish-message queue-broker exchange-name msg)))
+
+(defn bootstrap-provider-event
+  "Creates an event indicating to bootstrap a provider."
+  [provider-id start-index]
+  {:action :index-provider
+   :provider-id provider-id
+   :start-index start-index})

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -3,7 +3,7 @@
   (:require
     [cmr.bootstrap.data.bulk-index :as bulk]
     [cmr.bootstrap.data.rebalance-util :as rebalance-util]
-    [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
+    [cmr.bootstrap.services.dispatch.core :as dispatch]
     [cmr.common.cache :as cache]
     [cmr.common.concepts :as concepts]
     [cmr.common.log :refer (debug info warn error)]
@@ -28,13 +28,13 @@
   "Copy all the data for a provider (including collections and graunules) from catalog rest
   to the metadata db without blocking."
   [context dispatcher provider-id]
-  (dispatch-protocol/migrate-provider dispatcher context provider-id))
+  (dispatch/migrate-provider dispatcher context provider-id))
 
 (defn migrate-collection
   "Copy all the data for a given collection (including graunules) from catalog rest
   to the metadata db without blocking."
   [context dispatcher provider-id collection-id]
-  (dispatch-protocol/migrate-collection dispatcher context provider-id collection-id))
+  (dispatch/migrate-collection dispatcher context provider-id collection-id))
 
 (defn- get-provider
   "Returns the metadata db provider that matches the given provider id. Throws exception if
@@ -49,12 +49,12 @@
   "Bulk index all the collections and granules for a provider."
   [context dispatcher provider-id start-index]
   (get-provider context provider-id)
-  (dispatch-protocol/index-provider dispatcher context provider-id start-index))
+  (dispatch/index-provider dispatcher context provider-id start-index))
 
 (defn index-data-later-than-date-time
   "Bulk index all the concepts with a revision date later than the given date-time."
   [context dispatcher date-time]
-  (dispatch-protocol/index-data-later-than-date-time dispatcher context date-time))
+  (dispatch/index-data-later-than-date-time dispatcher context date-time))
 
 (defn- validate-collection
   "Validates to be bulk_indexed collection exists in cmr else an exception is thrown."
@@ -70,28 +70,28 @@
    (index-collection context dispatcher provider-id collection-id nil))
   ([context dispatcher provider-id collection-id options]
    (validate-collection context provider-id collection-id)
-   (dispatch-protocol/index-collection dispatcher context provider-id collection-id options)))
+   (dispatch/index-collection dispatcher context provider-id collection-id options)))
 
 (defn index-system-concepts
   "Bulk index all the tags, acls, and access-groups."
   [context dispatcher start-index]
-  (dispatch-protocol/index-system-concepts dispatcher context start-index))
+  (dispatch/index-system-concepts dispatcher context start-index))
 
 (defn index-concepts-by-id
   "Bulk index the concepts given by the concept-ids"
   [context dispatcher provider-id concept-type concept-ids]
-  (dispatch-protocol/index-concepts-by-id dispatcher context provider-id concept-type concept-ids))
+  (dispatch/index-concepts-by-id dispatcher context provider-id concept-type concept-ids))
 
 (defn delete-concepts-from-index-by-id
   "Bulk delete the concepts given by the concept-ids from the indexes"
   [context dispatcher provider-id concept-type concept-ids]
-  (dispatch-protocol/delete-concepts-from-index-by-id dispatcher context provider-id concept-type
+  (dispatch/delete-concepts-from-index-by-id dispatcher context provider-id concept-type
                                                       concept-ids))
 
 (defn bootstrap-virtual-products
   "Initializes virtual products."
   [context dispatcher provider-id entry-title]
-  (dispatch-protocol/bootstrap-virtual-products dispatcher context provider-id entry-title))
+  (dispatch/bootstrap-virtual-products dispatcher context provider-id entry-title))
 
 (defn- wait-until-index-set-hash-cache-times-out
   "Waits until the indexer's index set cache hash codes times out so that all of the indexer's will

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -16,7 +16,7 @@
   "A map of request types to which dispatcher to use for asynchronous requests."
   {:migrate-provider :core-async-dispatcher
    :migrate-collection :core-async-dispatcher
-   :index-provider :core-async-dispatcher
+   :index-provider :message-queue-dispatcher
    :index-data-later-than-date-time :core-async-dispatcher
    :index-collection :core-async-dispatcher
    :index-system-concepts :core-async-dispatcher

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/async.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/async.clj
@@ -1,8 +1,7 @@
-(ns cmr.bootstrap.services.dispatch.core-async-dispatch
+(ns cmr.bootstrap.services.dispatch.impl.async
   "Provides methods to insert migration requets on the appropriate channels."
   (:require
     [clojure.core.async :as async :refer [>!]]
-    [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
     [cmr.common.log :refer [info]]))
 
 (defn migrate-provider
@@ -111,10 +110,6 @@
    :index-concepts-by-id index-concepts-by-id
    :delete-concepts-from-index-by-id delete-concepts-from-index-by-id
    :bootstrap-virtual-products bootstrap-virtual-products})
-
-(extend CoreAsyncDispatcher
-        dispatch-protocol/Dispatch
-        dispatch-behavior)
 
 (defn- create-default-channels
   "Creates channels needed for all bootstrapping work and returns as a map of channel name to

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
@@ -1,10 +1,9 @@
-(ns cmr.bootstrap.services.dispatch.message-queue-dispatch
+(ns cmr.bootstrap.services.dispatch.impl.message-queue
   "Functions implementing the dispatch protocol to support synchronous calls."
   (:require
    [cmr.bootstrap.config :as config]
    [cmr.bootstrap.data.bulk-index :as bulk-index]
    [cmr.bootstrap.data.message-queue :as message-queue]
-   [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
    [cmr.common.services.errors :as errors]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]))
 
@@ -36,10 +35,6 @@
    :index-concepts-by-id (partial not-implemented :index-concepts-by-id)
    :delete-concepts-from-index-by-id (partial not-implemented :delete-concepts-from-index-by-id)
    :bootstrap-virtual-products (partial not-implemented :bootstrap-virtual-products)})
-
-(extend MessageQueueDispatcher
-        dispatch-protocol/Dispatch
-        dispatch-behavior)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Message handling

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/sync.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/sync.clj
@@ -1,10 +1,9 @@
-(ns cmr.bootstrap.services.dispatch.synchronous-dispatch
+(ns cmr.bootstrap.services.dispatch.impl.sync
   "Functions implementing the dispatch protocol to support synchronous calls."
   (:require
    [cmr.bootstrap.data.bulk-index :as bulk-index]
    [cmr.bootstrap.data.bulk-migration :as bulk-migration]
-   [cmr.bootstrap.data.virtual-products :as virtual-products]
-   [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]))
+   [cmr.bootstrap.data.virtual-products :as virtual-products]))
 
 (defn- migrate-provider
   "Copy all the data for a provider (including collections and graunules) from catalog rest
@@ -67,7 +66,3 @@
    :index-concepts-by-id index-concepts-by-id
    :delete-concepts-from-index-by-id delete-concepts-from-index-by-id
    :bootstrap-virtual-products bootstrap-virtual-products})
-
-(extend SynchronousDispatcher
-        dispatch-protocol/Dispatch
-        dispatch-behavior)

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/message_queue_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/message_queue_dispatch.clj
@@ -19,10 +19,10 @@
   "Bulk index all the collections and granules for a provider."
   [this context provider-id start-index]
   (let [event (message-queue/bootstrap-provider-event provider-id start-index)]
-    (message-queue/publish-bootstrap-event this event)))
+    (message-queue/publish-bootstrap-event context event)))
 
 (defrecord MessageQueueDispatcher
-  [queue-broker])
+  [])
 
 (def dispatch-behavior
   "Map of protocol definitions to the implementations of that protocol for the message queue
@@ -52,10 +52,6 @@
 (defmethod handle-bootstrap-provider-event :index-provider
   [context msg]
   (bulk-index/index-provider (:system context) (:provider-id msg) (:start-index msg)))
-
-;; Default ignores the provider event. There may be provider events we don't care about.
-(defmethod handle-bootstrap-provider-event :default
-  [_ _])
 
 (defn subscribe-to-events
   "Subscribe to event messages on bootstrap queues."

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/message_queue_dispatch.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/message_queue_dispatch.clj
@@ -1,0 +1,67 @@
+(ns cmr.bootstrap.services.dispatch.message-queue-dispatch
+  "Functions implementing the dispatch protocol to support synchronous calls."
+  (:require
+   [cmr.bootstrap.config :as config]
+   [cmr.bootstrap.data.bulk-index :as bulk-index]
+   [cmr.bootstrap.data.message-queue :as message-queue]
+   [cmr.bootstrap.services.dispatch.dispatch-protocol :as dispatch-protocol]
+   [cmr.common.services.errors :as errors]
+   [cmr.message-queue.queue.queue-protocol :as queue-protocol]))
+
+(defn- not-implemented
+  "Throws an exception indicating that the specified function is not implemented for
+  the message queue dispatcher."
+  [action & _]
+  (errors/internal-error!
+   (format "Message Queue Dispatcher does not support %s action." (name action))))
+
+(defn- index-provider
+  "Bulk index all the collections and granules for a provider."
+  [this context provider-id start-index]
+  (let [event (message-queue/bootstrap-provider-event provider-id start-index)]
+    (message-queue/publish-bootstrap-event this event)))
+
+(defrecord MessageQueueDispatcher
+  [queue-broker])
+
+(def dispatch-behavior
+  "Map of protocol definitions to the implementations of that protocol for the message queue
+  dispatcher."
+  {:migrate-provider (partial not-implemented :migrate-provider)
+   :migrate-collection (partial not-implemented :migrate-collection)
+   :index-provider index-provider
+   :index-data-later-than-date-time (partial not-implemented :index-data-later-than-date-time)
+   :index-collection (partial not-implemented :index-collection)
+   :index-system-concepts (partial not-implemented :index-system-concepts)
+   :index-concepts-by-id (partial not-implemented :index-concepts-by-id)
+   :delete-concepts-from-index-by-id (partial not-implemented :delete-concepts-from-index-by-id)
+   :bootstrap-virtual-products (partial not-implemented :bootstrap-virtual-products)})
+
+(extend MessageQueueDispatcher
+        dispatch-protocol/Dispatch
+        dispatch-behavior)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Message handling
+
+(defmulti handle-bootstrap-provider-event
+  "Handle the actions that can be requested for a provider via the bootstrap-provider-queue"
+  (fn [context msg]
+    (keyword (:action msg))))
+
+(defmethod handle-bootstrap-provider-event :index-provider
+  [context msg]
+  (bulk-index/index-provider (:system context) (:provider-id msg) (:start-index msg)))
+
+;; Default ignores the provider event. There may be provider events we don't care about.
+(defmethod handle-bootstrap-provider-event :default
+  [_ _])
+
+(defn subscribe-to-events
+  "Subscribe to event messages on bootstrap queues."
+  [context]
+  (let [queue-broker (get-in context [:system :queue-broker])]
+    (dotimes [n (config/bootstrap-provider-queue-listener-count)]
+      (queue-protocol/subscribe queue-broker
+                                (config/bootstrap-provider-queue-name)
+                                #(handle-bootstrap-provider-event context %)))))

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -10,9 +10,7 @@
    [cmr.bootstrap.data.bulk-index :as bi]
    [cmr.bootstrap.data.bulk-migration :as bm]
    [cmr.bootstrap.data.virtual-products :as vp]
-   [cmr.bootstrap.services.dispatch.core-async-dispatch :as core-async-dispatch]
-   [cmr.bootstrap.services.dispatch.message-queue-dispatch :as message-queue-dispatch]
-   [cmr.bootstrap.services.dispatch.synchronous-dispatch :as synchronous-dispatch]
+   [cmr.bootstrap.services.dispatch.core :as dispatch]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.services.jvm-info :as jvm-info]
    [cmr.common-app.services.kms-fetcher :as kf]
@@ -72,9 +70,9 @@
                                 :indexer indexer
                                 :access-control access-control}
              :db-batch-size (db-batch-size)
-             :core-async-dispatcher (core-async-dispatch/create-core-async-dispatcher)
-             :synchronous-dispatcher (synchronous-dispatch/->SynchronousDispatcher)
-             :message-queue-dispatcher (message-queue-dispatch/->MessageQueueDispatcher)
+             :core-async-dispatcher (dispatch/create-backend :async)
+             :synchronous-dispatcher (dispatch/create-backend :sync)
+             :message-queue-dispatcher (dispatch/create-backend :message-queue)
              :catalog-rest-user (mdb-config/catalog-rest-db-username)
              :db (oracle/create-db (bootstrap-config/db-spec "bootstrap-pool"))
              :web (web/create-web-server (transmit-config/bootstrap-port) routes/make-api)
@@ -104,7 +102,7 @@
     (bi/handle-bulk-index-requests started-system)
     (vp/handle-virtual-product-requests started-system)
     (when (:queue-broker this)
-      (message-queue-dispatch/subscribe-to-events {:system started-system}))
+      (dispatch/subscribe-to-events {:system started-system}))
     (info "Bootstrap system started")
     started-system))
 

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -219,7 +219,7 @@
   (assoc (access-control-system/create-system) :queue-broker queue-broker))
 
 (defn create-bootstrap-app
-  "Create an instance of the indexer application."
+  "Create an instance of the bootstrap application."
   [queue-broker]
   (assoc (bootstrap-system/create-system) :queue-broker queue-broker))
 

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -221,9 +221,7 @@
 (defn create-bootstrap-app
   "Create an instance of the indexer application."
   [queue-broker]
-  (-> (bootstrap-system/create-system)
-      (assoc :queue-broker queue-broker)
-      (assoc-in [:message-queue-dispatcher :queue-broker] queue-broker)))
+  (assoc (bootstrap-system/create-system) :queue-broker queue-broker))
 
 (defmulti create-ingest-app
   "Create an instance of the ingest application."

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -174,6 +174,7 @@
       (rmq-conf/merge-configs (vp-config/queue-config))
       (rmq-conf/merge-configs (access-control-config/queue-config))
       (rmq-conf/merge-configs (ingest-config/queue-config))
+      (rmq-conf/merge-configs (bootstrap-config/queue-config))
       (assoc :ttls ttls)))
 
 ;; for legacy reasons :external refers to Rabbit MQ

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -1,16 +1,17 @@
 (ns cmr.ingest.config
   "Contains functions to retrieve metadata db specific configuration"
-  (:require [cmr.common.config :as cfg :refer [defconfig]]
-            [cmr.oracle.config :as oracle-config]
-            [cmr.oracle.connection :as conn]
-            [cmr.message-queue.config :as rmq-conf]))
+  (:require
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.message-queue.config :as queue-config]
+   [cmr.oracle.config :as oracle-config]
+   [cmr.oracle.connection :as conn]))
 
 (defconfig bulk-update-cleanup-minimum-age
   "The minimum age(in days) of the rows in bulk-update-task-status table that can be cleaned up"
   {:default 90
    :type Long})
 
-(defconfig bulk-update-enabled 
+(defconfig bulk-update-enabled
   "Flag for whether or not bulk update is enabled."
   {:default true :type Boolean})
 
@@ -56,9 +57,9 @@
    :type Long})
 
 (defn queue-config
-  "Returns the rabbit mq configuration for the ingest application."
+  "Returns the queue configuration for the ingest application."
   []
-  (assoc (rmq-conf/default-config)
+  (assoc (queue-config/default-config)
          :queues [(ingest-queue-name)]
          :exchanges [(ingest-exchange-name) (provider-exchange-name)]
          :queues-to-exchanges

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -1,9 +1,8 @@
 (ns cmr.ingest.data.ingest-events
   "Allows broadcast of ingest events via the message queue"
-  (:require [cmr.ingest.config :as config]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.common.services.errors :as errors]
-            [cmr.message-queue.services.queue :as queue]))
+  (:require
+   [cmr.ingest.config :as config]
+   [cmr.message-queue.services.queue :as queue]))
 
 (defn publish-provider-event
   "Put a provider event on the message queue."

--- a/message-queue-lib/src/cmr/message_queue/config.clj
+++ b/message-queue-lib/src/cmr/message_queue/config.clj
@@ -76,4 +76,5 @@
                              (format "Queue was mapped to two different exchange sets: %s %s"
                                      (pr-str v1) (pr-str v2)))))
                        q-to-e
-                       (:queues-to-exchanges config2)))))))
+                       (:queues-to-exchanges config2))))
+        (update-in [:queues-to-policies] merge (:queues-to-policies config2)))))

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -100,8 +100,6 @@
   "Returns the Topic with the given display name."
   [sns-client exchange-name]
   (info "Calling SNS to get topic " exchange-name)
-  (debug "SNS Client" (pr-str sns-client))
-  (debug "Topics" (pr-str (.listTopics sns-client)))
   (let [exchange-name (normalize-queue-name exchange-name)
         topics (vec (.getTopics (.listTopics sns-client)))]
     (some (fn [topic]
@@ -190,7 +188,7 @@
      (.setQueueAttributes sqs-client set-queue-attrs-request)))
 
 (defn- create-exchange
-  "Creaete an SNS topic to be used as an exchange."
+  "Create an SNS topic to be used as an exchange."
   [sns-client exchange-name]
   (.createTopic sns-client (normalize-queue-name exchange-name)))
 

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -163,7 +163,7 @@
           (catch Throwable t
             (error t "Async handler for queue" queue-name "continuing after failed message receive.")
             ;; We want to avoid a tight loop in case the call to getMessages is failing immediately.
-            (Thread/sleep 60000)))
+            (Thread/sleep 1000)))
         (recur)))))
 
 (defn- create-queue

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -100,6 +100,8 @@
   "Returns the Topic with the given display name."
   [sns-client exchange-name]
   (info "Calling SNS to get topic " exchange-name)
+  (debug "SNS Client" (pr-str sns-client))
+  (debug "Topics" (pr-str (.listTopics sns-client)))
   (let [exchange-name (normalize-queue-name exchange-name)
         topics (vec (.getTopics (.listTopics sns-client)))]
     (some (fn [topic]
@@ -161,7 +163,7 @@
           (catch Throwable t
             (error t "Async handler for queue" queue-name "continuing after failed message receive.")
             ;; We want to avoid a tight loop in case the call to getMessages is failing immediately.
-            (Thread/sleep 100)))
+            (Thread/sleep 60000)))
         (recur)))))
 
 (defn- create-queue
@@ -299,7 +301,8 @@
       (doseq [queue (keys queues-to-exchanges)
               :let [exchanges (get queues-to-exchanges queue)]]
         (bind-queue-to-exchanges sns-client sqs-client exchanges queue))
-      (assoc this :sns-client sns-client :sqs-client sqs-client :normalized-queue-names normalized-queue-names)))
+      (assoc this :sns-client sns-client :sqs-client sqs-client
+             :normalized-queue-names normalized-queue-names)))
 
   (stop
     [this system]

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index_test.clj
@@ -25,9 +25,10 @@
     [cmr.transmit.config :as tc]
     [cmr.umm.echo10.echo10-core :as echo10]))
 
-(use-fixtures :each (join-fixtures [(ingest/reset-fixture {"provguid1" "PROV1"} {:grant-all-ingest? true
-                                                                                 :grant-all-search? true
-                                                                                 :grant-all-access-control? false})
+(use-fixtures :each (join-fixtures [(ingest/reset-fixture {"provguid1" "PROV1"}
+                                                          {:grant-all-ingest? true
+                                                           :grant-all-search? true
+                                                           :grant-all-access-control? false})
                                     tags/grant-all-tag-fixture]))
 
 (defn- save-collection


### PR DESCRIPTION
This pull request moves the bootstrapping of providers to a message queue.

The message queue is configured to allow messages to take up to 12 hours before considering them failed and to not ever retry a message. This will effectively allow operations to distribute messages for indexing providers across several nodes. Even if a message takes several days to process (like indexing all the granules for LPDAAC_ECS), the node that is processing that message will not attempt to pick up any other messages (listener count is set to 1). By not retrying we ensure that after 12 hours we don't have another bootstrap node kick off indexing for LPDAAC_ECS. The only downsides are that long messages will eventually move to the dead letter queue and the number of in flight messages on the message queue will not be correct. But since almost no one can get to the GP-MCE AWS console anyway, no one will notice any problem. 😄 

I also refactored the code as requested by Duncan in the prior pull request for this ticket.