### PR TITLE
CMR-3366: Change characteristics' datatype from string to enum.

### DIFF
--- a/umm-spec-lib/resources/json-schemas/umm/v1.10/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/umm/v1.10/umm-cmn-json-schema.json
@@ -863,10 +863,7 @@
         },
         "DataType": {
           "description": "The datatype of the Characteristic/attribute.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 80,
-          "pattern": "[\\w]{1,79}"
+          "$ref": "#/definitions/DataTypeEnum" 
         }
       },
       "required": ["Name", "Description", "DataType", "Unit", "Value"]

--- a/umm-spec-lib/src/cmr/umm_spec/migration/characteristics_data_type_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/characteristics_data_type_migration.clj
@@ -1,0 +1,63 @@
+(ns cmr.umm-spec.migration.characteristics-data-type-migration
+  "Contains helper functions for migrating between different versions of UMM characteristics' data type."
+  (:require
+   [clojure.set :as set] 
+   [clojure.string :as string]
+   [cmr.common.util :as util :refer [update-in-each]]
+   [cmr.umm-spec.util :as umm-spec-util]))
+
+(def mapping-up
+  "Defines mappings of Characteristics' data type values from v1.9 to v1.10.
+   Anything not in this map, and not equal to \"NOT APPLICABLE\", map it to \"STRING\"."
+  {"TIME/DIRECTION (ASCENDING)" "STRING"
+   "TIME/DIRECTION (DESCENDING)" "STRING"
+   "VARCHAR" "STRING"
+   "INTEGER" "INT"
+   "RADIOCARBON DATES" "STRING"
+   "STRING" "STRING"
+   "FLOAT" "FLOAT"
+   "INT" "INT"
+   "BOOLEAN" "BOOLEAN"
+   "DATE" "DATE"
+   "TIME" "TIME"
+   "DATETIME" "DATETIME"
+   "DATE_STRING" "DATE_STRING"
+   "TIME_STRING" "TIME_STRING"
+   "DATETIME_STRING" "DATETIME_STRING"})
+
+(defn migrate-data-type
+  "Migrate the Charateristics' data type from string to enum."
+  [characteristics]
+  (when-let [data-type (:DataType characteristics)]
+    (let [upper-case-data-type (string/upper-case data-type)]
+      (when-not (= umm-spec-util/NOT-APPLICABLE upper-case-data-type)    
+       (assoc characteristics :DataType (get mapping-up upper-case-data-type umm-spec-util/STRING))))))
+
+(defn update-each-characteristics
+  "Update all the characteristics in a given element: platform/instrument/child instrument."
+  [element]
+  (util/remove-nil-keys
+    (-> element
+        (update-in-each [:Characteristics] migrate-data-type)
+        (update :Characteristics #(remove nil? %))
+        (update :Characteristics seq))))
+             
+(defn migrate-instrument-characteristics-data-type
+  "Migrate instrument's characteristics' data types."
+  [instrument]
+  (-> instrument
+      update-each-characteristics 
+      (update-in-each [:ComposedOf] update-each-characteristics))) 
+
+(defn migrate-platform-characteristics-data-type
+  "Migrate platform's characteristics' data types."
+  [platform]
+  (-> platform
+      update-each-characteristics 
+      (update-in-each [:Instruments] migrate-instrument-characteristics-data-type))) 
+    
+(defn migrate-up
+  "Migrate Characteristics' data type from string to enum."
+  [c]
+  (-> c
+      (update-in-each [:Platforms] migrate-platform-characteristics-data-type))) 

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
@@ -7,6 +7,7 @@
    [cmr.common.mime-types :as mt]
    [cmr.common.util :as util :refer [update-in-each]]
    [cmr.umm-spec.location-keywords :as lk]
+   [cmr.umm-spec.migration.characteristics-data-type-migration :as characteristics-migration]
    [cmr.umm-spec.migration.contact-information-migration :as ci]
    [cmr.umm-spec.migration.collection-progress-migration :as coll-progress-migration]
    [cmr.umm-spec.migration.organization-personnel-migration :as op]
@@ -271,7 +272,8 @@
   [context c & _]
   (-> c
       coll-progress-migration/migrate-up
-      (update-in-each [:TemporalExtents] dissoc :TemporalRangeType)))
+      (update-in-each [:TemporalExtents] dissoc :TemporalRangeType)
+      characteristics-migration/migrate-up))
 
 (defmethod migrate-umm-version [:collection "1.10" "1.9"]
   [context c & _]

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -8,6 +8,7 @@
   [cmr.umm-spec.date-util :as date]
   [cmr.umm-spec.json-schema :as js]
   [cmr.umm-spec.location-keywords :as lk]
+  [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
   [cmr.umm-spec.models.umm-collection-models :as umm-c]
   [cmr.umm-spec.models.umm-common-models :as cmn]
   [cmr.umm-spec.related-url :as ru-gen]
@@ -284,6 +285,7 @@
       (update-in [:DataDates] conversion-util/fixup-dif10-data-dates)
       (update-in [:Distributions] su/remove-empty-records)
       (update-in-each [:Platforms] dif10-platform)
+      (update-in-each [:Platforms] char-data-type-migration/migrate-platform-characteristics-data-type)
       (update-in-each [:AdditionalAttributes] expected-dif10-additional-attribute)
       (update-in [:ProcessingLevel] dif10-processing-level)
       (assoc :CollectionProgress (conversion-util/expected-coll-progress 

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -7,6 +7,7 @@
    [cmr.common.util :as util :refer [update-in-each]]
    [cmr.umm-spec.date-util :as date]
    [cmr.umm-spec.location-keywords :as lk]
+   [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
    [cmr.umm-spec.models.umm-collection-models :as umm-c]
    [cmr.umm-spec.models.umm-common-models :as cmn]
    [cmr.umm-spec.related-url :as ru-gen]
@@ -289,6 +290,7 @@
       ;; CMR 3253 This is added because it needs to support DIF10 umm. when it does roundtrip,
       ;; dif10umm-echo10(with default)-umm(without default needs to be removed)
       (update-in-each [:Platforms] expected-echo10-platform-longname-with-default-value)
+      (update-in-each [:Platforms] char-data-type-migration/migrate-platform-characteristics-data-type)
       ;; CMR 2716 Getting rid of SpatialKeywords but keeping them for legacy purposes.
       (assoc :SpatialKeywords nil)
       (assoc :PaleoTemporalCoverages nil)

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
@@ -26,7 +26,7 @@
                  :Type "Aircraft"
                  :Characteristics [{:Name "OrbitalPeriod"
                                     :Description "Orbital period in decimal minutes."
-                                    :DataType "float"
+                                    :DataType "FLOAT"
                                     :Unit "Minutes"
                                     :Value "96.7"}]
                  :Instruments [{:ShortName "An Instrument"
@@ -36,14 +36,14 @@
                                 :OperationalModes ["on" "off"]
                                 :Characteristics [{:Name "Signal to Noise Ratio"
                                                    :Description "Is that necessary?"
-                                                   :DataType "float"
+                                                   :DataType "FLOAT"
                                                    :Unit "dB"
                                                    :Value "10"}]
                                 :ComposedOf [{:ShortName "ABC"
                                               :LongName "Long Range Sensor"
                                               :Characteristics [{:Name "Signal to Noise Ratio"
                                                                  :Description "Is that necessary?"
-                                                                 :DataType "float"
+                                                                 :DataType "FLOAT"
                                                                  :Unit "dB"
                                                                  :Value "10"}]
                                               :Technique "Drunken Fist"}]}]}]

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -10,6 +10,7 @@
     [cmr.umm-spec.iso19115-2-util :as iso-util]
     [cmr.umm-spec.json-schema :as js]
     [cmr.umm-spec.location-keywords :as lk]
+    [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
     [cmr.umm-spec.models.umm-collection-models :as umm-c]
     [cmr.umm-spec.models.umm-common-models :as cmn]
     [cmr.umm-spec.related-url :as ru-gen]
@@ -356,4 +357,5 @@
       (update :ScienceKeywords expected-science-keywords)
       (update :AccessConstraints conversion-util/expected-access-constraints)
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
+      (update-in-each [:Platforms] char-data-type-migration/migrate-platform-characteristics-data-type)
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -8,6 +8,7 @@
    [cmr.umm-spec.date-util :as du]
    [cmr.umm-spec.iso-keywords :as kws]
    [cmr.umm-spec.location-keywords :as lk]
+   [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
    [cmr.umm-spec.models.umm-collection-models :as umm-c]
    [cmr.umm-spec.models.umm-common-models :as cmn]
    [cmr.umm-spec.related-url :as ru-gen]
@@ -321,4 +322,5 @@
         (update :ScienceKeywords expected-science-keywords)
         (assoc :PaleoTemporalCoverages nil)
         (assoc :MetadataDates nil)
-        (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))))
+        (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
+        (update-in-each [:Platforms] char-data-type-migration/migrate-platform-characteristics-data-type)))

--- a/umm-spec-lib/src/cmr/umm_spec/util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/util.clj
@@ -145,6 +145,14 @@
   "place holder string value for NOT PROVIDED string field"
   "NOT PROVIDED")
 
+(def NOT-APPLICABLE
+  "place holder string value for NOT APPLICABLE string field"
+  "NOT APPLICABLE")
+
+(def STRING
+  "place holder string value for string field not in the enum list."
+  "STRING")
+
 (def not-provided-data-center
   "Place holder to use when a data center is not provided."
   (cmn/map->DataCenterType

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -10,6 +10,7 @@
     [cmr.umm-spec.date-util :as date]
     [cmr.umm-spec.dif-util :as dif-util]
     [cmr.umm-spec.json-schema :as js]
+    [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
     [cmr.umm-spec.url :as url]
     [cmr.umm-spec.util :as su :refer [without-default-value-of]]
     [cmr.umm-spec.xml-to-umm-mappings.dif10.additional-attribute :as aa]
@@ -29,8 +30,10 @@
 
 (defn- parse-characteristics
   [el]
-  (for [characteristic (select el "Characteristics")]
-    (fields-from characteristic :Name :Description :DataType :Unit :Value)))
+  (seq (remove nil? 
+         (map char-data-type-migration/migrate-data-type
+           (for [characteristic (select el "Characteristics")]
+             (fields-from characteristic :Name :Description :DataType :Unit :Value))))))
 
 (defn- parse-projects-impl
   [doc sanitize?]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -9,6 +9,7 @@
    [cmr.umm-spec.date-util :as date]
    [cmr.umm-spec.json-schema :as js]
    [cmr.umm-spec.location-keywords :as lk]
+   [cmr.umm-spec.migration.characteristics-data-type-migration :as char-data-type-migration]
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.data-contact :as dc]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.related-url :as ru]
@@ -45,7 +46,9 @@
 (defn parse-characteristics
   "Returns a seq of UMM characteristic records from the element's child Characteristics."
   [el]
-  (map parse-characteristic (select el "Characteristics/Characteristic")))
+  (seq (remove nil?
+         (map char-data-type-migration/migrate-data-type
+           (map parse-characteristic (select el "Characteristics/Characteristic"))))))
 
 (defn parse-sensor
   "Returns a UMM Sensor record from an ECHO10 Sensor element."

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -26,7 +26,7 @@
 
 (def tested-collection-formats
   "Seq of formats to use in round-trip conversion and XML validation tests."
-  [:dif :dif10 :iso19115])
+  [:dif :dif10 :echo10 :iso19115 :iso-smap])
 
 (def test-context (lkt/setup-context-for-test))
 
@@ -36,7 +36,7 @@
 
 (def collection-destination-formats
   "Converting to these formats is tested in the roundrobin test."
-  [:dif10 :dif :iso19115])
+  [:echo10 :dif10 :dif :iso19115 :iso-smap])
 
 (def collection-format-examples
   "Map of format type to example file"

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -26,7 +26,7 @@
 
 (def tested-collection-formats
   "Seq of formats to use in round-trip conversion and XML validation tests."
-  [:dif :dif10 :echo10 :iso19115 :iso-smap])
+  [:dif :dif10 :iso19115])
 
 (def test-context (lkt/setup-context-for-test))
 
@@ -36,7 +36,7 @@
 
 (def collection-destination-formats
   "Converting to these formats is tested in the roundrobin test."
-  [:echo10 :dif10 :dif :iso19115 :iso-smap])
+  [:dif10 :dif :iso19115])
 
 (def collection-format-examples
   "Map of format type to example file"

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1133,6 +1133,213 @@
            collection-contact-persons))))
 
 (deftest migrate-1_9-up-to-1_10
+  (testing "Characteristics data type migration from version 1.9 to 1.10"
+  (is (= [{:ShortName "Platform 1"
+           :LongName "Example Platform Long Name 1"
+           :Type "Aircraft"
+           :Characteristics [{:Name "OrbitalPeriod"
+                              :Description "Orbital period in decimal minutes."
+                              :DataType "STRING"
+                              :Unit "Minutes"
+                              :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "INT"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "FLOAT"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "INT"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "BOOLEAN"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "DATE"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "TIME"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "DATETIME"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "DATE_STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "TIME_STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "DATETIME_STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}
+                              {:Name "OrbitalPeriod"
+                               :Description "Orbital period in decimal minutes."
+                               :DataType "STRING"
+                               :Unit "Minutes"
+                               :Value "96.7"}] 
+           :Instruments [{:ShortName "An Instrument"
+                          :LongName "The Full Name of An Instrument v123.4"
+                          :Technique "Two cans and a string"
+                          :NumberOfInstruments 1
+                          :OperationalModes ["on" "off"]
+                          :Characteristics [{:Name "Signal to Noise Ratio"
+                                             :Description "Is that necessary?"
+                                             :DataType "STRING"
+                                             :Unit "dB"
+                                             :Value "10"}]
+                          :ComposedOf [{:ShortName "ABC"
+                                        :LongName "Long Range Sensor"
+                                        :Technique "Drunken Fist"}]}]}] 
+        (:Platforms
+          (vm/migrate-umm {} :collection "1.9" "1.10"
+            {:Platforms [{:ShortName "Platform 1"
+                          :LongName "Example Platform Long Name 1"
+                          :Type "Aircraft"
+                          :Characteristics [{:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "time/Direction (ascending)"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Time/direction (descending)"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "VarchaR"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Integer"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Radiocarbon Dates"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "String"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Float"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "int"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "boolean"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Date"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Time"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Datetime"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Date_String"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "time_string"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "Datetime_String"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "randomstring"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}
+                                            {:Name "OrbitalPeriod"
+                                             :Description "Orbital period in decimal minutes."
+                                             :DataType "not applicable"
+                                             :Unit "Minutes"
+                                             :Value "96.7"}]
+                          :Instruments [{:ShortName "An Instrument"
+                                         :LongName "The Full Name of An Instrument v123.4"
+                                         :Technique "Two cans and a string"
+                                         :NumberOfInstruments 1
+                                         :OperationalModes ["on" "off"]
+                                         :Characteristics [{:Name "Signal to Noise Ratio"
+                                                            :Description "Is that necessary?"
+                                                            :DataType "randomstring"
+                                                            :Unit "dB"
+                                                            :Value "10"}
+                                                            nil]
+                                         :ComposedOf [{:ShortName "ABC"
+                                                       :LongName "Long Range Sensor"
+                                                       :Characteristics [{:Name "Signal to Noise Ratio"
+                                                                          :Description "Is that necessary?"
+                                                                          :DataType "not applicable"
+                                                                          :Unit "dB"
+                                                                          :Value "10"}]
+                                                       :Technique "Drunken Fist"}]}]}]})))))
+ 
   (testing "TemporalRangeType migration from version 1.9 to 1.10"
   (is (= [{:PrecisionOfSeconds "3"
            :EndsAtPresentFlag "false"


### PR DESCRIPTION
Running into some test failures in generate-and-parse that I don't understand.
For example, I made the same code changes in dif10_expected_conversion.clj and echo10_expected_conversion.clj, dif10 format worked fine, but echo10's expected result some how removed all the platformtype/instrumenttype. Same for iso19115 and iso_smap case. I used the same code for them, iso19115 worked, but iso_smap expected result miss the platformtype/instrumenttype.
So, the round-trip test work for dif10 and iso19115, but won't work for echo10 and iso_smap.
Just want to put the PR out there to get some feedbacks.