### PR TITLE
CMR-4479 Add support for concept-id service lookup

### DIFF
--- a/search-app/src/cmr/search/api/concepts_lookup.clj
+++ b/search-app/src/cmr/search/api/concepts_lookup.clj
@@ -16,7 +16,7 @@
 ;;; Constants
 
 (def find-by-concept-id-concept-types
-  #{:collection :granule :variable})
+  #{:collection :granule :service :variable})
 
 (def supported-concept-id-retrieval-mime-types
   {:collection #{mt/any
@@ -40,6 +40,9 @@
               mt/echo10
               mt/iso19115
               mt/iso-smap}
+   :service #{mt/any
+              mt/xml
+              mt/umm-json}}
    :variable #{mt/any
                mt/xml
                mt/umm-json}})

--- a/search-app/src/cmr/search/api/concepts_lookup.clj
+++ b/search-app/src/cmr/search/api/concepts_lookup.clj
@@ -42,7 +42,7 @@
               mt/iso-smap}
    :service #{mt/any
               mt/xml
-              mt/umm-json}}
+              mt/umm-json}
    :variable #{mt/any
                mt/xml
                mt/umm-json}})
@@ -66,7 +66,6 @@
         (format (str "Retrieving concept by concept id is not supported for "
                      "concept type [%s].")
                 (name concept-type))))
-
     (if revision-id
       ;; We don't support Atom or JSON (yet) for lookups that include
       ;; revision-id due to limitations of the current transformer
@@ -121,7 +120,5 @@
       ;; XXX REMOVE this check and the stubs once the service and
       ;;     the associations work is complete
       (if (headers "cmr-prototype-umm")
-        (stubs/handle-prototype-request
-         path-w-extension params headers)
-        (find-concept-by-cmr-concept-id
-         ctx path-w-extension params headers)))))
+        (stubs/handle-prototype-request path-w-extension params headers)
+        (find-concept-by-cmr-concept-id ctx path-w-extension params headers)))))

--- a/search-app/src/cmr/search/services/acl_service.clj
+++ b/search-app/src/cmr/search/services/acl_service.clj
@@ -13,18 +13,18 @@
   (fn [context acls concept]
     (:concept-type concept)))
 
+;; services currently have no ACLs, so return `true` for all ACL checks
+(defmethod acls-match-concept? :service
+  [context acls concept]
+  true)
+
 ;; tags have no acls so we always assume it matches
 (defmethod acls-match-concept? :tag
   [context acls concept]
   true)
 
-;; When plans solidify around acl checks for variable concepts, we'll update this.
+;; variables currently have no ACLs, so return `true` for all ACL checks
 (defmethod acls-match-concept? :variable
-  [context acls concept]
-  true)
-
-;; When plans solidify around acl checks for service concepts, we'll update this.
-(defmethod acls-match-concept? :service
   [context acls concept]
   true)
 
@@ -32,10 +32,16 @@
   [context acls concept]
   false)
 
-;; XXX This code is a point of contention for adding new concepts: on both
+;; XXX To be fixed with CMR-4394
+;;
+;;     See also:
+;;       * https://wiki.earthdata.nasa.gov/display/CMR/Towards+Improved+CMR+Concept+Creation
+;;       * https://wiki.earthdata.nasa.gov/display/CMR/CMR+Concept+Creation+API
+;;
+;;     This code is a point of contention for adding new concepts: on both
 ;;     occasions where we added varible and service support (e.g. to the
 ;;     `/search/concepts` route), tests failed with ACL errors due to this ns
-;;     not getting updated both in the function below as well as above in the
+;;     not getting updated, both in the function below as well as above in the
 ;;     `acls-match-concept?` multimethod.
 ;;
 ;;     This needs to be taken into account when we plan for refactoring the
@@ -45,7 +51,7 @@
 ;;     programming by conventions is a slow path to developer insanity and
 ;;     software project failure! Instead, all parts of the code that need to be
 ;;     touched should be replaced with APIs (e.g., protocols and their impl'ns)
-;;     with each method documented and, all toegher, being the only things a
+;;     with each method documented and, all together, being the only things a
 ;;     developer needs to add/change (in this instance) a new concept.
 (def concept-type->applicable-field
   "A mapping of concept type to the field in the ACL indicating if it is collection or granule

--- a/search-app/src/cmr/search/services/acl_service.clj
+++ b/search-app/src/cmr/search/services/acl_service.clj
@@ -23,15 +23,36 @@
   [context acls concept]
   true)
 
+;; When plans solidify around acl checks for service concepts, we'll update this.
+(defmethod acls-match-concept? :service
+  [context acls concept]
+  true)
+
 (defmethod acls-match-concept? :default
   [context acls concept]
   false)
 
+;; XXX This code is a point of contention for adding new concepts: on both
+;;     occasions where we added varible and service support (e.g. to the
+;;     `/search/concepts` route), tests failed with ACL errors due to this ns
+;;     not getting updated both in the function below as well as above in the
+;;     `acls-match-concept?` multimethod.
+;;
+;;     This needs to be taken into account when we plan for refactoring the
+;;     APIs and development process for adding concepts to the CMR. The fact
+;;     that this crucial change is tucked away in this part of the code with no
+;;     logical "pointers" or hints to it anywhere else is deeply problematic ...
+;;     programming by conventions is a slow path to developer insanity and
+;;     software project failure! Instead, all parts of the code that need to be
+;;     touched should be replaced with APIs (e.g., protocols and their impl'ns)
+;;     with each method documented and, all toegher, being the only things a
+;;     developer needs to add/change (in this instance) a new concept.
 (def concept-type->applicable-field
   "A mapping of concept type to the field in the ACL indicating if it is collection or granule
   applicable."
   {:granule :granule-applicable
    :collection :collection-applicable
+   :service :service-applicable
    :variable :variable-applicable})
 
 (defn filter-concepts

--- a/system-int-test/src/cmr/system_int_test/utils/service_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/service_util.clj
@@ -18,6 +18,10 @@
 (def default-opts {:accept-format :json
                    :content-type content-type})
 
+(defn token-opts
+  [token]
+  (merge default-opts {:token token}))
+
 (defn grant-all-service-fixture
   "A test fixture that grants all users the ability to create and modify services."
   [f]

--- a/system-int-test/src/cmr/system_int_test/utils/service_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/service_util.clj
@@ -13,12 +13,22 @@
    [cmr.system-int-test.utils.url-helper :as url]
    [cmr.umm-spec.versioning :as versioning]))
 
-(def schema-version versioning/current-service-version)
-(def content-type "application/vnd.nasa.cmr.umm+json")
-(def default-opts {:accept-format :json
-                   :content-type content-type})
+(def content-type
+  "The default content type used in the tests below."
+  "application/vnd.nasa.cmr.umm+json")
+
+(def versioned-content-type
+  "A versioned default content type used in the tests."
+  (mt/with-version content-type versioning/current-service-version))
+
+(def default-opts
+  "Default HTTP client options for use in the tests below."
+  {:accept-format :json
+   :content-type content-type})
 
 (defn token-opts
+  "A little testing utility function that adds a user token to the default
+  headers (HTTP client options)."
   [token]
   (merge default-opts {:token token}))
 
@@ -36,12 +46,12 @@
   ([metadata-attrs attrs]
     (-> (merge {:provider-id "PROV1"} metadata-attrs)
         (data-umm-s/service-concept)
-        (assoc :format (mt/with-version content-type schema-version))
+        (assoc :format versioned-content-type)
         (merge attrs)))
   ([metadata-attrs attrs idx]
     (-> (merge {:provider-id "PROV1"} metadata-attrs)
         (data-umm-s/service-concept idx)
-        (assoc :format (mt/with-version content-type schema-version))
+        (assoc :format versioned-content-type)
         (merge attrs))))
 
 (defn ingest-service

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -15,13 +15,28 @@
    [cmr.transmit.variable :as transmit-variable]
    [cmr.umm-spec.versioning :as versioning]))
 
-(def schema-version versioning/current-variable-version)
 (def unique-index (atom 0))
-(def content-type "application/vnd.nasa.cmr.umm+json")
-(def default-opts {:accept-format :json
-                   :content-type content-type})
+
+(def content-type
+  "The default content type used in the tests below."
+  "application/vnd.nasa.cmr.umm+json")
+
+(def versioned-content-type
+  "A versioned default content type used in the tests."
+  (mt/with-version content-type versioning/current-service-version))
+
+(def utf-versioned-content-type
+  "A default versioned content type with the charset set to UTF-8."
+  (str versioned-content-type "; charset=utf-8"))
+
+(def default-opts
+  "Default HTTP client options for use in the tests below."
+  {:accept-format :json
+   :content-type content-type})
 
 (defn token-opts
+  "A little testing utility function that adds a user token to the default
+  headers (HTTP client options)."
   [token]
   (merge default-opts {:token token}))
 
@@ -86,12 +101,12 @@
   ([metadata-attrs attrs]
     (-> (merge {:provider-id "PROV1"} metadata-attrs)
         (data-umm-v/variable-concept)
-        (assoc :format (mt/with-version content-type schema-version))
+        (assoc :format versioned-content-type)
         (merge attrs)))
   ([metadata-attrs attrs idx]
     (-> (merge {:provider-id "PROV1"} metadata-attrs)
         (data-umm-v/variable-concept :umm-json idx)
-        (assoc :format (mt/with-version content-type schema-version))
+        (assoc :format versioned-content-type)
         (merge attrs))))
 
 (defn make-unique-variable-concept

--- a/system-int-test/test/cmr/system_int_test/ingest/service_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/service_ingest_test.clj
@@ -3,7 +3,7 @@
   For service permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [clojure.test :refer :all]
-   [cmr.common.log :as log :refer (debug info warn error)]`
+   [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.system :as s]

--- a/system-int-test/test/cmr/system_int_test/ingest/service_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/service_ingest_test.clj
@@ -3,8 +3,7 @@
   For service permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [clojure.test :refer :all]
-   [cmr.common.log :as log :refer (debug info warn error)]
-   [cmr.common.mime-types :as mt]
+   [cmr.common.log :as log :refer (debug info warn error)]`
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.system :as s]

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
@@ -209,10 +209,7 @@
   (let [{token :token} (variable-util/setup-update-acl
                           (s/context) "PROV1" "user1" "update-group")
         concept (assoc (variable-util/make-variable-concept)
-                       :format (str (mt/with-version
-                                      variable-util/content-type
-                                      variable-util/schema-version)
-                                    "; charset=utf-8"))
+                       :format variable-util/utf-versioned-content-type)
         {:keys [status]} (ingest/ingest-concept
                           concept
                           (variable-util/token-opts token))]

--- a/system-int-test/test/cmr/system_int_test/search/service/concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/concept_retrieval_test.clj
@@ -1,0 +1,180 @@
+(ns cmr.system-int-test.search.service.concept-retrieval-test
+  "Integration test for service retrieval via the following endpoints:
+
+  * /concepts/:concept-id
+  * /concepts/:concept-id/:revision-id"
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [cmr.common.mime-types :as mt]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.service-util :as service]))
+
+(use-fixtures
+ :each
+ (join-fixtures
+  [(ingest/reset-fixture {"provguid1" "PROV1"})
+   service/grant-all-service-fixture]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Helper utility functions
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- get-svc
+  "Ingest a single svc given a svc-name."
+  [svc-name]
+  (service/ingest-service-with-attrs {:Name svc-name}))
+
+(defn- get-updated-svc
+  "Update (re-ingest) an existing (old) service with new data."
+  [old-svc data]
+  (index/wait-until-indexed)
+  (service/ingest-service-with-attrs
+   (merge data
+          {:native-id (:native-id old-svc)})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Retrieve by concept-id - general test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest retrieve-service-by-concept-id-any-accept-header
+  (let [svc1-name "service1"
+        svc1-name-new "service1-new"
+        del-svc-name "deleted-service"
+        svc1-v1 (get-svc svc1-name)
+        del-svc (get-svc del-svc-name)
+        _ (index/wait-until-indexed)
+        del-concept (mdb/get-concept (:concept-id del-svc))]
+    (ingest/delete-concept del-concept
+                           (service/token-opts (e/login (s/context) "user1")))
+    (index/wait-until-indexed)
+    (testing "retrieval of a deleted service results in a 404"
+      (let [{:keys [status errors]} (search/get-search-failure-xml-data
+                                     (search/retrieve-concept
+                                      (:concept-id del-svc)
+                                      nil
+                                      {:accept mt/any
+                                       :throw-exceptions true}))]
+        (is (= 404 status))
+        (is (= [(format "Concept with concept-id [%s] could not be found."
+                        (:concept-id del-svc))]
+               errors))))
+    (let [svc1-v2 (get-updated-svc svc1-v1 {:Name svc1-name-new})]
+      (testing (str "Sanity check that the test service got updated and its "
+                    "revision id was incremented.")
+        (is (= 2
+               (inc (:revision-id svc1-v1))
+               (:revision-id svc1-v2))))
+      (let [response (search/retrieve-concept
+                      (:concept-id svc1-v1)
+                      nil
+                      {:accept mt/any})
+            response-v1 (search/retrieve-concept
+                         (:concept-id svc1-v1)
+                         1
+                         {:accept mt/any})
+            response-v2 (search/retrieve-concept
+                         (:concept-id svc1-v1)
+                         2
+                         {:accept mt/any})]
+          (testing "retrieval by service concept-id returns the latest revision."
+            (is (= svc1-name-new
+                   (:Name (json/parse-string (:body response) true)))))
+          (testing (str "retrieval by service concept-id and revision-id returns "
+                    "the specified service")
+            (is (= svc1-name
+                   (:Name (json/parse-string (:body response-v1) true))))
+            (is (= svc1-name-new
+                   (:Name (json/parse-string (:body response-v2) true)))))))
+    (testing "retrieval by service concept-id and incorrect revision-id returns error"
+      (let [no-rev 10000
+            {:keys [status errors]} (search/get-search-failure-xml-data
+                                     (search/retrieve-concept
+                                      (:concept-id svc1-v1)
+                                      no-rev
+                                      {:accept mt/any
+                                       :throw-exceptions true}))]
+        (is (= 404 status))
+        (is (= [(format (str "Concept with concept-id [%s] and revision-id [%s] "
+                             "does not exist.")
+                        (:concept-id svc1-v1)
+                        no-rev)]
+               errors))))
+    (testing "retrieval by non-existent service and revision returns error"
+      (let [no-svc "S404404404-PROV1"
+            no-rev 10000
+            {:keys [status errors]} (search/get-search-failure-xml-data
+                                     (search/retrieve-concept
+                                      no-svc
+                                      no-rev
+                                      {:accept mt/any
+                                       :throw-exceptions true}))]
+        (is (= 404 status))
+        (is (= [(format (str "Concept with concept-id [%s] and revision-id [%s] "
+                             "does not exist.")
+                        no-svc
+                        no-rev)]
+               errors))))))
+
+(deftest retrieve-service-by-concept-id-umm-json-accept-header
+  (let [svc1-name "service1"
+        svc1-name-new "service1-new"
+        svc1-v1 (get-svc svc1-name)
+        svc1-v2 (get-updated-svc svc1-v1 {:Name svc1-name-new})
+        ;; responses
+        response (search/retrieve-concept
+                  (:concept-id svc1-v1)
+                  nil
+                  {:accept mt/umm-json})
+        response-v1 (search/retrieve-concept
+                     (:concept-id svc1-v1)
+                     1
+                     {:accept mt/umm-json})
+        response-v2 (search/retrieve-concept
+                     (:concept-id svc1-v1)
+                     2
+                     {:accept mt/umm-json})]
+    (testing "retrieval by service concept-id returns the latest revision."
+      (is (= svc1-name-new
+             (:Name (json/parse-string (:body response) true)))))
+    (testing (str "retrieval by service concept-id and revision-id returns "
+              "the specified service")
+      (is (= svc1-name
+             (:Name (json/parse-string (:body response-v1) true))))
+      (is (= svc1-name-new
+             (:Name (json/parse-string (:body response-v2) true)))))
+    (testing "retrieval by service concept-id and incorrect revision-id returns error"
+      (let [no-rev 10000
+            {:keys [status body]} (search/retrieve-concept
+                                     (:concept-id svc1-v1)
+                                     no-rev
+                                     {:accept mt/umm-json})
+            errors (:errors (json/parse-string body true))]
+        (is (= 404 status))
+        (is (= [(format (str "Concept with concept-id [%s] and revision-id [%s] "
+                             "does not exist.")
+                        (:concept-id svc1-v1)
+                        no-rev)]
+               errors))))
+    (testing "unsupported content types return an error"
+      (let [unsupported-mt "unsupported/mime-type"
+            {:keys [status errors]} (search/get-search-failure-xml-data
+                                     (search/retrieve-concept
+                                      (:concept-id svc1-v1)
+                                      nil
+                                      {:accept unsupported-mt
+                                       :throw-exceptions true}))]
+        (is (= 400 status))
+        (is (= [(format (str "The mime types specified in the accept header "
+                             "[%s] are not supported.")
+                        unsupported-mt)]
+               errors))))))


### PR DESCRIPTION
Summary:

This adds the service concept as a valid type when querying the `/search/concepts` CMR resource.

Previous comment, during the WIP PR for this branch:

@ygliuvt I'm getting a null exception when running the new tests against the `/search/concepts` resource with a service concept it. I haven't been able to track down where the error is coming from. I'm wondering if something is missing from our service work for this to be supported? (i.e., another ticket) or if there's some part of the CMR that needs to be updated that produces this sort of side effect (e.g., an ACL update somewhere ... I seem to remember we did something like that with UMM-Vars ...).