### PR TITLE
CMR-4495 service force delete

### DIFF
--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
@@ -1,19 +1,28 @@
 (ns cmr.metadata-db.int-test.concepts.force-delete-test
   "Contains integration test for emptying database via force-delete."
-  (:require [clojure.test :refer :all]
-            [clj-http.client :as client]
-            [cheshire.core :as cheshire]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
-            [cmr.metadata-db.int-test.concepts.concept-delete-spec :as cd-spec]))
+  (:require
+   [cheshire.core :as cheshire]
+   [clj-http.client :as client]
+   [clojure.test :refer :all]
+   [cmr.metadata-db.int-test.concepts.concept-delete-spec :as cd-spec]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as cs-spec]
+   [cmr.metadata-db.int-test.utility :as util]))
 
-;;; fixtures
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}
-                                                 {:provider-id "SMAL_PROV" :small true}))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Fixtures & one-off utility functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;; tests
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(use-fixtures :each (util/reset-database-fixture
+                     {:provider-id "REG_PROV" :small false}
+                     {:provider-id "SMAL_PROV" :small false}))
+
+(defmethod cs-spec/gen-concept :service
+  [_ provider-id uniq-num attributes]
+  (util/service-concept provider-id uniq-num attributes))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest force-delete-concepts-test
   (doseq [concept-type [:collection :granule]]
@@ -39,7 +48,7 @@
 
 (deftest force-delete-collection-revision-delete-associated-tag
  (testing "force delete collection revision cascade to delete tag associations associated with the collection revision"
-   (let [concept (c-spec/gen-concept :collection "REG_PROV" 1 {})
+   (let [concept (cs-spec/gen-concept :collection "REG_PROV" 1 {})
          saved-concept (util/save-concept concept)
          concept-id (:concept-id saved-concept)
          tag1 (util/create-and-save-tag 1)
@@ -66,3 +75,82 @@
        ;; tag association associated with other collection revision or whole collection is not deleted
        (util/is-tag-association-deleted? ta1 false)
        (util/is-tag-association-deleted? ta3 false)))))
+
+(deftest force-delete-service
+  (let [coll (util/create-and-save-collection "REG_PROV" 1)
+        coll-concept-id (:concept-id coll)
+        misc-svc (util/create-and-save-service "REG_PROV" 42)
+        misc-svc-assn (util/create-and-save-service-association
+                       coll misc-svc 1)
+        expected-svc-concept-id "S1200000003-REG_PROV"
+        expected-revision-ids [1 2 3]
+        revision-count 3]
+    (testing "delete most recent revision"
+      (let [latest-revision (util/create-and-save-service
+                             "REG_PROV" 1 revision-count)
+            concept-id (:concept-id latest-revision)
+            svc-assn (util/create-and-save-service-association
+                      coll latest-revision 1)]
+        (testing "initial conditions"
+          ;; creation results as expected
+          (is (= expected-svc-concept-id concept-id))
+          (is (= (last expected-revision-ids) (:revision-id latest-revision)))
+          ;; service revisions in db
+          (is (= 4
+                 (count (:concepts (util/find-concepts :service)))))
+          (is (= 200 (:status (util/get-concept-by-id-and-revision
+                               concept-id (last expected-revision-ids)))))
+          (is (= 200 (:status (util/get-concept-by-id-and-revision
+                               concept-id (second expected-revision-ids)))))
+          (is (= 200 (:status (util/get-concept-by-id-and-revision
+                               concept-id (first expected-revision-ids)))))
+          ;; make sure service association in place
+          (is (= "SA1200000004-CMR" (:concept-id svc-assn)))
+          (is (= coll-concept-id
+                 (get-in svc-assn [:extra-fields :associated-concept-id])))
+          (is (= expected-svc-concept-id
+                 (get-in svc-assn [:extra-fields :service-concept-id])))
+          ;; make sure collection associations in place
+          (is (not (:deleted (:concept (util/get-concept-by-id "SA1200000004-CMR"))))))
+        (testing "just the most recent revision is deleted"
+          (util/force-delete-concept concept-id (last expected-revision-ids))
+          (is (= 404 (:status (util/get-concept-by-id-and-revision
+                               concept-id (last expected-revision-ids)))))
+          (is (= 200 (:status (util/get-concept-by-id-and-revision
+                               concept-id (second expected-revision-ids)))))
+          (is (= 200 (:status (util/get-concept-by-id-and-revision
+                               concept-id (first expected-revision-ids))))))
+        (testing "service association has been deleted"
+          (is (:deleted (:concept (util/get-concept-by-id "SA1200000004-CMR")))))))
+    (testing "delete oldest revision"
+      (let [latest-revision (util/create-and-save-service
+                             "REG_PROV" 2 revision-count)
+            concept-id (:concept-id latest-revision)
+            svc-assn (util/create-and-save-service-association
+                      coll latest-revision 2)]
+        (is (= "SA1200000006-CMR" (:concept-id svc-assn)))
+        (util/force-delete-concept concept-id (first expected-revision-ids))
+        (is (= 200 (:status (util/get-concept-by-id-and-revision
+                             concept-id (last expected-revision-ids)))))
+        (is (= 200 (:status (util/get-concept-by-id-and-revision
+                             concept-id (second expected-revision-ids)))))
+        (is (= 404 (:status (util/get-concept-by-id-and-revision
+                             concept-id (first expected-revision-ids)))))
+        (testing "service association has not been deleted"
+          (is (not (:deleted (:concept (util/get-concept-by-id "SA1200000006-CMR"))))))))
+    (testing "delete middle revision"
+      (let [latest-revision (util/create-and-save-service
+                             "REG_PROV" 3 revision-count)
+            concept-id (:concept-id latest-revision)
+            svc-assn (util/create-and-save-service-association
+                      coll latest-revision 3)]
+        (is (= "SA1200000008-CMR" (:concept-id svc-assn)))
+        (util/force-delete-concept concept-id (second expected-revision-ids))
+        (is (= 200 (:status (util/get-concept-by-id-and-revision
+                             concept-id (last expected-revision-ids)))))
+        (is (= 404 (:status (util/get-concept-by-id-and-revision
+                             concept-id (second expected-revision-ids)))))
+        (is (= 200 (:status (util/get-concept-by-id-and-revision
+                             concept-id (first expected-revision-ids)))))
+        (testing "service association has not been deleted"
+          (is (not (:deleted (:concept (util/get-concept-by-id "SA1200000008-CMR"))))))))))

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -644,9 +644,8 @@
   [concept]
   (let [{:keys [concept-id revision-id]} concept
         stored-concept (:concept (get-concept-by-id-and-revision concept-id revision-id))]
-    (is (= (util/remove-nil-keys (expected-concept concept))
-           (util/remove-nil-keys
-            (dissoc stored-concept :revision-date :transaction-id :created-at))))))
+    (is (= (expected-concept concept)
+           (dissoc stored-concept :revision-date :transaction-id :created-at)))))
 
 (defn is-tag-association-deleted?
   "Returns if the ta is marked as deleted in metadata-db"

--- a/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int_test/cmr/metadata_db/int_test/utility.clj
@@ -644,7 +644,9 @@
   [concept]
   (let [{:keys [concept-id revision-id]} concept
         stored-concept (:concept (get-concept-by-id-and-revision concept-id revision-id))]
-    (is (= (expected-concept concept) (dissoc stored-concept :revision-date :transaction-id :created-at)))))
+    (is (= (util/remove-nil-keys (expected-concept concept))
+           (util/remove-nil-keys
+            (dissoc stored-concept :revision-date :transaction-id :created-at))))))
 
 (defn is-tag-association-deleted?
   "Returns if the ta is marked as deleted in metadata-db"

--- a/metadata-db-app/src/cmr/metadata_db/api/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/concepts.clj
@@ -1,16 +1,17 @@
 (ns cmr.metadata-db.api.concepts
   "Defines the HTTP URL routes that deal with concepts."
-  (:require [compojure.core :refer :all]
-            [cmr.metadata-db.api.route-helpers :as rh]
-            [clojure.string :as str]
-            [cmr.common.services.errors :as errors]
-            [cmr.metadata-db.services.messages :as msg]
-            [inflections.core :as inf]
-            [cheshire.core :as json]
-            [cmr.common.util :as util]
-            [cmr.metadata-db.services.concept-service :as concept-service]
-            [cmr.metadata-db.services.search-service :as search-service]
-            [cmr.common.log :refer (debug info warn error)]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.util :as util]
+   [cmr.metadata-db.api.route-helpers :as rh]
+   [cmr.metadata-db.services.concept-service :as concept-service]
+   [cmr.metadata-db.services.messages :as msg]
+   [cmr.metadata-db.services.search-service :as search-service]
+   [compojure.core :refer :all]
+   [inflections.core :as inf]))
 
 (defn as-int
   "Parses the string to return an integer"
@@ -117,7 +118,6 @@
 (def concepts-api-routes
   (routes
     (context "/concepts" []
-
       (context "/search" []
         ;; get multiple concepts by concept-id and revision-id
         (POST "/concept-revisions" {:keys [params request-context body]}
@@ -131,7 +131,6 @@
           (find-concepts request-context params))
         (POST "/:concept-type" {:keys [params request-context]}
           (find-concepts request-context params)))
-
       ;; saves a concept
       (POST "/" {:keys [request-context params body]}
         (save-concept-revision request-context params body))

--- a/metadata-db-app/src/cmr/metadata_db/api/provider.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/provider.clj
@@ -1,12 +1,13 @@
 (ns cmr.metadata-db.api.provider
   "Defines the HTTP URL routes for the application."
-  (:require [clojure.walk :as walk]
-            [compojure.core :refer :all]
-            [cmr.acl.core :as acl]
-            [cheshire.core :as json]
-            [cmr.metadata-db.api.route-helpers :as rh]
-            [cmr.metadata-db.services.provider-service :as provider-service]
-            [cmr.common.log :refer (debug info warn error)]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.walk :as walk]
+   [cmr.acl.core :as acl]
+   [cmr.common.log :refer [debug info warn error]]
+   [cmr.metadata-db.api.route-helpers :as rh]
+   [cmr.metadata-db.services.provider-service :as provider-service]
+   [compojure.core :refer :all]))
 
 (defn- save-provider
   "Save a provider."

--- a/metadata-db-app/src/cmr/metadata_db/api/route_helpers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/route_helpers.clj
@@ -1,5 +1,6 @@
 (ns cmr.metadata-db.api.route-helpers
-  (:require [cmr.common.mime-types :as mt]))
+  (:require
+   [cmr.common.mime-types :as mt]))
 
 (def json-header
   {"Content-Type" (mt/with-utf-8 mt/json)})

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -664,9 +664,10 @@
     ;; delete the related service associations
     (delete-associations
      context concept-type concept-id revision-id :service-association)
-      ;; Do not queue the concept revision deletion event for now.
-      (ingest-events/publish-concept-revision-delete-msg
-       context concept-id revision-id)))
+    ;; XXX Do not queue the concept revision deletion event for now.
+    ; (ingest-events/publish-concept-revision-delete-msg
+    ;  context concept-id revision-id)
+    ))
 
 (defmethod force-delete-cascading-events :default
   [context concept-type concept-id revision-id]

--- a/system-int-test/test/cmr/system_int_test/search/service/force_delete_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/force_delete_test.clj
@@ -1,0 +1,55 @@
+(ns cmr.system-int-test.search.service.force-delete-test
+  "This tests force-deleting a service concept and the impact on
+  service/collection associations."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.service-util :as service]
+   [cmr.system-int-test.utils.association-util :as au]
+   [cmr.transmit.config :refer [mock-echo-system-token]
+                        :rename {mock-echo-system-token token}]))
+
+(use-fixtures
+ :each
+ (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(defn- get-collection-services
+  []
+  (let [{{[{{services :services} :associations}] :entries} :results}
+       (search/find-concepts-json :collection {})]
+    services))
+
+(deftest force-delete-service-with-associations
+  (let [coll (data-umm-c/collection-concept {})
+        {coll-concept-id :concept-id} (ingest/ingest-concept coll)
+        _ (service/ingest-service)
+        svc-concept (service/ingest-service)
+        {svc-concept-id :concept-id} svc-concept
+        _ (index/wait-until-indexed)
+        {[assn-response] :body} (au/associate-by-concept-ids
+                                 token
+                                 svc-concept-id
+                                 [{:concept-id coll-concept-id}])
+        {{svc-assn-concept-id :concept-id} :service-association} assn-response]
+    (testing "initial conditions"
+      (is (= 2 (:revision-id svc-concept)))
+      (is (= coll-concept-id
+             (get-in assn-response [:associated-item :concept-id])))
+      (is (contains? (get-collection-services) svc-concept-id)))
+    (testing "just the last revision is deleted"
+      (mdb/force-delete-concept svc-concept-id 1)
+      ;; the service association has not been deleted
+      (is (contains? (get-collection-services) svc-concept-id)))
+    (testing "just the most recent revision is deleted"
+      ;; now the service association has been deleted
+      (mdb/force-delete-concept svc-concept-id 2)
+      (index/wait-until-indexed)
+      (is (not (contains? (get-collection-services) svc-concept-id))))))


### PR DESCRIPTION
This adds a check to cascading deletes for service concepts as well as some more metadata-db integration tests.

I will updates services to do something similar (also adding missing tests) once this PR is reviewed.