### PR TITLE
CMR-4396 - Disable :cli for jobs and use system ACL for scheduler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,81 @@
-*/testreports.xml
-/target
+###############################
+### Dev Env Files
+###############################
 /.lein-*
+profiles.clj
+
+###############################
+### Test Files
+###############################
+*/testreports.xml
+
+###############################
+### Build Files
+###############################
+/target
+pom.xml
+/ingest-app/resources/public/
+
+###############################
+### macOS
+###############################
+.DS_Store
+
+###############################
+### IntelliJ
+###############################
 .idea/
 *.iml
-.DS_Store
+
+###############################
+### Visual Studio
+###############################
 .vscode
-profiles.clj
-/ingest-app/resources/public/
-pom.xml
+
+###############################
+### Emacs ignore pattersm
+###############################
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -199,7 +199,7 @@
   ;; Prevent jobs from blocking calls to reset
   (humanizer-report-service/set-retry-count! 0)
   (humanizer-report-service/set-humanizer-report-generator-job-wait! 0)
-  (content-service/set-generation-interval! 60)
+  (content-service/set-static-content-generation-interval! 60)
 
   ;; uncomment this line to start gorilla repl.
   ;;(system/set-gorilla-repl-port! 8090)

--- a/search-app/src/cmr/search/services/content_service.clj
+++ b/search-app/src/cmr/search/services/content_service.clj
@@ -15,6 +15,7 @@
    [cmr.search.site.pages :as pages]
    [cmr.search.site.static :as static]
    [cmr.search.site.util :as site-utils]
+   [cmr.transmit.config :as transmit-config]
    [cmr.transmit.metadata-db :as mdb]))
 
 (def cache-key
@@ -27,7 +28,7 @@
   {:default 0
    :type Long})
 
-(defconfig generation-interval
+(defconfig static-content-generation-interval
   "Number of seconds between `static-content-generator-job` runs."
   {:default (* 60 60 24)
    :type Long})
@@ -142,10 +143,12 @@
 ;;       particular ACL settings provided by the HTTP request context.
 (defjob StaticContentGeneratorJob
   [_job-context system]
-  (generate-content {:system system :execution-context :cli}))
+  (-> {:system system}
+      (transmit-config/with-echo-system-token)
+      (generate-content)))
 
 (def static-content-generator-job
   "The job definition used by the system job scheduler."
   {:job-type StaticContentGeneratorJob
-   :interval (generation-interval)
+   :interval (static-content-generation-interval)
    :start-delay (+ (default-job-start-delay) (static-content-generation-job-delay))})

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -35,11 +35,11 @@
   request context which contains the state of a running CMR."
   :execution-context)
 
-(defmethod get-providers :cli
-  [context]
-  (let [providers-url (format "%sproviders"
-                              (config/application-public-root-url :ingest))]
-    (util/endpoint-get providers-url {:accept mt/json})))
+;; (defmethod get-providers :cli
+;;   [context]
+;;   (let [providers-url (format "%sproviders"
+;;                               (config/application-public-root-url :ingest))]
+;;     (util/endpoint-get providers-url {:accept mt/json})))
 
 (defmethod get-providers :default
   [context]
@@ -55,16 +55,16 @@
   request context which contains the state of a running CMR."
   (fn [context & args] (:execution-context context)))
 
-(defmethod collection-data :cli
-  [context tag provider-id]
-  (as-> (config/application-public-root-url :search) data
-        (format "%scollections" data)
-        (util/endpoint-get data {:accept mt/umm-json-results
-                                 :query-params {:provider provider-id
-                                                :tag-key tag
-                                                :page-size 2000}})
-        (:items data)
-        (sort-by #(get-in % [:umm :EntryTitle]) data)))
+;; (defmethod collection-data :cli
+;;   [context tag provider-id]
+;;   (as-> (config/application-public-root-url :search) data
+;;         (format "%scollections" data)
+;;         (util/endpoint-get data {:accept mt/umm-json-results
+;;                                  :query-params {:provider provider-id
+;;                                                 :tag-key tag
+;;                                                 :page-size 2000}})
+;;         (:items data)
+;;         (sort-by #(get-in % [:umm :EntryTitle]) data)))
 
 (defmethod collection-data :default
   [context tag provider-id]

--- a/search-app/src/cmr/search/site/static.clj
+++ b/search-app/src/cmr/search/site/static.clj
@@ -9,8 +9,7 @@
    [cmr.search.site.data :as data]
    [cmr.search.site.static.directory :as directory]
    [cmr.search.site.static.site :as site]
-   [cmr.search.site.util :as util]
-   [cmr.transmit.config :as transmit])
+   [cmr.search.site.util :as util])
   (:gen-class))
 
 ;; Contextual data that is used for static content in the absense of a system
@@ -69,6 +68,7 @@
   $ lein run -m cmr.search.site.static prep
   $ lein run -m cmr.search.site.static api
   $ lein run -m cmr.search.site.static site
+  $ lein run -m cmr.search.site.static static-site
   $ lein run -m cmr.search.site.static all"
   [doc-type]
   (case (keyword doc-type)
@@ -79,5 +79,4 @@
     :all (do
            (-main :prep)
            (-main :api)
-           (-main :site)
-           (-main :static-site))))
+           (-main :site))))


### PR DESCRIPTION
This update includes a fix from Chris that addresses permissions issues that were ultimately preventing the job scheduler from rendering pages to the cache.

It also includes some minor cleanup and additional support for Emacs (ignore files).