### PR TITLE
CMR-4578 - Update response to provide correct data for computing cotent type

### DIFF
--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -4,6 +4,7 @@
   :dependencies [[com.github.fge/json-schema-validator "2.2.6"]
                  ;; XXX REMOVE the following deps when the stubbed
                  ;;     responses are replaced with the real ones
+                 ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
                  [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
                   :exclusions [cljs-http
                                clj-http

--- a/search-app/src/cmr/search/api/concepts_lookup.clj
+++ b/search-app/src/cmr/search/api/concepts_lookup.clj
@@ -1,9 +1,12 @@
 (ns cmr.search.api.concepts-lookup
   "Defines the API for concepts lookup in the CMR."
   (:require
-   ;; XXX REMOVE the next two requires once the service and associations work is complete
+   ;; XXX REMOVE the next three requires once the service and associations work is complete
+   ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
    [clojure.string :as string]
    [cmr-edsc-stubs.core :as stubs]
+   [cmr.common.util :as util]
+   ;; end XXX
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common.concepts :as concepts]
    [cmr.common.log :refer (debug info warn error)]
@@ -120,7 +123,8 @@
       {params :params headers :headers ctx :request-context}
       ;; XXX REMOVE this check and the stubs once the service and
       ;;     the associations work is complete
-      (if (= "true" (string/lower-case (headers "cmr-prototype-umm")))
+      ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
+      (if (= "true" (util/safe-lowercase (headers "cmr-prototype-umm")))
         (core-api/search-response
          ctx
          {:results (stubs/handle-prototype-request path-w-extension params headers)

--- a/search-app/src/cmr/search/api/concepts_lookup.clj
+++ b/search-app/src/cmr/search/api/concepts_lookup.clj
@@ -1,7 +1,8 @@
 (ns cmr.search.api.concepts-lookup
   "Defines the API for concepts lookup in the CMR."
   (:require
-   ;; XXX REMOVE the next require once the service and associations work is complete
+   ;; XXX REMOVE the next two requires once the service and associations work is complete
+   [clojure.string :as string]
    [cmr-edsc-stubs.core :as stubs]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common.concepts :as concepts]
@@ -119,6 +120,9 @@
       {params :params headers :headers ctx :request-context}
       ;; XXX REMOVE this check and the stubs once the service and
       ;;     the associations work is complete
-      (if (headers "cmr-prototype-umm")
-        (stubs/handle-prototype-request path-w-extension params headers)
+      (if (= "true" (string/lower-case (headers "cmr-prototype-umm")))
+        (core-api/search-response
+         ctx
+         {:results (stubs/handle-prototype-request path-w-extension params headers)
+          :result-format :umm-json})
         (find-concept-by-cmr-concept-id ctx path-w-extension params headers)))))

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -2,9 +2,12 @@
   "Defines the API for search-by-concept in the CMR."
   (:require
    [clojure.string :as string]
-   ;; XXX REMOVE the next two requires once the service and associations work is complete
+   ;; XXX REMOVE the next three requires once the service and associations work is complete
+   ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
    [clojure.string :as string]
    [cmr-edsc-stubs.core :as stubs]
+   [cmr.common.util :as util]
+   ;; end XXX
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
    [cmr.common.cache :as cache]
@@ -149,7 +152,8 @@
       {params :params headers :headers ctx :request-context query-string :query-string}
       ;; XXX REMOVE this check and the stubs once the service and
       ;;     the associations work is complete
-      (if (= "true" (string/lower-case (headers "cmr-prototype-umm")))
+      ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
+      (if (= "true" (util/safe-lowercase (headers "cmr-prototype-umm")))
         (core-api/search-response
          ctx
          {:results (stubs/handle-prototype-request

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -2,7 +2,8 @@
   "Defines the API for search-by-concept in the CMR."
   (:require
    [clojure.string :as string]
-   ;; XXX REMOVE the next require once the service and associations work is complete
+   ;; XXX REMOVE the next two requires once the service and associations work is complete
+   [clojure.string :as string]
    [cmr-edsc-stubs.core :as stubs]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
@@ -148,9 +149,15 @@
       {params :params headers :headers ctx :request-context query-string :query-string}
       ;; XXX REMOVE this check and the stubs once the service and
       ;;     the associations work is complete
-      (if (headers "cmr-prototype-umm")
-        (stubs/handle-prototype-request
-         path-w-extension params headers query-string)
+      (if (= "true" (string/lower-case (headers "cmr-prototype-umm")))
+        (core-api/search-response
+         ctx
+         {:results (stubs/handle-prototype-request
+                    path-w-extension
+                    params
+                    (assoc headers "CMR-Hits" 42 "CMR-Took" 42)
+                    query-string)
+          :result-format :json})
         (find-concepts ctx path-w-extension params headers query-string)))
     ;; Find concepts - form encoded or JSON
     (POST "/"


### PR DESCRIPTION
Also:
* Added explicit check for true value (now "false" header will bypass stubs).
* Forced result type for concept-lookup to be umm-json
* Forced result type for concept search to be json
* Arbitrarily set CMR-Hits and CMR-Took headers for concept search