### PR TITLE
CMR-4593: Platform parsing error during index.

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -115,12 +115,12 @@
 (defn safe-lowercase
   "Returns the given string in lower case safely."
   [v]
-  (when v (string/lower-case v)))
+  (when (some? v) (string/lower-case v)))
 
 (defn safe-uppercase
   "Returns the given string in upper case safely."
   [v]
-  (when v (string/upper-case v)))
+  (when (some? v) (string/upper-case v)))
 
 (defn match-enum-case
   "Given a string and a collection of valid enum values, return the proper-cased

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -773,3 +773,15 @@
 
     "Set of numbers"
     #{1 7 52 3} 52))
+
+(deftest safe-lower-upper-case-test
+  (testing "safe-lowercase"
+    (is (= (util/safe-lowercase false) (str/lower-case false)))
+    (is (= (util/safe-lowercase true) (str/lower-case true)))
+    (is (= (util/safe-lowercase "StRing") (str/lower-case "StRing")))
+    (is (= (util/safe-lowercase nil) nil)))
+  (testing "safe-upperrcase"
+    (is (= (util/safe-uppercase false) (str/upper-case false)))
+    (is (= (util/safe-uppercase true) (str/upper-case true)))
+    (is (= (util/safe-uppercase "StRing") (str/upper-case "StRing")))
+    (is (= (util/safe-uppercase nil) nil)))) 

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/platform.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/platform.clj
@@ -1,8 +1,10 @@
 (ns cmr.indexer.data.concepts.collection.platform
   "Contains functions for converting platform hierarchies into elastic documents"
-  (:require [clojure.string :as str]
-            [cmr.common-app.services.kms-fetcher :as kf]
-            [cmr.common-app.services.kms-lookup :as kms-lookup]))
+  (:require 
+    [clojure.string :as str]
+    [cmr.common-app.services.kms-fetcher :as kf]
+    [cmr.common-app.services.kms-lookup :as kms-lookup]
+    [cmr.common.util :as util]))
 
 
 (def default-platform-values
@@ -30,4 +32,4 @@
      :long-name long-name
      :long-name.lowercase (str/lower-case long-name)
      :uuid uuid
-     :uuid.lowercase (when uuid (str/lower-case uuid))}))
+     :uuid.lowercase (util/safe-lowercase uuid)}))

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2021,7 +2021,7 @@ Examples of sorting by start_date in descending(Most recent data first) and asce
 
 ### <a name="retrieving-concepts-by-concept-id-and-revision-id"></a> Retrieve concept with a given concept-id or concept-id & revision-id
 
-This allows retrieving the metadata for a single concept. This is only supported for collections, granules, variables, and services. If no format is specified the native format (and the native version if exists) of the metadata will be returned.
+This allows retrieving the metadata for a single concept. This is only supported for collections, granules, variables, and services. If no format is specified the native format of the metadata (and the native version, if it exists) will be returned.
 
 By concept id
 


### PR DESCRIPTION
1. The index error is caused by platform's short name being nil in an old collection C179003298-ORNL_DAAC revision 27.
2. Verified that the bad collection couldn't be ingested by the current code because of the nil platform short name.
3. Modified safe-lowercase, safe-uppercase because they don't work on the case when the parameter is boolean false.  Added unit tests for it.
4. Modified the search api doc to correct a grammar mistake from an earlier ticket.