### PR TITLE
CMR-4524: Fix to only delete specific keys from cubby on calls to reset

### DIFF
--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -19,6 +19,11 @@
   "The key used to store the acl cache in the system cache map."
   :acls)
 
+(def acl-keys-to-track
+  "The collection of keys which should be deleted from cubby whenever someone attempts to clear the
+  ACL cache."
+  [":acls-hash-code"])
+
 (defn create-acl-cache*
   "Creates the acl cache using the given cmr cache protocol implementation and object-identity-types.
   The object-identity-types are specified and stored as extra information in the cache so that when
@@ -45,7 +50,8 @@
   [object-identity-types]
   (create-acl-cache* (stl-cache/create-single-thread-lookup-cache
                       (consistent-cache/create-consistent-cache
-                       {:hash-timeout-seconds (acl-cache-consistent-timeout-seconds)}))
+                       {:hash-timeout-seconds (acl-cache-consistent-timeout-seconds)
+                        :keys-to-track acl-keys-to-track}))
                      object-identity-types))
 
 (defn- context->cached-object-identity-types
@@ -117,4 +123,3 @@
   {:job-type RefreshAclCacheJob
    :job-key job-key
    :interval 3600})
-

--- a/common-app-lib/src/cmr/common_app/cache/consistent_cache.clj
+++ b/common-app-lib/src/cmr/common_app/cache/consistent_cache.clj
@@ -91,7 +91,7 @@
     [this key]
     (let [mem-value (c/get-value memory-cache key)]
       (when (and (not (nil? mem-value))
-                 (= (hash mem-value) 
+                 (= (hash mem-value)
                     (c/get-value hash-cache (key->hash-cache-key key))))
         mem-value)))
 
@@ -144,12 +144,9 @@
    (create-consistent-cache nil))
   ([options]
    (let [timeout (get options :hash-timeout-seconds (consistent-cache-default-hash-timeout-seconds))
-         hash-cache (fallback-with-timeout (cubby-cache/create-cubby-cache) timeout)
+         hash-cache (cubby-cache/create-cubby-cache options)
          main-cache (mem-cache/create-in-memory-cache)]
-     (create-consistent-cache main-cache hash-cache)))
+     (create-consistent-cache main-cache (fallback-with-timeout hash-cache timeout))))
   ([memory-cache hash-cache]
    (->ConsistentMemoryCache
     memory-cache hash-cache)))
-
-
-

--- a/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
+++ b/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
@@ -1,7 +1,11 @@
 (ns cmr.common-app.cache.cubby-cache
   "An implementation of the CMR cache protocol on top of the cubby application. Cubby only supports
   persistence and returning strings so this automatically serializes and deserializes the keys and
-  values with EDN. Any key or value serializable to EDN is supported."
+  values with EDN. Any key or value serializable to EDN is supported. Operationally cubby uses
+  Elasticsearch as a backend store, and multiple applications have multiple caches which use cubby.
+  Therefore calling reset on a cubby cache will not delete all of the data stored in the backend.
+  Instead when creating a cubby cache the caller must provide a list of keys which should be deleted
+  when calling reset on that particular cache."
   (:require
    [clojure.edn :as edn]
    [cmr.common.cache :as c]
@@ -21,7 +25,11 @@
 ;; Implements the CmrCache protocol by saving data in the cubby application
 (defrecord CubbyCache
   [;; A context containing a connection to cubby
-   context-with-conn]
+   context-with-conn
+
+   ;; A collection of keys used by this cache. Only these keys will be deleted from the backend
+   ;; store on calls to reset
+   keys-to-track]
 
   c/CmrCache
   (get-keys
@@ -43,7 +51,8 @@
 
   (reset
     [this]
-    (cubby/delete-all-values context-with-conn))
+    (doseq [the-key keys-to-track]
+      (cubby/delete-value context-with-conn (serialize the-key))))
 
   (set-value
     [this key value]
@@ -51,7 +60,8 @@
 
 (defn create-cubby-cache
   "Creates an instance of the cubby cache."
-  []
-  (->CubbyCache {:system (config/system-with-connections {} [:cubby])}))
-
-
+  ([]
+   (create-cubby-cache nil))
+  ([options]
+   (->CubbyCache {:system (config/system-with-connections {} [:cubby])}
+                 (:keys-to-track options))))

--- a/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
+++ b/common-app-lib/src/cmr/common_app/cache/cubby_cache.clj
@@ -3,7 +3,7 @@
   persistence and returning strings so this automatically serializes and deserializes the keys and
   values with EDN. Any key or value serializable to EDN is supported. Operationally cubby uses
   Elasticsearch as a backend store, and multiple applications have multiple caches which use cubby.
-  Therefore calling reset on a cubby cache will not delete all of the data stored in the backend.
+  Therefore calling reset on a cubby cache should not delete all of the data stored in the backend.
   Instead when creating a cubby cache the caller must provide a list of keys which should be deleted
   when calling reset on that particular cache."
   (:require

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -30,7 +30,8 @@
   :collection-granule-aggregation-cache)
 
 (defconfig coll-gran-agg-cache-consistent-timeout-seconds
-  "The number of seconds between when the collection granule aggregate cache should check with cubby for consistence"
+  "The number of seconds between when the collection granule aggregate cache should check with
+   cubby for consistence."
   {:default (* 5 60) ; 5 minutes
    :type Long})
 
@@ -44,8 +45,8 @@
     ;; But if it's not available we'll fetch it from cubby.
     (fallback-cache/create-fallback-cache
 
-      ;; Consistent cache is required so that if we have multiple instances of the indexer we'll have
-      ;; only a single indexer refreshing it's cache.
+      ;; Consistent cache is required so that if we have multiple instances of the indexer we'll
+      ;; have only a single indexer refreshing it's cache.
       (consistent-cache/create-consistent-cache
        {:hash-timeout-seconds (coll-gran-agg-cache-consistent-timeout-seconds)})
       (cubby-cache/create-cubby-cache))))

--- a/indexer-app/src/cmr/indexer/system.clj
+++ b/indexer-app/src/cmr/indexer/system.clj
@@ -46,6 +46,11 @@
   {:default 5
    :type Long})
 
+(def index-set-mappings-cubby-keys
+  "The list of keys related to index-set-mappings which should be deleted when we want to clear
+  the index-set-mappings cache."
+  [":concept-mapping-types-hash-code" ":concept-indices-hash-code"])
+
 (defconfig log-level
   "App logging level"
   {:default "info"})
@@ -61,7 +66,8 @@
              :caches {af/acl-cache-key (af/create-consistent-acl-cache
                                         [:catalog-item :system-object :provider-object])
                       index-set/index-set-cache-key (consistent-cache/create-consistent-cache
-                                                     {:hash-timeout-seconds (index-set-cache-consistent-timeout-seconds)})
+                                                     {:hash-timeout-seconds (index-set-cache-consistent-timeout-seconds)
+                                                      :keys-to-track index-set-mappings-cubby-keys})
                       acl/token-imp-cache-key (acl/create-token-imp-cache)
                       kf/kms-cache-key (kf/create-kms-cache)
                       cgac/coll-gran-aggregate-cache-key (cgac/create-cache)

--- a/system-int-test/test/cmr/system_int_test/common_app_cache_test.clj
+++ b/system-int-test/test/cmr/system_int_test/common_app_cache_test.clj
@@ -5,19 +5,53 @@
             [cmr.common-app.cache.consistent-cache :as consistent-cache]
             [cmr.common-app.cache.consistent-cache-spec :as consistent-cache-spec]
             [cmr.common-app.cache.cubby-cache :as cubby-cache]
-            [cmr.common.cache :as c]
+            [cmr.common.cache :as cache]
             [cmr.common.cache.cache-spec :as cache-spec]))
 
+(def cubby-options
+  "The options to pass into cubby when creating the cache. For the cache spec we test that calls
+  to reset remove the :foo and :bar keys and their hash key counterparts."
+  {:keys-to-track [:foo :bar ":foo-hash-code" ":bar-hash-code"]})
+
 (deftest cubby-cache-functions-as-cache-test
-  (cache-spec/assert-cache (cubby-cache/create-cubby-cache)))
+  (cache-spec/assert-cache (cubby-cache/create-cubby-cache cubby-options)
+                           false))
 
 ;; Test the consistent cache backed by the real cubby cache
 (deftest consistent-cache-functions-as-cache-test
-  (cache-spec/assert-cache (consistent-cache/create-consistent-cache)))
+  (cache-spec/assert-cache (consistent-cache/create-consistent-cache cubby-options)
+                           false))
 
 (deftest consistent-cache-functions-as-consistent-cache-test
   (consistent-cache-spec/assert-consistent-cache
-    (consistent-cache/create-consistent-cache)
-    (consistent-cache/create-consistent-cache)
+    (consistent-cache/create-consistent-cache cubby-options)
+    (consistent-cache/create-consistent-cache cubby-options)
     (consistent-cache/consistent-cache-default-hash-timeout-seconds)))
 
+(deftest cubby-reset-only-deletes-specified-keys
+  (let [cubby-cache (cubby-cache/create-cubby-cache cubby-options)]
+    (cache/set-value cubby-cache :alpha "Alpha value")
+    (cache/set-value cubby-cache :beta "Beta value")
+    (cache/set-value cubby-cache :foo "Foo value")
+    (testing "Initial cached values are set correctly"
+      (is (= "Alpha value" (cache/get-value cubby-cache :alpha)))
+      (is (= "Beta value" (cache/get-value cubby-cache :beta)))
+      (is (= "Foo value" (cache/get-value cubby-cache :foo))))
+    (testing "All cached keys are listed"
+      (let [cached-keys (set (cache/get-keys cubby-cache))]
+        (are [the-key]
+          (contains? cached-keys the-key)
+          :alpha
+          :beta
+          :foo)))
+    (testing "Reset cache"
+      (cache/reset cubby-cache)
+      (let [cached-keys (set (cache/get-keys cubby-cache))]
+        (testing "Foo key is deleted from the cache since it is tracked"
+          (is (not (contains? cached-keys :foo)))
+          (is (nil? (cache/get-value cubby-cache :foo))))
+        (testing "Alpha and beta keys remain in the cache since they are not tracked"
+          (is (contains? cached-keys :alpha))
+          (is (contains? cached-keys :beta))
+          (is (= "Alpha value" (cache/get-value cubby-cache :alpha)))
+          (is (= "Beta value" (cache/get-value cubby-cache :beta))))))))


### PR DESCRIPTION
I found that the previous change I made was still resulting in data being deleted from cubby because the one cache that it cleared was a consistent cache which uses cubby underneath to store a hash code. As a result I changed the design of cubby so that data can only be explicitly deleted from cubby by registering a list of keys that the caller wants to be deleted from cubby on any calls to reset on that cache.