### PR TITLE
CMR-4520: Fix to index variable to collection associations

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -390,7 +390,7 @@
   (let [var-associations (meta-db/get-associations-by-collection-concept-id
                           context coll-concept-id coll-revision-id :variable-association)]
     (doseq [association var-associations]
-      (index-variable context (get-in association [:extra-fields :variable-concept-id])))))
+      (index-variable context (get-in association [:extra-fields :variable-concept-id]) {}))))
 
 (defmethod index-concept :tag-association
   [context concept parsed-concept options]

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -354,7 +354,7 @@
               elastic-options)))))))
 
 (defn- index-associated-collection
-  "Index the associated collection conept of the given concept. This is used by indexing tag
+  "Index the associated collection concept of the given concept. This is used by indexing tag
    association and variable association. Indexing them is essentially indexing their associated
    collection concept."
   [context concept options]
@@ -374,15 +374,15 @@
 
 (defn- index-variable
   "Index the associated variable concept of the given variable concept id."
-  [context variable-concept-id]
+  [context variable-concept-id options]
   (let [var-concept (meta-db/get-latest-concept context variable-concept-id)
         parsed-var-concept (cp/parse-concept context var-concept)]
-    (index-concept context var-concept parsed-var-concept {})))
+    (index-concept context var-concept parsed-var-concept options)))
 
 (defn- index-associated-variable
   "Index the associated variable concept of the given variable association concept."
-  [context concept]
-  (index-variable context (get-in concept [:extra-fields :variable-concept-id])))
+  [context concept options]
+  (index-variable context (get-in concept [:extra-fields :variable-concept-id]) options))
 
 (defn- reindex-associated-variables
   "Reindex variables associated with the collection"
@@ -399,7 +399,8 @@
 (defmethod index-concept :variable-association
   [context concept parsed-concept options]
   (index-associated-collection context concept options)
-  (index-associated-variable context concept))
+  (index-associated-variable context concept {})
+  (index-associated-variable context concept {:all-revisions-index? true}))
 
 (defn index-concept-by-concept-id-revision-id
   "Index the given concept and revision-id"

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -320,18 +320,21 @@
    (transmit-variable/search-for-variables (s/context) params {:raw? true
                                                                :http-options {:accept :json}})))
 
+(defn- matches-concept-id-and-revision-id?
+  "Returns true if the item matches the provided concept-id and revision-id."
+  [item concept-id revision-id]
+  (let [metadata (:meta item)]
+    (and (= concept-id (:concept-id metadata))
+         (= revision-id (:revision-id metadata)))))
+
 (defn- get-single-variable-from-umm-json
   "Returns a single variable from a UMM JSON response. Returns nil if the provided concept-id and
   revision-id are not found."
   [umm-json-response concept-id revision-id]
-  (let [variables (filter (fn [item]
-                            (let [metadata (:meta item)]
-                              (and (= concept-id (:concept-id metadata))
-                                   (= revision-id (:revision-id metadata)))))
-                          (get-in umm-json-response [:results :items]))
-        variables-count (count variables)]
+  (let [variables (filter #(matches-concept-id-and-revision-id? % concept-id revision-id)
+                          (get-in umm-json-response [:results :items]))]
     ;; Sanity check that no more than one variable matches the concept-id and revision-id
-    (is (<= 0 variables-count 1))
+    (is (<= 0 (count variables) 1))
     (first variables)))
 
 (defn assert-variable-associations

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -319,3 +319,27 @@
   (search/process-response
    (transmit-variable/search-for-variables (s/context) params {:raw? true
                                                                :http-options {:accept :json}})))
+
+(defn- get-single-variable-from-umm-json
+  "Returns a single variable from a UMM JSON response. Returns nil if the provided concept-id and
+  revision-id are not found."
+  [umm-json-response concept-id revision-id]
+  (let [variables (filter (fn [item]
+                            (let [metadata (:meta item)]
+                              (and (= concept-id (:concept-id metadata))
+                                   (= revision-id (:revision-id metadata)))))
+                          (get-in umm-json-response [:results :items]))
+        variables-count (count variables)]
+    ;; Sanity check that no more than one variable matches the concept-id and revision-id
+    (is (<= 0 variables-count 1))
+    (first variables)))
+
+(defn assert-variable-associations
+  "Asserts that the expected variable associations are returned for the given variable concept."
+  [variable expected-associations search-params]
+  (let [umm-json-response (search/find-concepts-umm-json
+                           :variable (merge search-params
+                                            {:concept_id (:concept-id variable)}))
+        variable-revision (get-single-variable-from-umm-json
+                           umm-json-response (:concept-id variable) (:revision-id variable))]
+    (is (= expected-associations (:associations variable-revision)))))

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_revisions_search_test.clj
@@ -59,10 +59,8 @@
         (do
           ;; find references with all revisions
           (variables/assert-variable-references-match variables (search/find-refs :variable params))
-
           ;; search in JSON with all-revisions
           (variables/assert-variable-search variables (variables/search params))
-
           ;; search in UMM JSON with all-revisions
           (du/assert-variable-umm-jsons-match
            umm-version/current-variable-version variables
@@ -125,40 +123,31 @@
       (metadata-db/force-delete-concept
         (:concept-id var2-3-tombstone) (:revision-id var2-3-tombstone))
       (index/wait-until-indexed)
-
       ;; force deleted revisions are no longer in the search result
       (variables/assert-variable-references-match
        [var1-2-tombstone var1-3 var2-1 var2-2 var3]
        (search/find-refs :variable {:all-revisions true}))
-
       ;; Associate a collection and variable
       (variables/associate-by-concept-ids token
                                           (:concept-id var1-3)
                                           [{:concept-id (:concept-id coll1)}])
-
       (index/wait-until-indexed)
-
       (let [expected-associations {:collections [{:concept-id (:concept-id coll1)}]}]
         (testing "associations to collections are captured in the variables all revisions endpoint"
           (variables/assert-variable-associations var1-3 expected-associations
                                                   {:all_revisions true}))
-
         (let [var1-4 (variables/ingest-variable var1-concept)]
           (index/wait-until-indexed)
-
           (testing (str "associations are correct in the all revisions endpoint when ingesting a "
                         "new variable revision")
             (variables/assert-variable-associations var1-4 expected-associations
                                                     {:all_revisions true}))
-
           (testing "force delete cascade to variable association"
             ;; search collections by variable native-id found the collection
             (d/refs-match? [coll1] (search/find-refs :collection {:variable_native_id "var1"}))
-
             ;; force delete the latest revision of the variable cascade to variable association
             (metadata-db/force-delete-concept (:concept-id var1-4) (:revision-id var1-4))
             (index/wait-until-indexed)
-
             ;; search collections by variable native-id no longer found the collection
             (d/refs-match? [] (search/find-refs :collection {:variable_native_id "var1"}))))))))
 

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_revisions_search_test.clj
@@ -131,20 +131,36 @@
        [var1-2-tombstone var1-3 var2-1 var2-2 var3]
        (search/find-refs :variable {:all-revisions true}))
 
-      (testing "force delete cascade to variable association"
-        (variables/associate-by-concept-ids token
-                                            (:concept-id var1-3)
-                                            [{:concept-id (:concept-id coll1)}])
-        (index/wait-until-indexed)
-        ;; search collections by variable native-id found the collection
-        (d/refs-match? [coll1] (search/find-refs :collection {:variable_native_id "var1"}))
+      ;; Associate a collection and variable
+      (variables/associate-by-concept-ids token
+                                          (:concept-id var1-3)
+                                          [{:concept-id (:concept-id coll1)}])
 
-        ;; force delete the latest revision of the variable cascade to variable association
-        (metadata-db/force-delete-concept (:concept-id var1-3) (:revision-id var1-3))
-        (index/wait-until-indexed)
-        
-        ;; search collections by variable native-id no longer found the collection
-        (d/refs-match? [] (search/find-refs :collection {:variable_native_id "var1"}))))))
+      (index/wait-until-indexed)
+
+      (let [expected-associations {:collections [{:concept-id (:concept-id coll1)}]}]
+        (testing "associations to collections are captured in the variables all revisions endpoint"
+          (variables/assert-variable-associations var1-3 expected-associations
+                                                  {:all_revisions true}))
+
+        (let [var1-4 (variables/ingest-variable var1-concept)]
+          (index/wait-until-indexed)
+
+          (testing (str "associations are correct in the all revisions endpoint when ingesting a "
+                        "new variable revision")
+            (variables/assert-variable-associations var1-4 expected-associations
+                                                    {:all_revisions true}))
+
+          (testing "force delete cascade to variable association"
+            ;; search collections by variable native-id found the collection
+            (d/refs-match? [coll1] (search/find-refs :collection {:variable_native_id "var1"}))
+
+            ;; force delete the latest revision of the variable cascade to variable association
+            (metadata-db/force-delete-concept (:concept-id var1-4) (:revision-id var1-4))
+            (index/wait-until-indexed)
+
+            ;; search collections by variable native-id no longer found the collection
+            (d/refs-match? [] (search/find-refs :collection {:variable_native_id "var1"}))))))))
 
 (deftest search-all-revisions-error-cases
   (testing "variable search with all_revisions bad value"


### PR DESCRIPTION
MMT found a bug that we do not update the variables all revisions index when creating a new variable to collection association.

The change is to make sure we index to both variables indexes whenever we process a variable association event.