### PR TITLE
CMR-4570 

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -189,11 +189,11 @@
                         :update-value {:Category "EARTH SCIENCE"
                                        :Term "MARINE SEDIMENTS"
                                        :Topic "OCEANS"}}]
-    
+
     ;; Initiate bulk update that shouldn't add any duplicates.
     (let [response (ingest/bulk-update-collections "PROV1" duplicate-body)
           _ (index/wait-until-indexed)
-          collection-response (ingest/bulk-update-task-status "PROV1" response)]
+          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
       (is (= "COMPLETE" (:task-status collection-response))))
 
     (side/eval-form `(ingest-config/set-bulk-update-enabled! false))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -189,12 +189,13 @@
                         :update-value {:Category "EARTH SCIENCE"
                                        :Term "MARINE SEDIMENTS"
                                        :Topic "OCEANS"}}]
+    
     ;; Initiate bulk update that shouldn't add any duplicates.
-    (ingest/bulk-update-collections "PROV1" duplicate-body)
-    ;; Wait for queueing/indexing to catch up
-    (index/wait-until-indexed)
-    (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+    (let [response (ingest/bulk-update-collections "PROV1" duplicate-body)
+          _ (index/wait-until-indexed)
+          collection-response (ingest/bulk-update-task-status "PROV1" response)]
       (is (= "COMPLETE" (:task-status collection-response))))
+
     (side/eval-form `(ingest-config/set-bulk-update-enabled! false))
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
@@ -206,8 +207,8 @@
       (is (= 404 (:status collection-response)))
       (is (= ["Bulk update task with task id [2] could not be found."]
              (:errors collection-response))))
-
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
+
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
       (is (= 200 (:status response)))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -189,6 +189,12 @@
                         :update-value {:Category "EARTH SCIENCE"
                                        :Term "MARINE SEDIMENTS"
                                        :Topic "OCEANS"}}]
+    ;; Initiate bulk update that shouldn't add anything, including duplicates.
+    (ingest/bulk-update-collections "PROV1" duplicate-body)
+    ;; Wait for queueing/indexing to catch up
+    (index/wait-until-indexed)
+    (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+      (is (= "COMPLETE" (:task-status collection-response))))
     (side/eval-form `(ingest-config/set-bulk-update-enabled! false))
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
@@ -196,22 +202,17 @@
       (is (= ["Bulk update is disabled."] (:errors response))))
     ;; Wait for queueing/indexing to catch up
     (index/wait-until-indexed)
-    (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+    (let [collection-response (ingest/bulk-update-task-status "PROV1" 2)]
       (is (= 404 (:status collection-response)))
-      (is (= ["Bulk update task with task id [1] could not be found."]
+      (is (= ["Bulk update task with task id [2] could not be found."]
              (:errors collection-response))))
 
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
     ;; Kick off bulk update
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
       (is (= 200 (:status response)))
-      ;; Initiate bulk update that shouldn't add anything, including duplicates.
-      (ingest/bulk-update-collections "PROV1" duplicate-body)
       ;; Wait for queueing/indexing to catch up
       (index/wait-until-indexed)
-      (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
-        (is (= "COMPLETE" (:task-status collection-response))))
-
       ;; Check that each concept was updated
       (doseq [concept-id concept-ids
               :let [concept (-> (search/find-concepts-umm-json :collection
@@ -219,8 +220,7 @@
                                 :results
                                 :items
                                 first)]]
-        (is (= 3
-               (:revision-id (:meta concept))))
+        (is (= 3 (:revision-id (:meta concept))))
         (is (= "2017-01-01T00:00:00Z"
                (:revision-date (:meta concept))))
         (some #(= {:Date "2017-01-01T00:00:00Z" :Type "UPDATE"} %) (:MetadataDates (:umm concept)))
@@ -261,15 +261,17 @@
                         :update-value [{:Category "EARTH SCIENCE"
                                         :Term "MARINE SEDIMENTS"
                                         :Topic "OCEANS"}
-                                       {:Category "EARTH SCIENCE2"
-                                        :Topic "HUMAN DIMENSIONS2"
-                                        :Term "ENVIRONMENTAL IMPACTS2"
-                                        :VariableLevel1 "HEAVY METALS CONCENTRATION2"}]}]
+                                       {:Category "EARTH SCIENCE1"
+                                        :Topic "HUMAN DIMENSIONS1"
+                                        :Term "ENVIRONMENTAL IMPACTS1"
+                                        :VariableLevel1 "HEAVY METALS CONCENTRATION1"}]}]
+       ;; Initiate bulk update that shouldn't add anything, including duplicates.
+       (ingest/bulk-update-collections "PROV1" duplicate-body)
+       ;; Wait for queueing/indexing to catch up
+       (index/wait-until-indexed)
        ;; Kick off bulk update
        (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
          (is (= 200 (:status response)))
-         ;; Initiate bulk update that shouldn't add anything, including duplicates.
-         (ingest/bulk-update-collections "PROV1" duplicate-body)
          ;; Wait for queueing/indexing to catch up
          (index/wait-until-indexed)
          (let [collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -194,8 +194,6 @@
     ;; Wait for queueing/indexing to catch up
     (index/wait-until-indexed)
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
-      ;; Wait for queueing/indexing to catch up
-      (index/wait-until-indexed)
       (is (= "COMPLETE" (:task-status collection-response))))
     (side/eval-form `(ingest-config/set-bulk-update-enabled! false))
     ;; Kick off bulk update

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -191,6 +191,8 @@
                                        :Topic "OCEANS"}}]
     ;; Initiate bulk update that shouldn't add any duplicates.
     (ingest/bulk-update-collections "PROV1" duplicate-body)
+    ;; Wait for queueing/indexing to catch up
+    (index/wait-until-indexed)
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
       ;; Wait for queueing/indexing to catch up
       (index/wait-until-indexed)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -189,7 +189,7 @@
                         :update-value {:Category "EARTH SCIENCE"
                                        :Term "MARINE SEDIMENTS"
                                        :Topic "OCEANS"}}]
-    ;; Initiate bulk update that shouldn't add anything, including duplicates.
+    ;; Initiate bulk update that shouldn't add any duplicates.
     (ingest/bulk-update-collections "PROV1" duplicate-body)
     ;; Wait for queueing/indexing to catch up
     (index/wait-until-indexed)
@@ -265,7 +265,7 @@
                                         :Topic "HUMAN DIMENSIONS1"
                                         :Term "ENVIRONMENTAL IMPACTS1"
                                         :VariableLevel1 "HEAVY METALS CONCENTRATION1"}]}]
-       ;; Initiate bulk update that shouldn't add anything, including duplicates.
+       ;; Initiate bulk update that shouldn't add any duplicates.
        (ingest/bulk-update-collections "PROV1" duplicate-body)
        ;; Wait for queueing/indexing to catch up
        (index/wait-until-indexed)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -191,9 +191,9 @@
                                        :Topic "OCEANS"}}]
     ;; Initiate bulk update that shouldn't add any duplicates.
     (ingest/bulk-update-collections "PROV1" duplicate-body)
-    ;; Wait for queueing/indexing to catch up
-    (index/wait-until-indexed)
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+      ;; Wait for queueing/indexing to catch up
+      (index/wait-until-indexed)
       (is (= "COMPLETE" (:task-status collection-response))))
     (side/eval-form `(ingest-config/set-bulk-update-enabled! false))
     ;; Kick off bulk update

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -82,6 +82,8 @@
           (update-in umm update-field #(concat % update-value))
           (update-in umm update-field #(conj % update-value)))
         (util/update-in-each umm update-field util/remove-nil-keys)
+        ;; In order to do distinct, convert the list of models to a list of maps
+        (update-in umm update-field #(map (partial into {}) %))
         (update-in umm update-field distinct)))
 
 (defmethod apply-umm-list-update :clear-all-and-replace


### PR DESCRIPTION
This PR fixes issue where duplicates were still being added, after bulk-update was modified to remove duplicates on ADD_TO_EXISTING update-type.  