### PR TITLE
Cmr 4558

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/params.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/params.clj
@@ -168,6 +168,16 @@
        :sort-keys (parse-sort-key (:sort-key params) aliases)
        :result-format (:result-format params)}])))
 
+(defn generate-param-query-conditions
+  "Generate the search conditions for the query based on the parameters"
+  [context concept-type params]
+  (let [options (u/map-keys->kebab-case (get params :options {}))
+        params (dissoc params :options)]
+    (when (not (empty? params))
+      (map (fn [[param value]]
+             (parameter->condition context concept-type param value options))
+           params))))
+
 (defmulti parse-query-level-params
   "Extracts parameters apply at the query level page-size and result format and returns a tuple of
    leftover parameters and a map as query attributes.

--- a/common-app-lib/src/cmr/common_app/services/search/params.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/params.clj
@@ -173,7 +173,7 @@
   [context concept-type params]
   (let [options (u/map-keys->kebab-case (get params :options {}))
         params (dissoc params :options)]
-    (when (not (empty? params))
+    (when (seq params)
       (map (fn [[param value]]
              (parameter->condition context concept-type param value options))
            params))))

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -23,7 +23,6 @@
    [cmr.dev-system.tests :as tests]
    [cmr.ingest.system :as ingest-system]
    [cmr.message-queue.config :as q-config]
-   [cmr.search.services.content-service :as content-service]
    [cmr.search.services.humanizers.humanizer-report-service :as humanizer-report-service]
    [cmr.search.system :as search-system]
    [cmr.system-int-test.system :as sit-sys]
@@ -200,7 +199,6 @@
   ;; Prevent jobs from blocking calls to reset
   (humanizer-report-service/set-retry-count! 0)
   (humanizer-report-service/set-humanizer-report-generator-job-wait! 0)
-  (content-service/set-static-content-generation-interval! 60)
 
   ;; uncomment this line to start gorilla repl.
   ;;(system/set-gorilla-repl-port! 8090)

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -244,7 +244,6 @@
                            granule-end-date)
         humanized-values (humanizer/collection-humanizers-elastic context collection)]
     (merge {:concept-id concept-id
-            :doi doi
             :doi-stored doi
             :doi.lowercase doi-lowercase
             :revision-id revision-id

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -245,6 +245,7 @@
         humanized-values (humanizer/collection-humanizers-elastic context collection)]
     (merge {:concept-id concept-id
             :doi doi
+            :doi-stored doi
             :doi.lowercase doi-lowercase
             :revision-id revision-id
             :concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -286,6 +286,7 @@
           :entry-id           (m/stored m/string-field-mapping)
           :entry-id.lowercase m/string-field-mapping
           :doi           m/string-field-mapping
+          :doi-stored    (m/stored m/string-field-mapping)
           :doi.lowercase m/string-field-mapping
           :entry-title           (m/stored m/string-field-mapping)
           :entry-title.lowercase m/string-field-mapping

--- a/search-app/resources/templates/search-provider-tag-landing-links.html
+++ b/search-app/resources/templates/search-provider-tag-landing-links.html
@@ -25,13 +25,13 @@
       {% for holding in holdings %}
       <tr>
         <td>
-          <a href="{{ holding.link-href }}">{{ holding.umm.EntryTitle }}</a>
+          <a href="{{ holding.link-href }}">{{ holding.entry-title }}</a>
         </td>
         <td>
-          {{ holding.umm.ShortName }}
+          {{ holding.short-name }}
         </td>
         <td>
-          {{ holding.umm.Version }}
+          {{ holding.version-id }}
         </td>
       </tr>
       {% endfor %}

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -57,7 +57,8 @@
                           :variable-name :variable-names
                           :variable-native-id :variable-native-ids
                           :measurement :measurements
-                          :author :authors}]
+                          :author :authors
+                          :doi :doi-stored}]
     (if (use-doc-values-fields)
       (merge default-mappings spatial-doc-values-field-mappings)
       default-mappings)))

--- a/search-app/src/cmr/search/services/content_service.clj
+++ b/search-app/src/cmr/search/services/content_service.clj
@@ -2,52 +2,8 @@
   "Provides service functions for generating static content."
   (:require
    [clojure.string :as string]
-   [cmr.acl.core :as acl]
-   [cmr.common-app.cache.consistent-cache :as consistent-cache]
-   [cmr.common-app.cache.cubby-cache :as cubby-cache]
-   [cmr.common.cache :as cache]
-   [cmr.common.cache.fallback-cache :as fallback-cache]
-   [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
-   [cmr.common.config :refer [defconfig]]
-   [cmr.common.jobs :refer [defjob default-job-start-delay]]
-   [cmr.common.log :refer :all]
-   [cmr.common.util :as util]
-   [cmr.search.site.pages :as pages]
-   [cmr.search.site.static :as static]
-   [cmr.search.site.util :as site-utils]
-   [cmr.transmit.config :as transmit-config]
-   [cmr.transmit.metadata-db :as mdb]))
-
-(def cache-key
-  "The key used to store the static content cache in the system cache map."
-  :static-content-cache)
-
-(defconfig static-content-generation-job-delay
-  "Number of seconds the `static-content-generator-job` should wait after
-  collection cache refresh job starts."
-  {:default 0
-   :type Long})
-
-(defconfig static-content-generation-interval
-  "Number of seconds between `static-content-generator-job` runs."
-  {:default (* 60 60 24)
-   :type Long})
-
-(defn create-cache
-  "This function creates the composite cache that is used for caching the
-  static content data. With the given composition we get the following
-  features:
-  * A cubby cache that holds the generated content (centralized storage in
-    an ElasticSearch backend);
-  * A single-threaded cache that circumvents potential race conditions
-    between HTTP requests for a report and Quartz cluster jobs that save
-    report data.
-
-  This function is intended to be called by a function that sets up caches for
-  an application (e.g., cmr.search.system/create-system)."
-  []
-  (stl-cache/create-single-thread-lookup-cache
-   (cubby-cache/create-cubby-cache)))
+   [cmr.common.log :refer [debug]]
+   [cmr.search.site.pages :as pages]))
 
 (defn get-page-content
   "Given a context and route (optionally provider id and tag), get the
@@ -62,28 +18,6 @@
      (pages/sitemap-provider-tag context provider-id tag)
      (pages/provider-tag-directory context provider-id tag))))
 
-(defn cache-page
-  "Cache a page for a given route. If the content is supplied, simply cache
-  that; if only a route is supplied, get the content for that route and then
-  cache it. If a provider id and tag are supplied, get the appopriate content
-  given those args, and cache the result."
-  ([context route]
-   (cache-page context route (get-page-content context route)))
-  ([context route content]
-   (debug "Caching" route)
-   (cache/set-value (cache/context->cache context cache-key) route content))
-  ([context route provider-id tag]
-    (cache-page context
-                route
-                (get-page-content context route provider-id tag))))
-
-(defn- create-lookup-fn
-  "A convenience function that is intended for use by the caching API when a
-  cache miss is encountered."
-  [args]
-  (debug "Route" (second args) "not found in cache")
-  (fn [] (apply get-page-content args)))
-
 (defn retrieve-page
   "Attempt to retrieve from the cache the page data for a given route. If no
   value is found in the cache, genereate the content, cache it, and then return
@@ -94,61 +28,5 @@
   and tag)."
   [context params route & remaining]
   (debug "Retrieving" route "with params" params "and remaining args" remaining)
-  (let [args (concat [context route] remaining)
-        regenerate? (= "true" (util/safe-lowercase (:regenerate params)))]
-    ;; Only admins can force the pages and sitemaps in the cache to be
-    ;; regenerated.
-    (when regenerate?
-      (acl/verify-ingest-management-permission context :update)
-      (debug "Forcing resource regeneration/cache update" route)
-      (apply cache-page args))
-    (cache/get-value (cache/context->cache context cache-key)
-                     route
-                     (create-lookup-fn args))))
-
-(defn- cache-top-level-content
-  "Cache all the content for the expensive, top-level routes."
-  [context]
-  (cache-page context "/sitemap.xml")
-  (cache-page context "/site/sitemap.xml")
-  (cache-page context "/site/collections/directory/eosdis"))
-
-(defn- cache-directory-content
-  "Cache all the content for the expensive, directory-level routes."
-  [context]
-  (let [provider-ids (map :provider-id (mdb/get-providers context))]
-    (debug "Providers:" provider-ids)
-    (doseq [provider-id provider-ids]
-      (doseq [tag (keys site-utils/supported-directory-tags)]
-        (doseq [route [(format "/site/collections/directory/%s/%s" provider-id tag)
-                       (format "/site/collections/directory/%s/%s/sitemap.xml"
-                               provider-id
-                               tag)]]
-          (cache-page context route provider-id tag))))))
-
-(defn generate-content
-  "Cache all the content for the expensive routes. This is the function
-  intended for use by the static content job scheduler."
-  [context]
-  (info "Generating site content for caching")
-  (let [[ms _] (util/time-execution
-                (do
-                  (cache-top-level-content context)
-                  (cache-directory-content context)))]
-    (info (format "Content generated in %d ms" ms))))
-
-;; A job for generating static content
-;; Note: since content generation is being done via a job without an HTTP
-;;       context, we use the :cli execution context that doesn't require
-;;       particular ACL settings provided by the HTTP request context.
-(defjob StaticContentGeneratorJob
-  [_job-context system]
-  (-> {:system system}
-      (transmit-config/with-echo-system-token)
-      (generate-content)))
-
-(def static-content-generator-job
-  "The job definition used by the system job scheduler."
-  {:job-type StaticContentGeneratorJob
-   :interval (static-content-generation-interval)
-   :start-delay (+ (default-job-start-delay) (static-content-generation-job-delay))})
+  (let [args (concat [context route] remaining)]
+    (apply get-page-content args)))

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -70,6 +70,8 @@
         (sort-by #(get-in % [:umm :EntryTitle]) data)))
 
 (defn-timed get-collection-data
+  "Get the collection data from elastic by provider id and tag. Sort results
+  by entry title"
   [context tag provider-id]
   (let [conditions (query-svc/generate-query-conditions-for-parameters
                     context
@@ -81,11 +83,15 @@
                                   :skip-acls? false
                                   :page-size :unlimited
                                   :result-format :query-specified
-                                  :result-fields [:concept-id :doi-stored :entry-title :short-name :version-id]})
+                                  :result-fields [:concept-id
+                                                  :doi-stored
+                                                  :entry-title
+                                                  :short-name
+                                                  :version-id]})
         result (query-exec/execute-query context query)]
     (sort-by :entry-title (:items result))))
 
-(defmethod collection-data :default
+(defn-timed collection-data :default
   [context tag provider-id]
   (get-collection-data context tag provider-id))
 

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -91,7 +91,7 @@
         result (query-exec/execute-query context query)]
     (sort-by :entry-title (:items result))))
 
-(defn-timed collection-data :default
+(defmethod collection-data :default
   [context tag provider-id]
   (get-collection-data context tag provider-id))
 

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -18,6 +18,7 @@
    [cmr.common-app.site.data :as common-data]
    [cmr.common.log :refer :all]
    [cmr.common.mime-types :as mt]
+   [cmr.common.util :refer [defn-timed]]
    [cmr.search.services.query-service :as query-svc]
    [cmr.search.site.util :as util]
    [cmr.transmit.config :as config]
@@ -68,7 +69,7 @@
         (:items data)
         (sort-by #(get-in % [:umm :EntryTitle]) data)))
 
-(defmethod collection-data :default
+(defn-timed get-collection-data
   [context tag provider-id]
   (let [conditions (query-svc/generate-query-conditions-for-parameters
                     context
@@ -84,7 +85,11 @@
         result (query-exec/execute-query context query)]
     (sort-by :entry-title (:items result))))
 
-(defn provider-data
+(defmethod collection-data :default
+  [context tag provider-id]
+  (get-collection-data context tag provider-id))
+
+(defn-timed provider-data
   "Create a provider data structure suitable for template iteration to
   generate links.
 
@@ -98,7 +103,7 @@
      :collections collections
      :collections-count (count collections)}))
 
-(defn providers-data
+(defn-timed providers-data
   "Given a list of provider maps, create the nested data structure needed
   for rendering providers in a template."
   [context tag providers]

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -109,7 +109,7 @@
   [context tag providers]
   (debug "Using providers:" providers)
   (->> providers
-       (map (partial provider-data context tag))
+       (pmap (partial provider-data context tag))
        ;; Only want to include providers with EOSDIS collections
        (remove #(zero? (get % :collections-count 0)))
        (sort-by :id)))

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -78,7 +78,7 @@
                      :provider provider-id})
         query (query-model/query {:concept-type :collection
                                   :condition (gc/and-conds conditions)
-                                  :skip-acls? true
+                                  :skip-acls? false
                                   :page-size :unlimited
                                   :result-format :query-specified
                                   :result-fields [:concept-id :doi-stored :entry-title :short-name :version-id]})

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -12,6 +12,7 @@
   (:require
    [clj-time.core :as clj-time]
    [clojure.string :as string]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
    [cmr.common-app.services.search.query-execution :as query-exec]
    [cmr.common-app.services.search.query-model :as query-model]
    [cmr.common-app.site.data :as common-data]
@@ -69,21 +70,19 @@
 
 (defmethod collection-data :default
   [context tag provider-id]
-  (let [query (query-svc/make-concepts-query
-               context
-               :collection
-               {:tag-key tag
-                :provider provider-id
-                :result-format {:format :umm-json-results}})
+  (let [conditions (query-svc/generate-query-conditions-for-parameters
+                    context
+                    :collection
+                    {:tag-key tag
+                     :provider provider-id})
         query (query-model/query {:concept-type :collection
-                                  :condition (:condition query)
+                                  :condition (gc/and-conds conditions)
                                   :skip-acls? true
                                   :page-size :unlimited
                                   :result-format :query-specified
                                   :result-fields [:concept-id :doi-stored :entry-title :short-name :version-id]})
         result (query-exec/execute-query context query)]
     (sort-by :entry-title (:items result))))
-
 
 (defn provider-data
   "Create a provider data structure suitable for template iteration to

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -28,7 +28,6 @@
    [cmr.search.models.query :as q]
    [cmr.search.routes :as routes]
    [cmr.search.services.acls.collections-cache :as coll-cache]
-   [cmr.search.services.content-service :as content-service]
    [cmr.search.services.humanizers.humanizer-report-service :as hrs]
    [cmr.search.services.query-execution.has-granules-results-feature :as hgrf]
    [cmr.transmit.config :as transmit-config]))
@@ -128,8 +127,7 @@
                       metadata-cache/cache-key (metadata-cache/create-cache)
                       common-health/health-cache-key (common-health/create-health-cache)
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
-                      hrs/report-cache-key (hrs/create-report-cache)
-                      content-service/cache-key (content-service/create-cache)}
+                      hrs/report-cache-key (hrs/create-report-cache)}
              :public-conf (public-conf)
              collection-renderer/system-key (collection-renderer/create-collection-renderer)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)
@@ -143,8 +141,7 @@
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           coll-cache/refresh-collections-cache-for-granule-acls-job
                           jvm-info/log-jvm-statistics-job
-                          hrs/humanizer-report-generator-job
-                          content-service/static-content-generator-job])}]
+                          hrs/humanizer-report-generator-job])}]
     (transmit-config/system-with-connections
       sys
       [:index-set :echo-rest :metadata-db :kms :cubby :access-control])))

--- a/search-app/test/cmr/search/test/site/data.clj
+++ b/search-app/test/cmr/search/test/site/data.clj
@@ -6,31 +6,17 @@
 (def cmr-base-url "http://cmr.test.host/")
 
 (def coll-data-1
-  {:meta
-    {:provider-id "PROV1"
-     :concept-id "C1200000003-PROV1"}
-   :umm
-    {"ShortName" "s3"
-     "EntryTitle" "coll3"
-     "Version" "6"}})
+  {:concept-id "C1200000003-PROV1"
+   :short-name "s3"
+   :entry-title "coll3"
+   :version-id "6"})
 
 (def coll-data-2
-  {:meta
-    {:provider-id "PROV1"
-     :concept-id "C1200000003-PROV1"}
-   :umm
-    {"ShortName" "s3"
-     "EntryTitle" "coll3"
-     "Version" "7"
-     "DOI"
-     {"Authority" "auth6"
-      "DOI" "doi6"}}})
-
-(deftest doi-link
-  (testing "generate a link from doi data"
-    (let [data {"DOI" "doi:10.7265/N5R78C49"}]
-      (is (= "http://dx.doi.org/doi:10.7265/N5R78C49"
-             (data/doi-link data))))))
+  {:concept-id "C1200000003-PROV1"
+   :short-name "s3"
+   :entry-title "coll3"
+   :version-id "7"
+   :doi-stored "doi6"})
 
 (deftest cmr-link
   (testing "generate a cmr landing page from a host and a concept id"
@@ -38,13 +24,6 @@
           concept-id "C1200196931-SCIOPS"]
       (is (= "https://cmr.sit.earthdata.nasa.gov/concepts/C1200196931-SCIOPS.html"
              (data/cmr-link cmr-host concept-id))))))
-
-(deftest get-doi
-  (testing "try to get the doi entry from data that doesn't have one"
-    (is (not (data/get-doi coll-data-1))))
-  (testing "get the doi entry"
-    (is (= {"DOI" "doi6" "Authority" "auth6"}
-           (data/get-doi coll-data-2)))))
 
 (deftest has-doi?
   (testing "check for doi in data that doesn't have one"
@@ -55,10 +34,6 @@
 (deftest cmr-link
   (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
          (data/cmr-link cmr-base-url "C1200000003-PROV1"))))
-
-(deftest doi-link
-  (is (= "http://dx.doi.org/doi6"
-         (data/doi-link {"DOI" "doi6" "Authority" "auth6"}))))
 
 (deftest make-href
   (testing "with no doi data (cmr-only)"
@@ -73,14 +48,14 @@
     (let [data (data/make-holding-data cmr-base-url coll-data-1)]
       (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
              (:link-href data)))
-      (is (= "coll3" (get-in data [:umm "EntryTitle"])))
-      (is (= "s3" (get-in data [:umm "ShortName"])))
-      (is (= "6" (get-in data [:umm "Version"])))))
+      (is (= "coll3" (:entry-title data)))
+      (is (= "s3" (:short-name data)))
+      (is (= "6" (:version-id data)))))
   (testing "with an entry title, short name, and doi"
     (let [data (data/make-holding-data cmr-base-url coll-data-2)]
       (is (= "http://dx.doi.org/doi6" (:link-href data)))
-      (is (= "s3" (get-in data [:umm "ShortName"])))
-      (is (= "7" (get-in data [:umm "Version"]))))))
+      (is (= "s3" (:short-name data)))
+      (is (= "7" (:version-id data))))))
 
 (deftest make-holdings-data
   (let [data (->> [coll-data-1 coll-data-2]
@@ -88,8 +63,8 @@
                   (vec))]
     (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
            (get-in data [0 :link-href])))
-    (is (= "s3" (get-in data [0 :umm "ShortName"])))
-    (is (= "6" (get-in data [0 :umm "Version"])))
+    (is (= "s3" (get-in data [0 :short-name])))
+    (is (= "6" (get-in data [0 :version-id])))
     (is (= "http://dx.doi.org/doi6" (get-in data [1 :link-href])))
-    (is (= "s3" (get-in data [1 :umm "ShortName"])))
-    (is (= "7" (get-in data [1 :umm "Version"])))))
+    (is (= "s3" (get-in data [1 :short-name])))
+    (is (= "7" (get-in data [1 :version-id])))))

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -710,6 +710,26 @@
       (setup-providers providers options))
      (f))))
 
+(defn grant-all-search
+  "Grants all users access to search for any collections or granules from the passed in list of
+  provider ids."
+  [provider-ids]
+  (doseq [provider-id provider-ids]
+    (echo-util/grant (s/context)
+                     [echo-util/guest-read-ace
+                      echo-util/registered-user-read-ace]
+                     :catalog_item_identity
+                     (assoc (echo-util/catalog-item-id provider-id)
+                            :collection_applicable true
+                            :granule_applicable true))))
+
+(defn grant-all-search-fixture
+  "Fixture to grant all users search access for the provider-ids passed in."
+  [provider-ids]
+  (fn [f]
+    (grant-all-search provider-ids)
+    (f)))
+
 (defn clear-caches
   "Clears caches in the ingest application"
   []

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -110,7 +110,6 @@
         (url/search-read-caches-url) [
          "acls"
          "collections-for-gran-acls"
-         (name content-service/cache-key)
          "has-granules-map"
          "health"
          "humanizer-report-cache"

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -174,7 +174,6 @@
 
 (def collections-fixture
   (fn [f]
-    (search/refresh-collection-metadata-cache)
     (setup-collections)
     (f)))
 
@@ -275,14 +274,6 @@
       (is (not (expected-provider1-col1-link? body))))
     (testing "provider page should have header links"
       (is (expected-header-link? body)))))
-
-(deftest regeneration-permissions
-  (site/assert-search-directory-regen-permissions
-   "eosdis directory level"
-   "site/collections/directory/eosdis?regenerate=true")
-  (site/assert-search-directory-regen-permissions
-   "provider/tag level"
-   "site/collections/directory/PROV1/gov.nasa.eosdis?regenerate=true"))
 
 ;; Note that the following test was originally in the unit tests for
 ;; cmr-search (thus its similarity to those tests) but had to be moved into

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -110,38 +110,49 @@
   (let [[c1-p1 c2-p1 c3-p1
          c1-p2 c2-p2 c3-p2
          c1-p4 c2-p4 c3-p4] (doall (for [p ["PROV1" "PROV2" "NONEOSDIS"]
-                                  n (range 1 4)]
-                              (d/ingest-umm-spec-collection
-                               p
-                               (assoc exp-conv/example-collection-record
-                                      :ShortName (str "s" n)
-                                      :EntryTitle (str "Collection Item " n))
-                               {:format :umm-json
-                                :accept-format :json})))
+                                         n (range 1 4)]
+                                     (d/ingest-umm-spec-collection
+                                       p
+                                       (assoc exp-conv/example-collection-record
+                                             :ShortName (str "s" n)
+                                             :EntryTitle (str "Collection Item " n))
+                                       {:format :umm-json
+                                        :accept-format :json})))
          _ (index/wait-until-indexed)
          [c1-p3 c2-p3 c3-p3] (doall (for [n (range 101 104)]
-                               (d/ingest-umm-spec-collection
-                                "PROV3"
-                                (assoc exp-conv/example-collection-record
-                                       :ShortName (str "s" n)
-                                       :EntryTitle (str "Collection Item " n)
-                                       :DOI (cm/map->DoiType
-                                             {:DOI (str "doi" n)
-                                              :Authority (str "auth" n)}))
-                                {:format :umm-json
-                                 :accept-format :json})))
+                                      (d/ingest-umm-spec-collection
+                                       "PROV3"
+                                       (assoc exp-conv/example-collection-record
+                                              :ShortName (str "s" n)
+                                              :EntryTitle (str "Collection Item " n)
+                                              :DOI (cm/map->DoiType
+                                                    {:DOI (str "doi" n)
+                                                     :Authority (str "auth" n)}))
+                                       {:format :umm-json
+                                        :accept-format :json})))
          _ (index/wait-until-indexed)
          ;; Let's create another collection that will put the total over the
          ;; default of 10 values so that we can ensure the :unlimited option
          ;; is being used in the directory page data.
          over-ten-colls (doall (for [n (range 1001 1017)]
-                          (d/ingest-umm-spec-collection
-                           "PROV2"
-                           (assoc exp-conv/example-collection-record
-                                  :ShortName (str "s" n)
-                                  :EntryTitle (str "Collection Item " n))
-                           {:format :umm-json
-                            :accept-format :json})))]
+                                 (d/ingest-umm-spec-collection
+                                  "PROV2"
+                                  (assoc exp-conv/example-collection-record
+                                         :ShortName (str "s" n)
+                                         :EntryTitle (str "Collection Item " n))
+                                  {:format :umm-json
+                                   :accept-format :json})))
+         [admin-1 admin-2] (doall (for [n (range 110 113)]
+                                    (d/ingest-umm-spec-collection
+                                     "ONLYADMIN"
+                                     (assoc exp-conv/example-collection-record
+                                            :ShortName (str "s" n)
+                                            :EntryTitle (str "Collection Item " n)
+                                            :DOI (cm/map->DoiType
+                                                  {:DOI (str "doi" n)
+                                                   :Authority (str "auth" n)}))
+                                     {:format :umm-json
+                                      :accept-format :json})))]
     (reset! test-collections
             {"PROV1" (sort (map :concept-id [c1-p1 c2-p1 c3-p1]))
              "PROV2" (sort (map :concept-id (conj over-ten-colls c1-p2 c2-p2 c3-p2)))
@@ -155,7 +166,7 @@
           doi-colls [c1-p3 c2-p3 c3-p3]
           non-eosdis-provider-colls [c1-p4 c2-p4 c3-p4]
           all-colls (flatten [over-ten-colls nodoi-colls doi-colls non-eosdis-provider-colls])
-          tag-colls (conj over-ten-colls c2-p1 c2-p2 c2-p3 c3-p1 c3-p2 c3-p3)
+          tag-colls (conj over-ten-colls c2-p1 c2-p2 c2-p3 c3-p1 c3-p2 c3-p3 admin-1 admin-2)
           tag (tags/save-tag
                 user-token
                 (tags/make-tag {:tag-key "gov.nasa.eosdis"})
@@ -165,7 +176,7 @@
       (is (= 3 (count notag-colls)))
       (is (= 6 (count nodoi-colls)))
       (is (= 3 (count doi-colls)))
-      (is (= 22 (count tag-colls)))
+      (is (= 24 (count tag-colls)))
       (is (= 28 (count all-colls))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -184,7 +195,12 @@
                                              "provguid2" "PROV2"
                                              "provguid3" "PROV3"
                                              "provguid4" "NONEOSDIS"
-                                             "provguid5" "NOCOLLS"})
+                                             "provguid5" "NOCOLLS"
+                                             "provguid6" "ONLYADMIN"
+                                             "provguid7" "someadmin"}
+                                            {:grant-all-search? false})
+                      (ingest/grant-all-search-fixture ["PROV1" "PROV2" "PROV3" "NONEOSDIS"
+                                                        "NOCOLLS"])
                       tags/grant-all-tag-fixture
                       collections-fixture]))
 

--- a/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
@@ -192,12 +192,3 @@
     (testing "the collections not tagged with eosdis shouldn't show up"
       (is (not (string/includes?
                 body (format "%s.html</loc>" (first colls))))))))
-
-(deftest regeneration-permissions
-  (site/assert-search-directory-regen-permissions
-   "master sitemap" "sitemap.xml?regenerate=true")
-  (site/assert-search-directory-regen-permissions
-   "content sitemap" "site/sitemap.xml?regenerate=true")
-  (site/assert-search-directory-regen-permissions
-   "provider/tag sitemap"
-   "site/collections/directory/PROV1/gov.nasa.eosdis/sitemap.xml?regenerate=true"))


### PR DESCRIPTION
Only show guest permitted collections on the directory page.

Removed the caching for this page and improved performance by hitting elastic directly to get the info instead of getting the umm-json response. This changed the expected response format in data.clj so there are changes to the html and tests to go with that. 
