### PR TITLE
CMR-4524: Do not clear out the caches when updating indexes

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -200,7 +200,7 @@
         (let [request-handler (if use-compression?
                                 (create-gzip-handler (.getHandler server) MIN_GZIP_SIZE)
                                 (.getHandler server))
-              request-handler (if true ;use-access-log?
+              request-handler (if use-access-log?
                                 (create-access-log-handler request-handler)
                                 request-handler)]
           (doto server

--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -200,7 +200,7 @@
         (let [request-handler (if use-compression?
                                 (create-gzip-handler (.getHandler server) MIN_GZIP_SIZE)
                                 (.getHandler server))
-              request-handler (if use-access-log?
+              request-handler (if true ;use-access-log?
                                 (create-access-log-handler request-handler)
                                 request-handler)]
           (doto server

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -579,9 +579,7 @@
 (defn update-indexes
   "Updates the index mappings and settings."
   [context params]
-  (cache/reset-caches context)
-  (es/update-indexes context params)
-  (cache/reset-caches context))
+  (es/update-indexes context params))
 
 (def health-check-fns
   "A map of keywords to functions to be called for health checks"

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -576,10 +576,19 @@
   (es/reset-es-store context)
   (cache/reset-caches context))
 
+(defn- reset-index-set-mappings-cache
+  "Resets the index set mappings cache. It is important that the latest mappings are used whenever
+  we try to update the indexes in Elasticsearch."
+  [context]
+  (let [index-set-mappings-cache (get-in context [:system :caches idx-set/index-set-cache-key])]
+    (cache/reset index-set-mappings-cache)))
+
 (defn update-indexes
   "Updates the index mappings and settings."
   [context params]
-  (es/update-indexes context params))
+  (reset-index-set-mappings-cache context)
+  (es/update-indexes context params)
+  (reset-index-set-mappings-cache context))
 
 (def health-check-fns
   "A map of keywords to functions to be called for health checks"


### PR DESCRIPTION
This is to prevent deleting all data in Elasticsearch from the Cubby application on deployment of the indexer application. I traced through the source code to when the clear cache calls were first added, and I don't see any reason why caches need to be cleared before and after updating the indexes.