### PR TITLE
CMR-4479: Added a list of supported MIME types for service search by …

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2049,13 +2049,10 @@ The following extensions and MIME types are supported by the `/concepts/` resour
   * `dif10`     "application/dif10+xml"
   * `atom`      "application/atom+xml"
 
-The following extensions and MIME types are supported by the `/concepts/` resource for the variable concept type:
+The following extensions and MIME types are supported by the `/concepts/` resource for the variable and service concept types:
 
-  * `umm_json`     "application/vnd.nasa.cmr.umm+json;version=1.1"
+  * `umm_json`     "application/vnd.nasa.cmr.umm+json"
 
-The following extensions and MIME types are supported by the `/concepts/` resource for the service concept type:
-
-  * `umm_json`     "application/vnd.nasa.cmr.umm+json;version=1.0"
 
 ### <a name="search-with-post"></a> Search with POST
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2053,6 +2053,10 @@ The following extensions and MIME types are supported by the `/concepts/` resour
 
   * `umm_json`     "application/vnd.nasa.cmr.umm+json;version=1.1"
 
+The following extensions and MIME types are supported by the `/concepts/` resource for the service concept type:
+
+  * `umm_json`     "application/vnd.nasa.cmr.umm+json;version=1.0"
+
 ### <a name="search-with-post"></a> Search with POST
 
 Search collections or granules with query parameters encoded form in POST request body.


### PR DESCRIPTION
…concept-id in the Search api.md

A separate list of supported MIME type extensions were created for Services.  This is instead of adding it to the similar variables list that has a different schema version number.