### PR TITLE
CMR-4553 Status detail message for Bulk Update is truncated

### DIFF
--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -128,7 +128,7 @@
        (let [statement (str "UPDATE bulk_update_coll_status "
                             "SET status = ?, status_message = ?"
                             "WHERE task_id = ? AND concept_id = ?")
-             status-message (util/trunc status-message 255)]
+             status-message (util/trunc status-message 4000)]
          (j/db-do-prepared db statement [status status-message task-id concept-id])
          (let [task-collections (su/query db
                                           (su/build (su/select

--- a/ingest-app/src/migrations/009_update_bulk_status_message.clj
+++ b/ingest-app/src/migrations/009_update_bulk_status_message.clj
@@ -8,8 +8,8 @@
   []
   (println "migrations.009-update-bulk-status-message up...")
   (j/db-do-commands (config/db)
-                    "ALTER TABLE bulk_update_task_status MODIFY
-                     (status_message VARCHAR(1030))"))
+                    "ALTER TABLE bulk_update_coll_status MODIFY
+                     (status_message VARCHAR(4000))"))
 
 (defn down
   "Migrates the database down to version 8."

--- a/ingest-app/src/migrations/009_update_bulk_status_message.clj
+++ b/ingest-app/src/migrations/009_update_bulk_status_message.clj
@@ -9,7 +9,7 @@
   (println "migrations.009-update-bulk-status-message up...")
   (j/db-do-commands (config/db)
                     "ALTER TABLE bulk_update_coll_status MODIFY
-                     (status_message VARCHAR(4000))"))
+                     (status_message VARCHAR2(4000))"))
 
 (defn down
   "Migrates the database down to version 8."
@@ -17,4 +17,4 @@
   (println "migrations.009-update-bulk-status-message down...")
   (j/db-do-commands (config/db) "TRUNCATE TABLE bulk_update_coll_status")
   (j/db-do-commands (config/db) "ALTER TABLE bulk_update_coll_status MODIFY
-                                 (status_message VARCHAR(255))"))
+                                 (status_message VARCHAR2(255))"))

--- a/ingest-app/src/migrations/009_update_bulk_status_message.clj
+++ b/ingest-app/src/migrations/009_update_bulk_status_message.clj
@@ -14,4 +14,7 @@
 (defn down
   "Migrates the database down to version 8."
   []
-  (println "migrations.009-update-bulk-status-message down..."))
+  (println "migrations.009-update-bulk-status-message down...")
+  (j/db-do-commands (config/db) "TRUNCATE TABLE bulk_update_coll_status")
+  (j/db-do-commands (config/db) "ALTER TABLE bulk_update_coll_status MODIFY
+                                 (status_message VARCHAR(255))"))

--- a/ingest-app/src/migrations/009_update_bulk_status_message.clj
+++ b/ingest-app/src/migrations/009_update_bulk_status_message.clj
@@ -14,7 +14,4 @@
 (defn down
   "Migrates the database down to version 8."
   []
-  (println "migrations.009-update-bulk-status-message down...")
-  (j/db-do-commands (config/db) "TRUNCATE TABLE bulk_update_coll_status")
-  (j/db-do-commands (config/db) "ALTER TABLE bulk_update_coll_status MODIFY
-                                 (status_message VARCHAR2(255))"))
+  (println "migrations.009-update-bulk-status-message down..."))

--- a/ingest-app/src/migrations/009_update_bulk_status_message.clj
+++ b/ingest-app/src/migrations/009_update_bulk_status_message.clj
@@ -1,0 +1,17 @@
+(ns migrations.009-update-bulk-status-message
+  (:require
+   [clojure.java.jdbc :as j]
+   [config.migrate-config :as config]))
+
+(defn up
+  "Migrates the database up to version 9."
+  []
+  (println "migrations.009-update-bulk-status-message up...")
+  (j/db-do-commands (config/db)
+                    "ALTER TABLE bulk_update_task_status MODIFY
+                     (status_message VARCHAR(1030))"))
+
+(defn down
+  "Migrates the database down to version 8."
+  []
+  (println "migrations.009-update-bulk-status-message down..."))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -84,6 +84,34 @@
                 :Instruments [{:ShortName "atm"
                                :LongName "airborne topographic mapper"}]}]})
 
+(def large-status-message-umm
+  {:RelatedUrls [{:Description "Related url description"
+                  :URL "www.foobarbazquxquux.com"
+                  :URLContentType "DistributionURL"
+                  :Type "GET DATA"
+                  :Subtype "ECHO"
+                  :GetData {:Format "ascii"
+                            :Size 10.0
+                            :Unit "MB"
+                            :Fees "fees"}}
+                 {:Description "Related url description"
+                  :URL "www.foobarbazquxquux.com"
+                  :URLContentType "DistributionURL"
+                  :Type "GET DATA"
+                  :Subtype "ECHO"
+                  :GetData {:Format "ascii"
+                            :Size 10.0
+                            :Unit "MB"
+                            :Fees "fees"}}
+                 {:Description "Related url description"
+                  :URL "www.foobarbazquxquux.com"
+                  :URLContentType "DistributionURL"
+                  :Type "GET DATA"
+                  :Subtype "ECHO"
+                  :GetData {:Format "ascii"
+                            :Size 10.0
+                            :Unit "MB"
+                            :Fees "fees"}}]})
 
 (defn- generate-concept-id
   [index provider]
@@ -351,16 +379,22 @@
         (is (= "COMPLETE" (:task-status collection-response)))))))
 
 (deftest bulk-update-large-status-message-test
-  (let [coll-metadata (slurp (io/resource "dif-samples/cmr-4455-collection.xml"))
-        concept (ingest/ingest-concept
-                 (ingest/concept :collection "PROV1" "foo" :dif coll-metadata))
+  (let [concept-ids (ingest-collection-in-umm-json-format large-status-message-umm) 
         _ (index/wait-until-indexed)
-        bulk-update-body {:concept-ids [(:concept-id concept)]
+        bulk-update-body {:concept-ids concept-ids
                           :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
                                          :Topic "HUMAN DIMENSIONS"
                                          :Term "ENVIRONMENTAL IMPACTS"
-                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}]))
-    ;; Kick off bulk update
+                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
+        response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+        task-id (:task-id (ingest/bulk-update-collections "PROV1" bulk-update-body))]
+    (index/wait-until-indexed)
+    (let [collection-response (ingest/bulk-update-task-status "PROV1" task-id)
+          collection-status (first (:collection-statuses collection-response))]
+      (is (= "COMPLETE" (:task-status collection-response)))
+      (is (= "COMPLETE" (:status collection-status)))
+      (is (< 255 (count (:status-message collection-status)))))))
+

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -349,3 +349,18 @@
       (index/wait-until-indexed)
       (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
         (is (= "COMPLETE" (:task-status collection-response)))))))
+
+(deftest bulk-update-large-status-message-test
+  (let [coll-metadata (slurp (io/resource "dif-samples/cmr-4455-collection.xml"))
+        concept (ingest/ingest-concept
+                 (ingest/concept :collection "PROV1" "foo" :dif coll-metadata))
+        _ (index/wait-until-indexed)
+        bulk-update-body {:concept-ids [(:concept-id concept)]
+                          :name "TEST NAME"
+                          :update-type "ADD_TO_EXISTING"
+                          :update-field "SCIENCE_KEYWORDS"
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "HUMAN DIMENSIONS"
+                                         :Term "ENVIRONMENTAL IMPACTS"
+                                         :VariableLevel1 "HEAVY METALS CONCENTRATION"}}]))
+    ;; Kick off bulk update

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -389,7 +389,6 @@
                                          :Topic "HUMAN DIMENSIONS"
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
-        response (ingest/bulk-update-collections "PROV1" bulk-update-body)
         task-id (:task-id (ingest/bulk-update-collections "PROV1" bulk-update-body))]
     (index/wait-until-indexed)
     (let [collection-response (ingest/bulk-update-task-status "PROV1" task-id)


### PR DESCRIPTION
This PR modifies bulk update to allow for larger status messages by removing the truncation, and migrating the database column to 4000 (a size that is subject to change).  Before status messages were limited to 255 characters.