### PR TITLE
CMR-4457: Update java version to Java 8 update 144

### DIFF
--- a/access-control-app/Dockerfile
+++ b/access-control-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-access-control-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3011

--- a/bootstrap-app/Dockerfile
+++ b/bootstrap-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-bootstrap-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3006

--- a/cubby-app/Dockerfile
+++ b/cubby-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-cubby-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3007

--- a/dev-system/Dockerfile
+++ b/dev-system/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-dev-system-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 2999

--- a/index-set-app/Dockerfile
+++ b/index-set-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-index-set-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3005

--- a/indexer-app/Dockerfile
+++ b/indexer-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-indexer-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3004

--- a/ingest-app/Dockerfile
+++ b/ingest-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-ingest-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3002

--- a/metadata-db-app/Dockerfile
+++ b/metadata-db-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-metadata-db-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3001

--- a/search-app/Dockerfile
+++ b/search-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-search-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3003

--- a/virtual-product-app/Dockerfile
+++ b/virtual-product-app/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 # Install Java and clean up.
-RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-x64.rpm' \
- && rpm -Uvh jdk-8u45-linux-x64.rpm \
- && rm jdk-8u45-linux-x64.rpm
-ENV JAVA_HOME /usr/java/jdk1.8.0_45/jre
+RUN curl -LO --cookie 'oraclelicense=accept-securebackup-cookie' 'http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.rpm' \
+&& rpm -Uvh jdk-8u144-linux-x64.rpm \
+&& rm jdk-8u144-linux-x64.rpm
+ENV JAVA_HOME /usr/java/jdk1.8.0_144/jre
 
 COPY target/cmr-virtual-product-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3009


### PR DESCRIPTION
Update 45 returned a 404 page and the docker image failed to be built. I ran through all of our Sprint 83 demos using this updated Dockerfile.