### PR TITLE
Cmr 4580 fix parameter validation new

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/params.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/params.clj
@@ -23,6 +23,15 @@
                             (not (and (string? value) (= "" (string/trim value)))))]
     (into {} (filter (comp not-empty-string? second) params))))
 
+(defn sanitize-without-removing-empty-params
+  "Manipulates the parameters to make them easier to process"
+  [params]
+  (-> params
+      u/map-keys->kebab-case
+      (update-in [:sort-key] #(when % (if (sequential? %)
+                                        (map sanitize-sort-key %)
+                                        (sanitize-sort-key %))))))
+
 (defn sanitize-params
   "Manipulates the parameters to make them easier to process"
   [params]

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -276,17 +276,14 @@
           m
           m))
 
-(defn remove-non-empty-keys
-  "Removes keys mapping to non-empty values in a map."
+(defn select-blank-keys 
+  "Keep the keys with blank values in a map."
   [m]
-  (reduce (fn [m kv]
-            (let [v (val kv)
-                  k (key kv)] 
-              (if (and (some? v) (not (and (string? v) (= "" (string/trim v)))))
-                (dissoc m k)
-                m)))
-          m
-          m))
+  (select-keys m 
+    (for [[k v] m 
+      :when (or (nil? v)  
+                (and (string? v) (string/blank? v)))] 
+      k)))
 
 (defn inflate-nil-keys
   "Occupy nil values with a given default value."

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -281,8 +281,8 @@
   [m]
   (select-keys m 
     (for [[k v] m 
-      :when (or (nil? v)  
-                (and (string? v) (string/blank? v)))] 
+          :when (or (nil? v)  
+                    (and (string? v) (string/blank? v)))] 
       k)))
 
 (defn inflate-nil-keys

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -276,6 +276,18 @@
           m
           m))
 
+(defn remove-non-nil-and-non-empty-keys
+  "Removes keys mapping to non-nil and non-empty values in a map."
+  [m]
+  (reduce (fn [m kv]
+            (let [v (val kv)
+                  k (key kv)] 
+              (if (and (some? v) (not (and (string? v) (= "" (string/trim v)))))
+                (dissoc m k)
+                m)))
+          m
+          m))
+
 (defn inflate-nil-keys
   "Occupy nil values with a given default value."
   [m filler]

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -276,8 +276,8 @@
           m
           m))
 
-(defn remove-non-nil-and-non-empty-keys
-  "Removes keys mapping to non-nil and non-empty values in a map."
+(defn remove-non-empty-keys
+  "Removes keys mapping to non-empty values in a map."
   [m]
   (reduce (fn [m kv]
             (let [v (val kv)

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -741,6 +741,13 @@
               ; We don't want an ExecutionException, we want to get the null pointer exception
               (is false "Fast-map threw ExecutionException and should throw NullPointerException")))))))
 
+(deftest select-blank-keys
+  (testing "select-blank-keys function"
+    (is (=  {:a "" :b " " :c nil}
+            (util/select-blank-keys {:a "" :b " " :c nil :d "a" :e [1 2 3]})))
+    (is (= {} 
+           (util/select-blank-keys nil)))))  
+
 (deftest max-compare-test
   (util/are3
     [coll expected-max]

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -780,7 +780,7 @@
     (is (= (util/safe-lowercase true) (str/lower-case true)))
     (is (= (util/safe-lowercase "StRing") (str/lower-case "StRing")))
     (is (= (util/safe-lowercase nil) nil)))
-  (testing "safe-upperrcase"
+  (testing "safe-uppercase"
     (is (= (util/safe-uppercase false) (str/upper-case false)))
     (is (= (util/safe-uppercase true) (str/upper-case true)))
     (is (= (util/safe-uppercase "StRing") (str/upper-case "StRing")))

--- a/search-app/src/cmr/search/routes.clj
+++ b/search-app/src/cmr/search/routes.clj
@@ -5,7 +5,7 @@
   routes that apply to both (e.g., robots.txt)."
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [cmr.acl.core :as acl]
    [cmr.common.api.errors :as errors]
    [cmr.common-app.api.request-context-user-augmenter :as context-augmenter]
@@ -29,9 +29,9 @@
   [query-str]
   (when query-str
     (let [query-str (-> query-str
-                        (str/replace #"%5B" "[")
-                        (str/replace #"%5D" "]")
-                        (str/replace #"\[\]" ""))]
+                        (string/replace #"%5B" "[")
+                        (string/replace #"%5D" "]")
+                        (string/replace #"\[\]" ""))]
       (last (some #(re-find % query-str)
                   [#"(^|&)(.*?)=.*?&\2\["
                    #"(^|&)(.*?)\[.*?&\2="])))))
@@ -61,6 +61,31 @@
                 request
                 :body-copy body
                 :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
+
+
+(defn add-equal-sign-to-params-in-list
+  "Add = sign to each parameter in the param-list if it doesn't already exist."
+  [param-list]
+  (map #(if (and (string? %)
+                 (not= "" (string/trim %))
+                 (not (string/includes? % "=")))
+          (str % "=")
+          %) param-list)) 
+
+(defn parameter-without-equal-sign-handler
+  "Add = sign to each param in the query-string that doesn't contain the = sign so that it could make it
+   to the params without nil value and get validated."
+  [handler]
+  (fn [request]
+    (let [query-string (some-> (:query-string request)
+                               (string/split #"&")
+                               add-equal-sign-to-params-in-list)
+          query-string (if (sequential? query-string)
+                         (string/join "&" query-string)
+                         query-string)]
+      (handler (assoc
+                request
+                :query-string query-string)))))
 
 (defn default-error-format
   "Determine the format that errors should be returned in based on the request URI."
@@ -104,4 +129,5 @@
       (cmr-context/build-request-context-handler system)
       common-routes/pretty-print-response-handler
       params/wrap-params
+      parameter-without-equal-sign-handler
       copy-of-body-handler))

--- a/search-app/src/cmr/search/routes.clj
+++ b/search-app/src/cmr/search/routes.clj
@@ -62,15 +62,17 @@
                 :body-copy body
                 :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
 
-
 (defn add-equal-sign-to-params-in-list
-  "Add = sign to each parameter in the param-list if it doesn't already exist."
+  "Add = sign to each parameter in the param-list if it is a string
+   and it's not blank and it doesn't already contain = sign"
   [param-list]
-  (map #(if (and (string? %)
-                 (not= "" (string/trim %))
-                 (not (string/includes? % "=")))
-          (str % "=")
-          %) param-list)) 
+  (map (fn [param]
+         (if (and (string? param)
+                  (not (string/blank? param))
+                  (not (string/includes? param "=")))
+           (str param "=")
+           param)) 
+       param-list))
 
 (defn parameter-without-equal-sign-handler
   "Add = sign to each param in the query-string that doesn't contain the = sign so that it could make it

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -708,6 +708,14 @@
       concept-type safe-params (parameter-validations concept-type) type-errors))
   params)
 
+(defn validate-empty-parameters
+  "Validates parameters with no values. Only need to validate if the parameter name is valid.
+   Returns parameters if validation was successful so it can be chained with other calls."
+  [concept-type params]
+  (cpv/validate-parameters
+    concept-type params [cpv/unrecognized-params-validation])
+  params)
+
 (defn validate-standard-query-parameters
   "Validates the query parameters passed in with an AQL or JSON search.
   Throws exceptions to send to the user. Returns parameters if validation

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -150,7 +150,7 @@
   [context concept-type params]
   (let [empty-params 
          (some-> params 
-                 u/remove-non-empty-keys
+                 u/select-blank-keys
                  common-params/sanitize-without-removing-empty-params
                  ;; empty equator crossing start date and end date are not useful
                  ;; towards the final replacement of equator-crossing-date.

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -144,6 +144,38 @@
   [params]
   (or (:tag-data params) (:tag_data params)))
 
+
+(defn- validate-empty-or-nil-parameters
+  "validate only the empty or nil valued parameters"
+  [context concept-type params]
+  (let [empty-or-nil-params 
+         (some-> params 
+                 u/remove-non-nil-and-non-empty-keys
+                 common-params/sanitize-without-removing-empty-params
+                 ;; empty or nil equator crossing start date and end date are not useful
+                 ;; towards the final replacement of equator-crossing-date.
+                 (dissoc :equator-crossing-start-date :equator-crossing-end-date))]
+    (some->> empty-or-nil-params
+             lp/replace-parameter-aliases
+             (lp/process-legacy-multi-params-conditions concept-type)
+             (lp/replace-science-keywords-or-option concept-type)
+             (psn/replace-provider-short-names context)
+             (pv/validate-empty-parameters concept-type)))) 
+
+(defn- remove-nil-from-sequential-values
+   "Remove all the nils from all the sequential values in a map.
+    This is used to fix the 500 error when params contain
+    :concept-id [C123-PROV1 nil]."
+  [params]
+  (u/map-values 
+    #(if (sequential? %) 
+       (let [new-v (remove nil? %)]
+         (if (seq new-v)
+           (into [] new-v)
+           nil))
+        %)
+    params)) 
+
 (defn make-concepts-query
   "Utility function for generating an elastic-ready query."
   ([context concept-type params]
@@ -152,9 +184,11 @@
         (make-concepts-query
          context concept-type params)))
   ([context concept-type params tag-data]
+   (validate-empty-or-nil-parameters context concept-type params)
    (->> params
         common-params/sanitize-params
         (add-tag-data-to-params tag-data)
+        remove-nil-from-sequential-values
         ;; CMR-2553 remove the following line
         drop-ignored-params
         ;; handle legacy parameters

--- a/search-app/test/cmr/search/test/routes.clj
+++ b/search-app/test/cmr/search/test/routes.clj
@@ -1,6 +1,8 @@
 (ns cmr.search.test.routes
-  (:require [clojure.test :refer :all]
-            [cmr.search.routes :as r])
+  (:require 
+    [clojure.test :refer :all]
+    [cmr.common.util :refer [are3]]
+    [cmr.search.routes :as r])
   (:use ring.mock.request))
 
 (def ^:private web (#'cmr.search.routes/build-routes
@@ -20,3 +22,13 @@
          "foo[]=1&options[foo][pattern]=true" nil
          "foo=1&bar_foo[baz]=2" nil
          "foo[baz]=1&bar_foo=2" nil)))
+
+(deftest add-equal-sign-to-params-in-list
+  (testing "add-equal-sign-to-params-in-list adds = to each non-blank string param that doesn't contain ="
+    (are3 [old-param-list new-param-list]
+      (is (= new-param-list
+             (r/add-equal-sign-to-params-in-list old-param-list)))
+      "testing empty list case"
+      [""] [""]
+      "testing non-empty list case" 
+      ["abc" "123" 456 " "] ["abc=" "123=" 456 " "])))

--- a/system-int-test/test/cmr/system_int_test/search/collection_temporal_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_temporal_search_test.clj
@@ -404,6 +404,22 @@
     (let [{:keys [status errors]} (search/find-refs :collection {"temporal[]" "2010-13-12T12:00:00,"})]
       (is (= 400 status))
       (is (re-find #"temporal start datetime is invalid: \[2010-13-12T12:00:00\] is not a valid datetime" (first errors)))))
+  (testing "search by empty invalid parameter."
+    (let [{:keys [status errors]} (search/find-concepts-json :collection {"tempora" ""})]
+      (is (= 400 status))
+      (is (= "Parameter [tempora] was not recognized." (first errors)))))
+  (testing "search by nil invalid parameter."
+    (let [{:keys [status errors]} (search/find-concepts-json :collection {"tempora" nil})]
+      (is (= 400 status))
+      (is (= "Parameter [tempora] was not recognized." (first errors)))))
+  (testing "search by empty valid parameter."
+    (let [{:keys [status errors]} (search/find-concepts-json :collection {"temporal" ""})]
+      (is (= 200 status))
+      (is (= nil (first errors)))))
+  (testing "search by nil valid parameter."
+    (let [{:keys [status errors]} (search/find-concepts-json :collection {"temporal" nil})]
+      (is (= 200 status))
+      (is (= nil (first errors)))))
   (testing "periodic temporal search that produces empty search ranges."
     (let [{:keys [status errors]} (search/find-refs :collection
                                    {"temporal[]" "2016-05-10T08:18:16Z,2016-05-10T08:34:31Z,131,131"})]

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
@@ -319,6 +319,10 @@
    (testing "invalid include-facets"
      (is (= {:errors ["Parameter include_facets must take value of true, false, or v2, but was [foo]"] :status 400}
             (search/find-refs :collection {:include-facets "foo"})))
+     (is (= {:errors ["Parameter [invalid_param] was not recognized."] :status 400}
+            (search/find-refs :collection {:include-facets "v2" :invalid-param ""})))
+     (is (= {:errors ["Parameter [invalid_param] was not recognized."] :status 400}
+            (search/find-refs :collection {:include-facets "v2" :invalid-param nil})))
      (is (= {:errors ["Parameter [include_facets] was not recognized."] :status 400}
             (search/find-refs :granule {:include-facets true}))))
 

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
@@ -326,6 +326,12 @@
      (is (= {:errors ["Parameter [include_facets] was not recognized."] :status 400}
             (search/find-refs :granule {:include-facets true}))))
 
+   (testing "valid include-facets"
+     (is (= 200 
+            (:status (search/find-concepts-json :collection {:include-facets "v2" :concept-id ""}))))
+     (is (= 200
+            (:status (search/find-concepts-json :collection {:include-facets "v2" :concept-id nil})))))
+
    (testing "retreving all facets in different formats"
      (let [expected-facets [{:field "data_center"
                              :value-counts [["Larc" 3] ["Dist" 1] ["GSFC" 1] ["Proc" 1]]}

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
@@ -319,9 +319,10 @@
            ",0.7" [gran4 gran5]
            "-70.0,31.0" [gran1 gran2 gran4 gran5]
            "-70.0,120.0" [gran1 gran2 gran3 gran4 gran5]
-           ;; Empty cloud cover is allowed.
+           ;; Empty and nil cloud cover is allowed.
            ;; It is as if no cloud cover parameter is present and will find everything.
-           "" [gran1 gran2 gran3 gran4 gran5 gran6]))
+           "" [gran1 gran2 gran3 gran4 gran5 gran6]
+           nil [gran1 gran2 gran3 gran4 gran5 gran6]))
 
     (testing "search by cloud-cover with min value greater than max value"
       (let [min-value 30.0


### PR DESCRIPTION
Acceptance Criteria for search parameter validation :

1) invalid_parameter returns a 400
2) invalid_parameter= returns a 400
3) invalid_parameter&include_facets=v2 returns 400
4) invalid_parameter=&include_facets=v2 returns 400
5) valid_parameter pretends that parameter wasn't passed in (whatever the existing behavior is)
6) valid_parameter= pretends that parameter wasn't passed in (whatever the existing behavior is)
7) valid_parameter&include_facets=v2 pretends that parameter wasn't passed in
8) valid_parameter=&include_facets=v2 pretends that parameter wasn't passed in