### PR TITLE
CMR-3365 Convert VerticalSpatialDomainType to an enum

### DIFF
--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
@@ -1275,9 +1275,7 @@
       "properties": {
         "Type": {
           "description": "Describes the type of the area of vertical space covered by the collection locality.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 80
+          "$ref": "#/definitions/VerticalSpatialDomainTypeEnum"
         },
         "Value": {
           "description": "Describes the extent of the area of vertical space covered by the collection. Must be accompanied by an Altitude Encoding Method description. The datatype for this attribute is the value of the attribute VerticalSpatialDomainType. The unit for this attribute is the value of either DepthDistanceUnits or AltitudeDistanceUnits.",
@@ -1507,6 +1505,10 @@
       "type": "number",
       "minimum": -180,
       "maximum": 180
+    },
+    "VerticalSpatialDomainTypeEnum": {
+      "type": "string",
+      "enum": ["Atmosphere Layer", "Maximum Altitude", "Maximum Depth", "Minimum Altitude", "Minimum Depth"]
     },
     "GranuleSpatialRepresentationEnum": {
       "type": "string",

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
@@ -294,7 +294,7 @@
       distance-units-migration/migrate-distance-units-to-enum
       ;; Remove the possible empty maps after setting geographic coordinate units and/or distance-units to nil.
       util/remove-empty-maps
-      (update :VerticalSpatialDomains spatial-conversion/drop-invalid-vertical-spatial-domains)
+      (update-in [:SpatialExtent :VerticalSpatialDomains] spatial-conversion/drop-invalid-vertical-spatial-domains)
       char-data-type-normalization/migrate-up))
 
 (defmethod migrate-umm-version [:collection "1.10" "1.9"]

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
@@ -294,6 +294,7 @@
       distance-units-migration/migrate-distance-units-to-enum
       ;; Remove the possible empty maps after setting geographic coordinate units and/or distance-units to nil.
       util/remove-empty-maps
+      (update :VerticalSpatialDomains spatial-conversion/drop-invalid-vertical-spatial-domains)
       char-data-type-normalization/migrate-up))
 
 (defmethod migrate-umm-version [:collection "1.10" "1.9"]

--- a/umm-spec-lib/src/cmr/umm_spec/spatial_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/spatial_conversion.clj
@@ -2,9 +2,9 @@
   "Defines functions that convert umm spec spatial types to spatial lib spatial shapes."
   (:require
    [clojure.string :as string]
+   [cmr.common.xml.parse :as xml-parse]
    [cmr.spatial.line-string :as ls]
    [cmr.spatial.mbr :as mbr]
-   [cmr.common.xml.parse :as xml-parse]
    [cmr.spatial.point :as point]
    [cmr.spatial.polygon :as poly]
    [cmr.spatial.ring-relations :as rr]))
@@ -44,6 +44,7 @@
                            tiling-identification-systems)]
     (when-not (empty? tiling-id-systems)
       tiling-id-systems)))
+
 (def valid-vertical-spatial-domain-types
   "Valid values for VerticalSpatialDomainType according to UMM spec v1.10.0"
   ["Atmosphere Layer"
@@ -52,33 +53,20 @@
    "Minimum Altitude"
    "Minimum Depth"])
 
-(def squished-valid-vertical-spatial-domain-types
-  "Valid values for VerticalSpatialDomainType. Split and joined by \"\" to make
-   validation easier. DIF10 values are separated by `_` and all others are separated
-   by spaces."
-  ["AtmosphereLayer"
-   "MaximumAltitude"
-   "MaximumDepth"
-   "MinimumAltitude"
-   "MinimumDepth"])
-
 (defn vertical-spatial-domain-type-is-valid?
   "Return true or false based on whether or not the given value matches
    one of the valid values in valid-vertical-spatial-domain-types."
   [vs-domain-type]
-  (let [squished-vs-domain-type (-> vs-domain-type
-                                    (string/split #"( |_)")
-                                    string/join)]
-   (some #(= squished-vs-domain-type %) squished-valid-vertical-spatial-domain-types)))
+  (some #(= vs-domain-type %) valid-vertical-spatial-domain-types))
 
 (defn drop-invalid-vertical-spatial-domains
   "Any VerticalSpatialDomain with a Type not in valid-vertical-spatial-domain-types
    is not considered valid according to UMM spec v1.10.0 and should be dropped.
    This behavior will eventually generate errors"
   [vertical-spatial-domains]
-  (filter
-   #(vertical-spatial-domain-type-is-valid? (:Type %))
-   vertical-spatial-domains))
+  (seq (filter
+         #(vertical-spatial-domain-type-is-valid? (:Type %))
+         vertical-spatial-domains)))
 
 (defn convert-vertical-spatial-domains-from-xml
   "Given a name to key into an xml file, extract Vertical Spatial Domains
@@ -86,6 +74,7 @@
   [vertical-spatial-domains]
   (->> vertical-spatial-domains
        (map #(xml-parse/fields-from % :Type :Value))
+       (map #(update % :Type (fn [x] (string/replace x "_" " "))))
        drop-invalid-vertical-spatial-domains))
 
 (defn boundary->ring

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -93,6 +93,7 @@
         spatial-extent)
       (update-in [:HorizontalSpatialDomain :Geometry] conversion-util/geometry-with-coordinate-system)
       (update-in-each [:HorizontalSpatialDomain :Geometry :GPolygons] conversion-util/fix-echo10-dif10-polygon)
+      (update [:VerticalSpatialDomains] spatial-conversion/drop-invalid-vertical-spatial-domains)
       conversion-util/prune-empty-maps))
 
 (defn- expected-dif10-contact-mechanisms

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -111,11 +111,11 @@
   "Returns the expected ECHO10 SpatialExtent for comparison with the umm model."
   [spatial-extent]
  (as-> spatial-extent se
-     (conversion-util/prune-empty-maps se)
-     (update se :VerticalSpatialDomains spatial-conversion/drop-invalid-vertical-spatial-domains)
-     (if (get-in se [:HorizontalSpatialDomain :Geometry])
-       (update-in se [:HorizontalSpatialDomain :Geometry] conversion-util/geometry-with-coordinate-system)
-       se)))
+       (conversion-util/prune-empty-maps se)
+       (update se :VerticalSpatialDomains spatial-conversion/drop-invalid-vertical-spatial-domains)
+       (if (get-in se [:HorizontalSpatialDomain :Geometry])
+         (update-in se [:HorizontalSpatialDomain :Geometry] conversion-util/geometry-with-coordinate-system)
+         se)))
 
 (defn- expected-echo10-platform-longname-with-default-value
   "Returns the expected ECHO10 LongName with default value."

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -110,12 +110,12 @@
 (defn- expected-echo10-spatial-extent
   "Returns the expected ECHO10 SpatialExtent for comparison with the umm model."
   [spatial-extent]
-  (let [spatial-extent (conversion-util/prune-empty-maps spatial-extent)]
-    (if (get-in spatial-extent [:HorizontalSpatialDomain :Geometry])
-      (update-in spatial-extent
-                 [:HorizontalSpatialDomain :Geometry]
-                 conversion-util/geometry-with-coordinate-system)
-      spatial-extent)))
+ (as-> spatial-extent se
+     (conversion-util/prune-empty-maps se)
+     (update se :VerticalSpatialDomains spatial-conversion/drop-invalid-vertical-spatial-domains)
+     (if (get-in se [:HorizontalSpatialDomain :Geometry])
+       (update-in se [:HorizontalSpatialDomain :Geometry] conversion-util/geometry-with-coordinate-system)
+       se)))
 
 (defn- expected-echo10-platform-longname-with-default-value
   "Returns the expected ECHO10 LongName with default value."

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
@@ -71,9 +71,9 @@
                     :HorizontalSpatialDomain {:ZoneIdentifier "Danger Zone"
                                                :Geometry {:CoordinateSystem "GEODETIC"
                                                           :BoundingRectangles [{:NorthBoundingCoordinate 45.0 :SouthBoundingCoordinate -81.0 :WestBoundingCoordinate 25.0 :EastBoundingCoordinate 30.0}]}}
-                    :VerticalSpatialDomains [{:Type "Some kind of type"
+                    :VerticalSpatialDomains [{:Type "Atmosphere Layer"
                                               :Value "Some kind of value"}
-                                             {:Type "Some kind of type2"
+                                             {:Type "Maximum Depth"
                                               :Value "Some kind of value2"}]
                     :OrbitParameters {:SwathWidth 2.0
                                       :Period 96.7

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -23,8 +23,8 @@
     [cmr.umm-spec.url :as url]
     [cmr.umm-spec.util :as su]
     [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
-    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as xml-to-umm-data-contact]
-    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]))
+    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
+    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as xml-to-umm-data-contact]))
 
 (defn- propagate-first
   "Returns coll with the first element's value under k assoc'ed to each element in coll.
@@ -330,6 +330,8 @@
       (assoc :DirectoryNames nil)
       fix-bounding-rectangles
       (update :SpatialExtent update-iso-spatial)
+      (update-in [:SpatialExtent :VerticalSpatialDomains]
+                 spatial-conversion/drop-invalid-vertical-spatial-domains)
       (update :TemporalExtents expected-iso-19115-2-temporal)
       (update :DataDates expected-iso19115-data-dates)
       (update :DataLanguage #(or % "eng"))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -294,9 +294,10 @@
    be compared to the actual translation."
   [umm-coll]
   (-> umm-coll
-<<<<<<< HEAD
       (assoc :DirectoryNames nil)
       (update-in [:SpatialExtent] expected-smap-iso-spatial-extent)
+      (update-in [:SpatialExtent :VerticalSpatialDomains]
+                 spatial-conversion/drop-invalid-vertical-spatial-domains)
       (update-in [:DataDates] expected-smap-data-dates)
       (update :DataLanguage #(or % "eng"))
       (update :TemporalExtents expected-temporal)
@@ -327,37 +328,3 @@
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)))
-=======
-        (assoc :DirectoryNames nil)
-        (update-in [:SpatialExtent] expected-smap-iso-spatial-extent)
-        (update-in [:SpatialExtent :VerticalSpatialDomains]
-                   spatial-conversion/drop-invalid-vertical-spatial-domains)
-        (update-in [:DataDates] expected-smap-data-dates)
-        (update :DataLanguage #(or % "eng"))
-        (update :TemporalExtents expected-temporal)
-        (assoc :MetadataAssociations nil) ;; Not supported for ISO SMAP
-        (update :ISOTopicCategories iso-shared/expected-iso-topic-categories)
-        (update :DataCenters expected-data-centers)
-        (assoc :VersionDescription nil)
-        (assoc :ContactGroups nil)
-        (assoc :ContactPersons (expected-contact-persons
-                                 (iso-shared/update-contact-persons-from-collection-citation
-                                   (:ContactPersons umm-coll)
-                                   (iso-shared/trim-collection-citation (first (:CollectionCitations umm-coll))))
-                                 "Technical Contact"))
-        (update :CollectionCitations expected-collection-citations)
-        (assoc :UseConstraints nil)
-        (assoc :AccessConstraints nil)
-        (assoc :SpatialKeywords nil)
-        (assoc :TemporalKeywords nil)
-        (assoc :AdditionalAttributes nil)
-        (update :ProcessingLevel su/convert-empty-record-to-nil)
-        (assoc :Distributions nil)
-        (assoc :PublicationReferences nil)
-        (assoc :AncillaryKeywords nil)
-        (update :RelatedUrls expected-iso-smap-related-urls)
-        (update :ScienceKeywords expected-science-keywords)
-        (assoc :PaleoTemporalCoverages nil)
-        (assoc :MetadataDates nil)
-        (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))))
->>>>>>> CMR-3365 Convert VerticalSpatialDomainType to an enum

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -294,6 +294,7 @@
    be compared to the actual translation."
   [umm-coll]
   (-> umm-coll
+<<<<<<< HEAD
       (assoc :DirectoryNames nil)
       (update-in [:SpatialExtent] expected-smap-iso-spatial-extent)
       (update-in [:DataDates] expected-smap-data-dates)
@@ -326,3 +327,37 @@
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)))
+=======
+        (assoc :DirectoryNames nil)
+        (update-in [:SpatialExtent] expected-smap-iso-spatial-extent)
+        (update-in [:SpatialExtent :VerticalSpatialDomains]
+                   spatial-conversion/drop-invalid-vertical-spatial-domains)
+        (update-in [:DataDates] expected-smap-data-dates)
+        (update :DataLanguage #(or % "eng"))
+        (update :TemporalExtents expected-temporal)
+        (assoc :MetadataAssociations nil) ;; Not supported for ISO SMAP
+        (update :ISOTopicCategories iso-shared/expected-iso-topic-categories)
+        (update :DataCenters expected-data-centers)
+        (assoc :VersionDescription nil)
+        (assoc :ContactGroups nil)
+        (assoc :ContactPersons (expected-contact-persons
+                                 (iso-shared/update-contact-persons-from-collection-citation
+                                   (:ContactPersons umm-coll)
+                                   (iso-shared/trim-collection-citation (first (:CollectionCitations umm-coll))))
+                                 "Technical Contact"))
+        (update :CollectionCitations expected-collection-citations)
+        (assoc :UseConstraints nil)
+        (assoc :AccessConstraints nil)
+        (assoc :SpatialKeywords nil)
+        (assoc :TemporalKeywords nil)
+        (assoc :AdditionalAttributes nil)
+        (update :ProcessingLevel su/convert-empty-record-to-nil)
+        (assoc :Distributions nil)
+        (assoc :PublicationReferences nil)
+        (assoc :AncillaryKeywords nil)
+        (update :RelatedUrls expected-iso-smap-related-urls)
+        (update :ScienceKeywords expected-science-keywords)
+        (assoc :PaleoTemporalCoverages nil)
+        (assoc :MetadataDates nil)
+        (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))))
+>>>>>>> CMR-3365 Convert VerticalSpatialDomainType to an enum

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10/spatial.clj
@@ -1,5 +1,6 @@
 (ns cmr.umm-spec.umm-to-xml-mappings.dif10.spatial
   (:require
+   [camel-snake-kebab.core :as csk]
    [cmr.common.xml.gen :refer :all]
    [cmr.umm-spec.util :as u]))
 
@@ -58,6 +59,14 @@
      [:Minimum_Value (:MinimumValue coord)]
      [:Maximum_Value (:MaximumValue coord)]]))
 
+(defn- convert-vertical-spatial-domains
+  "Validate and convert vertical spatial domains to UMM-C v1.10.0"
+  [vertical-spatial-domains]
+  (map
+   (fn [spatial-domain]
+    (update spatial-domain :Type #(csk/->Camel_Snake_Case %)))
+   vertical-spatial-domains))
+
 (defn spatial-element
   "Returns DIF10 Spatial_Coverage element from given UMM-C record."
   [c]
@@ -83,7 +92,7 @@
         [:Inclination_Angle (:InclinationAngle o)]
         [:Number_Of_Orbits (:NumberOfOrbits o)]
         [:Start_Circular_Latitude (:StartCircularLatitude o)]])
-     (for [vert (:VerticalSpatialDomains sp)]
+     (for [vert (convert-vertical-spatial-domains (:VerticalSpatialDomains sp))]
        [:Vertical_Spatial_Info
         (elements-from vert :Type :Value)])
      [:Spatial_Info

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10/spatial.clj
@@ -60,7 +60,7 @@
      [:Maximum_Value (:MaximumValue coord)]]))
 
 (defn- convert-vertical-spatial-domains
-  "Validate and convert vertical spatial domains to UMM-C v1.10.0"
+  "Validate and convert vertical spatial domains to dif10"
   [vertical-spatial-domains]
   (map
    (fn [spatial-domain]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/echo10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/echo10/spatial.clj
@@ -1,6 +1,8 @@
 (ns cmr.umm-spec.umm-to-xml-mappings.echo10.spatial
-  (:require [cmr.common.xml.gen :refer :all]
-            [cmr.umm-spec.util :as u]))
+  (:require
+   [cmr.common.xml.gen :refer :all]
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
+   [cmr.umm-spec.util :as u]))
 
 (defn- point-contents
   "Returns the inner lon/lat elements for an ECHO Point from a UMM PointType
@@ -56,7 +58,8 @@
            (map bounding-rect-element (:BoundingRectangles geom))
            (map polygon-element (:GPolygons geom))
            (map line-element (:Lines geom))])])
-     (for [vert (:VerticalSpatialDomains sp)]
+     (for [vert (spatial-conversion/drop-invalid-vertical-spatial-domains
+                 (:VerticalSpatialDomains sp))]
        [:VerticalSpatialDomain
         (elements-from vert :Type :Value)])
      [:OrbitParameters

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2/spatial.clj
@@ -2,6 +2,7 @@
   "Functions for generating ISO19115-2 XML elements from UMM spatial records."
   (:require
    [camel-snake-kebab.core :as csk]
+   [cmr.common.util :as util]
    [cmr.spatial.derived :as d]
    [cmr.spatial.encoding.gmd :as gmd]
    [cmr.spatial.line-string :as ls]
@@ -10,8 +11,8 @@
    [cmr.spatial.polygon :as poly]
    [cmr.spatial.relations :as r]
    [cmr.spatial.ring-relations :as rr]
-   [cmr.umm.umm-spatial :as umm-s]
-   [cmr.common.util :as util]))
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
+   [cmr.umm.umm-spatial :as umm-s]))
 
 (defn spatial-point
   [umm-point]
@@ -114,7 +115,8 @@
 (defn generate-vertical-domain
   "Returns a geographic element for the vertical domain"
   [c]
-  (when-let [vertical-domains (get-in c [:SpatialExtent :VerticalSpatialDomains])]
+  (when-let [vertical-domains (spatial-conversion/drop-invalid-vertical-spatial-domains
+                               (get-in c [:SpatialExtent :VerticalSpatialDomains]))]
     (for [x (range (count vertical-domains))
            :let [vertical-domain (nth vertical-domains x)]]
       [:gmd:geographicElement

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
@@ -6,6 +6,7 @@
     [cmr.umm-spec.date-util :as du]
     [cmr.umm-spec.iso-keywords :as kws]
     [cmr.umm-spec.iso19115-2-util :as iso]
+    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.spatial :as iso19115-spatial-conversion]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.collection-citation :as collection-citation]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.collection-progress :as collection-progress]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.distributions-related-url :as sdru]
@@ -164,6 +165,7 @@
          [:gmd:extent
           [:gmd:EX_Extent
            (generate-spatial-extent (:SpatialExtent c))
+           (iso19115-spatial-conversion/generate-vertical-domain c)
            (for [temporal (:TemporalExtents c)
                  rdt (:RangeDateTimes temporal)]
              [:gmd:temporalElement

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10/spatial.clj
@@ -56,9 +56,8 @@
      :HorizontalSpatialDomain      (let [[geom] (select spatial "Geometry")]
                                      {:Geometry (parse-geometry geom)
                                       :ZoneIdentifier (value-of spatial "Zone_Identifier")})
-     :VerticalSpatialDomains       (->> (select spatial "Vertical_Spatial_Info")
-                                        spatial-conversion/convert-vertical-spatial-domains-from-xml
-                                        (map #(update % :Type (fn [x] (string/replace x "_" " ")))))
+     :VerticalSpatialDomains       (spatial-conversion/convert-vertical-spatial-domains-from-xml
+                                    (select spatial "Vertical_Spatial_Info"))
      :OrbitParameters              (let [[o] (select spatial "Orbit_Parameters")]
                                      {:SwathWidth (value-of o "Swath_Width")
                                       :Period (value-of o "Period")

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10/spatial.clj
@@ -2,6 +2,7 @@
   "Defines mappings from DIF 10 XML spatial elements into UMM records"
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [cmr.common.xml.parse :refer :all]
    [cmr.common.xml.simple-xpath :refer [select text]]
    [cmr.umm-spec.spatial-conversion :as spatial-conversion]
@@ -55,8 +56,9 @@
      :HorizontalSpatialDomain      (let [[geom] (select spatial "Geometry")]
                                      {:Geometry (parse-geometry geom)
                                       :ZoneIdentifier (value-of spatial "Zone_Identifier")})
-     :VerticalSpatialDomains       (for [vert-elem (select spatial "Vertical_Spatial_Info")]
-                                     (fields-from vert-elem :Type :Value))
+     :VerticalSpatialDomains       (->> (select spatial "Vertical_Spatial_Info")
+                                        spatial-conversion/convert-vertical-spatial-domains-from-xml
+                                        (map #(update % :Type (fn [x] (string/replace x "_" " ")))))
      :OrbitParameters              (let [[o] (select spatial "Orbit_Parameters")]
                                      {:SwathWidth (value-of o "Swath_Width")
                                       :Period (value-of o "Period")

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/spatial.clj
@@ -1,9 +1,11 @@
 (ns cmr.umm-spec.xml-to-umm-mappings.echo10.spatial
   "Defines mappings from ECHO10 XML spatial elements into UMM records"
   (:require
-   [clojure.string :as str]
+   [camel-snake-kebab.internals.misc :as csk-misc]
+   [clojure.string :as string]
    [cmr.common.xml.parse :refer :all]
    [cmr.common.xml.simple-xpath :refer [select text]]
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
    [cmr.umm-spec.util :as u]))
 
 (defn- parse-point
@@ -47,13 +49,13 @@
   [doc sanitize?]
   (if-let [[spatial] (select doc "/Collection/Spatial")]
     {:SpatialCoverageType          (when-let [sct (value-of spatial "SpatialCoverageType")]
-                                     (str/upper-case sct))
+                                     (string/upper-case sct))
      :GranuleSpatialRepresentation (value-of spatial "GranuleSpatialRepresentation")
      :HorizontalSpatialDomain      (let [[horiz] (select spatial "HorizontalSpatialDomain")]
                                      {:ZoneIdentifier (value-of horiz "ZoneIdentifier")
                                       :Geometry       (parse-geometry (first (select horiz "Geometry")))})
-     :VerticalSpatialDomains       (for [vert (select spatial "VerticalSpatialDomain")]
-                                     (fields-from vert :Type :Value))
+     :VerticalSpatialDomains       (spatial-conversion/convert-vertical-spatial-domains-from-xml
+                                    (select spatial "VerticalSpatialDomain"))
      :OrbitParameters              (fields-from (first (select spatial "OrbitParameters"))
                                                 :SwathWidth
                                                 :Period

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2/spatial.clj
@@ -6,6 +6,7 @@
    [cmr.common.xml.simple-xpath :refer [select text]]
    [cmr.spatial.encoding.gmd :as gmd]
    [cmr.umm-spec.iso19115-2-util :as iso]
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.distributions-related-url :as iso-shared-distrib]))
 
 (def coordinate-system-xpath
@@ -93,7 +94,7 @@
     (into {} (for [[k ^String v] (partition 2 (str/split orbit-string #":? "))]
                [(keyword k) (Double/parseDouble v)]))))
 
-(defn- parse-vertical-domains
+(defn parse-vertical-domains
   "Parse the vertical domain from the ISO XML document. Vertical domains are encoded in an ISO XML
   document as a single string like this:
   \"Type: Some type Value: Some value\""
@@ -120,5 +121,6 @@
                                      (when sanitize? "NO_SPATIAL"))
    :HorizontalSpatialDomain {:Geometry (parse-geometry doc extent-info sanitize?)
                              :ZoneIdentifier (value-of doc zone-identifier-xpath)}
-   :VerticalSpatialDomains (parse-vertical-domains doc)
+   :VerticalSpatialDomains (spatial-conversion/drop-invalid-vertical-spatial-domains
+                            (parse-vertical-domains doc))
    :OrbitParameters (parse-orbit-parameters doc)})

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -162,7 +162,7 @@
                             (when sanitize? u/not-provided-temporal-extents))
        :ScienceKeywords (parse-science-keywords data-id-el sanitize?)
        :LocationKeywords (kws/parse-location-keywords data-id-el)
-       :SpatialExtent (spatial/parse-spatial data-id-el sanitize?)
+       :SpatialExtent (spatial/parse-spatial doc data-id-el sanitize?)
        :TilingIdentificationSystems (tiling/parse-tiling-system data-id-el)
        :CollectionDataType (value-of (select doc collection-data-type-xpath) ".")
        ;; Required by UMM-C

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap/spatial.clj
@@ -2,6 +2,8 @@
   "Functions for parsing UMM spatial records out of ISO SMAP XML documents."
   (:require
    [cmr.common.xml.parse :refer :all]
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
+   [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.spatial :as iso-19115-2-spatial]
    [cmr.common.xml.simple-xpath :refer [select]]
    [cmr.umm-spec.util :as su]))
 
@@ -27,11 +29,13 @@
 
 (defn parse-spatial
   "Returns UMM SpatialExtentType map from SMAP ISO data identifier XML document."
-  [data-id-el sanitize?]
+  [doc data-id-el sanitize?]
   (if-let [bounding-rectangles (parse-bounding-rectangles data-id-el)]
     {:SpatialCoverageType "HORIZONTAL"
      :GranuleSpatialRepresentation "GEODETIC"
      :HorizontalSpatialDomain {:Geometry {:CoordinateSystem "GEODETIC"
-                                          :BoundingRectangles bounding-rectangles}}}
+                                          :BoundingRectangles bounding-rectangles}}
+     :VerticalSpatialDomains (spatial-conversion/drop-invalid-vertical-spatial-domains
+                              (iso-19115-2-spatial/parse-vertical-domains doc))}
     (when sanitize?
       su/not-provided-spatial-extent)))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap/spatial.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap/spatial.clj
@@ -2,10 +2,10 @@
   "Functions for parsing UMM spatial records out of ISO SMAP XML documents."
   (:require
    [cmr.common.xml.parse :refer :all]
-   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
-   [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.spatial :as iso-19115-2-spatial]
    [cmr.common.xml.simple-xpath :refer [select]]
-   [cmr.umm-spec.util :as su]))
+   [cmr.umm-spec.spatial-conversion :as spatial-conversion]
+   [cmr.umm-spec.util :as su]
+   [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.spatial :as iso-19115-2-spatial]))
 
 (def bounding-rectangles-xpath-str
   "gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox")

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1520,7 +1520,20 @@
     (is (= "COMPLETE"
          (:CollectionProgress
            (vm/migrate-umm {} :collection "1.9" "1.10"
-                          {:CollectionProgress "COMPLETE"}))))))
+                          {:CollectionProgress "COMPLETE"}))))
+  (testing "VerticalSpatialDomains migration from 1.9.0 to 1.10.0"
+    (let [vsds {:VerticalSpatialDomains [{:Type "An Invalid Type"
+                                          :Value "I can't believe I'm going down for this too"}
+                                         {:Type "Atmosphere Layer"
+                                          :Value "The Earth has one of these"}
+                                         {:Type "Maximum Altitude"
+                                          :Value "There is no limit if you believe -Bob Ross"}]}
+          result (vm/migrate-umm {} :collection "1.9" "1.10" vsds)]
+      (is (= [{:Value "The Earth has one of these", 
+               :Type "Atmosphere Layer"}
+              {:Value "There is no limit if you believe -Bob Ross",
+               :Type "Maximum Altitude"}]
+           (:VerticalSpatialDomains result)))))))
 
 (deftest migrate-1_10-down-to-1_9
   (testing "CollectionProgress migration from version 1.10 to 1.9"

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1522,18 +1522,21 @@
            (vm/migrate-umm {} :collection "1.9" "1.10"
                           {:CollectionProgress "COMPLETE"}))))
   (testing "VerticalSpatialDomains migration from 1.9.0 to 1.10.0"
-    (let [vsds {:VerticalSpatialDomains [{:Type "An Invalid Type"
-                                          :Value "I can't believe I'm going down for this too"}
-                                         {:Type "Atmosphere Layer"
-                                          :Value "The Earth has one of these"}
-                                         {:Type "Maximum Altitude"
-                                          :Value "There is no limit if you believe -Bob Ross"}]}
+    (let [vsds {:SpatialExtent
+                {:VerticalSpatialDomains [{:Type "An Invalid Type"
+                                           :Value "I can't believe I'm going down for this too"}
+                                          {:Type "AtmosphereLayer"
+                                           :Value "I am invalid"}
+                                          {:Type "Atmosphere Layer"
+                                           :Value "The Earth has one of these"}
+                                          {:Type "Maximum Altitude"
+                                           :Value "There is no limit if you believe -Bob Ross"}]}}
           result (vm/migrate-umm {} :collection "1.9" "1.10" vsds)]
-      (is (= [{:Value "The Earth has one of these", 
+      (is (= [{:Value "The Earth has one of these",
                :Type "Atmosphere Layer"}
               {:Value "There is no limit if you believe -Bob Ross",
                :Type "Maximum Altitude"}]
-           (:VerticalSpatialDomains result)))))))
+           (get-in result [:SpatialExtent :VerticalSpatialDomains])))))))
 
 (deftest migrate-1_10-down-to-1_9
   (testing "CollectionProgress migration from version 1.10 to 1.9"


### PR DESCRIPTION
There is still some cleanup that needs to be done (mostly just moving stuff into an iso-shared/spatial.clj file), as well as a rebase but I wanted the chance to get eyes on this