### PR TITLE
CMR-4555: Make sure metadata-db can publish messages to the deleted tombstones granule exchange

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/config.clj
+++ b/metadata-db-app/src/cmr/metadata_db/config.clj
@@ -88,4 +88,5 @@
   (assoc (rmq-conf/default-config)
          :exchanges [(deleted-concept-revision-exchange-name)
                      (ingest-exchange-name)
-                     (access-control-exchange-name)]))
+                     (access-control-exchange-name)
+                     (deleted-granule-exchange-name)]))


### PR DESCRIPTION
I tested `cmr.system-int-test.ingest.deleted-granules-index-test` with local SNS and SQS. The test failed before the change and passed after the change when using SNS and SQS.