### PR TITLE
CMR-4517: Fixed FIND_AND_REMOVE for bulkupdate.

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -102,9 +102,9 @@
 
 (defn- ingest-collection-in-umm-json-format
   "Ingest a collection in UMM Json format and return a list of one concept-id.
-   This is used to test the FIND_AND_REMOVE on platforms/instruments. Since differenct
-   formats keep different parts of the platforms/instruments, can't combine them together
-   to test what's found and what's removed."
+   This is used to test the CMR-4517, on complete removal of platforms/instruments. 
+   Since it's only testing the bulk update part after the ingest, which format to use 
+   for ingest is irrelevant. So it's easier to just test with one format of ingest."
   [attribs]
   (let [collection (data-umm-c/collection-concept
                      (data-umm-c/collection 1 attribs)

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -34,9 +34,12 @@
 (defmethod apply-umm-list-update :find-and-remove
   [update-type umm update-field update-value find-value]
   (if (seq (get-in umm update-field))
-    (update-in umm update-field #(remove (fn [x]
-                                           (value-matches? find-value x))
-                                         %))
+    (let [umm-updated (update-in umm update-field #(remove (fn [x]
+                                                             (value-matches? find-value x))
+                                                     %))]
+      (if (seq (get-in umm-updated update-field))
+        umm-updated
+        (update-in umm-updated update-field seq)))
     umm))
 
 (defmethod apply-umm-list-update :find-and-replace


### PR DESCRIPTION
FIND_AND_REMOVE should be able to remove all the found Platforms/Instruments/DataCenters/ScienceKeywords/LocationKeywords. unless it's required.
Before the fix, if you try to remove all of the platforms, it will give error saying the array is too short because it's empty. After the fix, it will just say that the Platforms is required.

Instruments and LocationKeywords are not required, so now we are able to remove all of the instruments and LocationKeywords.