### PR TITLE
CMR-4527: Set UTF-8 charset in content-type header returned by keywords endpoints

### DIFF
--- a/dev-system/src/cmr/dev_system/control.clj
+++ b/dev-system/src/cmr/dev_system/control.clj
@@ -89,14 +89,14 @@
 
     ;; Allow code eval
     side-api/eval-routes
-    
+
     ;; Retrieve KMS resources
     (GET "/kms/:keyword-scheme/:filename" [keyword-scheme filename]
       (let [resource (io/resource (str "kms_examples/" keyword-scheme "/" filename))]
         (if resource
           {:status 200
            :body (slurp resource)
-           :headers {"Content-Type" "application/csv"}}
+           :headers {"Content-Type" "application/csv; charset=utf-8"}}
           (route/not-found "KMS resource not found\n"))))
 
     ;; For debugging. Gets the state of the world in relations to ACLs and what's indexed

--- a/search-app/src/cmr/search/api/keyword.clj
+++ b/search-app/src/cmr/search/api/keyword.clj
@@ -161,7 +161,7 @@
           keyword-hierarchy (cmr-keyword-scheme kf/nested-fields-mappings)
           hierarchical-keywords (flat-keywords->hierarchical-keywords keywords keyword-hierarchy)]
       {:staus 200
-       :headers {"Content-Type" (mt/format->mime-type :json)}
+       :headers {"Content-Type" (mt/with-utf-8 mt/json)}
        :body (json/generate-string hierarchical-keywords)})))
 
 (def keyword-api-routes

--- a/transmit-lib/src/cmr/transmit/kms.clj
+++ b/transmit-lib/src/cmr/transmit/kms.clj
@@ -199,7 +199,8 @@
         url (format "%s/%s" (conn/root-url conn) gcmd-resource-name)
         params (merge
                  (config/conn-params conn)
-                 {:throw-exceptions true})
+                 {:headers {:accept-charset "utf-8"}
+                  :throw-exceptions true})
         start (System/currentTimeMillis)
         response (client/get url params)]
     (debug


### PR DESCRIPTION
This is a potential fix for a problem MMT has been seeing with the keywords endpoints (CMR-4426). I can't reproduce CMR-4426, so I have no idea if this will change anything, but it does make sense to do regardless.