### PR TITLE
CMR-4528: Fixed the bug that caused the deleted-granule search respon…

### DIFF
--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -466,7 +466,7 @@
                   (rfh/printable-result-format result-format) (pr-str params)))
     {:results results-str
      :hits (:hits results)
-     :result-format (:result-format result-format)}))
+     :result-format result-format}))
 
 (defn- shape-param->tile-set
   "Converts a shape of given type to the set of tiles which the shape intersects"

--- a/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
@@ -108,7 +108,7 @@
       (are3 [params granules]
         (is (= (set (map :concept-id granules))
                (set (find-deleted-granules params))))
-
+        
         "after tomorrow"
         {:revision_date (t/plus- (t/now) (t/days 1))}
         []
@@ -116,6 +116,14 @@
         "after yesterday"
         {:revision_date (t/minus- (t/now) (t/days 1))}
         [granule1-prov1 granule2-prov1 granule3-prov1-2 granule4-prov2]))
+
+    (testing "content-type in search header"
+      (are3 [params]
+        (is (= "application/json; charset=utf-8" 
+               (get-in (search/find-deleted-granules params) [:headers :Content-Type])))
+
+        "deleted granule search header contains application/json content-type."
+        {:revision_date (t/minus- (t/now) (t/days 1))}))
 
     (testing "Search for all after date for provider"
       (are3 [params granules]
@@ -177,3 +185,4 @@
       (is (= (:status response) 400))
       (is (= ["Result format [xml] is not supported by deleted granules search. The only format that is supported is json"]
              (:errors response))))))
+

--- a/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/deleted_granules_index_test.clj
@@ -117,13 +117,10 @@
         {:revision_date (t/minus- (t/now) (t/days 1))}
         [granule1-prov1 granule2-prov1 granule3-prov1-2 granule4-prov2]))
 
-    (testing "content-type in search header"
-      (are3 [params]
-        (is (= "application/json; charset=utf-8" 
-               (get-in (search/find-deleted-granules params) [:headers :Content-Type])))
-
-        "deleted granule search header contains application/json content-type."
-        {:revision_date (t/minus- (t/now) (t/days 1))}))
+    (testing "Deleted granule search header contains application/json content-type"
+      (let [results (search/find-deleted-granules {:revision_date (t/minus- (t/now) (t/days 1))})]
+        (is (= "application/json; charset=utf-8"
+               (get-in results [:headers :content-type])))))
 
     (testing "Search for all after date for provider"
       (are3 [params granules]


### PR DESCRIPTION
…se header to miss the Content-Type

          which was why the pretty-print wouldn't work.