### PR TITLE
CMR-4570 Bulk Update 'Add to Existing' should not duplicate an existing Science or Location keyword

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -204,9 +204,9 @@
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
-          ;; Initiate bulk update that shouldn't add anything, including duplicates.
-      (ingest/bulk-update-collections "PROV1" duplicate-body)
       (is (= 200 (:status response)))
+      ;; Initiate bulk update that shouldn't add anything, including duplicates.
+      (ingest/bulk-update-collections "PROV1" duplicate-body)
       ;; Wait for queueing/indexing to catch up
       (index/wait-until-indexed)
       (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
@@ -267,10 +267,10 @@
                                         :VariableLevel1 "HEAVY METALS CONCENTRATION2"}]}]
        ;; Kick off bulk update
        (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
-             ;; Initiate bulk update that shouldn't add anything, including duplicates.
          (is (= 200 (:status response)))
-         ;; Wait for queueing/indexing to catch up
+         ;; Initiate bulk update that shouldn't add anything, including duplicates.
          (ingest/bulk-update-collections "PROV1" duplicate-body)
+         ;; Wait for queueing/indexing to catch up
          (index/wait-until-indexed)
          (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
            (is (= "COMPLETE" (:task-status collection-response))))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -270,7 +270,7 @@
        (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
              ;; Initiate bulk update that shouldn't add anything, including duplicates.
              _ (ingest/bulk-update-collections "PROV1" duplicate-body)]
-        (is (= 200 (:status response))
+         (is (= 200 (:status response)))
          ;; Wait for queueing/indexing to catch up
          (index/wait-until-indexed)
          (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
@@ -294,7 +294,7 @@
                   {:VariableLevel1 "HEAVY METALS CONCENTRATION2"
                    :Category "EARTH SCIENCE2"
                    :Term "ENVIRONMENTAL IMPACTS2"
-                   :Topic "HUMAN DIMENSIONS2"}])))))))
+                   :Topic "HUMAN DIMENSIONS2"}]))))))
 
 (deftest data-center-bulk-update
     (let [concept-ids (ingest-collection-in-each-format data-centers-umm)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -68,7 +68,7 @@
                   :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
                                                       :Type "HOME PAGE"
                                                       :URL "http://nsidc.org/daac/index.html"}]}}]})
- 
+
 (def find-update-keywords-umm
   {:ScienceKeywords [{:Category "EARTH SCIENCE"
                       :Topic "ATMOSPHERE"
@@ -160,20 +160,19 @@
 
 (defn- ingest-collection-in-umm-json-format
   "Ingest a collection in UMM Json format and return a list of one concept-id.
-   This is used to test the CMR-4517, on complete removal of platforms/instruments. 
-   Since it's only testing the bulk update part after the ingest, which format to use 
+   This is used to test the CMR-4517, on complete removal of platforms/instruments.
+   Since it's only testing the bulk update part after the ingest, which format to use
    for ingest is irrelevant. So it's easier to just test with one format of ingest."
   [attribs]
   (let [collection (data-umm-c/collection-concept
                      (data-umm-c/collection 1 attribs)
                      :umm-json)]
     [(:concept-id (ingest/ingest-concept
-                   (assoc collection :concept-id (generate-concept-id 1 "PROV1"))))])) 
+                   (assoc collection :concept-id (generate-concept-id 1 "PROV1"))))]))
 
 (deftest bulk-update-science-keywords
   ;; Ingest a collection in each format with science keywords to update
   (let [concept-ids (ingest-collection-in-each-format science-keywords-umm)
-        _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
                           :name "TEST NAME"
                           :update-type "ADD_TO_EXISTING"
@@ -204,10 +203,9 @@
 
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
     ;; Kick off bulk update
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
           ;; Initiate bulk update that shouldn't add anything, including duplicates.
-          _ (index/wait-until-indexed)
-          _ (ingest/bulk-update-collections "PROV1" duplicate-body)]
+      (ingest/bulk-update-collections "PROV1" duplicate-body)
       (is (= 200 (:status response)))
       ;; Wait for queueing/indexing to catch up
       (index/wait-until-indexed)
@@ -221,7 +219,7 @@
                                 :results
                                 :items
                                 first)]]
-        (is (= 3 
+        (is (= 3
                (:revision-id (:meta concept))))
         (is (= "2017-01-01T00:00:00Z"
                (:revision-date (:meta concept))))
@@ -237,9 +235,9 @@
                  :Topic "HUMAN DIMENSIONS"}]
                (:ScienceKeywords (:umm concept))))))))
 
-(deftest bulk-update-add-to-existing-multiple-science-keywords 
+(deftest bulk-update-add-to-existing-multiple-science-keywords
   ;; This test is the same as the previous bulk-update-science-keywords test except
-  ;; that it shows that update-value could be an array of objects. 
+  ;; that it shows that update-value could be an array of objects.
   ;; Ingest a collection in each format with science keywords to update
   (let [concept-ids (ingest-collection-in-each-format science-keywords-umm)
         _ (index/wait-until-indexed)
@@ -268,11 +266,11 @@
                                         :Term "ENVIRONMENTAL IMPACTS2"
                                         :VariableLevel1 "HEAVY METALS CONCENTRATION2"}]}]
        ;; Kick off bulk update
-       (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+       (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
              ;; Initiate bulk update that shouldn't add anything, including duplicates.
-             _ (ingest/bulk-update-collections "PROV1" duplicate-body)]
          (is (= 200 (:status response)))
          ;; Wait for queueing/indexing to catch up
+         (ingest/bulk-update-collections "PROV1" duplicate-body)
          (index/wait-until-indexed)
          (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
            (is (= "COMPLETE" (:task-status collection-response))))
@@ -320,7 +318,7 @@
                                     :results
                                     :items
                                     first)]]
-           (is (= 2 
+           (is (= 2
                   (:revision-id (:meta concept))))
            (is (= [{:ShortName "NSIDC"
                     :Roles ["ORIGINATOR"]}
@@ -534,7 +532,7 @@
         (is (= "COMPLETE" (:task-status collection-response)))))))
 
 (deftest bulk-update-large-status-message-test
-  (let [concept-ids (ingest-collection-in-umm-json-format large-status-message-umm) 
+  (let [concept-ids (ingest-collection-in-umm-json-format large-status-message-umm)
         _ (index/wait-until-indexed)
         bulk-update-body {:concept-ids concept-ids
                           :name "TEST NAME"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -206,6 +206,7 @@
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
           ;; Initiate bulk update that shouldn't add anything, including duplicates.
+          _ (index/wait-until-indexed)
           _ (ingest/bulk-update-collections "PROV1" duplicate-body)]
       (is (= 200 (:status response)))
       ;; Wait for queueing/indexing to catch up

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -79,9 +79,8 @@
   [update-type umm update-field update-value find-value]
   (let [umm (if (sequential? update-value)
               (update-in umm update-field #(concat % update-value))
-              (update-in umm update-field #(conj % update-value)))
-        umm (update-in umm update-field distinct)]
-    umm))
+              (update-in umm update-field #(conj % update-value)))]
+    (update-in umm update-field distinct)))
 
 (defmethod apply-umm-list-update :clear-all-and-replace
   [update-type umm update-field update-value find-value]

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -28,7 +28,7 @@
                           (= home-page Type))]
            {:URLContentType data-center-url
             :Type home-page
-            :URL URL}))) 
+            :URL URL})))
 
 (defn- home-page-url?
   "Check if a related url is a data center home page url."
@@ -77,12 +77,12 @@
 
 (defmethod apply-umm-list-update :add-to-existing
   [update-type umm update-field update-value find-value]
-  (let [umm (if (sequential? update-value)
-              (update-in umm update-field #(concat % update-value))
-              (update-in umm update-field #(conj % update-value)))]
-    (-> umm
-        (util/update-in-each update-field util/remove-nil-keys)
-        (update-in update-field distinct))))
+  (as-> umm umm
+        (if (sequential? update-value)
+          (update-in umm update-field #(concat % update-value))
+          (update-in umm update-field #(conj % update-value)))
+        (util/update-in-each umm update-field util/remove-nil-keys)
+        (update-in umm update-field distinct)))
 
 (defmethod apply-umm-list-update :clear-all-and-replace
   [update-type umm update-field update-value find-value]
@@ -128,22 +128,22 @@
 (defmethod apply-umm-list-update :find-and-update-home-page-url
   ;; This is a special case that applies to DataCenter ContactInformation update only.
   ;; All other updates outside of ContactInformation remains the same as find-and-update.
-  ;; We only want to update the home page url inside the :ContactInformation :RelatedUrls. 
+  ;; We only want to update the home page url inside the :ContactInformation :RelatedUrls.
   ;; We don't want to replace the :ContactInformation with the new one in update-value.
   ;; Any information other than the home page url value under :ContactInformation
-  ;; in update-value is not used. 
+  ;; in update-value is not used.
   [update-type umm update-field update-value find-value]
   (if (seq (get-in umm update-field))
     (let [update-value (util/remove-nil-keys update-value)]
       ;; For each entry in update-field, if we find it using the find params,
       ;; update only the fields supplied in update-value with nils removed, except for the
-      ;; ContactInformation part of the update-value. 
+      ;; ContactInformation part of the update-value.
       (update-in umm update-field #(distinct (map (fn [x]
                                                     (if (value-matches? find-value x)
                                                       (data-center-update x update-value)
                                                       x))
                                                   %))))
-    umm)) 
+    umm))
 
 (defn apply-update
   "Apply an update to a umm record. Check for field-specific function and use that

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -77,9 +77,11 @@
 
 (defmethod apply-umm-list-update :add-to-existing
   [update-type umm update-field update-value find-value]
-  (if (sequential? update-value)
-    (update-in umm update-field #(concat % update-value))
-    (update-in umm update-field #(conj % update-value))))
+  (let [umm (if (sequential? update-value)
+              (update-in umm update-field #(concat % update-value))
+              (update-in umm update-field #(conj % update-value)))
+        umm (update-in umm update-field distinct)]
+    umm))
 
 (defmethod apply-umm-list-update :clear-all-and-replace
   [update-type umm update-field update-value find-value]

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -80,7 +80,9 @@
   (let [umm (if (sequential? update-value)
               (update-in umm update-field #(concat % update-value))
               (update-in umm update-field #(conj % update-value)))]
-    (update-in umm update-field distinct)))
+    (-> umm
+        (util/update-in-each update-field util/remove-nil-keys)
+        (update-in update-field distinct))))
 
 (defmethod apply-umm-list-update :clear-all-and-replace
   [update-type umm update-field update-value find-value]

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -29,9 +29,10 @@
 
        "Add to existing"
        :add-to-existing
-       {:Category "EARTH SCIENCE SERVICES"
-        :Topic "DATA ANALYSIS AND VISUALIZATION"
-        :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+       [{:Category "EARTH SCIENCE SERVICES"
+         :Topic "DATA ANALYSIS AND VISUALIZATION"
+         :Term "GEOGRAPHIC INFORMATION SYSTEMS"}
+        {:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}]
        nil
        {:EntryTitle "Test"
         :ScienceKeywords [{:Category "EARTH SCIENCE" :Topic "top" :Term "ter"}

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -177,8 +177,13 @@
 
        "Add to existing"
        :add-to-existing
-       {:Category "CONTINENT"
-        :Type "EUROPE"}
+       [{:Category "CONTINENT"
+         :Type "EUROPE"}
+        {:Category "CONTINENT"
+         :Type "ASIA"
+         :Subregion1 "WESTERN ASIA"
+         :Subregion2 "MIDDLE EAST"
+         :Subregion3 "GAZA STRIP"}]
        nil
        {:LocationKeywords [{:Category "CONTINENT"
                             :Type "ASIA"


### PR DESCRIPTION
This PR removes any duplicate values on bulk update :add-to-existing for location keywords and science keywords.