### PR TITLE
CMR-4401: Remove bootstrap, force responsive tables

### DIFF
--- a/common-app-lib/resources/public/site/css/cmr.css
+++ b/common-app-lib/resources/public/site/css/cmr.css
@@ -63,3 +63,22 @@ footer .badge {
     position: relative;
     top: -2px;
 }
+
+.table-container {
+  overflow-x: auto;
+}
+
+.responsive-table {
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+}
+
+.responsive-table th,
+.responsive-table td {
+  vertical-align: top;
+}
+
+.responsive-table thead th {
+  vertical-align: bottom;
+}

--- a/common-app-lib/resources/templates/structure.html
+++ b/common-app-lib/resources/templates/structure.html
@@ -14,7 +14,6 @@
     <!-- EUI -->
     <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
     <link href="{{ base-url }}site/css/eui.css" rel="stylesheet" />
     <link href="{{ base-url }}site/css/cmr.css" rel="stylesheet" />
     {% endblock %}

--- a/search-app/resources/templates/search-provider-tag-landing-links.html
+++ b/search-app/resources/templates/search-provider-tag-landing-links.html
@@ -12,28 +12,30 @@
   Each is linked to the collection's landing page.
 </p>
 
-<table id="data-providers" class="table table-responsive-lg">
-  <thead>
-    <tr>
-      <th>Collection</th>
-      <th>Short Name</th>
-      <th>Version</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for holding in holdings %}
-    <tr>
-      <td>
-        <a href="{{ holding.link-href }}">{{ holding.umm.EntryTitle }}</a>
-      </td>
-      <td>
-        {{ holding.umm.ShortName }}
-      </td>
-      <td>
-        {{ holding.umm.Version }}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="table-container">
+  <table id="data-providers" class="responsive-table">
+    <thead>
+      <tr>
+        <th>Collection</th>
+        <th>Short Name</th>
+        <th>Version</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for holding in holdings %}
+      <tr>
+        <td>
+          <a href="{{ holding.link-href }}">{{ holding.umm.EntryTitle }}</a>
+        </td>
+        <td>
+          {{ holding.umm.ShortName }}
+        </td>
+        <td>
+          {{ holding.umm.Version }}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}


### PR DESCRIPTION
Bootstrap had a bunch of conflicting styles that messed with margins and positioning - this just fixes that while keeping tables relatively mobile-friendly. Behavior is the same as with bootstrap, but it's conflict free