### PR TITLE
CMR-4397 don't use :temporals for granule search

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -163,7 +163,7 @@
 
             :native-id native-id
             :native-id.lowercase (s/lower-case native-id)
-            
+
             :provider-id provider-id
             :provider-id-doc-values provider-id
             :provider-id.lowercase (s/lower-case provider-id)
@@ -209,10 +209,6 @@
             :start-date-doc-values (index-util/date->elastic start-date)
             :end-date (index-util/date->elastic end-date)
             :end-date-doc-values (index-util/date->elastic end-date)
-            ;; this is to make granule temporal search nested because it 
-            ;; shares the same code as the nested collection temporal search.
-            :temporals [{:start-date (index-util/date->elastic start-date) 
-                         :end-date (index-util/date->elastic end-date)}]
             :two-d-coord-name two-d-coord-name
             :two-d-coord-name.lowercase (when two-d-coord-name (s/lower-case two-d-coord-name))
             :start-coordinate-1 start-coordinate-1

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -516,10 +516,8 @@
      :end-date (m/stored m/date-field-mapping)
      :end-date-doc-values                (-> m/date-field-mapping m/stored m/doc-values)
 
-     ;; granule temporal search is not nested but it shares the same code
-     ;; with the collection temporal search which is nested. So we need
-     ;; a nested index structure even though for granules it's just using one
-     ;; start-date, end-date.
+     ;; No longer indexing to :temporals due to performance issues, but cannot
+     ;; delete from elastic index
      :temporals temporal-mapping
      :size (m/stored m/float-field-mapping)
      :size-doc-values (-> m/float-field-mapping m/stored m/doc-values)

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -316,7 +316,6 @@
                                 (when-not (str/blank? (:include-tags params))
                                   [:tags])
                                 ;; Always include temporal, the processor will see if any temporal conditions exist
-                                ;; Not specific to relevancy, but currently used for temporal relevancy
                                 [:temporal-conditions])
         keywords (when (:keyword params)
                    (str/split (str/lower-case (:keyword params)) #" "))

--- a/search-app/src/cmr/search/services/query_execution/temporal_conditions_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/temporal_conditions_results_feature.clj
@@ -1,5 +1,7 @@
 (ns cmr.search.services.query-execution.temporal-conditions-results-feature
-  "Functions to pull out temporal conditions in pre-processing and get the temporal
+  "Functions for temporal pre-processing. Add concept-type to the condition because
+  when we create the elastic conditions we need special processing based on
+  concept type. Pull out temporal conditions in pre-processing and get the temporal
   range data from the query. This is done during pre-processing since down the road temporal
   conditions get very complicated and it's easier to pull them out here."
   (:require
@@ -12,9 +14,10 @@
 
 (defmethod query-execution/pre-process-query-result-feature :temporal-conditions
   [_ query _]
-  (if-let [temporal-ranges (temporal-range-extractor/extract-query-temporal-ranges query)]
-    (assoc query ::temporal-ranges temporal-ranges)
-    query))
+  (let [query (assoc-in query [:condition :concept-type] (:concept-type query))]
+    (if-let [temporal-ranges (temporal-range-extractor/extract-query-temporal-ranges query)]
+      (assoc query ::temporal-ranges temporal-ranges)
+      query)))
 
 (defn get-query-temporal-conditions
  [query]


### PR DESCRIPTION
No longer index to temporals for granules, update temporal search to have conditions for granules. This fixes granule performance issues.