### PR TITLE
Fixing CMR-4515 intermittent test failure and fixing the DIF 9

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -77,8 +77,15 @@
   "Returns the expected DIF parsed spatial extent for the given spatial extent."
   [spatial]
   (let [vertical-domains (expected-dif-vertical-domains spatial)
+        horizontal-domains (seq (get-in spatial [:HorizontalSpatialDomain :Geometry :BoundingRectangles]))
+        spatial-coverage (when (or horizontal-domains (not-empty vertical-domains))
+                           (if (and horizontal-domains (not-empty vertical-domains))
+                             "HORIZONTAL_VERTICAL"
+                             (if horizontal-domains
+                               "HORIZONTAL"
+                               "VERTICAL")))
         spatial (-> spatial
-                    (assoc :SpatialCoverageType "HORIZONTAL"
+                    (assoc :SpatialCoverageType spatial-coverage
                            :OrbitParameters nil
                            :VerticalSpatialDomains vertical-domains)
                     (update-in [:HorizontalSpatialDomain] assoc
@@ -88,9 +95,9 @@
                                :Points nil
                                :Lines nil
                                :GPolygons nil))]
-    (if (seq (get-in spatial [:HorizontalSpatialDomain :Geometry :BoundingRectangles]))
+    (if horizontal-domains
       spatial
-      (assoc spatial :SpatialCoverageType nil :HorizontalSpatialDomain nil))))
+      (assoc spatial :HorizontalSpatialDomain nil))))
 
 (defn- expected-dif-contact-mechanisms
   "Returns the expected DIF contact mechanisms"

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9/spatial_extent.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9/spatial_extent.clj
@@ -114,10 +114,15 @@
   (let [horizontal-domain (parse-horizontal-domain doc)
         vertical-domain (parse-vertical-domains doc)]
     (when (or horizontal-domain vertical-domain)
-      (into {}
-            [{:SpatialCoverageType "HORIZONTAL"}
+      (let [spatial-type (if (and horizontal-domain vertical-domain)
+                           "HORIZONTAL_VERTICAL"
+                           (if horizontal-domain
+                             "HORIZONTAL"
+                             "VERTICAL"))]
+        (into {}
+            [{:SpatialCoverageType spatial-type}
              horizontal-domain
-             vertical-domain]))))
+             vertical-domain])))))
 
 (defn parse-spatial-extent
   "Parse the spatial extent from the passed in document. Return the spatial extent record."

--- a/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/dif9/spatial_extent.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/dif9/spatial_extent.clj
@@ -35,7 +35,7 @@
 
 (def expected-full-double-spatial-coverage
   {:GranuleSpatialRepresentation "CARTESIAN"
-   :SpatialCoverageType "HORIZONTAL"
+   :SpatialCoverageType "HORIZONTAL_VERTICAL"
    :HorizontalSpatialDomain
    {:Geometry {:CoordinateSystem "CARTESIAN"
                :BoundingRectangles [{:NorthBoundingCoordinate "-90"
@@ -86,7 +86,7 @@
 
 (def expected-full-single-spatial-coverage
   {:GranuleSpatialRepresentation "CARTESIAN"
-   :SpatialCoverageType "HORIZONTAL"
+   :SpatialCoverageType "HORIZONTAL_VERTICAL"
    :HorizontalSpatialDomain
    {:Geometry {:CoordinateSystem "CARTESIAN"
                :BoundingRectangles [{:NorthBoundingCoordinate "-90"
@@ -146,7 +146,7 @@
 
 (def expected-just-vertical-spatial-coverage
   {:GranuleSpatialRepresentation "CARTESIAN"
-   :SpatialCoverageType "HORIZONTAL"
+   :SpatialCoverageType "VERTICAL"
    :VerticalSpatialDomains [{:Type "Minimum Altitude"
                              :Value "0"}
                             {:Type "Maximum Altitude"
@@ -172,7 +172,7 @@
 
 (def expected-partial-vertical-spatial-coverage
   {:GranuleSpatialRepresentation "CARTESIAN"
-   :SpatialCoverageType "HORIZONTAL"
+   :SpatialCoverageType "VERTICAL"
    :VerticalSpatialDomains [{:Type "Minimum Altitude"
                              :Value "0"}
                             {:Type "Maximum Altitude"


### PR DESCRIPTION
SpatialCoverageType change where we should determine the SpatailCoverageType based on Horizontal, Vertical, or both types of mappings.