### PR TITLE
CMR-4432 HTML preview title should be Entry Title

### DIFF
--- a/collection-renderer-lib/resources/collection_preview/collection_preview.erb
+++ b/collection-renderer-lib/resources/collection_preview/collection_preview.erb
@@ -15,7 +15,7 @@ metadata =  JSON.parse(umm_json)
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Common Metadata Repository</title>
+  <title><%= metadata['EntryTitle']%></title>
   <meta name="description" content="">
   <%= csrf_meta_tag %>
 

--- a/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
+++ b/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
@@ -22,9 +22,9 @@
 
 (deftest render-default-collection
   (let [coll expected-conversion/example-collection-record
-          ^String html (cr/render-collection (renderer-context) coll)]
-      (is html "Expected some HTML to be returned")
-      (is (.contains html (:EntryTitle coll)))))
+        ^String html (cr/render-collection (renderer-context) coll)]
+    (is html "Expected some HTML to be returned")
+    (is (.contains html (:EntryTitle coll)))))
 
 ;; This checks that we can render any UMM collection without getting an exception.
 ;; A small number of tries is done to avoid making tests take a long time.
@@ -36,6 +36,6 @@
 ;; Verify that the title of the html is the entry title
 (deftest render-title-as-entry-title
   (let [coll expected-conversion/example-collection-record
-            ^String html (cr/render-collection (renderer-context) coll)]
-        (is html "Expected a title containing the entry title")
-        (is (.contains html (str "<title>" (:EntryTitle coll) "</title>")))))
+         ^String html (cr/render-collection (renderer-context) coll)]
+    (is html "Expected a title containing the entry title")
+    (is (.contains html (str "<title>" (:EntryTitle coll) "</title>")))))

--- a/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
+++ b/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
@@ -22,9 +22,9 @@
 
 (deftest render-default-collection
   (let [coll expected-conversion/example-collection-record
-        ^String html (cr/render-collection (renderer-context) coll)]
-    (is html "Expected some HTML to be returned")
-    (is (.contains html (:EntryTitle coll)))))
+          ^String html (cr/render-collection (renderer-context) coll)]
+      (is html "Expected some HTML to be returned")
+      (is (.contains html (:EntryTitle coll)))))
 
 ;; This checks that we can render any UMM collection without getting an exception.
 ;; A small number of tries is done to avoid making tests take a long time.
@@ -33,4 +33,9 @@
     (let [^String html (cr/render-collection (renderer-context) umm-record)]
       (and html (.contains html (:EntryTitle umm-record))))))
 
-
+;; Verify that the title of the html is the entry title
+(deftest render-title-as-entry-title
+  (let [coll expected-conversion/example-collection-record
+            ^String html (cr/render-collection (renderer-context) coll)]
+        (is html "Expected a title containing the entry title")
+        (is (.contains html (str "<title>" (:EntryTitle coll) "</title>")))))


### PR DESCRIPTION
HTML collection preview now uses the entry title of a collection for the title of the HTML page