### PR TITLE
CMR-4685: Modified bulk update to allow data center home page url to …

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -640,6 +640,7 @@ The following update types are supported:
   * Clear all and replace - clear the list and replace with the update value.
   * Find and replace - replace any instance in the list that matches the find value with the update value.
   * Find and update - merge update value into any instance in the list that matches the find value.
+  * Find and update home page url - A special case for Find and update that only applies to datacenter update. 
   * Find and remove - remove any instance from the list that matches the find value.
 
 Bulk update post request takes the following parameters:
@@ -655,7 +656,7 @@ Update types that include a FIND will match on the fields supplied in the find v
 
 The difference between `FIND_AND_UPDATE` and `FIND_AND_REPLACE` is `FIND_AND_REPLACE` will remove the matches and replace them entirely with the values specified in update value, while with `FIND_AND_UPDATE`, only the field(s) specified in the update value will be replaced, with the rest of the original value retained. For example, with a platform update value of `{"ShortName": "A340-600"}`, only the short name will be updated during a find and update, while the long name, instruments, and other fields retain their values. If a field specified in the update value doesn't exist in the matches, the field will be added.
 
-`FIND_AND_UPDATE_HOME_PAGE_URL` is a special case for `FIND_AND_UPDATE`. It can only be used with Update field being DATA_CENTERS. It is the same as FIND_AND_UPDATE except that when update value contains ContactInformation, it doesn't replace the ContactInformation, instead it only replaces the datacenter HOME PAGE URL part with the value specified in the RelatedUrls, if it exists, and leave everything else in the ContactInformation untouched. 
+`FIND_AND_UPDATE_HOME_PAGE_URL` is a special case for `FIND_AND_UPDATE`. It can only be used with Update field being `DATA_CENTERS`. It is the same as `FIND_AND_UPDATE` except that when update value contains ContactInformation, it doesn't replace the ContactInformation, instead it only replaces the datacenter HOME PAGE URL part with the new datacenter HOME PAGE URL specified in the RelatedUrls, if it exists, and leave everything else in the ContactInformation untouched. If the new datacenter HOME PAGE URL is not present in the update value, the HOME PAGE URL of the found data centers will be removed.
 
 Instruments are nested within platforms so instrument updates are applied to all platforms in the collection, when applying
 `ADD_TO_EXISTING` and `CLEAR_ALL_AND_REPLACE` bulk updates to the instruments.

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -640,7 +640,7 @@ The following update types are supported:
   * Clear all and replace - clear the list and replace with the update value.
   * Find and replace - replace any instance in the list that matches the find value with the update value.
   * Find and update - merge update value into any instance in the list that matches the find value.
-  * Find and update home page url - A special case for Find and update that only applies to datacenter update. 
+  * Find and update home page url - A special case for Find and update. 
   * Find and remove - remove any instance from the list that matches the find value.
 
 Bulk update post request takes the following parameters:
@@ -656,7 +656,7 @@ Update types that include a FIND will match on the fields supplied in the find v
 
 The difference between `FIND_AND_UPDATE` and `FIND_AND_REPLACE` is `FIND_AND_REPLACE` will remove the matches and replace them entirely with the values specified in update value, while with `FIND_AND_UPDATE`, only the field(s) specified in the update value will be replaced, with the rest of the original value retained. For example, with a platform update value of `{"ShortName": "A340-600"}`, only the short name will be updated during a find and update, while the long name, instruments, and other fields retain their values. If a field specified in the update value doesn't exist in the matches, the field will be added.
 
-`FIND_AND_UPDATE_HOME_PAGE_URL` is a special case for `FIND_AND_UPDATE`. It can only be used with Update field being `DATA_CENTERS`. It is the same as `FIND_AND_UPDATE` except that when update value contains ContactInformation, it doesn't replace the ContactInformation, instead it only replaces the datacenter HOME PAGE URL part with the new datacenter HOME PAGE URL specified in the RelatedUrls, if it exists, and leave everything else in the ContactInformation untouched. If the new datacenter HOME PAGE URL is not present in the update value, the HOME PAGE URL of the found data centers will be removed.
+`FIND_AND_UPDATE_HOME_PAGE_URL` is a special case for `FIND_AND_UPDATE`. It can only be used with Update field being `DATA_CENTERS`. It is the same as `FIND_AND_UPDATE` except that when update value contains ContactInformation, it doesn't replace the ContactInformation, instead it only replaces the data center HOME PAGE URL part with the new data center HOME PAGE URL specified in the RelatedUrls, if it exists, and leaves everything else in the ContactInformation untouched. If the new data center HOME PAGE URL is not present in the update value, the HOME PAGE URL of the found data centers will be removed.
 
 Instruments are nested within platforms so instrument updates are applied to all platforms in the collection, when applying
 `ADD_TO_EXISTING` and `CLEAR_ALL_AND_REPLACE` bulk updates to the instruments.

--- a/umm-spec-lib/src/cmr/umm_spec/field_update.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/field_update.clj
@@ -40,9 +40,9 @@
   "Apply special home-page-url update to data-center using the update-value.
    If the new home-page-url is provided in the update-value.
       a. If data-center-related-urls contains home-page-url, update it with the new home-page-url.
-         if the new home-page-url is not present in update-value, remove the home-page-url from data center.
       b. If data-center-related-urls doesn't contain home-page-url, add the new home-page-url to it.
-      Note: Anything other than the home-page-url in update-value are ignored."
+   If the new home-page-url is not present in update-value, remove the home-page-url from data center.
+   Note: Anything other than the home-page-url in update-value are ignored."
   [data-center update-value]
   (let [update-value-related-urls (get-in update-value [:ContactInformation :RelatedUrls])
         update-value-home-page-url (get-home-page-url update-value-related-urls)

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -216,6 +216,133 @@
        {:Subregion1 "WESTERN ASIA"}
        {:LocationKeywords [{:Subregion1 "EASTERN ASIA"}]})))
 
+(deftest data-center-home-page-url-updates
+  (testing "DataCenter home page url updates when home page url is present in the update-value."
+    (let [umm {:DataCenters [{:ShortName "ShortName"
+                              :LongName "Hydrogeophysics Group, Aarhus University "
+                              :Roles ["ARCHIVER", "DISTRIBUTOR"]
+                              :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"}
+                                                                 {:URLContentType "DataCenterURL"
+                                                                  :Type "PROJECT HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"} ]
+                                                   :ContactMechanisms  [{:Type "Telephone"
+                                                                         :Value "1 303 492 6199 x" }
+                                                                        {:Type  "Fax"
+                                                                         :Value "1 303 492 2468 x" }
+                                                                        {:Type  "Email"
+                                                                         :Value "nsidc@nsidc.org" }]}}
+                             {:ShortName "ShortName"
+                              :LongName "Hydrogeophysics Group, Aarhus University "
+                              :Roles ["ARCHIVER"]}
+                             {:ShortName "ShortName"
+                              :Roles ["PROCESSOR"]
+                              :ContactPersons [{:Roles ["Data Center Contact"]
+                                                :LastName "Smith"}]
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"}]}}]}]
+      (are3 [update-type update-value find-value result]
+        (is (= result
+               (field-update/apply-update update-type umm [:DataCenters] update-value find-value)))
+
+        "Find and update home page url" 
+        :find-and-update-home-page-url
+        {:ShortName "NewShortName" :LongName "NewLongName" :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                                               :Type "HOME PAGE"
+                                                                                               :URL "http://nsidc.org/daac/newindex.html"}]}}
+        {:ShortName "ShortName"}
+        {:DataCenters [{:ShortName "NewShortName"
+                              :LongName "NewLongName"
+                              :Roles ["ARCHIVER", "DISTRIBUTOR"]
+                              :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/newindex.html"}
+                                                                 {:URLContentType "DataCenterURL"
+                                                                  :Type "PROJECT HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"} ]
+                                                   :ContactMechanisms  [{:Type "Telephone"
+                                                                         :Value "1 303 492 6199 x" }
+                                                                        {:Type  "Fax"
+                                                                         :Value "1 303 492 2468 x" }
+                                                                        {:Type  "Email"
+                                                                         :Value "nsidc@nsidc.org" }]}}
+                             {:ShortName "NewShortName"
+                              :LongName "NewLongName"
+                              :Roles ["ARCHIVER"]
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/newindex.html"}]}}
+                             {:ShortName "NewShortName"
+                              :LongName "NewLongName"
+                              :Roles ["PROCESSOR"]
+                              :ContactPersons [{:Roles ["Data Center Contact"]
+                                                :LastName "Smith"}]
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/newindex.html"}]}}]}))) 
+  (testing "DataCenter home page url updates when home page url is NOT present in the update-value."
+    (let [umm {:DataCenters [{:ShortName "ShortName"
+                              :LongName "Hydrogeophysics Group, Aarhus University "
+                              :Roles ["ARCHIVER", "DISTRIBUTOR"]
+                              :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"}
+                                                                 {:URLContentType "DataCenterURL"
+                                                                  :Type "PROJECT HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"} ]
+                                                   :ContactMechanisms  [{:Type "Telephone"
+                                                                         :Value "1 303 492 6199 x" }
+                                                                        {:Type  "Fax"
+                                                                         :Value "1 303 492 2468 x" }
+                                                                        {:Type  "Email"
+                                                                         :Value "nsidc@nsidc.org" }]}}
+                             {:ShortName "ShortName"
+                              :LongName "Hydrogeophysics Group, Aarhus University "
+                              :Roles ["ARCHIVER"]}
+                             {:ShortName "ShortName"
+                              :Roles ["PROCESSOR"]
+                              :ContactPersons [{:Roles ["Data Center Contact"]
+                                                :LastName "Smith"}]
+                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                  :Type "HOME PAGE"
+                                                                  :URL "http://nsidc.org/daac/index.html"}]}}]}]
+      (are3 [update-type update-value find-value result]
+        (is (= result
+               (field-update/apply-update update-type umm [:DataCenters] update-value find-value)))
+
+        "Find and update home page url"
+        :find-and-update-home-page-url
+        {:ShortName "NewShortName" :LongName "NewLongName" :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                                                               :Type "NOT A HOME PAGE"
+                                                                                               :URL "http://nsidc.org/daac/newindex.html"}]}}
+        {:ShortName "ShortName"}
+        {:DataCenters [{:ShortName "NewShortName"
+                        :LongName "NewLongName"
+                        :Roles ["ARCHIVER", "DISTRIBUTOR"]
+                        :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
+                        :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                            :Type "PROJECT HOME PAGE"
+                                                            :URL "http://nsidc.org/daac/index.html"} ]
+                                             :ContactMechanisms  [{:Type "Telephone"
+                                                                   :Value "1 303 492 6199 x" }
+                                                                  {:Type  "Fax"
+                                                                   :Value "1 303 492 2468 x" }
+                                                                  {:Type  "Email"
+                                                                   :Value "nsidc@nsidc.org" }]}}
+                       {:ShortName "NewShortName"
+                        :LongName "NewLongName"
+                        :Roles ["ARCHIVER"]}
+                       {:ShortName "NewShortName"
+                        :LongName "NewLongName"
+                        :Roles ["PROCESSOR"]
+                        :ContactPersons [{:Roles ["Data Center Contact"]
+                                          :LastName "Smith"}]}]}))))
+
 (deftest platform-instrument-name-updates
  (testing "Platform name updates"
    (let [umm {:Platforms [{:ShortName "Platform 1"

--- a/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/field_update.clj
@@ -255,35 +255,35 @@
                                                                                                :URL "http://nsidc.org/daac/newindex.html"}]}}
         {:ShortName "ShortName"}
         {:DataCenters [{:ShortName "NewShortName"
-                              :LongName "NewLongName"
-                              :Roles ["ARCHIVER", "DISTRIBUTOR"]
-                              :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
-                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
-                                                                  :Type "HOME PAGE"
-                                                                  :URL "http://nsidc.org/daac/newindex.html"}
-                                                                 {:URLContentType "DataCenterURL"
-                                                                  :Type "PROJECT HOME PAGE"
-                                                                  :URL "http://nsidc.org/daac/index.html"} ]
-                                                   :ContactMechanisms  [{:Type "Telephone"
-                                                                         :Value "1 303 492 6199 x" }
-                                                                        {:Type  "Fax"
-                                                                         :Value "1 303 492 2468 x" }
-                                                                        {:Type  "Email"
-                                                                         :Value "nsidc@nsidc.org" }]}}
-                             {:ShortName "NewShortName"
-                              :LongName "NewLongName"
-                              :Roles ["ARCHIVER"]
-                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
-                                                                  :Type "HOME PAGE"
-                                                                  :URL "http://nsidc.org/daac/newindex.html"}]}}
-                             {:ShortName "NewShortName"
-                              :LongName "NewLongName"
-                              :Roles ["PROCESSOR"]
-                              :ContactPersons [{:Roles ["Data Center Contact"]
-                                                :LastName "Smith"}]
-                              :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
-                                                                  :Type "HOME PAGE"
-                                                                  :URL "http://nsidc.org/daac/newindex.html"}]}}]}))) 
+                        :LongName "NewLongName"
+                        :Roles ["ARCHIVER", "DISTRIBUTOR"]
+                        :Uuid "ef941ad9-1662-400d-a24a-c300a72c1531"
+                        :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                            :Type "HOME PAGE"
+                                                            :URL "http://nsidc.org/daac/newindex.html"}
+                                                           {:URLContentType "DataCenterURL"
+                                                            :Type "PROJECT HOME PAGE"
+                                                            :URL "http://nsidc.org/daac/index.html"} ]
+                                             :ContactMechanisms  [{:Type "Telephone"
+                                                                   :Value "1 303 492 6199 x" }
+                                                                  {:Type  "Fax"
+                                                                   :Value "1 303 492 2468 x" }
+                                                                  {:Type  "Email"
+                                                                   :Value "nsidc@nsidc.org" }]}}
+                       {:ShortName "NewShortName"
+                        :LongName "NewLongName"
+                        :Roles ["ARCHIVER"]
+                        :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                            :Type "HOME PAGE"
+                                                            :URL "http://nsidc.org/daac/newindex.html"}]}}
+                       {:ShortName "NewShortName"
+                        :LongName "NewLongName"
+                        :Roles ["PROCESSOR"]
+                        :ContactPersons [{:Roles ["Data Center Contact"]
+                                          :LastName "Smith"}]
+                        :ContactInformation {:RelatedUrls [{:URLContentType "DataCenterURL"
+                                                            :Type "HOME PAGE"
+                                                            :URL "http://nsidc.org/daac/newindex.html"}]}}]}))) 
   (testing "DataCenter home page url updates when home page url is NOT present in the update-value."
     (let [umm {:DataCenters [{:ShortName "ShortName"
                               :LongName "Hydrogeophysics Group, Aarhus University "


### PR DESCRIPTION
…be removed when the new value is not present.

1. When doing FIND_AND_UPDATE_HOME_PAGE_URL on DataCenter, if the update-value doesn't contain a new home page url,  the original home page url of the found DataCenters should be removed.

2. Any empty RelatedUrls and ContactInformation will be removed following the home page url update/removal. 

3. Added the unit tests and Integration tests.

4. Modified the api doc.