### PR TITLE
CMR-4508 - Add stubbed collection and associated variables/services data

### DIFF
--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -108,6 +108,7 @@
        (remove #(nil? (val %)))
        (into {})
        (merge @settings/run-modes)
+       ((fn [x] (println "Resetting with the run modes:" x) x))
        (reset! settings/run-modes)))
 
 (defn reset-modes!

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -49,7 +49,25 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies ~(concat '[[org.clojure/clojure "1.8.0"]
+  :dependencies ~(concat '[[gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
+                            :exclusions [org.clojure/clojurescript
+                                         org.clojure/data.xml
+                                         com.google.code.findbugs/jsr305
+                                         clj-http
+                                         cljs-http
+                                         org.clojure/core.async
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader]]
+                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                            :exclusions [org.clojure/clojurescript
+                                         com.google.code.findbugs/jsr305
+                                         gov.nasa.earthdata/cmr-client
+                                         cljs-http
+                                         org.clojure/core.async
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader
+                                         org.clojure/java.jdbc]]
+                           [org.clojure/clojure "1.8.0"]
                            [org.clojure/tools.nrepl "0.2.12"]
                            ;; Add groovy to support groovy scripting in elastic
                            [org.codehaus.groovy/groovy-all "2.4.0"]]

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -49,8 +49,52 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies ~(concat '[[org.clojure/clojure "1.8.0"]
+  :dependencies ~(concat '[[gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
+                            :exclusions [org.clojure/clojurescript
+                                         org.clojure/data.xml
+                                         com.google.code.findbugs/jsr305
+                                         clj-http
+                                         cljs-http
+                                         org.clojure/core.async
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader]]
+                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                            :exclusions [org.clojure/clojurescript
+                                         com.google.code.findbugs/jsr305
+                                         gov.nasa.earthdata/cmr-client
+                                         cljs-http
+                                         org.clojure/core.async
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader
+                                         org.clojure/java.jdbc]]
+                           [org.clojure/clojure "1.8.0"]
                            [org.clojure/tools.nrepl "0.2.12"]
+                           ;; XXX REMOVE the following deps when the stubbed
+                           ;;     responses are replaced with the real ones
+                           [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
+                            :exclusions [cljs-http
+                                         com.google.code.findbugs/jsr305
+                                         gov.nasa.earthdata/cmr-client
+                                         instaparse
+                                         org.clojure/clojurescript
+                                         org.clojure/core.async
+                                         org.clojure/data.xml
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader
+                                         org.clojure/java.jdbc
+                                         ring/ring-codec]]
+                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                            :exclusions [cljs-http
+                                         com.google.code.findbugs/jsr305
+                                         gov.nasa.earthdata/cmr-client
+                                         instaparse
+                                         org.clojure/clojurescript
+                                         org.clojure/core.async
+                                         org.clojure/data.xml
+                                         org.clojure/tools.analyzer.jvm
+                                         org.clojure/tools.reader
+                                         org.clojure/java.jdbc
+                                         ring/ring-codec]]
                            ;; Add groovy to support groovy scripting in elastic
                            [org.codehaus.groovy/groovy-all "2.4.0"]]
                          project-dependencies)

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -49,25 +49,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies ~(concat '[[gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
-                            :exclusions [org.clojure/clojurescript
-                                         org.clojure/data.xml
-                                         com.google.code.findbugs/jsr305
-                                         clj-http
-                                         cljs-http
-                                         org.clojure/core.async
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader]]
-                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
-                            :exclusions [org.clojure/clojurescript
-                                         com.google.code.findbugs/jsr305
-                                         gov.nasa.earthdata/cmr-client
-                                         cljs-http
-                                         org.clojure/core.async
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader
-                                         org.clojure/java.jdbc]]
-                           [org.clojure/clojure "1.8.0"]
+  :dependencies ~(concat '[[org.clojure/clojure "1.8.0"]
                            [org.clojure/tools.nrepl "0.2.12"]
                            ;; Add groovy to support groovy scripting in elastic
                            [org.codehaus.groovy/groovy-all "2.4.0"]]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -2,6 +2,17 @@
   :description "Provides a public search API for concepts in the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
   :dependencies [[com.github.fge/json-schema-validator "2.2.6"]
+                 ;; XXX REMOVE the following dep when the stubbed
+                 ;;     responses are replaced with the real ones
+                 [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                  :exclusions [org.clojure/clojurescript
+                               com.google.code.findbugs/jsr305
+                               gov.nasa.earthdata/cmr-client
+                               cljs-http
+                               org.clojure/core.async
+                               org.clojure/tools.analyzer.jvm
+                               org.clojure/tools.reader
+                               org.clojure/java.jdbc]]
                  [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -2,17 +2,32 @@
   :description "Provides a public search API for concepts in the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
   :dependencies [[com.github.fge/json-schema-validator "2.2.6"]
-                 ;; XXX REMOVE the following dep when the stubbed
+                 ;; XXX REMOVE the following deps when the stubbed
                  ;;     responses are replaced with the real ones
-                 [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
-                  :exclusions [org.clojure/clojurescript
+                 [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
+                  :exclusions [cljs-http
                                com.google.code.findbugs/jsr305
                                gov.nasa.earthdata/cmr-client
-                               cljs-http
+                               instaparse
+                               org.clojure/clojurescript
                                org.clojure/core.async
+                               org.clojure/data.xml
                                org.clojure/tools.analyzer.jvm
                                org.clojure/tools.reader
-                               org.clojure/java.jdbc]]
+                               org.clojure/java.jdbc
+                               ring/ring-codec]]
+                 [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                  :exclusions [cljs-http
+                               com.google.code.findbugs/jsr305
+                               gov.nasa.earthdata/cmr-client
+                               instaparse
+                               org.clojure/clojurescript
+                               org.clojure/core.async
+                               org.clojure/data.xml
+                               org.clojure/tools.analyzer.jvm
+                               org.clojure/tools.reader
+                               org.clojure/java.jdbc
+                               ring/ring-codec]]
                  [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -393,7 +393,12 @@
           (OPTIONS "/" req common-routes/options-response)
           (GET "/"
               {params :params headers :headers ctx :request-context}
-              (find-concept-by-cmr-concept-id ctx path-w-extension params headers)))
+              ;; XXX REMOVE this check and the stubs once the service and
+               ;;     the associations work is complete
+               (if (headers "cmr-prototype-umm")
+                 (stubs/handle-prototype-request
+                  path-w-extension params headers)
+                 (find-concept-by-cmr-concept-id ctx path-w-extension params headers))))
 
         ;; Find concepts
         (context ["/:path-w-extension" :path-w-extension #"(?:(?:granules)|(?:collections)|(?:variables)|(?:services))(?:\..+)?"] [path-w-extension]

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -3,6 +3,8 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as string]
+   ;; XXX REMOVE the next require once the service and associations work is complete
+   [cmr-edsc-stubs.core :as stubs]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.health :as common-health]
@@ -394,11 +396,16 @@
               (find-concept-by-cmr-concept-id ctx path-w-extension params headers)))
 
         ;; Find concepts
-        (context ["/:path-w-extension" :path-w-extension #"(?:(?:granules)|(?:collections)|(?:variables))(?:\..+)?"] [path-w-extension]
+        (context ["/:path-w-extension" :path-w-extension #"(?:(?:granules)|(?:collections)|(?:variables)|(?:services))(?:\..+)?"] [path-w-extension]
           (OPTIONS "/" req common-routes/options-response)
           (GET "/"
                {params :params headers :headers ctx :request-context query-string :query-string}
-               (find-concepts ctx path-w-extension params headers query-string))
+               ;; XXX REMOVE this check and the stubs once the service and
+               ;;     the associations work is complete
+               (if (headers "cmr-prototype-umm")
+                 (stubs/handle-prototype-request
+                  path-w-extension params headers query-string)
+                 (find-concepts ctx path-w-extension params headers query-string)))
           ;; Find concepts - form encoded or JSON
           (POST "/"
                 {params :params headers :headers ctx :request-context body :body-copy}


### PR DESCRIPTION
## Summary
This is done in support of the EDSC team's need to develop against an API that won't be completed for several more weeks, but which they need access to sooner for their own development and testing.

## Stubbed Endpoints

The following endpoints offer an option of stubbed data:

* https://CMR-HOST/search/collections
* https://CMR-HOST/search/collections?concept_id=XXX
* https://CMR-HOST/search/concepts/XXX

Additionally:
* The responses from each are currently only in UMM-JSON format.
* The concept ID parameter may be either single-valued or multi-valued (usage for this is the same as the non-prototype API searches)
* The collection responses will always return the same collection, no matter how it is called (there is only one stubbed collection)
* The collection responses contain the new boolean fields `has-variables`, `has-transforms`, and `has-formats`

## Special Usage

In order to tell CMR you would like to use the endpoints against stubbed data, a custom HTTP header must be set: `CMR-Prototype-UMM: true`.

## Examples

Get the collection:

```
curl --silent \
  -H "Accept: application/json" \
  -H "CMR-Prototype-UMM: true" \
  "https://CMR-HOST/search/collections?concept_id\[\]=C123" | \
jq .
```

or

```
curl --silent \
  -H "CMR-Prototype-UMM: true" \
  "https://CMR-HOST/search/collections.json?concept_id\[\]=C123" | \
jq .
```

Get the collection associations:

```
curl --silent \
  -H "CMR-Prototype-UMM: true" \
  "https://CMR-HOST/search/collections.json?concept_id\[\]=C123" |  \
jq .feed.entry[0].associations
```

Note that for each of those calls we used the `application/json` content type; the remaining calls are all UMM-JSON instead.

Concept lookups for stubbed service and variables is also supported:

```
curl --silent \
  -H "Accept: application/vnd.nasa.cmr.umm+json;version=1.9" \
  -H "CMR-Prototype-UMM: true" \
  "https://CMR-HOST/search/concepts/S0001-GES_DISC" | \
jq .
```
```
curl --silent \
  -H "Accept: application/vnd.nasa.cmr.umm+json;version=1.9" \
  -H "CMR-Prototype-UMM: true" \
  "https://CMR-HOST/search/concepts/V00011-GES_DISC" | \
jq .
```

## Responses

As mentioned, the responses are in UMM-JSON format, so have the following form:

```json
{
  "hits": 1,
  "took": 42,
  "items": [
    {
      "meta": {
        "revision-id": 1,
        "deleted": false,
        "format": "application/vnd.nasa.cmr.umm+json",
        "provider-id": "GES_DISC",
        "user-id": "cmr-edsc-stubs",
        "native-id": "XXX",
        "concept-id": "XXX",
        "revision-date": "2017-09-27T18:20:46Z",
        "concept-type": "XXX"
      },
      "umm": {
          ...
      }
    }
  ]
}
```

## Questions

1. We have currently only provided stubs for UMM-JSON response data; from the notes it sounds like this is all that EDSC will need for now; please correct this assumption, if others are needed.
1. Based on my current understanding of EDSC's needs and the changes to the development/feature plans in the course of the related conversation, it seems that only the `/search/collections`, and `/search/concepts` endpoints are needed; is this correct?

## Notes

1. The code change in this PR is quite small due to the fact that it was all put in throw-away, third-party libraries; for those interested, the code that supports these changes is available in the following locations:
 * https://github.com/oubiwann/cmr-edsc-stubs/commits/master
 * https://github.com/oubiwann/cmr-sample-data/commits/master