### PR TITLE
CMR-4370 Change variable association provider ACL

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -124,6 +124,16 @@ NOTE from CMR-1908 that when reindexing a provider the collections are not reind
 
     curl -i -XPOST http://localhost:3006/bulk_index/system_concepts
 
+### Bulk index variables:
+
+For a single provider:
+
+    curl -i -XPOST http://localhost:3006/bulk_index/variables/PROV1
+
+For all providers:
+
+    curl -i -XPOST http://localhost:3006/bulk_index/variables
+
 ### Initialize Virtual Products
 
 Virtual collections contain granules derived from a source collection. Only granules specified in the source collections in the virtual product app configuration will be considered. Virtual granules will only be created in the configured destination virtual collections if they already exist. To initialize virtual granules from existing source granules, use the following command:

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -100,3 +100,8 @@
   (-> concept-id
       concept-id->concept-prefix
       concept-prefix->concept-type))
+
+(defn concept-id->provider-id
+  "Returns the provider-id associated with the given concept-id."
+  [concept-id]
+  (:provider-id (parse-concept-id concept-id)))

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -19,8 +19,8 @@
    [cmr.search.api.community-usage-metrics :as metrics-api]
    [cmr.search.api.humanizer :as humanizers-api]
    [cmr.search.api.keyword :as keyword-api]
-   [cmr.search.api.tags-api :as tags-api]
-   [cmr.search.api.variables-api :as variables-api]
+   [cmr.search.api.tags :as tags-api]
+   [cmr.search.api.variables :as variables-api]
 
    ;; Required here to make sure the multimethod function implementation is available
    [cmr.search.data.elastic-results-to-query-results]

--- a/search-app/src/cmr/search/api/tags.clj
+++ b/search-app/src/cmr/search/api/tags.clj
@@ -1,4 +1,4 @@
-(ns cmr.search.api.tags-api
+(ns cmr.search.api.tags
   "Defines the API for tagging collections in the CMR."
   (:require
    [cheshire.core :as json]

--- a/search-app/src/cmr/search/api/variables.clj
+++ b/search-app/src/cmr/search/api/variables.clj
@@ -1,4 +1,4 @@
-(ns cmr.search.api.variables-api
+(ns cmr.search.api.variables
   "Defines the API for associating/dissociating variables with collections in the CMR."
   (:require
    [cheshire.core :as json]

--- a/search-app/src/cmr/search/services/query_walkers/provider_id_extractor.clj
+++ b/search-app/src/cmr/search/services/query_walkers/provider_id_extractor.clj
@@ -11,10 +11,6 @@
     [c]
     "Extract provider-ids"))
 
-(defn- concept-id->provider-id
-  [concept-id]
-  (:provider-id (concepts/parse-concept-id concept-id)))
-
 (extend-protocol ExtractProviderIds
   cmr.common_app.services.search.query_model.Query
   (extract-provider-ids
@@ -43,8 +39,8 @@
       [:any]
       (case field
         :provider [value]
-        :collection-concept-id [(concept-id->provider-id value)]
-        :concept-id [(concept-id->provider-id value)]
+        :collection-concept-id [(concepts/concept-id->provider-id value)]
+        :concept-id [(concepts/concept-id->provider-id value)]
         ;;else
         [:any])))
 
@@ -53,8 +49,8 @@
     [{:keys [field values]}]
     (case field
       :provider values
-      :collection-concept-id (map concept-id->provider-id values)
-      :concept-id (map concept-id->provider-id values)
+      :collection-concept-id (map concepts/concept-id->provider-id values)
+      :concept-id (map concepts/concept-id->provider-id values)
       ;;else
       [:any]))
 

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -59,13 +59,20 @@
 (defn setup-update-acl
   "Set up the ACLs for UMM-Var update permissions and return the ids+token"
   ([context provider-id]
-   (setup-update-acl context provider-id "umm-var-user42" "umm-var-guid42"))
+   (setup-update-acl
+    context provider-id :update "umm-var-user42" "umm-var-guid42"))
+  ([context provider-id permission-type]
+   (setup-update-acl
+    context provider-id permission-type "umm-var-user42" "umm-var-guid42"))
   ([context provider-id user-name group-name]
+   (setup-update-acl
+    context provider-id :update user-name group-name))
+  ([context provider-id permission-type user-name group-name]
    (let [update-group-id (echo-util/get-or-create-group context group-name)
          update-token (echo-util/login context user-name [update-group-id])
          token-context (assoc context :token update-token)
          update-grant-id (echo-util/grant-group-provider-admin
-                          token-context update-group-id provider-id :update)]
+                          token-context update-group-id provider-id permission-type)]
      {:user-name user-name
       :group-name group-name
       :group-id update-group-id

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -33,6 +33,29 @@
   (echo-util/grant-all-variable (s/context))
   (f))
 
+(defn setup-acl
+  [group-name user-name user-type]
+  (let [gid (echo-util/get-or-create-group (s/context) group-name)
+        token (echo-util/login (s/context) user-name [gid])
+        grant-id (echo-util/grant (assoc (s/context) :token token)
+                                   [{:permissions [:read]
+                                     :user_type user-type}]
+                                   :system_identity
+                                   {:target nil})]
+     {:user-name user-name
+      :group-name group-name
+      :group-id gid
+      :grant-id grant-id
+      :token token}))
+
+(defn setup-guest-acl
+  [gid-name uid-name]
+  (setup-acl gid-name uid-name :guest))
+
+(defn setup-registered-acl
+  [gid-name uid-name]
+  (setup-acl gid-name uid-name :registered))
+
 (defn setup-update-acl
   "Set up the ACLs for UMM-Var update permissions and return the ids+token"
   ([context provider-id]

--- a/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
@@ -1,26 +1,25 @@
-(ns cmr.system-int-test.search.acls.collection-acl-search-test
-  "Tests searching for collections with ACLs in place"
+(ns cmr.system-int-test.search.acls.collection
+  "Tests searching for collections with ACLs in place."
   (:require
-    [cmr.common-app.test.side-api :as side]
-    [clojure.test :refer :all]
-    [clojure.string :as str]
-    [cmr.acl.acl-fetcher :as acl-fetcher]
-    [cmr.common.services.messages :as msg]
-    [cmr.common.util :refer [are2] :as util]
-    [cmr.mock-echo.client.echo-util :as e]
-    [cmr.system-int-test.data2.atom :as da]
-    [cmr.system-int-test.data2.collection :as dc]
-    [cmr.system-int-test.data2.core :as d]
-    [cmr.system-int-test.data2.opendata :as od]
-    [cmr.system-int-test.system :as s]
-    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-    [cmr.system-int-test.utils.index-util :as index]
-    [cmr.system-int-test.utils.ingest-util :as ingest]
-    [cmr.system-int-test.utils.metadata-db-util :as mdb]
-    [cmr.system-int-test.utils.search-util :as search]
-    [cmr.transmit.access-control :as ac]
-    [cmr.transmit.config :as tc]))
-
+   [cmr.common-app.test.side-api :as side]
+   [clojure.test :refer :all]
+   [clojure.string :as str]
+   [cmr.acl.acl-fetcher :as acl-fetcher]
+   [cmr.common.services.messages :as msg]
+   [cmr.common.util :refer [are2] :as util]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.atom :as da]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.opendata :as od]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.transmit.access-control :as ac]
+   [cmr.transmit.config :as tc]))
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"

--- a/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
@@ -1,20 +1,21 @@
-(ns cmr.system-int-test.search.acls.granule-acl-search-test
-  "Tests searching for collections with ACLs in place"
-  (:require [clojure.test :refer :all]
-            [clojure.string :as str]
-            [cmr.common.services.messages :as msg]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.search-util :as search]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.system-int-test.data2.collection :as dc]
-            [cmr.system-int-test.data2.atom :as da]
-            [cmr.system-int-test.data2.granule :as dg]
-            [cmr.system-int-test.data2.granule-counts :as gran-counts]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.system-int-test.system :as s]
-            [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-            [cmr.transmit.config :as tc]))
+(ns cmr.system-int-test.search.acls.granule
+  "Tests searching for collections with ACLs in place."
+  (:require
+   [clojure.test :refer :all]
+   [clojure.string :as str]
+   [cmr.common.services.messages :as msg]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.atom :as da]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.granule-counts :as gran-counts]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.transmit.config :as tc]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
                                            "provguid2" "PROV2"

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule.clj
@@ -1,4 +1,4 @@
-(ns cmr.system-int-test.search.acls.temporal-acl-search-test
+(ns cmr.system-int-test.search.acls.temporal-collection-granule
   "Tests searching for collections and granules with temporal ACLs in place."
   (:require
    [clj-time.core :as t]
@@ -21,7 +21,6 @@
    [cmr.system-int-test.utils.search-util :as search]
    [cmr.transmit.config :as tc]
    [cmr.transmit.echo.conversion :as echo-conversion]))
-
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1"}

--- a/system-int-test/test/cmr/system_int_test/search/acls/variable_association.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/variable_association.clj
@@ -1,0 +1,79 @@
+(ns cmr.system-int-test.search.acls.variable-association
+  "Tests searching for variables associations with ACLs in place."
+  (:require
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.common.util :refer [are3]]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.variable-util :as variable-util]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}
+                                          {:grant-all-search? false
+                                           :grant-all-ingest? false}))
+
+(deftest variable-association-acls-test
+  (let [{guest-token :token} (variable-util/setup-guest-acl
+                              "umm-var-guid1" "umm-var-user1")
+        {registered-token :token} (variable-util/setup-registered-acl
+                                   "umm-var-guid2" "umm-var-user2")
+        {update-token :token} (variable-util/setup-update-acl
+                               (s/context) "PROV1")
+        {create-token :token} (variable-util/setup-update-acl
+                               (s/context) "PROV1" :create)
+        {delete-token :token} (variable-util/setup-update-acl
+                               (s/context) "PROV1" :delete)
+        coll-concept-id (->> {:token update-token}
+                              (d/ingest "PROV1" (dc/collection))
+                              :concept-id)
+        var-concept (variable-util/make-variable-concept)
+        {var-concept-id :concept-id} (variable-util/ingest-variable
+                                      var-concept
+                                      {:token update-token})]
+    (index/wait-until-indexed)
+    (testing "disallowed variable association responses"
+      (are3 [token expected]
+        (let [response (variable-util/associate-by-concept-ids
+                        token
+                        var-concept-id
+                        [{:concept-id coll-concept-id}])]
+          (is (= expected (:status response))))
+        "no token provided"
+        nil 401
+        "guest user denied"
+        guest-token 401
+        "regular user denied"
+        registered-token 401))
+     (testing "disallowed variable dissociation responses"
+      (are3 [token expected]
+        (let [response (variable-util/dissociate-by-concept-ids
+                        token
+                        var-concept-id
+                        [{:concept-id coll-concept-id}])]
+          (is (= expected (:status response)))
+          (is (string/includes?
+               "You do not have permission to perform that action."
+               (first (:errors response)))))
+        "no token provided"
+        nil 401
+        "guest user denied"
+        guest-token 401
+        "regular user denied"
+        registered-token 401))
+    (testing "allowed variable association responses"
+      (let [response (variable-util/associate-by-concept-ids
+                      create-token
+                      var-concept-id
+                      [{:concept-id coll-concept-id}])]
+        (is (= 200 (:status response)))))
+    (testing "allowed variable dissociation responses"
+      (let [response (variable-util/dissociate-by-concept-ids
+                      delete-token
+                      var-concept-id
+                      [{:concept-id coll-concept-id}])]
+        (is (= 200 (:status response)))))))


### PR DESCRIPTION
We're moving from system-based to provider-based, just like we did for variables themselves. We didn't do this originally, since variable associations aren't directly linked to providers, but the difference of permissions has been difficult for OPS and MMT.

~~Note that no system integration tests existed specifically for the `system-object` ACL for variables associations, so this change didn't cause any tests to fail. Liu and I have chatted about some tests we can add -- I'm working on that now and will push to this branch when something's in place.~~

Tests for variable association ACLs are now in place.