### PR TITLE
CMR-4565 Fix the RelatedURL validation

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/dif_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/dif_util.clj
@@ -75,7 +75,6 @@
   ["GET SERVICE" "ACCESS MAP VIEWER"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "ACCESS MAP VIEWER"}
   ["GET SERVICE" "ACCESS MOBILE APP"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "ACCESS MOBILE APP"}
   ["GET SERVICE" "ACCESS WEB SERVICE"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "ACCESS WEB SERVICE"}
-  ["GET SERVICE" "DATA LIST"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "DATA LIST"}
   ["GET SERVICE" "GET MAP SERVICE"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "MAP SERVICE"}
   ["GET SERVICE" "GET SOFTWARE PACKAGE"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "SOFTWARE PACKAGE"}
   ["GET SERVICE" "GET WEB COVERAGE SERVICE (WCS)"] {:URLContentType "DistributionURL" :Type "GET SERVICE" :Subtype "WEB COVERAGE SERVICE (WCS)"}

--- a/umm-spec-lib/src/cmr/umm_spec/util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/util.clj
@@ -107,7 +107,7 @@
   (keys (get valid-url-content-types-map url-content-type)))
 
 (defn valid-subtypes-for-type
-  "Returns all SubTypes for URLContentType/Type combination"
+  "Returns all Subtypes for URLContentType/Type combination"
   [url-content-type type]
   (get-in valid-url-content-types-map [url-content-type type]))
 

--- a/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
@@ -9,7 +9,7 @@
    (org.apache.commons.validator.routines UrlValidator)))
 
 (defn- valid-url-content-types-combo?
-  "Returns true if valid Type and SubType for URLContentType, nil otherwise."
+  "Returns true if valid Type and Subtype for URLContentType, nil otherwise."
   [url-content-type type sub-type]
   (when (and (some #(= type %) (su/valid-types-for-url-content-type url-content-type))
              (or (nil? sub-type)
@@ -17,13 +17,13 @@
     true))
 
 (defn- related-url-type-validation
-  "Validate the Type and SubType being valid for the accompanying URLContentType"
+  "Validate the Type and Subtype being valid for the accompanying URLContentType"
   [field-path value]
-  (let [{:keys [URLContentType Type SubType]} value]
-    (when-not (valid-url-content-types-combo? URLContentType Type SubType)
+  (let [{:keys [URLContentType Type Subtype]} value]
+    (when-not (valid-url-content-types-combo? URLContentType Type Subtype)
       {field-path
-       [(vu/escape-error-string (format "URLContentType: %s, Type: %s, SubType: %s is not a vaild URLContentType/Type/SubType combination."
-                                        URLContentType Type SubType))]})))
+       [(vu/escape-error-string (format "URLContentType: %s, Type: %s, Subtype: %s is not a vaild URLContentType/Type/Subtype combination."
+                                        URLContentType Type Subtype))]})))
 
 (defn- data-center-url-content-type-validation
   "Validates the URLContentType for DataCenter ContactInformation"

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/related_url.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/related_url.clj
@@ -35,7 +35,6 @@
   "GET DATA : ECHO" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "ECHO"}
   "VIEW PROJECT HOME PAGE" {:URLContentType "CollectionURL", :Type "PROJECT HOME PAGE"}
   "GET RELATED VISUALIZATION" {:URLContentType "VisualizationURL", :Type "GET RELATED VISUALIZATION"}
-  "GET DATA : SSW" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "SSW"}
   "GET SERVICE : GET WEB MAP SERVICE (WMS)" {:URLContentType "DistributionURL", :Type "GET SERVICE", :Subtype "WEB MAP SERVICE (WMS)"}
   "GET SERVICE : GET WEB COVERAGE SERVICE (WCS)" {:URLContentType "DistributionURL", :Type "GET SERVICE", :Subtype "WEB COVERAGE SERVICE (WCS)"}
   "GET DATA : DATACAST URL" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "DATACAST URL"}
@@ -54,7 +53,6 @@
   "Project Home Page" {:URLContentType "CollectionURL", :Type "PROJECT HOME PAGE"}
   "Get Data" {:URLContentType "DistributionURL", :Type "GET DATA"}
   "Reference Materials" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
-  "GET DATA : THREDDS CATALOG" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "THREDDS CATALOG"}
   "VIEW RELATED INFORMATION : GENERAL DOCUMENTATION" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
   "VIEW RELATED INFORMATION : HOW-TO" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "HOW-TO"}
   "Related URLs" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
@@ -81,7 +79,6 @@
   "text/html" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
   "Anomalies" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
   "Collection DOI" {:URLContentType "CollectionURL", :Type "DOI"}
-  "GET DATA : EOSDIS DATA POOL" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "EOSDUS DATA POOL"}
   "GET DATA : LANCE" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "LANCE"}
   "Type:GET DATA Subtype:LANCE" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "LANCE"}
   "Type:GET DATA Subtype:ECHO" {:URLContentType "DistributionURL", :Type "GET DATA", :Subtype "ECHO"}

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
@@ -19,15 +19,15 @@
                      {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                      :URLContentType "DistributionURL"
                                      :Type "GET DATA"
-                                     :SubType "ECHO"}
+                                     :Subtype "ECHO"}
                                     {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                      :URLContentType "PublicationURL"
                                      :Type "VIEW RELATED INFORMATION"
-                                     :SubType "USER'S GUIDE"}
+                                     :Subtype "USER'S GUIDE"}
                                     {:URL "http://www.google.com"
                                      :URLContentType "VisualizationURL"
                                      :Type "GET RELATED VISUALIZATION"
-                                     :SubType "MAP"}]})))
+                                     :Subtype "MAP"}]})))
 
   (testing "Multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -35,27 +35,27 @@
       {:RelatedUrls [{:URL "http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip"
                       :URLContentType "DistributionURL"
                       :Type "GET DATA"
-                      :SubType "ECHO"}
+                      :Subtype "ECHO"}
                      {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                       :URLContentType "PublicationURL"
                       :Type "VIEW RELATED INFORMATION"
-                      :SubType "USER'S GUIDE"}
+                      :Subtype "USER'S GUIDE"}
                      {:URL "https://www.foo.com"
                       :URLContentType "Bad URLContentType"
                       :Type "VIEW RELATED INFORMATION"
-                      :SubType "USER'S GUIDE"}
+                      :Subtype "USER'S GUIDE"}
                      {:URL "https://www.bar.com"
                       :URLContentType "PublicationURL"
                       :Type "Bad Type"
-                      :SubType "USER'S GUIDE"}
+                      :Subtype "USER'S GUIDE"}
                      {:URL "https://www.foobar.com"
                       :URLContentType "PublicationURL"
                       :Type "VIEW RELATED INFORMATION"
-                      :SubType "Bad SubType"}
+                      :Subtype "Bad Subtype"}
                      {:URL "https://www.baz.com"
                       :URLContentType "PublicationURL"
                       :Type "VIEW RELATED INFORMATION"
-                      :SubType "USER'S GUIDE"
+                      :Subtype "USER'S GUIDE"
                       :GetService {:MimeType "application/html"
                                    :FullName "Not provided"
                                    :DataID "Not provided"
@@ -63,16 +63,16 @@
                      {:URL "https://www.baz.com"
                       :URLContentType "PublicationURL"
                       :Type "VIEW RELATED INFORMATION"
-                      :SubType "USER'S GUIDE"
+                      :Subtype "USER'S GUIDE"
                       :GetData {:Size 10.0
                                 :Unit "MB"
                                 :Format "Not provided"}}]})
      [{:path [:RelatedUrls 4]
-       :errors ["URLContentType: PublicationURL, Type: VIEW RELATED INFORMATION, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: PublicationURL, Type: VIEW RELATED INFORMATION, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:RelatedUrls 3]
-       :errors ["URLContentType: PublicationURL, Type: Bad Type, SubType: USER'S GUIDE is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: PublicationURL, Type: Bad Type, Subtype: USER'S GUIDE is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: VIEW RELATED INFORMATION, SubType: USER'S GUIDE is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: Bad URLContentType, Type: VIEW RELATED INFORMATION, Subtype: USER'S GUIDE is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}
       {:path [:RelatedUrls 0 :URL]
@@ -114,15 +114,15 @@
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataCenterURL"
                          :Type "HOME PAGE"
-                         :SubType "Bad SubType"}]}}]})
+                         :Subtype "Bad Subtype"}]}}]})
      [{:path [:DataCenters 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 3]
-       :errors ["URLContentType: DataCenterURL, Type: Bad Type, SubType: null is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataCenterURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 4]
-       :errors ["URLContentType: DataCenterURL, Type: HOME PAGE, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataCenterURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, SubType: null is not a vaild URLContentType/Type/SubType combination."
+       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataCenterURL for DataCenter RelatedUrls"]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}]))
@@ -159,15 +159,15 @@
                           {:URL "https://www.foobar.com"
                            :URLContentType "DataContactURL"
                            :Type "HOME PAGE"
-                           :SubType "Bad SubType"}]}}]}]})
+                           :Subtype "Bad Subtype"}]}}]}]})
      [{:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 3]
-       :errors ["URLContentType: DataContactURL, Type: Bad Type, SubType: null is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 4]
-       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, SubType: null is not a vaild URLContentType/Type/SubType combination."
+       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataContactURL for ContactPersons or ContactGroups RelatedUrls"]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}]))
@@ -204,15 +204,15 @@
                           {:URL "https://www.foobar.com"
                            :URLContentType "DataContactURL"
                            :Type "HOME PAGE"
-                           :SubType "Bad SubType"}]}}]}]})
+                           :Subtype "Bad Subtype"}]}}]}]})
      [{:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 3]
-       :errors ["URLContentType: DataContactURL, Type: Bad Type, SubType: null is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 4]
-       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, SubType: null is not a vaild URLContentType/Type/SubType combination."
+       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataContactURL for ContactPersons or ContactGroups RelatedUrls"]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}])))
@@ -249,15 +249,15 @@
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataContactURL"
                          :Type "HOME PAGE"
-                         :SubType "Bad SubType"}]}}]})
+                         :Subtype "Bad Subtype"}]}}]})
      [{:path [:ContactPersons 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 3]
-       :errors ["URLContentType: DataContactURL, Type: Bad Type, SubType: null is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 4]
-       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, SubType: null is not a vaild URLContentType/Type/SubType combination."
+       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataContactURL for ContactPersons or ContactGroups RelatedUrls"]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}])))
@@ -295,32 +295,32 @@
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataContactURL"
                          :Type "HOME PAGE"
-                         :SubType "Bad SubType"}]}}]})
+                         :Subtype "Bad Subtype"}]}}]})
      [{:path [:ContactGroups 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 3]
-       :errors ["URLContentType: DataContactURL, Type: Bad Type, SubType: null is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 4]
-       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, SubType: Bad SubType is not a vaild URLContentType/Type/SubType combination."]}
+       :errors ["URLContentType: DataContactURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, SubType: null is not a vaild URLContentType/Type/SubType combination."
+       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataContactURL for ContactPersons or ContactGroups RelatedUrls"]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}])))
 
 (deftest collection-related-url-content-type-test
-  (testing "All valid URLContentType/Type/SubType combinations"
+  (testing "All valid URLContentType/Type/Subtype combinations"
     (doseq [URLContentType (keys su/valid-url-content-types-map)
             :let [valid-types (su/valid-types-for-url-content-type URLContentType)]]
       (doseq [Type valid-types
-              ;; Nil is a valid SubType for any URLContentType/Type combination. So we add it to valid-sub-types
+              ;; Nil is a valid Subtype for any URLContentType/Type combination. So we add it to valid-sub-types
               :let [valid-sub-types (conj (su/valid-subtypes-for-type URLContentType Type) nil)]]
-        (doseq [SubType valid-sub-types]
+        (doseq [Subtype valid-sub-types]
           (h/assert-valid (coll/map->UMM-C
                            {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                            :URLContentType URLContentType
                                            :Type Type
-                                           :SubType SubType}]})))))))
+                                           :Subtype Subtype}]})))))))
 
 (deftest collection-collection-citations-related-urls-validation
   (testing "Valid related urls"


### PR DESCRIPTION
This PR address multiple validation bugs regarding RelatedURLs

SubType should be referred to as Subtype in error message

A RelatedURL of:
{ "Description": "Guide Document for this product at NSIDC-wrong1", "URLContentType": "PublicationURL", "Type": "GET RELATED VISUALIZATION", "Subtype": "THREDDS DATA", "URL": "http://nsidc.org/data/docs/daac/ae_swe_ease-grids.gd.html" }

While the ContentURLType and Type message is correct, the SubType of null is not correct. 

a RelatedURL of: 
{ "Description": "Guide Document for this product at NSIDC-wrong1", "URLContentType": "PublicationURL", "Type": "VIEW RELATED INFORMATION", "Subtype": "THREDDS DATA", "URL": "http://nsidc.org/data/docs/daac/ae_swe_ease-grids.gd.html" }

Doesn't give any warning messages - THREDDS DATA is not a valid subtype for PublicationURL, VIEW RELATED INFORMATION.