### PR TITLE
CMR-4467 - Add a workaround for provider-id in services ingest until CMR-4468

### DIFF
--- a/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
@@ -43,6 +43,9 @@
   db."
   [service]
   {:concept-type :service
+   ;; The following is a placeholder until UMM-Service fully supports
+   ;; provider ids; see CMR-4468
+   :provider-id (or (:provider-id service) "CMR")
    :native-id (:native-id service)
    :metadata (pr-str service)
    :user-id (:originator-id service)


### PR DESCRIPTION
This hostfix is part of CMR-4467 (see PR #283). As soon as the tests pass, this can be merged, as it is an update to the already-merged PR.