### PR TITLE
CMR-4579 - Use the latest EDSC stubbed data with new concept-id.

### DIFF
--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -17,7 +17,7 @@
                                org.clojure/tools.reader
                                org.clojure/java.jdbc
                                ring/ring-codec]]
-                 [gov.nasa.earthdata/cmr-edsc-stubs "0.1.0-SNAPSHOT"
+                 [gov.nasa.earthdata/cmr-edsc-stubs "0.2.0-SNAPSHOT"
                   :exclusions [cljs-http
                                clj-http
                                com.google.code.findbugs/jsr305


### PR DESCRIPTION
Total changes in other repos for this:
* PRs:
  * https://github.com/cmr-exchange/sample-data/pull/4/files
  * https://github.com/cmr-exchange/edsc-stubs/pull/2/files
* Additional individual commits:
  * https://github.com/cmr-exchange/sample-data/commit/1c821489a1564e080cb9609f3a232327aaaae9f3
  * https://github.com/cmr-exchange/edsc-stubs/commit/2a7dc0877231d907928468a36413b01061f20e0c

All of thees have been pushed to Clojars, using a version increment