### PR TITLE
CMR-4508: Fix AWS SNS connection issue in by excluding clj-http versions pulled in from external libraries

### DIFF
--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -49,52 +49,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies ~(concat '[[gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
-                            :exclusions [org.clojure/clojurescript
-                                         org.clojure/data.xml
-                                         com.google.code.findbugs/jsr305
-                                         clj-http
-                                         cljs-http
-                                         org.clojure/core.async
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader]]
-                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
-                            :exclusions [org.clojure/clojurescript
-                                         com.google.code.findbugs/jsr305
-                                         gov.nasa.earthdata/cmr-client
-                                         cljs-http
-                                         org.clojure/core.async
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader
-                                         org.clojure/java.jdbc]]
-                           [org.clojure/clojure "1.8.0"]
-                           [org.clojure/tools.nrepl "0.2.12"]
-                           ;; XXX REMOVE the following deps when the stubbed
-                           ;;     responses are replaced with the real ones
-                           [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
-                            :exclusions [cljs-http
-                                         com.google.code.findbugs/jsr305
-                                         gov.nasa.earthdata/cmr-client
-                                         instaparse
-                                         org.clojure/clojurescript
-                                         org.clojure/core.async
-                                         org.clojure/data.xml
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader
-                                         org.clojure/java.jdbc
-                                         ring/ring-codec]]
-                           [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
-                            :exclusions [cljs-http
-                                         com.google.code.findbugs/jsr305
-                                         gov.nasa.earthdata/cmr-client
-                                         instaparse
-                                         org.clojure/clojurescript
-                                         org.clojure/core.async
-                                         org.clojure/data.xml
-                                         org.clojure/tools.analyzer.jvm
-                                         org.clojure/tools.reader
-                                         org.clojure/java.jdbc
-                                         ring/ring-codec]]
+  :dependencies ~(concat '[
                            ;; Add groovy to support groovy scripting in elastic
                            [org.codehaus.groovy/groovy-all "2.4.0"]]
                          project-dependencies)

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -6,6 +6,7 @@
                  ;;     responses are replaced with the real ones
                  [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
                   :exclusions [cljs-http
+                               clj-http
                                com.google.code.findbugs/jsr305
                                gov.nasa.earthdata/cmr-client
                                instaparse
@@ -18,6 +19,7 @@
                                ring/ring-codec]]
                  [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
                   :exclusions [cljs-http
+                               clj-http
                                com.google.code.findbugs/jsr305
                                gov.nasa.earthdata/cmr-client
                                instaparse


### PR DESCRIPTION
I also removed the references in dev-system since we only need to pull them in from one place (the search application).

I deployed this branch to SIT and verified that the connection issues are fixed.