### PR TITLE
CMR-4300 

### DIFF
--- a/index-set-app/src/cmr/index_set/services/index_service.clj
+++ b/index-set-app/src/cmr/index_set/services/index_service.clj
@@ -17,7 +17,7 @@
   (:import clojure.lang.ExceptionInfo))
 
 ;; configured list of cmr concepts
-(def concept-types [:collection :granule :tag :variable])
+(def concept-types [:collection :granule :deleted-granule :tag :variable])
 
 (defn context->es-store
   [context]

--- a/index-set-app/test/cmr/index_set/test/services/index_service_test.clj
+++ b/index-set-app/test/cmr/index_set/test/services/index_service_test.clj
@@ -29,5 +29,6 @@
                                                :C4-PROV3 "3_c4_prov3"
                                                :C5-PROV5 "3_c5_prov5"}
                                      :tag {}
-                                     :variable {}}}]
+                                     :variable {}
+                                     :deleted-granule {}}}]
     (is (= pruned-index-set (svc/prune-index-set (:index-set util/sample-index-set))))))

--- a/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
@@ -5,7 +5,7 @@
 
 (def deleted-granule-index-name
   "The name of the index in elastic search."
-  "deleted-granules")
+  "1_deleted_granules")
 
 (def deleted-granule-type-name
   "The name of the mapping type within the cubby elasticsearch index."
@@ -25,7 +25,7 @@
   (let [{:keys [concept-id provider-id extra-fields revision-date]} concept
         {:keys [granule-ur parent-collection-id]} extra-fields]
     {:concept-id concept-id
-     :delete-time revision-date
+     :revision-date revision-date
      :provider-id provider-id
      :granule-ur granule-ur
      :parent-collection-id parent-collection-id}))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -439,7 +439,7 @@
 (defmapping deleted-granule-mapping :deleted-granule
   "Defines the elasticsearch mapping for storing granules"
   {:concept-id (-> m/string-field-mapping m/stored m/doc-values)
-   :delete-time (-> m/date-field-mapping m/stored m/doc-values)
+   :revision-date (-> m/date-field-mapping m/stored m/doc-values)
    :provider-id (-> m/string-field-mapping m/stored m/doc-values)
    :granule-ur (-> m/string-field-mapping m/stored m/doc-values)
    :parent-collection-id (-> m/string-field-mapping m/stored m/doc-values)})
@@ -662,7 +662,7 @@
                               :settings collection-setting-v1}]
                             :mapping collection-mapping}
                :deleted-granule {:indexes
-                                 [{:name "deleted-granules"
+                                 [{:name "deleted_granules"
                                    :settings deleted-granule-setting}]
                                  :mapping deleted-granule-mapping}
                :granule {:indexes

--- a/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
+++ b/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
@@ -14,7 +14,7 @@
                            {:name "all-collection-revisions",
                             :settings i/collection-setting-v1},]
                  :mapping i/collection-mapping},
-    :deleted-granule {:indexes [{:name "deleted-granules",
+    :deleted-granule {:indexes [{:name "deleted_granules",
                                  :settings i/deleted-granule-setting}]
                       :mapping i/deleted-granule-mapping}
     :granule {:indexes

--- a/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
@@ -3,6 +3,7 @@
    This namespace tests that functionality"
   (:require
    [clojure.test :refer :all]
+   [cmr.indexer.data.concepts.deleted-granule :as deleted-granule]
    [cmr.metadata-db.services.concept-service :as concept-service]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
@@ -18,7 +19,9 @@
   "Check elastic search deleted-granules index from related deleted granule entry,
    Returns true if document exists, false if it does not."
   [concept-id]
-  (index/doc-present? "deleted-granules" "deleted-granule" concept-id))
+  (index/doc-present? deleted-granule/deleted-granule-index-name
+                      deleted-granule/deleted-granule-type-name
+                      concept-id))
 
 (deftest deleted-granules-test
   (testing "Ingest granule, delete, then reingest"


### PR DESCRIPTION
This PR is a front runner to the full solution for CMR-4300.  Its needed as a backport to prevent the current functionality from going to UAT tomorrow.  Currently the deleted-granules index is not being created, but instead a dynamically created index is created on index of a deleted-granule document, which breaks the mapping.
