### PR TITLE
CMR-4455 As a client, I would like to specify and retrieve a name identifier for bulk updates

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -641,7 +641,7 @@ The following update types are supported:
 Bulk update post request takes the following parameters:
 
   * Concept-ids (required) - a list of concept ids to update
-  * Name (required) - a name used to identify a update task 
+  * Name (optional) - a name used to identify a bulk update task 
   * Update type (required) - choose from the enumeration: `ADD_TO_EXISTING`, `CLEAR_ALL_AND_REPLACE`, `FIND_AND_REPLACE`, `FIND_AND_REMOVE`, `FIND_AND_UPDATE`
   * Update field (required) - choose from the enumeration: `SCIENCE_KEYWORDS`, `LOCATION_KEYWORDS`, `DATA_CENTERS`, `PLATFORMS`, `INSTRUMENTS`
   * Update value (required for all update types except for `FIND_AND_REMOVE`) - UMM-JSON representation of the update to make
@@ -667,7 +667,8 @@ Example: Initiate a bulk update of 3 collections. Find platforms that have Type 
 ```
 curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/collections -d
 '{"concept-ids": ["C1200000005-PROV1","C1200000006-PROV1","C1200000007-PROV1"],
-  "name": "TEST NAME"
+  "name": "TEST NAME",
+  "create-at": "2017-10-24T17:00:03.000Z",
   "update-type": "FIND_AND_UPDATE",
   "update-field": "PLATFORMS",
   "find-value": {"Type": "Aircraft"},

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -668,7 +668,6 @@ Example: Initiate a bulk update of 3 collections. Find platforms that have Type 
 curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/collections -d
 '{"concept-ids": ["C1200000005-PROV1","C1200000006-PROV1","C1200000007-PROV1"],
   "name": "TEST NAME",
-  "create-at": "2017-10-24T17:00:03.000Z",
   "update-type": "FIND_AND_UPDATE",
   "update-field": "PLATFORMS",
   "find-value": {"Type": "Aircraft"},

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -690,7 +690,7 @@ curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo
 
 The task ids and status of all bulk update tasks for a provider can be queried by sending an HTTP GET request to `%CMR-ENDPOINT%/providers/<provider-id>/bulk-update/collections/status`
 
-This returns a list of: task id, status (IN_PROGRESS or COMPLETE), a status message, and the original request JSON body.
+This returns a list of: created-at, name, task id, status (IN_PROGRESS or COMPLETE), a status message, and the original request JSON body.
 
 Example
 ```
@@ -700,18 +700,24 @@ curl -i -H "Echo-Token: XXXX" -H "Cmr-Pretty:true" https:// %CMR-ENDPOINT%/provi
 <result>
     <tasks>
         <task>
+            <created-at>2017-10-24T17:00:03.000Z</created-at>
+            <name>TEST NAME1</name>
             <task-id>21</task-id>
             <status>COMPLETE</status>
             <status-message>Task completed with 1 collection update failures out of 5</status-message>
             <request-json-body>{"concept-ids": ["C12807-PROV1","C17995-PROV1","C18002-PROV1","C18016-PROV1"],"update-type": "FIND_AND_REMOVE","update-field": "SCIENCE_KEYWORDS","find-value": {"Category": "EARTH SCIENCE","Topic": "HUMAN DIMENSIONS","Term": "ENVIRONMENTAL IMPACTS","VariableLevel1": "HEAVY METALS CONCENTRATION"}}</request-json-body>
         </task>
         <task>
+            <created-at>2017-10-24T17:00:03.000Z</created-at>
+            <name>TEST NAME2</name>
             <task-id>22</task-id>
             <status>COMPLETE</status>
             <status-message>Task completed with 1 collection update failures out of 3</status-message>
             <request-json-body>{"concept-ids": ["C13239-PROV1","C13276-PROV1","C13883-PROV1","C13286-PROV1"],"update-type": "CLEAR_ALL_AND_REPLACE","update-field": "SCIENCE_KEYWORDS","update-value": {"Category": "EARTH SCIENCE","Topic": "HUMAN DIMENSIONS","Term": "ENVIRONMENTAL IMPACTS","VariableLevel1": "HEAVY METALS CONCENTRATION"}}</request-json-body>
         </task>
         <task>
+            <created-at>2017-10-24T17:00:03.000Z</created-at>
+            <name>TEST NAME3</name>
             <task-id>2</task-id>
             <status>COMPLETE</status>
             <status-message>All collection updates completed successfully.</status-message>

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -667,6 +667,7 @@ Example: Initiate a bulk update of 3 collections. Find platforms that have Type 
 ```
 curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/collections -d
 '{"concept-ids": ["C1200000005-PROV1","C1200000006-PROV1","C1200000007-PROV1"],
+  "name": "TEST NAME"
   "update-type": "FIND_AND_UPDATE",
   "update-field": "PLATFORMS",
   "find-value": {"Type": "Aircraft"},
@@ -730,6 +731,8 @@ curl -i -H "Echo-Token: XXXX" -H "Cmr-Pretty:true" %CMR-ENDPOINT%/providers/PROV
 
 <?xml version="1.0" encoding="UTF-8"?>
 <result>
+    <created-at>2017-10-24T17:00:03.000Z</created-at>
+    <name>TEST NAME</name>
     <task-status>COMPLETE</task-status>
     <status-message>Task completed with 1 collection update failures out of 5</status-message>
     <request-json-body>{"concept-ids": ["C11984-PROV1","C11991-PROV1","C119916-PROV1","C14432-PROV1","C20000-PROV1"],"update-type": "FIND_AND_REMOVE","update-field": "SCIENCE_KEYWORDS","find-value": {"Category": "EARTH SCIENCE","Topic": "HUMAN DIMENSIONS","Term": "ENVIRONMENTAL IMPACTS","VariableLevel1": "HEAVY METALS CONCENTRATION"}}</request-json-body>

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -641,6 +641,7 @@ The following update types are supported:
 Bulk update post request takes the following parameters:
 
   * Concept-ids (required) - a list of concept ids to update
+  * Name (required) - a name used to identify a update task 
   * Update type (required) - choose from the enumeration: `ADD_TO_EXISTING`, `CLEAR_ALL_AND_REPLACE`, `FIND_AND_REPLACE`, `FIND_AND_REMOVE`, `FIND_AND_UPDATE`
   * Update field (required) - choose from the enumeration: `SCIENCE_KEYWORDS`, `LOCATION_KEYWORDS`, `DATA_CENTERS`, `PLATFORMS`, `INSTRUMENTS`
   * Update value (required for all update types except for `FIND_AND_REMOVE`) - UMM-JSON representation of the update to make

--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -54,5 +54,5 @@
           "type": "object"
         }
     },
-    "required": ["update-type", "update-field", "concept-ids", "name"]
+    "required": ["update-type", "update-field", "concept-ids"]
 }

--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -29,6 +29,11 @@
             },
             "minItems": 1
         },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
         "collection-ids": {
           "type": "array",
           "items": {
@@ -49,5 +54,5 @@
           "type": "object"
         }
     },
-    "required": ["update-type", "update-field", "concept-ids"]
+    "required": ["update-type", "update-field", "concept-ids", "name"]
 }

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -122,6 +122,7 @@
      headers
      {:status 200
       :created-at (:created-at task-status)
+      :name (:name task-status)
       :task-status (:status task-status)
       :status-message (:status-message task-status)
       :request-json-body (:request-json-body task-status)

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -101,6 +101,7 @@
    :body (xml/emit-str
           (xml/element :result {}
            (xml/element :created-at {} (str (:created-at result)))
+           (xml/element :name {} (str (:name result)))
            (xml/element :task-status {} (:task-status result))
            (xml/element :status-message {} (:status-message result))
            (xml/element :request-json-body {} (:request-json-body result))

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -34,27 +34,30 @@
 (defn- generate-xml-status-list
  "Generate XML for a status list with the format
  {:id :status :status-message}"
- ([result status-list-key status-key id-key]
-  (generate-xml-status-list result status-list-key status-key id-key nil))
- ([result status-list-key status-key id-key created-at-key]
-  (generate-xml-status-list result status-list-key status-key id-key created-at-key nil))
- ([result status-list-key status-key id-key created-at-key name-key]
-  (generate-xml-status-list result status-list-key status-key id-key created-at-key name-key nil))
- ([result status-list-key status-key id-key created-at-key name-key additional-keys]
-  (xml/element status-list-key {}
-    (for [status (get result status-list-key)
-          :let [message (:status-message status)]]
-     (xml/element status-key {}
-      (when created-at-key
-        (xml/element created-at-key {} (str (:created-at status))))
-      (when name-key 
-        (xml/element name-key {} (str (:name status))))
-      (xml/element id-key {} (get status id-key))
-      (xml/element :status {} (:status status))
-      (when message
-       (xml/element :status-message {} message))
-      (for [k additional-keys]
-       (xml/element k {} (get status k))))))))
+ [result status-list-key status-key id-key]
+ (xml/element status-list-key {}
+   (for [status (get result status-list-key)
+         :let [message (:status-message status)]]
+    (xml/element status-key {}
+     (xml/element id-key {} (get status id-key))
+     (xml/element :status {} (:status status))
+     (xml/element :status-message {} message)))))
+
+(defn- generate-xml-provider-tasks-list
+ "Generate XML for a status list with the format
+ {:id :status :status-message}"
+ [result status-list-key status-key id-key name-key created-at-key additional-keys]
+ (xml/element status-list-key {}
+   (for [status (get result status-list-key)
+         :let [message (:status-message status)]]
+    (xml/element status-key {}
+     (xml/element created-at-key {} (str (:created-at status)))
+     (xml/element name-key {} (str (:name status)))
+     (xml/element id-key {} (get status id-key))
+     (xml/element :status {} (:status status))
+     (xml/element :status-message {} message)
+     (for [k additional-keys]
+      (xml/element k {} (get status k)))))))
 
 (defmulti generate-provider-tasks-response
   "Convert a result to a proper response format"
@@ -73,9 +76,9 @@
    :headers {"Content-Type" (mt/format->mime-type :xml)}
    :body (xml/emit-str
           (xml/element :result {}
-                       (generate-xml-status-list result :tasks :task
-                                                 :task-id :created-at :name
-                                                 [:request-json-body])))})
+                       (generate-xml-provider-tasks-list result :tasks :task
+                                                         :task-id :name :created-at 
+                                                         [:request-json-body])))})
 
 (defn get-provider-tasks
   "Get all tasks and task statuses for provider."

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -93,7 +93,7 @@
               statement (str "INSERT INTO bulk_update_task_status "
                              "(task_id, provider_id, name, request_json_body, status)"
                              "VALUES (?, ?, ?, ?, ?)")
-              name (or (get (json/parse-string json-body) "name") task-ikd) 
+              name (or (get (json/parse-string json-body) "name") task-id) 
               values [task-id provider-id name (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
           (j/db-do-prepared db statement values)
           ;; Write a row to collection status for each concept id

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.data.bulk-update
   "Stores and retrieves bulk update status and task information."
   (:require
+   [cheshire.core :as json]
    [clojure.java.jdbc :as j]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :refer (debug info warn error)]
@@ -41,70 +42,71 @@
   (get-provider-bulk-update-status
     [db provider-id]
     (j/with-db-transaction
-     [conn db]
-     ;; Returns a list of bulk update statuses for the provider
-     (let [stmt (su/build (su/select [:created-at :task-id :status :status-message :request-json-body]
-                          (su/from bulk_update_task_status)
-                          (su/where `(= :provider-id ~provider-id))))
-           ;; Note: the column selected out of the database is created_at, instead of created-at.
-           statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn)) 
-                                (su/query conn stmt)))
-           statuses (map util/map-keys->kebab-case statuses)]
-      (map #(update % :request-json-body util/gzip-blob->string)
-           statuses))))
+      [conn db]
+      ;; Returns a list of bulk update statuses for the provider
+      (let [stmt (su/build (su/select [:created-at :task-id :name :status :status-message :request-json-body]
+                                      (su/from bulk_update_task_status)
+                                      (su/where `(= :provider-id ~provider-id))))
+            ;; Note: the column selected out of the database is created_at, instead of created-at.
+            statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn)) 
+                                 (su/query conn stmt)))
+            statuses (map util/map-keys->kebab-case statuses)]
+        (map #(update % :request-json-body util/gzip-blob->string)
+             statuses))))
 
   (get-bulk-update-task-status
     [db task-id]
     (j/with-db-transaction
-     [conn db]
-     ;; Returns a status for the particular task
-     (some-> conn 
-             (su/find-one (su/select [:created-at :status :status-message :request-json-body]
-                          (su/from bulk_update_task_status)
-                          (su/where `(= :task-id ~task-id))))
-             util/map-keys->kebab-case
-             (update :request-json-body util/gzip-blob->string)
-             (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
+      [conn db]
+      ;; Returns a status for the particular task
+      (some-> conn 
+              (su/find-one (su/select [:created-at :name :status :status-message :request-json-body]
+                                      (su/from bulk_update_task_status)
+                                      (su/where `(= :task-id ~task-id))))
+              util/map-keys->kebab-case
+              (update :request-json-body util/gzip-blob->string)
+              (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
 
   (get-bulk-update-task-collection-status
     [db task-id]
     ;; Get statuses for all collections by task id
     (map util/map-keys->kebab-case
-      (su/query db (su/build (su/select [:concept-id :status :status-message]
-                              (su/from "bulk_update_coll_status")
-                              (su/where `(= :task-id ~task-id)))))))
+         (su/query db (su/build (su/select [:concept-id :status :status-message]
+                                           (su/from "bulk_update_coll_status")
+                                           (su/where `(= :task-id ~task-id)))))))
 
   (get-bulk-update-collection-status
     [db task-id concept-id]
     ;; Get the status for a particular collection
     (su/find-one db (su/select [:status :status-message]
-                     (su/from "bulk_update_coll_status")
-                     (su/where `(and (= :task-id ~task-id)
-                                     (= :concept-id ~concept-id))))))
+                               (su/from "bulk_update_coll_status")
+                               (su/where `(and (= :task-id ~task-id)
+                                               (= :concept-id ~concept-id))))))
 
   (create-and-save-bulk-update-status
     [db provider-id json-body concept-ids]
     ;; In a transaction, add one row to the task status table and for each concept
     (try
-     (j/with-db-transaction
-      [conn db]
-      (let [task-id (:nextval (first (su/query db ["SELECT task_id_seq.NEXTVAL FROM DUAL"])))
-            statement (str "INSERT INTO bulk_update_task_status "
-                           "(task_id, provider_id, request_json_body, status)"
-                           "VALUES (?, ?, ?, ?)")
-            values [task-id provider-id (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
-       (j/db-do-prepared db statement values)
-       ;; Write a row to collection status for each concept id
-       (apply j/insert! conn
-              "bulk_update_coll_status"
-              ["task_id" "concept_id" "status"]
-              ;; set :transaction? false since we are already inside a transaction
-              (concat (map #(vector task-id % "PENDING") concept-ids) [:transaction? false]))
-       task-id))
-     (catch Exception e
-      (errors/throw-service-error :invalid-data
-       [(str "Error creating creating bulk update status "
-             (.getMessage e))]))))
+      (j/with-db-transaction
+        [conn db]
+        (let [task-id (:nextval (first (su/query db ["SELECT task_id_seq.NEXTVAL FROM DUAL"])))
+              statement (str "INSERT INTO bulk_update_task_status "
+                             "(task_id, provider_id, name, request_json_body, status)"
+                             "VALUES (?, ?, ?, ?, ?)")
+              name (get (json/parse-string json-body) "name") 
+              values [task-id provider-id name (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
+          (j/db-do-prepared db statement values)
+          ;; Write a row to collection status for each concept id
+          (apply j/insert! conn
+                 "bulk_update_coll_status"
+                 ["task_id" "concept_id" "status"]
+                 ;; set :transaction? false since we are already inside a transaction
+                 (concat (map #(vector task-id % "PENDING") concept-ids) [:transaction? false]))
+          task-id))
+      (catch Exception e
+        (errors/throw-service-error :invalid-data
+                                    [(str "Error creating creating bulk update status "
+                                          (.getMessage e))]))))
 
   (update-bulk-update-task-status
     [db task-id status status-message]
@@ -115,34 +117,34 @@
         (j/db-do-prepared db statement [status status-message task-id]))
       (catch Exception e
         (errors/throw-service-error :invalid-data
-         [(str "Error creating updating bulk update task status "
-               (.getMessage e))]))))
+                                    [(str "Error creating updating bulk update task status "
+                                          (.getMessage e))]))))
 
   (update-bulk-update-collection-status
     [db task-id concept-id status status-message]
     (try
       (j/with-db-transaction
-       [conn db]
-       (let [statement (str "UPDATE bulk_update_coll_status "
-                            "SET status = ?, status_message = ?"
-                            "WHERE task_id = ? AND concept_id = ?")
-             status-message (util/trunc status-message 255)]
-         (j/db-do-prepared db statement [status status-message task-id concept-id])
-         (let [task-collections (su/query db
-                                 (su/build (su/select
-                                            [:concept-id :status]
-                                            (su/from "bulk_update_coll_status")
-                                            (su/where `(= :task-id ~task-id)))))
-               pending-collections (filter #(= "PENDING" (:status %)) task-collections)
-               failed-collections (filter #(= "FAILED" (:status %)) task-collections)]
-           (when-not (seq pending-collections)
-             (update-bulk-update-task-status db task-id "COMPLETE"
-               (generate-task-status-message
-                 (count failed-collections) (count task-collections)))))))
+        [conn db]
+        (let [statement (str "UPDATE bulk_update_coll_status "
+                             "SET status = ?, status_message = ?"
+                             "WHERE task_id = ? AND concept_id = ?")
+              status-message (util/trunc status-message 255)]
+          (j/db-do-prepared db statement [status status-message task-id concept-id])
+          (let [task-collections (su/query db
+                                           (su/build (su/select
+                                                      [:concept-id :status]
+                                                      (su/from "bulk_update_coll_status")
+                                                      (su/where `(= :task-id ~task-id)))))
+                pending-collections (filter #(= "PENDING" (:status %)) task-collections)
+                failed-collections (filter #(= "FAILED" (:status %)) task-collections)]
+            (when-not (seq pending-collections)
+              (update-bulk-update-task-status db task-id "COMPLETE"
+                                              (generate-task-status-message
+                                               (count failed-collections) (count task-collections)))))))
       (catch Exception e
         (errors/throw-service-error :invalid-data
-         [(str "Error creating updating bulk update collection status "
-               (.getMessage e))]))))
+                                    [(str "Error creating updating bulk update collection status "
+                                          (.getMessage e))]))))
 
   (reset-bulk-update
     [db]

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -44,7 +44,7 @@
     (j/with-db-transaction
       [conn db]
       ;; Returns a list of bulk update statuses for the provider
-      (let [stmt (su/build (su/select [:created-at :task-id :name :status :status-message :request-json-body]
+      (let [stmt (su/build (su/select [:created-at :name :task-id :status :status-message :request-json-body]
                                       (su/from bulk_update_task_status)
                                       (su/where `(= :provider-id ~provider-id))))
             ;; Note: the column selected out of the database is created_at, instead of created-at.

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -93,7 +93,7 @@
               statement (str "INSERT INTO bulk_update_task_status "
                              "(task_id, provider_id, name, request_json_body, status)"
                              "VALUES (?, ?, ?, ?, ?)")
-              name (or (get (json/parse-string json-body) "name") task-id) 
+              name (get (json/parse-string json-body) "name" task-id)
               values [task-id provider-id name (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
           (j/db-do-prepared db statement values)
           ;; Write a row to collection status for each concept id

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -61,7 +61,7 @@
     [this provider-id json-body concept-ids]
     (swap! task-id-atom inc)
     (let [task-id (str @task-id-atom)
-          name (get (json/parse-string json-body) "name")]
+          name (get (json/parse-string json-body) "name" task-id)]
      (swap! task-status-atom conj {:created-at (str (time-keeper/now))
                                    :task-id task-id
                                    :name name

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.data.memory-db
   "Stores and retrieves the hashes of the ACLs for a provider."
   (:require
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :refer (debug info warn error)]
@@ -32,14 +33,14 @@
     [this provider-id]
     (some->> @task-status-atom
              (filter #(= provider-id (:provider-id %)))
-             (map #(select-keys % [:created-at :task-id :status :status-message :request-json-body]))))
+             (map #(select-keys % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-bulk-update-task-status
     [this task-id]
     (let [task-status (some->> @task-status-atom
                                (some #(when (= task-id (str (:task-id %)))
                                             %)))]
-      (select-keys task-status [:created-at :task-id :status :status-message :request-json-body])))
+      (select-keys task-status [:created-at :name :task-id :status :status-message :request-json-body])))
 
   (get-bulk-update-task-collection-status
     [this task-id]
@@ -59,9 +60,11 @@
   (create-and-save-bulk-update-status
     [this provider-id json-body concept-ids]
     (swap! task-id-atom inc)
-    (let [task-id (str @task-id-atom)]
+    (let [task-id (str @task-id-atom)
+          name (get (json/parse-string json-body) "name")]
      (swap! task-status-atom conj {:created-at (str (time-keeper/now))
-                                   :task-id task-id 
+                                   :task-id task-id
+                                   :name name
                                    :provider-id provider-id
                                    :request-json-body json-body
                                    :status "IN_PROGRESS"})

--- a/ingest-app/src/migrations/007_update_bulk_update_tables.clj
+++ b/ingest-app/src/migrations/007_update_bulk_update_tables.clj
@@ -1,6 +1,6 @@
-ns migrations.007-update-bulk-update-tables
+(ns migrations.007-update-bulk-update-tables
   (:require [clojure.java.jdbc :as j]
-            [config.migrate-config :as config])
+            [config.migrate-config :as config]))
 
 (defn up
   "Migrates the database up to version 7."

--- a/ingest-app/src/migrations/007_update_bulk_update_tables.clj
+++ b/ingest-app/src/migrations/007_update_bulk_update_tables.clj
@@ -1,6 +1,6 @@
-(ns migrations.007-update-bulk-update-tables
+ns migrations.007-update-bulk-update-tables
   (:require [clojure.java.jdbc :as j]
-            [config.migrate-config :as config]))
+            [config.migrate-config :as config])
 
 (defn up
   "Migrates the database up to version 7."

--- a/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
+++ b/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
@@ -11,7 +11,7 @@
                     "ALTER TABLE CMR_INGEST.bulk_update_task_status ADD
                      name VARCHAR(255) DEFAULT '' NOT NULL")
   (j/db-do-commands (config/db)
-                    "UPDATE table SET name = task_id
+                    "UPDATE CMR_INGEST.bulk_update_task_status SET name = task_id
                      WHERE name = ''"))
 
 (defn down

--- a/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
+++ b/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
@@ -12,7 +12,10 @@
                      name VARCHAR(255) DEFAULT NULL")
   (j/db-do-commands (config/db)
                     "UPDATE bulk_update_task_status SET name = task_id
-                     WHERE name IS NULL"))
+                     WHERE name IS NULL")
+  (j/db-do-commands (config/db)
+                    "ALTER TABLE bulk_update_task_status MODIFY
+                     (name VARCHAR(255) NOT NULL)"))
 
 (defn down
   "Migrates the database down to version 7."

--- a/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
+++ b/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
@@ -1,0 +1,19 @@
+(ns migrations.008-add-name-column-bulk-update-status
+  (:require
+   [clojure.java.jdbc :as j]
+   [config.migrate-config :as config]))
+
+(defn up
+  "Migrates the database up to version 8."
+  []
+  (println "migrations.008-add-name-column-bulk-update-status up...")
+  (j/db-do-commands (config/db)
+                    "ALTER TABLE CMR_INGEST.bulk_update_task_status ADD
+                     name VARCHAR(255) DEFAULT '' NOT NULL"))
+
+(defn down
+  "Migrates the database up to version 8."
+  []
+  (println "migrations.008-add-name-column-bulk-update-status up...")
+  (j/db-do-commands (config/db)
+                    "ALTER TABLE CMR_INGEST.bulk_update_task_status DROP COLUMN name"))

--- a/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
+++ b/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
@@ -9,7 +9,10 @@
   (println "migrations.008-add-name-column-bulk-update-status up...")
   (j/db-do-commands (config/db)
                     "ALTER TABLE CMR_INGEST.bulk_update_task_status ADD
-                     name VARCHAR(255) DEFAULT '' NOT NULL"))
+                     name VARCHAR(255) DEFAULT '' NOT NULL")
+  (j/db-do-commands (config/db)
+                    "UPDATE table SET name = task_id
+                     WHERE name = ''"))
 
 (defn down
   "Migrates the database up to version 8."

--- a/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
+++ b/ingest-app/src/migrations/008_add_name_column_bulk_update_status.clj
@@ -8,15 +8,15 @@
   []
   (println "migrations.008-add-name-column-bulk-update-status up...")
   (j/db-do-commands (config/db)
-                    "ALTER TABLE CMR_INGEST.bulk_update_task_status ADD
-                     name VARCHAR(255) DEFAULT '' NOT NULL")
+                    "ALTER TABLE bulk_update_task_status ADD
+                     name VARCHAR(255) DEFAULT NULL")
   (j/db-do-commands (config/db)
-                    "UPDATE CMR_INGEST.bulk_update_task_status SET name = task_id
-                     WHERE name = ''"))
+                    "UPDATE bulk_update_task_status SET name = task_id
+                     WHERE name IS NULL"))
 
 (defn down
-  "Migrates the database up to version 8."
+  "Migrates the database down to version 7."
   []
-  (println "migrations.008-add-name-column-bulk-update-status up...")
+  (println "migrations.008-add-name-column-bulk-update-status down...")
   (j/db-do-commands (config/db)
-                    "ALTER TABLE CMR_INGEST.bulk_update_task_status DROP COLUMN name"))
+                    "ALTER TABLE bulk_update_task_status DROP COLUMN name"))

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -542,21 +542,20 @@
           :status (:status response))))
 
 (defn bulk-update-provider-status
- "Get the tasks and statuses by provider"
- ([provider-id]
-  (bulk-update-provider-status provider-id nil))
- ([provider-id options]
-  (println "dbg2:" )
-  (let [accept-format (get options :accept-format :xml)
-        token (:token options)
-        params {:method :get
-                :url (url/ingest-collection-bulk-update-status-url provider-id)
-                :connection-manager (s/conn-mgr)
-                :throw-exceptions false}
-        params (merge params (when accept-format {:accept accept-format}))
-        params (merge params (when token {:headers {transmit-config/token-header token}}))
-        response (client/request params)]
-   (parse-bulk-update-provider-status-response response options))))
+  "Get the tasks and statuses by provider"
+  ([provider-id]
+   (bulk-update-provider-status provider-id nil))
+  ([provider-id options]
+   (let [accept-format (get options :accept-format :xml)
+         token (:token options)
+         params {:method :get
+                 :url (url/ingest-collection-bulk-update-status-url provider-id)
+                 :connection-manager (s/conn-mgr)
+                 :throw-exceptions false}
+         params (merge params (when accept-format {:accept accept-format}))
+         params (merge params (when token {:headers {transmit-config/token-header token}}))
+         response (client/request params)]
+     (parse-bulk-update-provider-status-response response options))))
 
 (defmulti parse-bulk-update-task-status-body
   "Parse the bulk update task status response body as a given format"

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -518,6 +518,7 @@
         (parse-xml-error-response-elem xml-elem)
         {:tasks (seq (for [task (cx/elements-at-path xml-elem [:tasks :task])]
                       {:created-at (cx/string-at-path task [:created-at])
+                       :name (cx/string-at-path task [:name])
                        :task-id (cx/string-at-path task [:task-id])
                        :status (cx/string-at-path task [:status])
                        :status-message (cx/string-at-path task [:status-message])
@@ -545,6 +546,7 @@
  ([provider-id]
   (bulk-update-provider-status provider-id nil))
  ([provider-id options]
+  (println "dbg2:" )
   (let [accept-format (get options :accept-format :xml)
         token (:token options)
         params {:method :get
@@ -568,6 +570,7 @@
       (if-let [errors (seq (cx/strings-at-path xml-elem [:error]))]
         (parse-xml-error-response-elem xml-elem)
         {:created-at (cx/string-at-path xml-elem [:created-at])
+         :name (cx/string-at-path xml-elem [:name])
          :task-status (cx/string-at-path xml-elem [:task-status])
          :status-message (cx/string-at-path xml-elem [:status-message])
          :request-json-body (cx/string-at-path xml-elem [:request-json-body])

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -132,14 +132,14 @@
              :update-value {:Category "EARTH SCIENCE"}}
             400
             ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]
-
-            "Missing name value"
+            "Invalid update field"
             {:concept-ids ["C1", "C2", "C3"]
-             :update-field "SCIENCE_KEYWORDS"
+             :name "TEST NAME"
+             :update-field "Science keywords"
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"}}
             400
-            ["object has missing required properties ([\"name\"])"]))))
+            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
 
             ;; Short-name/version currently not supported. Support will be added
             ;; back in with CMR-4129

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -131,14 +131,6 @@
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"}}
             400
-            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]
-            "Invalid update field"
-            {:concept-ids ["C1", "C2", "C3"]
-             :name "TEST NAME"
-             :update-field "Science keywords"
-             :update-type "ADD_TO_EXISTING"
-             :update-value {:Category "EARTH SCIENCE"}}
-            400
             ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
 
             ;; Short-name/version currently not supported. Support will be added

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -67,13 +67,15 @@
               (is (= error-messages errors)))
 
             "Missing concept-ids"
-            {:update-field "SCIENCE_KEYWORDS"
+            {:name "TEST NAME"
+             :update-field "SCIENCE_KEYWORDS"
              :update-type "ADD_TO_EXISTING"}
             400
             ["object has missing required properties ([\"concept-ids\"])"]
 
             "0 concept-ids"
             {:concept-ids []
+             :name "TEST NAME"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "ADD_TO_EXISTING"}
             400
@@ -82,18 +84,21 @@
 
             "Missing update field"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-type "ADD_TO_EXISTING"}
             400
             ["object has missing required properties ([\"update-field\"])"]
 
             "Missing update type"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-field "SCIENCE_KEYWORDS"}
             400
             ["object has missing required properties ([\"update-type\"])"]
 
             "Invalid update type"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "REPLACE"}
             400
@@ -101,6 +106,7 @@
 
             "Missing update value"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "FIND_AND_REPLACE"}
             400
@@ -108,6 +114,7 @@
 
             "Missing find value"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "FIND_AND_REPLACE"
              :update-value {:Category "EARTH SCIENCE"
@@ -119,11 +126,20 @@
 
             "Invalid update field"
             {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
              :update-field "Science keywords"
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"}}
             400
-            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
+            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]
+
+            "Missing name value"
+            {:concept-ids ["C1", "C2", "C3"]
+             :update-field "SCIENCE_KEYWORDS"
+             :update-type "ADD_TO_EXISTING"
+             :update-value {:Category "EARTH SCIENCE"}}
+            400
+            ["object has missing required properties ([\"name\"])"]))))
 
             ;; Short-name/version currently not supported. Support will be added
             ;; back in with CMR-4129

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -131,7 +131,13 @@
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"}}
             400
-            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
+            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]
+            "Invalid update field"
+            {:concept-ids ["C1", "C2", "C3"]
+             :name "TEST NAME"
+             :update-field "Science keywords"
+             :update-type "ADD_TO_EXISTING"
+             :update-value {:Category "EARTH SCIENCE"}}))))
 
             ;; Short-name/version currently not supported. Support will be added
             ;; back in with CMR-4129

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -81,7 +81,6 @@
             400
             ["/concept-ids array is too short: must have at least 1 elements but instance has 0 elements"]
 
-
             "Missing update field"
             {:concept-ids ["C1", "C2", "C3"]
              :name "TEST NAME"
@@ -131,13 +130,7 @@
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"}}
             400
-            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]
-            "Invalid update field"
-            {:concept-ids ["C1", "C2", "C3"]
-             :name "TEST NAME"
-             :update-field "Science keywords"
-             :update-type "ADD_TO_EXISTING"
-             :update-value {:Category "EARTH SCIENCE"}}))))
+            ["/update-field instance value (\"Science keywords\") not found in enum (possible values: [\"SCIENCE_KEYWORDS\",\"LOCATION_KEYWORDS\",\"DATA_CENTERS\",\"PLATFORMS\",\"INSTRUMENTS\"])"]))))
 
             ;; Short-name/version currently not supported. Support will be added
             ;; back in with CMR-4129

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_flow_test.clj
@@ -28,6 +28,7 @@
                                               (generate-concept-id x "PROV1"))))))
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
+                          :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -56,12 +57,14 @@
 
         (are3 [accept-format]
           (let [response (ingest/bulk-update-provider-status "PROV1"
-                          {:accept-format accept-format})]
+                                                             {:accept-format accept-format})]
             (is (= (set [{:task-id task-id-1,
+                          :name "TEST NAME"
                           :status-message "All collection updates completed successfully.",
                           :status "COMPLETE",
                           :request-json-body json-body}
                          {:task-id task-id-2,
+                          :name "TEST NAME"
                           :status-message "All collection updates completed successfully.",
                           :status "COMPLETE",
                           :request-json-body json-body}])
@@ -75,6 +78,7 @@
                          {:accept-format accept-format})]
            (is (= {:status-message "All collection updates completed successfully.",
                    :status 200,
+                   :name "TEST NAME"
                    :task-status "COMPLETE",
                    :request-json-body json-body
                    :collection-statuses [{:status-message nil,
@@ -92,6 +96,7 @@
 
 (deftest bulk-update-invalid-concept-id
   (let [bulk-update-body {:concept-ids ["C1200000100-PROV1" "C111"]
+                          :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -105,6 +110,7 @@
         status-response (dissoc status-response :created-at)]
     (is (= {:status-message "Task completed with 2 collection update failures out of 2",
             :status 200,
+            :name "TEST NAME"
             :request-json-body json-body
             :task-status "COMPLETE",
             :collection-statuses (set [{:status-message "Concept-id [C1200000100-PROV1] is not valid.",

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -118,6 +118,7 @@
   (let [concept-ids (ingest-collection-in-each-format science-keywords-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
+                          :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -173,6 +174,7 @@
           _ (index/wait-until-indexed)]
       (testing "Data center find and update"
         (let [bulk-update-body {:concept-ids concept-ids
+                                :name "TEST NAME"
                                 :update-type "FIND_AND_UPDATE"
                                 :update-field "DATA_CENTERS"
                                 :find-value {:ShortName "NSID"}
@@ -203,6 +205,7 @@
   (let [concept-ids (ingest-collection-in-each-format find-replace-keywords-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
+                          :name "TEST NAME"
                           :update-type "FIND_AND_REPLACE"
                           :update-field "SCIENCE_KEYWORDS"
                           :find-value {:Topic "ATMOSPHERE"}
@@ -236,6 +239,7 @@
   (let [concept-ids (ingest-collection-in-umm-json-format find-remove-all-platforms-instruments-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
+                          :name "TEST NAME"
                           :update-type "FIND_AND_REMOVE"
                           :update-field "INSTRUMENTS"
                           :find-value {:ShortName "atm"}}
@@ -271,6 +275,7 @@
   (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
+                          :name "TEST NAME"
                           :update-type "FIND_AND_UPDATE"
                           :update-field "SCIENCE_KEYWORDS"
                           :find-value {:Topic "ATMOSPHERE"}
@@ -311,6 +316,7 @@
                  (ingest/concept :collection "PROV1" "foo" :dif coll-metadata))
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids [(:concept-id concept)]
+                          :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -310,6 +310,25 @@
                 :VariableLevel2 "CLOUD LIQUID WATER/ICE"}]
               (:ScienceKeywords (:umm concept)))))))
 
+(deftest bulk-update-default-name-test
+  (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)
+        _ (index/wait-until-indexed)
+        bulk-update-body {:concept-ids concept-ids
+                          :update-type "FIND_AND_UPDATE"
+                          :update-field "SCIENCE_KEYWORDS"
+                          :find-value {:Topic "ATMOSPHERE"}
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "ATMOSPHERE"
+                                         :Term "AIR QUALITY"
+                                         :VariableLevel1 "EMISSIONS"}}
+        response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
+    (is (= 200 (:status response)))
+    ;; Wait for queueing/indexing to catch up
+    (index/wait-until-indexed)
+    (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
+      (is (= (:task-id response) (get collection-response :name)))
+      (is (= "COMPLETE" (:task-status collection-response))))))
+
 (deftest bulk-update-xml-to-umm-failure-test
   (let [coll-metadata (slurp (io/resource "dif-samples/cmr-4455-collection.xml"))
         concept (ingest/ingest-concept


### PR DESCRIPTION
This PR adds a name column to the bulk update status table.  That name is displayed for each task-id when status is queried.

Also, any task already in the database is migrated to have the name be the task-id.