### PR TITLE
Cmr 3366 change string to enum for data type cleanup

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
@@ -7,7 +7,6 @@
    [cmr.common.mime-types :as mt]
    [cmr.common.util :as util :refer [update-in-each]]
    [cmr.umm-spec.location-keywords :as lk]
-   [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.migration.contact-information-migration :as ci]
    [cmr.umm-spec.migration.collection-progress-migration :as coll-progress-migration]
    [cmr.umm-spec.migration.organization-personnel-migration :as op]
@@ -15,7 +14,8 @@
    [cmr.umm-spec.migration.spatial-extent-migration :as spatial-extent]
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.dif-util :as dif-util]
-   [cmr.umm-spec.versioning :refer [versions]]))
+   [cmr.umm-spec.versioning :refer [versions]]
+   [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utility Functions

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -8,7 +8,6 @@
   [cmr.umm-spec.date-util :as date]
   [cmr.umm-spec.json-schema :as js]
   [cmr.umm-spec.location-keywords :as lk]
-  [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
   [cmr.umm-spec.models.umm-collection-models :as umm-c]
   [cmr.umm-spec.models.umm-common-models :as cmn]
   [cmr.umm-spec.related-url :as ru-gen]
@@ -17,6 +16,7 @@
   [cmr.umm-spec.umm-to-xml-mappings.dif10 :as dif10]
   [cmr.umm-spec.url :as url]
   [cmr.umm-spec.util :as su]
+  [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
   [cmr.umm-spec.xml-to-umm-mappings.dif10.data-contact :as contact]))
 
 (def dif10-roles
@@ -285,7 +285,7 @@
       (update-in [:DataDates] conversion-util/fixup-dif10-data-dates)
       (update-in [:Distributions] su/remove-empty-records)
       (update-in-each [:Platforms] dif10-platform)
-      (update-in-each [:Platforms] char-data-type-normalization/migrate-platform-characteristics-data-type)
+      (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
       (update-in-each [:AdditionalAttributes] expected-dif10-additional-attribute)
       (update-in [:ProcessingLevel] dif10-processing-level)
       (assoc :CollectionProgress (conversion-util/expected-coll-progress 

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -7,7 +7,6 @@
    [cmr.common.util :as util :refer [update-in-each]]
    [cmr.umm-spec.date-util :as date]
    [cmr.umm-spec.location-keywords :as lk]
-   [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.models.umm-collection-models :as umm-c]
    [cmr.umm-spec.models.umm-common-models :as cmn]
    [cmr.umm-spec.related-url :as ru-gen]
@@ -15,7 +14,8 @@
    [cmr.umm-spec.test.location-keywords-helper :as lkt]
    [cmr.umm-spec.umm-to-xml-mappings.echo10.data-contact :as dc]
    [cmr.umm-spec.url :as url]
-   [cmr.umm-spec.util :as su]))
+   [cmr.umm-spec.util :as su]
+   [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]))
 
 (defn- fixup-echo10-data-dates
   [data-dates]
@@ -290,7 +290,7 @@
       ;; CMR 3253 This is added because it needs to support DIF10 umm. when it does roundtrip,
       ;; dif10umm-echo10(with default)-umm(without default needs to be removed)
       (update-in-each [:Platforms] expected-echo10-platform-longname-with-default-value)
-      (update-in-each [:Platforms] char-data-type-normalization/migrate-platform-characteristics-data-type)
+      (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
       ;; CMR 2716 Getting rid of SpatialKeywords but keeping them for legacy purposes.
       (assoc :SpatialKeywords nil)
       (assoc :PaleoTemporalCoverages nil)

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -10,7 +10,6 @@
     [cmr.umm-spec.iso19115-2-util :as iso-util]
     [cmr.umm-spec.json-schema :as js]
     [cmr.umm-spec.location-keywords :as lk]
-    [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
     [cmr.umm-spec.models.umm-collection-models :as umm-c]
     [cmr.umm-spec.models.umm-common-models :as cmn]
     [cmr.umm-spec.related-url :as ru-gen]
@@ -22,6 +21,7 @@
     [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.data-contact :as data-contact]
     [cmr.umm-spec.url :as url]
     [cmr.umm-spec.util :as su]
+    [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
     [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as xml-to-umm-data-contact]
     [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]))
 
@@ -357,5 +357,5 @@
       (update :ScienceKeywords expected-science-keywords)
       (update :AccessConstraints conversion-util/expected-access-constraints)
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
-      (update-in-each [:Platforms] char-data-type-normalization/migrate-platform-characteristics-data-type)
+      (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -8,7 +8,6 @@
    [cmr.umm-spec.date-util :as du]
    [cmr.umm-spec.iso-keywords :as kws]
    [cmr.umm-spec.location-keywords :as lk]
-   [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.models.umm-collection-models :as umm-c]
    [cmr.umm-spec.models.umm-common-models :as cmn]
    [cmr.umm-spec.related-url :as ru-gen]
@@ -19,6 +18,7 @@
    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.data-contact :as data-contact]
    [cmr.umm-spec.url :as url]
    [cmr.umm-spec.util :as su]
+   [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as xml-to-umm-data-contact])
  (:use
    [cmr.umm-spec.models.umm-collection-models]
@@ -323,4 +323,4 @@
         (assoc :PaleoTemporalCoverages nil)
         (assoc :MetadataDates nil)
         (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
-        (update-in-each [:Platforms] char-data-type-normalization/migrate-platform-characteristics-data-type)))
+        (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/characteristics_data_type_normalization.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/characteristics_data_type_normalization.clj
@@ -29,10 +29,10 @@
 (defn normalize-data-type
   "Migrate the Charateristics' data type from string to enum."
   [characteristics]
-  (when-let [data-type (:DataType characteristics)]
-    (let [upper-case-data-type (string/upper-case data-type)]
-       (assoc characteristics :DataType 
-         (get upper-case-string-to-enum-mapping upper-case-data-type umm-spec-util/STRING)))))
+  (let [data-type (:DataType characteristics)
+        upper-case-data-type (string/upper-case data-type)]
+    (assoc characteristics :DataType 
+      (get upper-case-string-to-enum-mapping upper-case-data-type umm-spec-util/STRING))))
 
 (defn update-each-characteristics
   "Update all the characteristics in a given element: platform/instrument/child instrument."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -10,9 +10,9 @@
     [cmr.umm-spec.date-util :as date]
     [cmr.umm-spec.dif-util :as dif-util]
     [cmr.umm-spec.json-schema :as js]
-    [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
     [cmr.umm-spec.url :as url]
     [cmr.umm-spec.util :as su :refer [without-default-value-of]]
+    [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
     [cmr.umm-spec.xml-to-umm-mappings.dif10.additional-attribute :as aa]
     [cmr.umm-spec.xml-to-umm-mappings.dif10.data-center :as center]
     [cmr.umm-spec.xml-to-umm-mappings.dif10.data-contact :as contact]
@@ -31,7 +31,7 @@
 (defn- parse-characteristics
   [el]
   (seq (remove nil? 
-         (map char-data-type-normalization/migrate-data-type
+         (map char-data-type-normalization/normalize-data-type
            (for [characteristic (select el "Characteristics")]
              (fields-from characteristic :Name :Description :DataType :Unit :Value))))))
 

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -31,9 +31,10 @@
 (defn- parse-characteristics
   [el]
   (seq (remove nil? 
-         (map char-data-type-normalization/normalize-data-type
-           (for [characteristic (select el "Characteristics")]
-             (fields-from characteristic :Name :Description :DataType :Unit :Value))))))
+    (map char-data-type-normalization/normalize-data-type
+      (remove nil?
+        (for [characteristic (select el "Characteristics")]
+          (fields-from characteristic :Name :Description :DataType :Unit :Value)))))))
 
 (defn- parse-projects-impl
   [doc sanitize?]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -46,9 +46,10 @@
 (defn parse-characteristics
   "Returns a seq of UMM characteristic records from the element's child Characteristics."
   [el]
-  (seq (remove nil?
-         (map (comp char-data-type-normalization/normalize-data-type parse-characteristic)
-              (select el "Characteristics/Characteristic")))))
+  (let [elements (select el "Characteristics/Characteristic")
+        parsed-characteristics (remove nil? (map parse-characteristic elements))] 
+    (seq (remove nil?
+           (map char-data-type-normalization/normalize-data-type parsed-characteristics)))))
 
 (defn parse-sensor
   "Returns a UMM Sensor record from an ECHO10 Sensor element."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -9,8 +9,8 @@
    [cmr.umm-spec.date-util :as date]
    [cmr.umm-spec.json-schema :as js]
    [cmr.umm-spec.location-keywords :as lk]
-   [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.util :as u]
+   [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.data-contact :as dc]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.related-url :as ru]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.spatial :as spatial]
@@ -47,7 +47,7 @@
   "Returns a seq of UMM characteristic records from the element's child Characteristics."
   [el]
   (seq (remove nil?
-         (map (comp char-data-type-normalization/migrate-data-type parse-characteristic)
+         (map (comp char-data-type-normalization/normalize-data-type parse-characteristic)
               (select el "Characteristics/Characteristic")))))
 
 (defn parse-sensor

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/characteristics_and_operationalmodes.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/characteristics_and_operationalmodes.clj
@@ -4,7 +4,7 @@
     [cmr.common.xml.parse :refer :all]
     [cmr.common.xml.simple-xpath :refer [select text]]
     [cmr.umm-spec.iso19115-2-util :refer [char-string-value]]
-    [cmr.umm-spec.migration.characteristics-data-type-normalization :as char-data-type-normalization]))
+    [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]))
 
 (def characteristics-and-operationalmodes-xpath
   "eos:otherProperty/gco:Record/eos:AdditionalAttributes/eos:AdditionalAttribute")
@@ -17,7 +17,7 @@
   [element]
   (seq 
     (remove nil?
-      (map char-data-type-normalization/migrate-data-type 
+      (map char-data-type-normalization/normalize-data-type 
         (for [chars (select element characteristics-and-operationalmodes-xpath)]
           (when-not (= "OperationalMode" (char-string-value chars (str pc-attr-base-path "/eos:name")))
             {:Name        (char-string-value chars (str pc-attr-base-path "/eos:name"))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/characteristics_and_operationalmodes.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/characteristics_and_operationalmodes.clj
@@ -15,16 +15,16 @@
 (defn parse-characteristics
   "Returns the parsed characteristics from the element."
   [element]
-  (seq 
-    (remove nil?
-      (map char-data-type-normalization/normalize-data-type 
+  (seq (remove nil?
+    (map char-data-type-normalization/normalize-data-type 
+      (remove nil?
         (for [chars (select element characteristics-and-operationalmodes-xpath)]
           (when-not (= "OperationalMode" (char-string-value chars (str pc-attr-base-path "/eos:name")))
             {:Name        (char-string-value chars (str pc-attr-base-path "/eos:name"))
              :Description (char-string-value chars (str pc-attr-base-path "/eos:description"))
              :DataType    (value-of chars (str pc-attr-base-path "/eos:dataType/eos:EOS_AdditionalAttributeDataTypeCode"))
              :Unit        (char-string-value chars (str pc-attr-base-path "/eos:parameterUnitsOfMeasure"))
-             :Value       (char-string-value chars (str "eos:value"))}))))))
+             :Value       (char-string-value chars (str "eos:value"))})))))))
 
 (defn parse-operationalmodes
   "Returns the parsed operationalmodes from the element."

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1342,8 +1342,7 @@
                                                             :Description "Is that necessary?"
                                                             :DataType "randomstring"
                                                             :Unit "dB"
-                                                            :Value "10"}
-                                                            nil]
+                                                            :Value "10"}]
                                          :ComposedOf [{:ShortName "ABC"
                                                        :LongName "Long Range Sensor"
                                                        :Characteristics [{:Name "Signal to Noise Ratio"


### PR DESCRIPTION
This is doing some cleanup after the merge for CMR-3366 
1. Moved the characteristics_data_type_normalization.clj from migration folder to xml_to_umm_mappings directory.
2. Removed the when-let [datatype (:DataType characteristics}] guard and clean up the code so that it won't produce any nil characteristics in the characteristics array.