### PR TITLE
CMR-4401: add bootstrap and make tables responsive

### DIFF
--- a/common-app-lib/resources/templates/structure.html
+++ b/common-app-lib/resources/templates/structure.html
@@ -14,6 +14,7 @@
     <!-- EUI -->
     <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
     <link href="{{ base-url }}site/css/eui.css" rel="stylesheet" />
     <link href="{{ base-url }}site/css/cmr.css" rel="stylesheet" />
     {% endblock %}

--- a/search-app/resources/templates/search-provider-tag-landing-links.html
+++ b/search-app/resources/templates/search-provider-tag-landing-links.html
@@ -12,7 +12,7 @@
   Each is linked to the collection's landing page.
 </p>
 
-<table id="data-providers">
+<table id="data-providers" class="table table-responsive-lg">
   <thead>
     <tr>
       <th>Collection</th>


### PR DESCRIPTION
Addresses issue with CMR directory pages not being mobile-friendly. I tried to avoid using bootstrap, but this is significantly cleaner/easier