### PR TITLE
CMR-4400 changes platform longname and shortname validation

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -46,6 +46,7 @@
     field-to-compare m
   }"
   [m fields-to-compare]
+  (proto-repl.saved-values/save 2)
   (if (map? m)
     (->> (select-keys m fields-to-compare)
          util/remove-nil-keys
@@ -140,16 +141,37 @@
   [kms-index location-string]
   (get-in kms-index [:locations-index (str/upper-case location-string)]))
 
-(defn lookup-by-umm-c-keyword
+(defn- remove-long-name-from-kms-index
+  [kms-index keyword-scheme]
+  (into {}
+    (for [[k v] (get-in kms-index [:umm-c-index keyword-scheme])]
+      [(dissoc k :long-name) v])))
+
+(defmulti lookup-by-umm-c-keyword
   "Takes a keyword as represented in UMM-C and returns the KMS keyword. Comparison is made case
   insensitively."
+  (fn [kms-index keyword-scheme umm-c-keyword]
+    keyword-scheme))
+
+(defmethod lookup-by-umm-c-keyword :platforms
   [kms-index keyword-scheme umm-c-keyword]
   (let [umm-c-keyword (csk-extras/transform-keys csk/->kebab-case umm-c-keyword)
         ;; CMR-3696 This is needed to compare the keyword category, which is mapped
         ;; to the UMM Platform Type field.  This will avoid complications with facets.
-        umm-c-keyword (if (= :platforms keyword-scheme)
-                         (set/rename-keys umm-c-keyword {:type :category})
-                         umm-c-keyword)
+        umm-c-keyword (set/rename-keys umm-c-keyword {:type :category})
+        comparison-map (normalize-for-lookup umm-c-keyword (kms-scheme->fields-for-umm-c-lookup
+                                                            keyword-scheme))]
+    (if (get umm-c-keyword :long-name)
+      ;; Check both longname and shortname
+      (get-in kms-index [:umm-c-index keyword-scheme comparison-map])
+      ;; Check just shortname
+      (-> kms-index
+          (remove-long-name-from-kms-index keyword-scheme)
+          (get comparison-map)))))
+
+(defmethod lookup-by-umm-c-keyword :default
+  [kms-index keyword-scheme umm-c-keyword]
+  (let [umm-c-keyword (csk-extras/transform-keys csk/->kebab-case umm-c-keyword)
         comparison-map (normalize-for-lookup umm-c-keyword (kms-scheme->fields-for-umm-c-lookup
                                                             keyword-scheme))]
     (get-in kms-index [:umm-c-index keyword-scheme comparison-map])))

--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -141,6 +141,8 @@
   (get-in kms-index [:locations-index (str/upper-case location-string)]))
 
 (defn- remove-long-name-from-kms-index
+  "Removes long-name from the umm-c-index keys in order to prevent validation when
+   long-name is not present in the umm-c-keyword.  We only want to validate long-name if it is not nil."
   [kms-index keyword-scheme]
   (into {}
     (for [[k v] (get-in kms-index [:umm-c-index keyword-scheme])]

--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -46,7 +46,6 @@
     field-to-compare m
   }"
   [m fields-to-compare]
-  (proto-repl.saved-values/save 2)
   (if (map? m)
     (->> (select-keys m fields-to-compare)
          util/remove-nil-keys

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
@@ -109,7 +109,13 @@
                        :subregion-2 "CHAD" :subregion-3 "AOUZOU"} "location1-uuid"
 
     "Lookup works without all matching fields present"
-    :spatial-keywords {:category "CONTINENT" :type "AFRICA"} "location2-uuid"))
+    :spatial-keywords {:category "CONTINENT" :type "AFRICA"} "location2-uuid")
+
+  ;; CMR-4400
+  (testing "Platform Shortname exists but Longname is nil"
+    (is (= {:short-name "PLAT1" :long-name "Platform 1" :category "Aircraft" :other-random-key 7 :uuid "plat1-uuid"}
+           (kms-lookup/lookup-by-umm-c-keyword kms-index :platforms
+                                               {:short-name "Plat1" :long-name nil :type "Aircraft"})))))
 
 (deftest lookup-by-short-name-test
   (testing "Full keyword map is returned by short-name lookup"

--- a/dev-system/resources/kms_examples/platforms/platforms.csv
+++ b/dev-system/resources/kms_examples/platforms/platforms.csv
@@ -2,6 +2,10 @@
 Category,Series_Entity,Short_Name,Long_Name,UUID
 "Aircraft","","A340-600","Airbus A340-600","bab77f95-aa34-42aa-9a12-922d1c9fae63"
 "Aircraft","","AIRCRAFT","","8bce0691-74e9-4363-8d1f-d453a318c62b"
-"Earth Observation Satellites","DMSP (Defense Meteorological Satellite Program)","DMSP 5B/F3","Defense Meteorological Satellite Program-F3","7ed12e98-95b1-406c-a58a-f4bbfa405269"
+"Aircraft","","ALTUS","","46392889-f6e2-4b06-8f79-87f2ff9d4349"
+"Aircraft","","B-200","Beechcraft King Air B-200","d6aa2406-0323-43c1-b890-3509ee22784e"
+"Aircraft","","CESSNA 188","","80374e6d-fef6-4b11-bcc4-53568a3db220"
+"Aircraft","","DHC-3","DeHavilland DHC-3 Otter","aef364b1-6a71-49c0-b248-6dc1ecd4eaa3"
 "Earth Observation Satellites","DIADEM","DIADEM-1D","","143a5181-7601-4cc7-96d1-2b1a04b08fa7"
+"Earth Observation Satellites","DMSP (Defense Meteorological Satellite Program)","DMSP 5B/F3","Defense Meteorological Satellite Program-F3","7ed12e98-95b1-406c-a58a-f4bbfa405269"
 "Earth Observation Satellites","NASA Decadal Survey","SMAP","Soil Moisture Active and Passive Observatory","7ee03239-24ff-433e-ab7e-8be8b9b2636b"

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
@@ -125,7 +125,11 @@
           "DMSP 5B/F3" "Defense Meteorological Satellite Program-F3" "foo"
 
           "Invalid combination"
-          "DMSP 5B/F3" "Airbus A340-600" "Earth Observation Satellites")
+          "DMSP 5B/F3" "Airbus A340-600" "Earth Observation Satellites"
+
+          ;;CMR-4400
+          "Long name is in Platform and nil in KMS"
+          "ALTUS" "foo" "Aircraft")
 
     (are2 [short-name long-name type]
           (assert-valid-keywords
@@ -138,8 +142,15 @@
           "Case Insensitive"
           "a340-600" "aiRBus A340-600" "aIrCrAfT"
 
-          "Long name is nil in Platform"
-          "a340-600" nil "Aircraft"))
+          ;; Next three scenarios are for CMR-4400
+          "Long name is in Platform and KMS"
+          "B-200" "Beechcraft King Air B-200" "Aircraft"
+
+          "Long name is nil in Platform and nil in KMS"
+          "CESSNA 188" nil "Aircraft"
+
+          "Long name is nil in Platform and not nil in KMS"
+          "DHC-3" nil "Aircraft"))
 
   (testing "DataCenter keyword validation"
     (testing "Invalid short name"

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
@@ -136,7 +136,10 @@
           "A340-600" "Airbus A340-600" "Aircraft"
 
           "Case Insensitive"
-          "a340-600" "aiRBus A340-600" "aIrCrAfT"))
+          "a340-600" "aiRBus A340-600" "aIrCrAfT"
+
+          "Long name is nil in Platform"
+          "a340-600" nil "Aircraft"))
 
   (testing "DataCenter keyword validation"
     (testing "Invalid short name"

--- a/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
@@ -146,7 +146,31 @@
                                   "uuid"
                                   "3e705ebc-c58f-460d-b5e7-1da05ee45cc1"}]}]}]}]}]}]}
    :platforms {"category"
-               [{"value" "Earth Observation Satellites",
+               [{"value" "Aircraft",
+                 "subfields" ["short_name"],
+                 "short_name"
+                 [{"value" "B-200",
+                   "subfields" ["long_name"],
+                   "long_name"
+                   [{"value" "Beechcraft King Air B-200",
+                     "uuid" "d6aa2406-0323-43c1-b890-3509ee22784e"}]}
+                  {"value" "DHC-3",
+                   "subfields" ["long_name"],
+                   "long_name"
+                   [{"value" "DeHavilland DHC-3 Otter",
+                     "uuid" "aef364b1-6a71-49c0-b248-6dc1ecd4eaa3"}]}
+                  {"value" "CESSNA 188",
+                   "uuid" "80374e6d-fef6-4b11-bcc4-53568a3db220"}
+                  {"value" "AIRCRAFT",
+                   "uuid" "8bce0691-74e9-4363-8d1f-d453a318c62b"}
+                  {"value" "ALTUS",
+                   "uuid" "46392889-f6e2-4b06-8f79-87f2ff9d4349"}
+                  {"value" "A340-600",
+                   "subfields" ["long_name"],
+                   "long_name"
+                   [{"value" "Airbus A340-600",
+                     "uuid" "bab77f95-aa34-42aa-9a12-922d1c9fae63"}]}]}
+                {"value" "Earth Observation Satellites",
                  "subfields" ["series_entity"],
                  "series_entity"
                  [{"value"
@@ -173,17 +197,7 @@
                      [{"value"
                        "Soil Moisture Active and Passive Observatory",
                        "uuid"
-                       "7ee03239-24ff-433e-ab7e-8be8b9b2636b"}]}]}]}
-                {"value" "Aircraft",
-                 "short_name"
-                 [{"value" "AIRCRAFT",
-                   "uuid" "8bce0691-74e9-4363-8d1f-d453a318c62b"}
-                  {"value" "A340-600",
-                   "subfields" ["long_name"],
-                   "long_name"
-                   [{"value" "Airbus A340-600",
-                     "uuid" "bab77f95-aa34-42aa-9a12-922d1c9fae63"}]}],
-                 "subfields" ["short_name"]}]}
+                       "7ee03239-24ff-433e-ab7e-8be8b9b2636b"}]}]}]}]}
    :instruments {"category"
                  [{"value" "Earth Remote Sensing Instruments",
                    "subfields" ["class"],


### PR DESCRIPTION
In this PR, we want to prevent KMS validation on Platform LongName when the LongName is nil due to some restrictions with ECHO-10.  We still want to validate ShortName in that case.  If both LongName and ShortName are present, then the validation should work as before.