### PR TITLE
CMR-3365 update var and service schemas, add case insensitivity

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -120,6 +120,16 @@
   [v]
   (when v (str/upper-case v)))
 
+(defn match-enum-case
+  "Given a string and a collection of valid enum values, return the proper-cased
+   value from the enum. The values will not differ, but this ensures that the
+   one returned is the proper case, even if that is a crazy mix"
+  [value enum-values]
+  (->> enum-values
+       (filter #(re-matches (re-pattern (str "(?i)" value)) %))
+       seq
+       first))
+
 (defn sequence->fn
   [vals]
   "Creates a stateful function that returns individual values from the

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.0/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.0/umm-cmn-json-schema.json
@@ -863,7 +863,7 @@
         },
         "DataType": {
           "description": "The datatype of the Characteristic/attribute.",
-          "$ref": "#/definitions/DataTypeEnum" 
+          "$ref": "#/definitions/DataTypeEnum"
         }
       },
       "required": ["Name", "Description", "DataType", "Unit", "Value"]
@@ -1275,9 +1275,7 @@
       "properties": {
         "Type": {
           "description": "Describes the type of the area of vertical space covered by the collection locality.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 80
+          "$ref": "#/definitions/VerticalSpatialDomainTypeEnum"
         },
         "Value": {
           "description": "Describes the extent of the area of vertical space covered by the collection. Must be accompanied by an Altitude Encoding Method description. The datatype for this attribute is the value of the attribute VerticalSpatialDomainType. The unit for this attribute is the value of either DepthDistanceUnits or AltitudeDistanceUnits.",
@@ -1322,8 +1320,7 @@
       "description": "Information about a two-dimensional tiling system related to this collection.",
       "properties": {
         "TilingIdentificationSystemName": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/TilingIdentificationSystemNameEnum"
         },
         "Coordinate1": {
           "$ref": "#/definitions/TilingCoordinateType"
@@ -1509,6 +1506,10 @@
       "minimum": -180,
       "maximum": 180
     },
+    "VerticalSpatialDomainTypeEnum": {
+      "type": "string",
+      "enum": ["Atmosphere Layer", "Maximum Altitude", "Maximum Depth", "Minimum Altitude", "Minimum Depth"]
+    },
     "GranuleSpatialRepresentationEnum": {
       "type": "string",
       "enum": ["CARTESIAN", "GEODETIC", "ORBIT", "NO_SPATIAL"]
@@ -1549,6 +1550,10 @@
     "GetDataTypeFormatEnum": {
       "type": "string",
       "enum": ["ascii", "binary", "GRIB", "BUFR", "HDF4", "HDF5", "HDF-EOS4", "HDF-EOS5", "jpeg", "png", "tiff", "geotiff", "kml", "Not provided"]
+    },
+    "TilingIdentificationSystemNameEnum": {
+       "type": "string",
+       "enum": ["CALIPSO", "MISR", "MODIS Tile EASE", "MODIS Tile SIN", "WELD Alaska Tile", "WELD CONUS Tile", "WRS-1", "WRS-2"]
     }
   }
 }

--- a/umm-spec-lib/resources/json-schemas/variable/umm/v1.0/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/variable/umm/v1.0/umm-cmn-json-schema.json
@@ -863,7 +863,7 @@
         },
         "DataType": {
           "description": "The datatype of the Characteristic/attribute.",
-          "$ref": "#/definitions/DataTypeEnum" 
+          "$ref": "#/definitions/DataTypeEnum"
         }
       },
       "required": ["Name", "Description", "DataType", "Unit", "Value"]
@@ -1275,9 +1275,7 @@
       "properties": {
         "Type": {
           "description": "Describes the type of the area of vertical space covered by the collection locality.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 80
+          "$ref": "#/definitions/VerticalSpatialDomainTypeEnum"
         },
         "Value": {
           "description": "Describes the extent of the area of vertical space covered by the collection. Must be accompanied by an Altitude Encoding Method description. The datatype for this attribute is the value of the attribute VerticalSpatialDomainType. The unit for this attribute is the value of either DepthDistanceUnits or AltitudeDistanceUnits.",
@@ -1508,6 +1506,10 @@
       "minimum": -180,
       "maximum": 180
     },
+    "VerticalSpatialDomainTypeEnum": {
+      "type": "string",
+      "enum": ["Atmosphere Layer", "Maximum Altitude", "Maximum Depth", "Minimum Altitude", "Minimum Depth"]
+    },
     "GranuleSpatialRepresentationEnum": {
       "type": "string",
       "enum": ["CARTESIAN", "GEODETIC", "ORBIT", "NO_SPATIAL"]
@@ -1550,8 +1552,8 @@
       "enum": ["ascii", "binary", "GRIB", "BUFR", "HDF4", "HDF5", "HDF-EOS4", "HDF-EOS5", "jpeg", "png", "tiff", "geotiff", "kml", "Not provided"]
     },
     "TilingIdentificationSystemNameEnum": {
-      "type": "string",
-      "enum": ["CALIPSO", "MISR", "MODIS Tile EASE", "MODIS Tile SIN", "WELD Alaska Tile", "WELD CONUS Tile", "WRS-1", "WRS-2"]
+       "type": "string",
+       "enum": ["CALIPSO", "MISR", "MODIS Tile EASE", "MODIS Tile SIN", "WELD Alaska Tile", "WELD CONUS Tile", "WRS-1", "WRS-2"]
     }
   }
 }

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version_migration.clj
@@ -245,17 +245,6 @@
      (dissoc :ComposedOf)
      (dissoc :NumberOfInstruments)))
 
-(defn migrate-tiling-identification-systems
-  "Migrate TilingIdentificationSystems from 1.9 up to 1.10
-   If a TilingIdentificationSystemName is not valid, the entire
-   TilingIdentificationSystem will be dropped."
-  [collection]
-  (let [tiling-id-systems (filter
-                           #(spatial-conversion/tile-id-system-name-is-valid?
-                             (:TilingIdentificationSystemName %))
-                           (:TilingIdentificationSystems collection))]
-   (assoc collection :TilingIdentificationSystems (seq tiling-id-systems))))
-
 (defmethod migrate-umm-version [:collection "1.8" "1.9"]
   [context c & _]
   (-> c
@@ -285,7 +274,7 @@
 (defmethod migrate-umm-version [:collection "1.9" "1.10"]
   [context c & _]
   (-> c
-      migrate-tiling-identification-systems
+      (update :TilingIdentificationSystems spatial-conversion/filter-and-translate-tiling-id-systems)
       coll-progress-migration/migrate-up
       (update-in-each [:TemporalExtents] dissoc :TemporalRangeType)
       (update-in [:SpatialInformation :VerticalCoordinateSystem :AltitudeSystemDefinition] dissoc :EncodingMethod)

--- a/umm-spec-lib/src/cmr/umm_spec/spatial_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/spatial_conversion.clj
@@ -2,6 +2,7 @@
   "Defines functions that convert umm spec spatial types to spatial lib spatial shapes."
   (:require
    [clojure.string :as string]
+   [cmr.common.util :as util]
    [cmr.common.xml.parse :as xml-parse]
    [cmr.spatial.line-string :as ls]
    [cmr.spatial.mbr :as mbr]
@@ -20,11 +21,15 @@
    "WRS-1"
    "WRS-2"])
 
+(def upcase-valid-tile-identification-system-names
+  "Upcase values to allow for case-insenitive validation"
+  (map util/safe-uppercase valid-tile-identification-system-names))
+
 (defn tile-id-system-name-is-valid?
   "Return whether or not the given TileIdentificationSystemName is one of the
    valid-tile-identification-system-names"
   [tile-system-id-name]
-  (some #(= tile-system-id-name %) valid-tile-identification-system-names))
+  (some #(= (util/safe-uppercase tile-system-id-name) %) upcase-valid-tile-identification-system-names))
 
 (defn translate-tile-id-system-name
   "Return nil or equivalent value if the given name does not match any
@@ -53,11 +58,16 @@
    "Minimum Altitude"
    "Minimum Depth"])
 
+(def upcase-valid-vertical-spatial-domain-types
+  "Upcase values to allow for case-insenitive validation"
+  (map util/safe-uppercase valid-vertical-spatial-domain-types))
+
 (defn vertical-spatial-domain-type-is-valid?
   "Return true or false based on whether or not the given value matches
    one of the valid values in valid-vertical-spatial-domain-types."
   [vs-domain-type]
-  (some #(= vs-domain-type %) valid-vertical-spatial-domain-types))
+  (some #(= (util/safe-uppercase vs-domain-type) %)
+        upcase-valid-vertical-spatial-domain-types))
 
 (defn drop-invalid-vertical-spatial-domains
   "Any VerticalSpatialDomain with a Type not in valid-vertical-spatial-domain-types

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1527,9 +1527,9 @@
                                            :Value "I can't believe I'm going down for this too"}
                                           {:Type "AtmosphereLayer"
                                            :Value "I am invalid"}
-                                          {:Type "Atmosphere Layer"
+                                          {:Type "AtMoSphErE LAYER"
                                            :Value "The Earth has one of these"}
-                                          {:Type "Maximum Altitude"
+                                          {:Type "MaximuM Altitude"
                                            :Value "There is no limit if you believe -Bob Ross"}]}}
           result (vm/migrate-umm {} :collection "1.9" "1.10" vsds)]
       (is (= [{:Value "The Earth has one of these",
@@ -1573,7 +1573,7 @@
                                             :MaximumValue 20}
                               :Coordinate2 {:MinimumValue 11
                                             :MaximumValue 20}}
-                            {:TilingIdentificationSystemName "CALIPSO"
+                            {:TilingIdentificationSystemName "cALIpSO"
                               :Coordinate1 {:MinimumValue 1
                                             :MaximumValue 10}}
                             {:TilingIdentificationSystemName "MODIS Tile EASE"
@@ -1582,10 +1582,9 @@
                             {:TilingIdentificationSystemName "WRS-1"
                               :Coordinate1 {:MinimumValue 1
                                             :MaximumValue 10}}]}
-        result (vm/migrate-umm {} :collection "1.9" "1.10" tiling-id-systems)
-        other-result (vm/migrate-tiling-identification-systems tiling-id-systems)]
+        result (vm/migrate-umm {} :collection "1.9" "1.10" tiling-id-systems)]
     (is (= (:TilingIdentificationSystems result)
-           [{:TilingIdentificationSystemName "misr",
+           [{:TilingIdentificationSystemName "MISR",
              :Coordinate1 {:MinimumValue 1, :MaximumValue 10},
              :Coordinate2 {:MinimumValue 1, :MaximumValue 10}}
             {:TilingIdentificationSystemName "CALIPSO",

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version_migration.clj
@@ -1353,39 +1353,39 @@
                                                        :Technique "Drunken Fist"}]}]}]})))))
   (testing "GeographicCoordinateUnits migration from version 1.9 to 1.10"
     (is (= {:HorizontalCoordinateSystem
-           {:GeographicCoordinateSystem 
+           {:GeographicCoordinateSystem
             {:GeographicCoordinateUnits "Decimal Degrees"}}}
        (:SpatialInformation
          (vm/migrate-umm {} :collection "1.9" "1.10"
                          {:SpatialInformation
                            {:HorizontalCoordinateSystem
-                             {:GeographicCoordinateSystem 
+                             {:GeographicCoordinateSystem
                                {:GeographicCoordinateUnits "Decimal degrees"}}}}))))
     (is (= {:HorizontalCoordinateSystem
-           {:GeographicCoordinateSystem 
+           {:GeographicCoordinateSystem
             {:GeographicCoordinateUnits "Kilometers"}}}
        (:SpatialInformation
          (vm/migrate-umm {} :collection "1.9" "1.10"
                          {:SpatialInformation
                            {:HorizontalCoordinateSystem
-                             {:GeographicCoordinateSystem 
+                             {:GeographicCoordinateSystem
                                {:GeographicCoordinateUnits "kiLometers"}}}}))))
     (is (= {:HorizontalCoordinateSystem
-           {:GeographicCoordinateSystem 
+           {:GeographicCoordinateSystem
             {:GeographicCoordinateUnits "Meters"}}}
        (:SpatialInformation
          (vm/migrate-umm {} :collection "1.9" "1.10"
                          {:SpatialInformation
                            {:HorizontalCoordinateSystem
-                             {:GeographicCoordinateSystem 
+                             {:GeographicCoordinateSystem
                                {:GeographicCoordinateUnits "mEters"}}}}))))
-    (is (= nil 
+    (is (= nil
        (:SpatialInformation
          (vm/migrate-umm {} :collection "1.9" "1.10"
                          {:SpatialInformation
                            {:HorizontalCoordinateSystem
-                             {:GeographicCoordinateSystem 
-                               {:GeographicCoordinateUnits "randomstring"}}}}))))) 
+                             {:GeographicCoordinateSystem
+                               {:GeographicCoordinateUnits "randomstring"}}}})))))
   (testing "DistanceUnits migration from version 1.9 to 1.10"
     (is (= {:VerticalCoordinateSystem
            {:AltitudeSystemDefinition {:DistanceUnits "HectoPascals"}
@@ -1448,7 +1448,7 @@
                            {:VerticalCoordinateSystem
                              {:AltitudeSystemDefinition {:DistanceUnits "kiLOmeters"}
                               :DepthSystemDefinition {:DistanceUnits "randomstring"}}}}))))
-    (is (= nil 
+    (is (= nil
        (:SpatialInformation
          (vm/migrate-umm {} :collection "1.9" "1.10"
                          {:SpatialInformation
@@ -1563,7 +1563,7 @@
 
 (deftest migrate-1-9-tiling-identification-systems-to-1-10
   (let [tiling-id-systems {:TilingIdentificationSystems
-                           [{:TilingIdentificationSystemName "MISR"
+                           [{:TilingIdentificationSystemName "misr"
                              :Coordinate1 {:MinimumValue 1
                                            :MaximumValue 10}
                              :Coordinate2 {:MinimumValue 1
@@ -1585,7 +1585,7 @@
         result (vm/migrate-umm {} :collection "1.9" "1.10" tiling-id-systems)
         other-result (vm/migrate-tiling-identification-systems tiling-id-systems)]
     (is (= (:TilingIdentificationSystems result)
-           [{:TilingIdentificationSystemName "MISR",
+           [{:TilingIdentificationSystemName "misr",
              :Coordinate1 {:MinimumValue 1, :MaximumValue 10},
              :Coordinate2 {:MinimumValue 1, :MaximumValue 10}}
             {:TilingIdentificationSystemName "CALIPSO",


### PR DESCRIPTION
This adds the TilingIdentificationSystem and VerticalSpatialDomain Enums to the UMM Var and Service common schema, as well as validate incoming data insensitive to case