### PR TITLE
Cmr 4320

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
@@ -1,0 +1,30 @@
+(ns cmr.umm-spec.validation.temporal-extent
+  "Defines validations for UMM temporal extents."
+  (:require
+   [clj-time.core :as time]
+   [cmr.common.validations.core :as validations-core]
+   [cmr.umm-spec.date-util :as date]
+   [cmr.umm-spec.validation.umm-spec-validation-utils :as util]))
+
+(defn- range-date-time-validation
+  "Defines range-date-time validation"
+  [field-path value]
+  (let [{:keys [BeginningDateTime EndingDateTime]} value]
+    (when (and BeginningDateTime EndingDateTime (time/after? BeginningDateTime EndingDateTime))
+      {field-path [(format "BeginningDateTime [%s] must be no later than EndingDateTime [%s]"
+                           (str BeginningDateTime) (str EndingDateTime))]})))
+
+(defn- temporal-end-date-in-past-validator
+  "Validate that the end date in TemporalExtents is in the past"
+  [field-path value]
+  (when (and value (not (date/is-in-past? value)))
+    {field-path [(str "Ending date should be in the past. Either set ending date to a date "
+                      "in the past or remove end date and set the ends at present flag to true.")]}))
+
+(def temporal-extent-warning-validation
+  {:RangeDateTimes (validations-core/every {:BeginningDateTime util/date-in-past-validator
+                                            :EndingDateTime temporal-end-date-in-past-validator})
+   :SingleDateTimes (validations-core/every util/date-in-past-validator)})
+
+(def temporal-extent-validation
+  {:RangeDateTimes (validations-core/every range-date-time-validation)})

--- a/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
@@ -25,7 +25,6 @@
   "Validate that the collection ends at present flag and end date time are
   not both set"
   [field-path value]
-  (proto-repl.saved-values/save 16)
   (when (and (= true (:EndsAtPresentFlag value))
              (seq (:RangeDateTimes value))
              (not (some nil? (map :EndingDateTime (:RangeDateTimes value)))))

--- a/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
@@ -21,10 +21,23 @@
     {field-path [(str "Ending date should be in the past. Either set ending date to a date "
                       "in the past or remove end date and set the ends at present flag to true.")]}))
 
+(defn- ends-at-present-validation
+  "Validate that the collection ends at present flag and end date time are
+  not both set"
+  [field-path value]
+  (proto-repl.saved-values/save 16)
+  (when (and (= true (:EndsAtPresentFlag value))
+             (seq (:RangeDateTimes value))
+             (not (some nil? (map :EndingDateTime (:RangeDateTimes value)))))
+    {field-path [(str "Ends at present flag is set to true, but an ending date is "
+                      "specified. Remove the latest ending date or set the ends at "
+                      "present flag to false.")]}))
+
 (def temporal-extent-warning-validation
-  {:RangeDateTimes (validations-core/every {:BeginningDateTime util/date-in-past-validator
-                                            :EndingDateTime temporal-end-date-in-past-validator})
-   :SingleDateTimes (validations-core/every util/date-in-past-validator)})
+  [ends-at-present-validation
+   {:RangeDateTimes (validations-core/every {:BeginningDateTime util/date-in-past-validator
+                                             :EndingDateTime temporal-end-date-in-past-validator})
+    :SingleDateTimes (validations-core/every util/date-in-past-validator)}])
 
 (def temporal-extent-validation
   {:RangeDateTimes (validations-core/every range-date-time-validation)})

--- a/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/temporal_extent.clj
@@ -33,10 +33,12 @@
                       "present flag to false.")]}))
 
 (def temporal-extent-warning-validation
+  "Temporal extent validations that will return warnings"
   [ends-at-present-validation
    {:RangeDateTimes (validations-core/every {:BeginningDateTime util/date-in-past-validator
                                              :EndingDateTime temporal-end-date-in-past-validator})
     :SingleDateTimes (validations-core/every util/date-in-past-validator)}])
 
 (def temporal-extent-validation
+  "Temporal extent validations that will return errors"
   {:RangeDateTimes (validations-core/every range-date-time-validation)})

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/temporal_extent.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/temporal_extent.clj
@@ -1,0 +1,104 @@
+(ns cmr.umm-spec.test.validation.temporal-extent
+  "This has tests for UMM temporal extent validations."
+  (:require
+   [clj-time.core :as time]
+   [clojure.test :refer :all]
+   [cmr.common.time-keeper :as time-keeper]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.umm-spec.models.umm-collection-models :as coll]
+   [cmr.umm-spec.models.umm-common-models :as c]
+   [cmr.umm-spec.test.validation.umm-spec-validation-test-helpers :as h]))
+
+(deftest collection-temporal-validation
+  (testing "valid temporal"
+    (let [r1 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:01Z")
+          r2 (h/range-date-time "1999-12-30T19:00:00Z" nil)
+          r3 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:00Z")
+          s1 (c/map->TemporalExtentType {:SingleDateTimes [(time/date-time 2014 12 1)]})]
+      (h/assert-valid (h/coll-with-range-date-times [[r1]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r2]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r3]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r1] [r2]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r1 r2] [r3]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r1 r2 r3]]))
+      (h/assert-valid (h/coll-with-range-date-times [[r1]] true)) ; EndsAtPresentFlag = true
+      (h/assert-warnings-valid (h/coll-with-range-date-times [[r1 r2] [r3]]))
+      (h/assert-warnings-valid (coll/map->UMM-C {:TemporalExtents [s1]}))))
+
+  (testing "invalid temporal"
+    (testing "single error"
+      (let [r1 (h/range-date-time "1999-12-30T19:00:02Z" "1999-12-30T19:00:01Z")
+            r2 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:00Z")]
+        (h/assert-invalid
+         (h/coll-with-range-date-times [[r1]])
+         [:TemporalExtents 0 :RangeDateTimes 0]
+         ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"])
+        (h/assert-invalid
+         (h/coll-with-range-date-times [[r2] [r1]])
+         [:TemporalExtents 1 :RangeDateTimes 0]
+         ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"])))
+
+    (testing "multiple errors"
+      (let [r1 (h/range-date-time "1999-12-30T19:00:02Z" "1999-12-30T19:00:01Z")
+            r2 (h/range-date-time "2000-12-30T19:00:02Z" "2000-12-30T19:00:01Z")]
+        (h/assert-multiple-invalid
+         (h/coll-with-range-date-times [[r1 r2]])
+         [{:path [:TemporalExtents 0 :RangeDateTimes 0],
+           :errors
+           ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"]}
+          {:path [:TemporalExtents 0 :RangeDateTimes 1],
+           :errors
+           ["BeginningDateTime [2000-12-30T19:00:02.000Z] must be no later than EndingDateTime [2000-12-30T19:00:01.000Z]"]}])
+        (h/assert-multiple-invalid
+         (h/coll-with-range-date-times [[r1] [r2]])
+         [{:path [:TemporalExtents 0 :RangeDateTimes 0],
+           :errors
+           ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"]}
+          {:path [:TemporalExtents 1 :RangeDateTimes 0],
+           :errors
+           ["BeginningDateTime [2000-12-30T19:00:02.000Z] must be no later than EndingDateTime [2000-12-30T19:00:01.000Z]"]}])))
+
+    (testing "dates in past"
+      (time-keeper/set-time-override! (time/date-time 2017 8 1))
+      (testing "range date times"
+        (let [r1 (h/range-date-time "2020-12-30T19:00:02Z" "2021-12-30T19:00:01Z")]
+          (h/assert-warnings-multiple-invalid
+           (h/coll-with-range-date-times [[r1]])
+           [{:path [:TemporalExtents 0 :RangeDateTimes 0 :BeginningDateTime],
+             :errors
+             ["Date should be in the past."]}
+            {:path [:TemporalExtents 0 :RangeDateTimes 0 :EndingDateTime],
+             :errors
+             [(str "Ending date should be in the past. Either set ending date to a date "
+                   "in the past or remove end date and set the ends at present flag to true.")]}])))
+      (testing "single date time"
+        (let [c1 (c/map->TemporalExtentType {:SingleDateTimes [(time/date-time 2014 12 1)
+                                                               (time/date-time 2020 12 30)]})]
+          (h/assert-warnings-invalid
+            (coll/map->UMM-C {:TemporalExtents [c1]})
+            [:TemporalExtents 0 :SingleDateTimes 1]
+            ["Date should be in the past."]))))))
+
+(deftest ends-at-present-validation
+  (let [r1 (h/range-date-time "1999-12-30T19:00:00Z" "2000-12-30T19:00:01Z")
+        r2 (h/range-date-time "2001-12-30T19:00:00Z" nil)
+        r3 (h/range-date-time "2003-12-30T19:00:00Z" "2005-12-30T19:00:00Z")]
+
+    (testing "valid ends at present configuration"
+      (are3 [range-date-times ends-at-present?]
+        (h/assert-warnings-valid (h/coll-with-range-date-times range-date-times ends-at-present?))
+
+        "ends at present true with nil end date"
+        [[r2]] true
+
+        "multiple ranges and ends at present true"
+        [[r1 r2]] true
+
+        "ends at present nil with nil end date"
+        [[r1 r2]] nil))
+
+   (testing "invalid ends at present configuration"
+     (h/assert-warnings-invalid
+       (h/coll-with-range-date-times [[r1 r3]] true)
+       [:TemporalExtents 0]
+       ["Ends at present flag is set to true, but an ending date is specified. Remove the latest ending date or set the ends at present flag to false."]))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_collection_validation_tests.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_collection_validation_tests.clj
@@ -99,77 +99,7 @@
               "DELETE date value: [2000-01-01T00:00:00.000Z] should be in the future. "
               "Earliest UPDATE date value: [2000-01-01T00:00:00.000Z] should be equal or later than CREATE date value: [2020-01-01T00:00:00.000Z]."
               "DELETE date value: [2000-01-01T00:00:00.000Z] should be equal or later than latest REVIEW date value: [2020-01-01T00:00:00.000Z]."]}]))
-) 
-
-(deftest collection-temporal-validation
-  (testing "valid temporal"
-    (let [r1 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:01Z")
-          r2 (h/range-date-time "1999-12-30T19:00:00Z" nil)
-          r3 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:00Z")
-          s1 (c/map->TemporalExtentType {:SingleDateTimes [(time/date-time 2014 12 1)]})]
-      (h/assert-valid (h/coll-with-range-date-times [[r1]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r2]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r3]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r1] [r2]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r1 r2] [r3]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r1 r2 r3]]))
-      (h/assert-valid (h/coll-with-range-date-times [[r1]] true)) ; EndsAtPresentFlag = true
-      (h/assert-warnings-valid (h/coll-with-range-date-times [[r1 r2] [r3]]))
-      (h/assert-warnings-valid (coll/map->UMM-C {:TemporalExtents [s1]}))))
-
-  (testing "invalid temporal"
-    (testing "single error"
-      (let [r1 (h/range-date-time "1999-12-30T19:00:02Z" "1999-12-30T19:00:01Z")
-            r2 (h/range-date-time "1999-12-30T19:00:00Z" "1999-12-30T19:00:00Z")]
-        (h/assert-invalid
-         (h/coll-with-range-date-times [[r1]])
-         [:TemporalExtents 0 :RangeDateTimes 0]
-         ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"])
-        (h/assert-invalid
-         (h/coll-with-range-date-times [[r2] [r1]])
-         [:TemporalExtents 1 :RangeDateTimes 0]
-         ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"])))
-
-    (testing "multiple errors"
-      (let [r1 (h/range-date-time "1999-12-30T19:00:02Z" "1999-12-30T19:00:01Z")
-            r2 (h/range-date-time "2000-12-30T19:00:02Z" "2000-12-30T19:00:01Z")]
-        (h/assert-multiple-invalid
-         (h/coll-with-range-date-times [[r1 r2]])
-         [{:path [:TemporalExtents 0 :RangeDateTimes 0],
-           :errors
-           ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"]}
-          {:path [:TemporalExtents 0 :RangeDateTimes 1],
-           :errors
-           ["BeginningDateTime [2000-12-30T19:00:02.000Z] must be no later than EndingDateTime [2000-12-30T19:00:01.000Z]"]}])
-        (h/assert-multiple-invalid
-         (h/coll-with-range-date-times [[r1] [r2]])
-         [{:path [:TemporalExtents 0 :RangeDateTimes 0],
-           :errors
-           ["BeginningDateTime [1999-12-30T19:00:02.000Z] must be no later than EndingDateTime [1999-12-30T19:00:01.000Z]"]}
-          {:path [:TemporalExtents 1 :RangeDateTimes 0],
-           :errors
-           ["BeginningDateTime [2000-12-30T19:00:02.000Z] must be no later than EndingDateTime [2000-12-30T19:00:01.000Z]"]}])))
-
-    (testing "dates in past"
-      (time-keeper/set-time-override! (time/date-time 2017 8 1))
-      (testing "range date times"
-        (let [r1 (h/range-date-time "2020-12-30T19:00:02Z" "2021-12-30T19:00:01Z")]
-          (h/assert-warnings-multiple-invalid
-           (h/coll-with-range-date-times [[r1]])
-           [{:path [:TemporalExtents 0 :RangeDateTimes 0 :BeginningDateTime],
-             :errors
-             ["Date should be in the past."]}
-            {:path [:TemporalExtents 0 :RangeDateTimes 0 :EndingDateTime],
-             :errors
-             [(str "Ending date should be in the past. Either set ending date to a date "
-                   "in the past or remove end date and set the ends at present flag to true.")]}])))
-      (testing "single date time"
-        (let [c1 (c/map->TemporalExtentType {:SingleDateTimes [(time/date-time 2014 12 1)
-                                                               (time/date-time 2020 12 30)]})]
-          (h/assert-warnings-invalid
-            (coll/map->UMM-C {:TemporalExtents [c1]})
-            [:TemporalExtents 0 :SingleDateTimes 1]
-            ["Date should be in the past."]))))))
+)
 
 (deftest collection-projects-validation
   (time-keeper/set-time-override! (time/date-time 2017 8 1))


### PR DESCRIPTION
Added validation to give a warning when the ends at present flag is true and the end date is set on a collection.

Moved temporal extent validation and tests into separate files.