### PR TITLE
CMR-4621: Make MMT tests faster

### DIFF
--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -183,7 +183,9 @@
         (handler msg)
         (update-message-queue-history broker-wrapper queue-name :process msg :success)
         (catch Exception e
-          (update-message-queue-history broker-wrapper queue-name :process msg :retry)
+          ;; Will return a retry up to the retry count and then a failure afterwards
+          (let [message-state (queue-response->message-state :retry msg)]
+            (update-message-queue-history broker-wrapper queue-name :process msg message-state))
           (throw e))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -102,9 +102,10 @@
          (Thread/sleep 10)
          (if (< (- (System/currentTimeMillis) start-time) ms-to-wait)
            (recur (set (current-message-states broker-wrapper)))
-           (warn (format "Waited %d ms for messages to complete, but they did not complete: %s"
+           (warn (format "Waited %d ms for messages to complete, but they did not complete. In progress: %s"
                          ms-to-wait
-                         (current-messages broker-wrapper)))))))))
+                         (pr-str (remove #(contains? terminal-states (:state %))
+                                         (current-messages broker-wrapper)))))))))))
 
 (defn- publish-to-queue
   "Publishes a message to the queue and captures the actions with the queue history."


### PR DESCRIPTION
Matthew and I found that there was an MMT test that was creating some invalid bulk update requests for CMR that resulted in a message on the CMR message queue that could not be processed. Found a bug in our local test broker that we weren't marking a request as failed after it had failed all retries. With this change the MMT tests went from:

Before:
```
Finished in 69 minutes 45 seconds (files took 4.31 seconds to load)
1550 examples, 0 failures
```
After:
```
Finished in 22 minutes 7 seconds (files took 4.08 seconds to load)
1550 examples, 0 failures
```

Now they only spend 11 seconds total in their calls to waiting for CMR indexing to complete:

```
|    11.370s |   0.025s |   0.147s |   452 | Helpers::CmrHelper#wait_for_cmr 
```