### PR TITLE
CMR-4430

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -52,8 +52,11 @@
   [db concepts concept]
   (if-not (:deleted concept)
     concepts
-    (let [variable-associations (variable/get-associations-for-variable-tombstone
-                                 db concept)
+    (let [variable-associations (concepts/find-latest-concepts
+                                 db
+                                 {:provider-id "CMR"}
+                                 {:concept-type :variable-association
+                                  :variable-concept-id (:concept-id concept)})
           tombstones (map (fn [ta] (-> ta
                                        (assoc :metadata "" :deleted true)
                                        (update :revision-id inc)))
@@ -61,8 +64,8 @@
       ;; publish variable-association delete events
       (doseq [tombstone tombstones]
         (ingest-events/publish-event
-          (:context db)
-          (ingest-events/concept-delete-event tombstone)))
+         (:context db)
+         (ingest-events/concept-delete-event tombstone)))
       (concat concepts tombstones))))
 
 (defmethod after-save :default

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -426,8 +426,8 @@
   (fn [context concept]
     (boolean (:deleted concept))))
 
-(defn- delete-associations
-  "Delete the associations that matches the given search params,
+(defn- tombstone-associations
+  "Tombstone the associations that matches the given search params,
   skip-publication? flag controls if association deletion event should be generated,
   skip-publication? true means no association deletion event should be generated."
   [context assoc-type search-params skip-publication?]
@@ -449,7 +449,7 @@
                         :associated-revision-id coll-revision-id
                         :exclude-metadata true
                         :latest true})]
-    (delete-associations context assoc-type search-params true)))
+    (tombstone-associations context assoc-type search-params true)))
 
 (defmulti delete-associated-variable-associations
   "Delete the variable associations associated with the given concept type and concept id."
@@ -473,7 +473,7 @@
                         :exclude-metadata true
                         :latest true})]
     ;; create variable association tombstones and queue the variable association delete events
-    (delete-associations context :variable-association search-params false)))
+    (tombstone-associations context :variable-association search-params false)))
 
 ;; true implies creation of tombstone for the revision
 (defmethod save-concept-revision true

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -585,7 +585,7 @@
         (when (= :collection concept-type)
           ;; delete the related tag associations and variable associations
           (delete-associated-tag-associations context concept-id revision-id)
-          (delete-associated-variable-associations context concept-id revision-id)
+          (delete-associated-variable-associations context concept-type concept-id revision-id)
           (ingest-events/publish-collection-revision-delete-msg context concept-id revision-id))
         (c/force-delete db concept-type provider concept-id revision-id))
       (cmsg/data-error :not-found
@@ -701,7 +701,7 @@
         (doseq [[concept-id revision-id] concept-id-revision-id-tuples]
           ;; delete the related tag associations and variable associations
           (delete-associated-tag-associations context concept-id (long revision-id))
-          (delete-associated-variable-associations context concept-id (long revision-id))
+          (delete-associated-variable-associations context concept-type concept-id (long revision-id))
           (ingest-events/publish-collection-revision-delete-msg context concept-id revision-id)))
       (c/force-delete-concepts db provider concept-type concept-id-revision-id-tuples))))
 


### PR DESCRIPTION
This changed how variable associations are indexed as a result of variable deletion. There is an indexing delay of 5 minutes that only occurs in SIT that this fix fixed. This has been tested in SIT.