### PR TITLE
CMR-4418: Clean up all variables as part of resetting providers function

### DIFF
--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/delete_provider_cascading_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/delete_provider_cascading_test.clj
@@ -1,0 +1,44 @@
+(ns cmr.metadata-db.int-test.delete-provider-cascading-test
+  "Tests that delete a provider cascading delete its concepts."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.metadata-db.int-test.utility :as util]))
+
+(use-fixtures :each (join-fixtures
+                      [(util/reset-database-fixture {:provider-id "REG_PROV" :small false}
+                                                    {:provider-id "PROV1" :small false})]))
+
+(defn- concept-deleted?
+  "Returns true if the concept does not exist in metadata db"
+  [concept]
+  (= 404 (:status (util/get-concept-by-id (:concept-id concept)))))
+
+(defn- concept-exist?
+  "Returns true if the concept exists in metadata db as a record including tombstone"
+  [concept]
+  (= 200 (:status (util/get-concept-by-id (:concept-id concept)))))
+
+(deftest delete-provider-cascade-delete-concepts
+  (let [coll1 (util/create-and-save-collection "REG_PROV" 1)
+        coll2 (util/create-and-save-collection "PROV1" 1)
+        gran1 (util/create-and-save-granule "REG_PROV" coll1 1)
+        gran2 (util/create-and-save-granule "PROV1" coll2 1)
+        variable1 (util/create-and-save-variable "REG_PROV" 1)
+        variable2 (util/create-and-save-variable "PROV1" 1)
+        variable-association1 (util/create-and-save-variable-association coll1 variable1 1)
+        variable-association2 (util/create-and-save-variable-association coll2 variable2 1)]
+
+    ;; Delete REG_PROV
+    (util/delete-provider "REG_PROV")
+
+    ;; Verify the REG_PROV's concepts are deleted
+    (is (concept-deleted? coll1))
+    (is (concept-deleted? gran1))
+    (is (concept-deleted? variable1))
+    (is (concept-deleted? variable-association1))
+
+    ;; Verify the PROV1's concepts still exist
+    (is (concept-exist? coll2))
+    (is (concept-exist? gran2))
+    (is (concept-exist? variable2))
+    (is (concept-exist? variable-association2))))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/delete_provider_cascading_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/delete_provider_cascading_test.clj
@@ -24,21 +24,31 @@
         gran1 (util/create-and-save-granule "REG_PROV" coll1 1)
         gran2 (util/create-and-save-granule "PROV1" coll2 1)
         variable1 (util/create-and-save-variable "REG_PROV" 1)
-        variable2 (util/create-and-save-variable "PROV1" 1)
+        variable2 (util/create-and-save-variable "PROV1" 2)
+        variable3 (util/create-and-save-variable "PROV1" 3)
         variable-association1 (util/create-and-save-variable-association coll1 variable1 1)
-        variable-association2 (util/create-and-save-variable-association coll2 variable2 1)]
+        variable-association2 (util/create-and-save-variable-association coll1 variable2 2)
+        variable-association3 (util/create-and-save-variable-association coll2 variable1 3)
+        variable-association4 (util/create-and-save-variable-association coll2 variable2 4)]
 
     ;; Delete REG_PROV
     (util/delete-provider "REG_PROV")
 
-    ;; Verify the REG_PROV's concepts are deleted
+    ;; Verify REG_PROV related concepts are deleted
     (is (concept-deleted? coll1))
     (is (concept-deleted? gran1))
     (is (concept-deleted? variable1))
+    ;; variable-association1, both collection and variable are related to the deleted provider
     (is (concept-deleted? variable-association1))
+    ;; variable-association2, collection is related to the deleted provider
+    (is (concept-deleted? variable-association2))
+    ;; variable-association3, variable is related to the deleted provider
+    (is (concept-deleted? variable-association3))
 
-    ;; Verify the PROV1's concepts still exist
+    ;; Verify concepts not related to the delete provider (REG_PROV) still exist
     (is (concept-exist? coll2))
     (is (concept-exist? gran2))
     (is (concept-exist? variable2))
-    (is (concept-exist? variable-association2))))
+    (is (concept-exist? variable3))
+    ;; variable-association4, either collection nor variable is related to the deleted provider
+    (is (concept-exist? variable-association4))))

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -390,9 +390,12 @@
                                                    [{:provider-id "CMR"}]
                                                    {:concept-type :variable-association})]
      (let [{:keys [concept-id revision-id variable-concept-id extra-fields]} var-association
-           {:keys [variable-concept-id]} extra-fields]
-       (when (= (:provider-id provider)
-                (:provider-id (cc/parse-concept-id variable-concept-id)))
+           {:keys [associated-concept-id variable-concept-id]} extra-fields
+           referenced-providers (map (comp :provider-id cc/parse-concept-id)
+                                     [associated-concept-id variable-concept-id])]
+       ;; If the variable association references the deleted provider through
+       ;; either collection or variable, delete the variable association
+       (when (some #{(:provider-id provider)} referenced-providers)
          (concepts/force-delete
            db :variable-association {:provider-id "CMR"} concept-id revision-id))))
 

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -384,12 +384,25 @@
    ;; Cascade to delete the concepts
    (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts db [provider] nil)]
      (concepts/force-delete db concept-type provider concept-id revision-id))
+
+   ; Cascade to delete the variable associations, this is a hacky way of doing things
+   (doseq [var-association (concepts/find-concepts db
+                                                   [{:provider-id "CMR"}]
+                                                   {:concept-type :variable-association})]
+     (let [{:keys [concept-id revision-id variable-concept-id extra-fields]} var-association
+           {:keys [variable-concept-id]} extra-fields]
+       (when (= (:provider-id provider)
+                (:provider-id (cc/parse-concept-id variable-concept-id)))
+         (concepts/force-delete
+           db :variable-association {:provider-id "CMR"} concept-id revision-id))))
+
    ;; to find items that reference the provider that should be deleted (e.g. ACLs)
    (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts
                                                           db
                                                           [pv/cmr-provider]
                                                           {:target-provider-id (:provider-id provider)})]
      (concepts/force-delete db concept-type pv/cmr-provider concept-id revision-id))
+   ;; finally delete the provider
    (swap! providers-atom dissoc (:provider-id provider)))
 
   (reset-providers

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -45,6 +45,10 @@
     (if small
       (delete-small-provider-concepts db provider)
       (ct/delete-provider-concept-tables db provider))
+    ;; Delete the variable associations related to the provider
+    (j/db-do-commands db (str "DELETE FROM cmr_variable_associations where variable_concept_id like 'V%-" provider-id "'"))
+    ;; Delete variables of the provider
+    (j/delete! db (ct/get-table-name provider :variable) ["provider_id = ?" provider-id])
     (j/delete! db :providers ["provider_id = ?" provider-id])))
 
 (extend-protocol p/ProvidersStore
@@ -87,10 +91,7 @@
   (reset-providers
     [db]
     (doseq [provider (p/get-providers db)]
-      (p/delete-provider db provider))
-    ;; delete the variables and vairable associations
-    (j/db-do-commands db "DELETE FROM cmr_variables")
-    (j/db-do-commands db "DELETE FROM cmr_variable_associations")))
+      (p/delete-provider db provider))))
 
 
 (comment

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -45,8 +45,10 @@
     (if small
       (delete-small-provider-concepts db provider)
       (ct/delete-provider-concept-tables db provider))
-    ;; Delete the variable associations related to the provider
+    ;; Delete the variable associations related to the provider via variable
     (j/db-do-commands db (str "DELETE FROM cmr_variable_associations where variable_concept_id like 'V%-" provider-id "'"))
+    ;; Delete the variable associations related to the provider via collection
+    (j/db-do-commands db (str "DELETE FROM cmr_variable_associations where associated_concept_id like 'C%-" provider-id "'"))
     ;; Delete variables of the provider
     (j/delete! db (ct/get-table-name provider :variable) ["provider_id = ?" provider-id])
     (j/delete! db :providers ["provider_id = ?" provider-id])))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -87,7 +87,10 @@
   (reset-providers
     [db]
     (doseq [provider (p/get-providers db)]
-      (p/delete-provider db provider))))
+      (p/delete-provider db provider))
+    ;; delete the variables and vairable associations
+    (j/db-do-commands db "DELETE FROM cmr_variables")
+    (j/db-do-commands db "DELETE FROM cmr_variable_associations")))
 
 
 (comment


### PR DESCRIPTION
We are cleaning up variables as part of the `reset` endpoint, just not in the `reset-providers` function call. MMT local dev is using the `reset-providers` function to help with the cleanup. This just added the two lines already in concept reset to the `reset-providers` function. I don't think it is worth a test, so none included.