### PR TITLE
Cmr 4580 fix parameter validation

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/params.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/params.clj
@@ -23,6 +23,15 @@
                             (not (and (string? value) (= "" (string/trim value)))))]
     (into {} (filter (comp not-empty-string? second) params))))
 
+(defn sanitize-without-removing-empty-params
+  "Manipulates the parameters to make them easier to process"
+  [params]
+  (-> params
+      u/map-keys->kebab-case
+      (update-in [:sort-key] #(when % (if (sequential? %)
+                                        (map sanitize-sort-key %)
+                                        (sanitize-sort-key %))))))
+
 (defn sanitize-params
   "Manipulates the parameters to make them easier to process"
   [params]

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -276,6 +276,18 @@
           m
           m))
 
+(defn remove-non-nil-and-non-empty-keys
+  "Removes keys mapping to non-nil and non-empty values in a map."
+  [m]
+  (reduce (fn [m kv]
+            (let [v (val kv)
+                  k (key kv)] 
+              (if (and (some? v) (not (and (string? v) (= "" (string/trim v)))))
+                (dissoc m k)
+                m)))
+          m
+          m))
+
 (defn inflate-nil-keys
   "Occupy nil values with a given default value."
   [m filler]

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -780,7 +780,7 @@
     (is (= (util/safe-lowercase true) (str/lower-case true)))
     (is (= (util/safe-lowercase "StRing") (str/lower-case "StRing")))
     (is (= (util/safe-lowercase nil) nil)))
-  (testing "safe-upperrcase"
+  (testing "safe-uppercase"
     (is (= (util/safe-uppercase false) (str/upper-case false)))
     (is (= (util/safe-uppercase true) (str/upper-case true)))
     (is (= (util/safe-uppercase "StRing") (str/upper-case "StRing")))

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -144,6 +144,38 @@
   [params]
   (or (:tag-data params) (:tag_data params)))
 
+
+(defn- validate-empty-or-nil-parameters
+  "validate only the empty or nil valued parameters"
+  [context concept-type params]
+  (let [empty-or-nil-params 
+         (some-> params 
+                 u/remove-non-nil-and-non-empty-keys
+                 common-params/sanitize-without-removing-empty-params
+                 ;; empty or nil equator crossing start date and end date are not useful
+                 ;; towards the final replacement of equator-crossing-date.
+                 (dissoc :equator-crossing-start-date :equator-crossing-end-date))]
+    (some->> empty-or-nil-params
+             lp/replace-parameter-aliases
+             (lp/process-legacy-multi-params-conditions concept-type)
+             (lp/replace-science-keywords-or-option concept-type)
+             (psn/replace-provider-short-names context)
+             (pv/validate-parameters concept-type)))) 
+
+(defn- remove-nil-from-sequential-values
+   "Remove all the nils from all the sequential values in a map.
+    This is used to fix the 500 error when params contain
+    :concept-id [C123-PROV1 nil]."
+  [params]
+  (u/map-values 
+    #(if (sequential? %) 
+       (let [new-v (remove nil? %)]
+         (if (seq new-v)
+           (into [] new-v)
+           nil))
+        %)
+    params)) 
+
 (defn make-concepts-query
   "Utility function for generating an elastic-ready query."
   ([context concept-type params]
@@ -152,9 +184,11 @@
         (make-concepts-query
          context concept-type params)))
   ([context concept-type params tag-data]
+   (validate-empty-or-nil-parameters context concept-type params)
    (->> params
         common-params/sanitize-params
         (add-tag-data-to-params tag-data)
+        remove-nil-from-sequential-values
         ;; CMR-2553 remove the following line
         drop-ignored-params
         ;; handle legacy parameters

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
@@ -321,7 +321,9 @@
            "-70.0,120.0" [gran1 gran2 gran3 gran4 gran5]
            ;; Empty cloud cover is allowed.
            ;; It is as if no cloud cover parameter is present and will find everything.
-           "" [gran1 gran2 gran3 gran4 gran5 gran6]))
+           ;; With the new implementation of the parameter validation that doesn't skip 
+           ;; the nil/empty parameter, this will fail validation.
+           "" []))
 
     (testing "search by cloud-cover with min value greater than max value"
       (let [min-value 30.0


### PR DESCRIPTION
This PR validates the parameters properly for the following collection search cases.
Will add some testings once the approach is approved.

1. collections?C123-PROV1
2. collections?C123-PROV1=
3. collections?concept_id[]=C123-PROV1&C345-PROV1
4. collections?C123-PROV1&include_facets=v2
5. collections?C123-PROV1=&include_facets=v2
7. collections?concept_id[]=C123-PROV1&concept_id (This used to throw 500 error, which was not included in this ticket)