### PR TITLE
CMR-4622:  Added functionality to set user-id in bulk update.

### DIFF
--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -25,7 +25,7 @@
           content (api-core/read-body! body)]
       (api-core/verify-provider-exists request-context provider-id)
       (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
-      (let [task-id (bulk-update/validate-and-save-bulk-update request-context provider-id content)]
+      (let [task-id (bulk-update/validate-and-save-bulk-update request-context provider-id content headers)]
         (api-core/generate-ingest-response
           headers
           {:status 200

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -4,7 +4,6 @@
    [clojure.data.xml :as xml]
    [clojure.string :as string]
    [cmr.acl.core :as acl]
-   [cmr.common.cache :as cache]
    [cmr.common.log :refer [debug info warn error]]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as srvc-errors]
@@ -13,22 +12,7 @@
    [cmr.ingest.config :as ingest-config]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.services.bulk-update-service :as bulk-update]
-   [cmr.ingest.services.ingest-service :as ingest]
-   [cmr.transmit.echo.tokens :as tokens]))
-
-(def user-id-cache-key
-  "The cache key for the token user id cache"
-  :token-user-ids)
-
-(defn- get-user-id
-  "Get user id based on context and headers"
-  [context headers]
-  (if-let [user-id (get headers "user-id")]
-    user-id
-    (when-let [token (get headers "echo-token")]
-      (cache/get-value (cache/context->cache context user-id-cache-key)
-                       token
-                       (partial tokens/get-user-id context token)))))
+   [cmr.ingest.services.ingest-service :as ingest]))
 
 (defn bulk-update-collections
   "Bulk update collections. Validate provider exists, check ACLs, and validate
@@ -39,7 +23,7 @@
         :bad-request "Bulk update is disabled.")
     (let [{:keys [body headers request-context]} request
           content (api-core/read-body! body)
-          user-id (get-user-id request-context headers)]
+          user-id (api-core/get-user-id request-context headers)]
       (api-core/verify-provider-exists request-context provider-id)
       (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
       (let [task-id (bulk-update/validate-and-save-bulk-update request-context provider-id content user-id)]

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -170,16 +170,20 @@
     {}
     {:threshold 1000}))
 
+(defn get-user-id
+  "Get user id based on context and headers"
+  [context headers]
+  (if-let [user-id (get headers "user-id")]
+    user-id
+    (when-let [token (get headers "echo-token")]
+      (cache/get-value (cache/context->cache context user-id-cache-key)
+                       token
+                       (partial tokens/get-user-id context token)))))
+
 (defn set-user-id
   "Associate user id to concept."
   [concept context headers]
-  (assoc concept :user-id
-         (if-let [user-id (get headers "user-id")]
-           user-id
-           (when-let [token (get headers transmit-config/token-header)]
-             (cache/get-value (cache/context->cache context user-id-cache-key)
-                              token
-                              (partial tokens/get-user-id context token))))))
+  (assoc concept :user-id (get-user-id context headers)))
 
 (defn- set-concept-id
   "Set concept-id and revision-id for the given concept based on the headers. Ignore the

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -181,20 +181,6 @@
                               token
                               (partial tokens/get-user-id context token))))))
 
-(defn set-user-id-for-bulk-update
-  "Associate user id to concept. This function is the same as set-user-id except that
-   when retrieving token and user-id, it uses :echo-token  and :user-id as keys because  
-   the \"echo-token\" and \"user-id\" keys are changed to :echo-token and :user-id
-   at handle-bulk-update-event"
-  [concept context headers]
-  (assoc concept :user-id
-         (if-let [user-id (get headers :user-id)]
-           user-id
-           (when-let [token (get headers :echo-token)]
-             (cache/get-value (cache/context->cache context user-id-cache-key)
-                              token
-                              (partial tokens/get-user-id context token))))))
-
 (defn- set-concept-id
   "Set concept-id and revision-id for the given concept based on the headers. Ignore the
   revision-id if no concept-id header is passed in."

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -181,6 +181,20 @@
                               token
                               (partial tokens/get-user-id context token))))))
 
+(defn set-user-id-for-bulk-update
+  "Associate user id to concept. This function is the same as set-user-id except that
+   when retrieving token and user-id, it uses :echo-token  and :user-id as keys because  
+   the \"echo-token\" and \"user-id\" keys are changed to :echo-token and :user-id
+   at handle-bulk-update-event"
+  [concept context headers]
+  (assoc concept :user-id
+         (if-let [user-id (get headers :user-id)]
+           user-id
+           (when-let [token (get headers :echo-token)]
+             (cache/get-value (cache/context->cache context user-id-cache-key)
+                              token
+                              (partial tokens/get-user-id context token))))))
+
 (defn- set-concept-id
   "Set concept-id and revision-id for the given concept based on the headers. Ignore the
   revision-id if no concept-id header is passed in."

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -173,9 +173,9 @@
 (defn get-user-id
   "Get user id based on context and headers"
   [context headers]
-  (if-let [user-id (get headers "user-id")]
+  (if-let [user-id (get headers transmit-config/user-id-header)]
     user-id
-    (when-let [token (get headers "echo-token")]
+    (when-let [token (get headers transmit-config/token-header)]
       (cache/get-value (cache/context->cache context user-id-cache-key)
                        token
                        (partial tokens/get-user-id context token)))))

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -54,18 +54,18 @@
    :provider-id provider-id})
 
 (defn ingest-bulk-update-event
-  [provider-id task-id bulk-update-params headers]
+  [provider-id task-id bulk-update-params user-id]
   {:action :bulk-update
    :provider-id provider-id
    :task-id task-id
    :bulk-update-params bulk-update-params
-   :headers headers})
+   :user-id user-id})
 
 (defn ingest-collection-bulk-update-event
-  [provider-id task-id concept-id bulk-update-params headers]
+  [provider-id task-id concept-id bulk-update-params user-id]
   {:action :collection-bulk-update
    :provider-id provider-id
    :task-id task-id
    :concept-id concept-id
    :bulk-update-params bulk-update-params
-   :headers headers})
+   :user-id user-id})

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -54,16 +54,18 @@
    :provider-id provider-id})
 
 (defn ingest-bulk-update-event
-  [provider-id task-id bulk-update-params]
+  [provider-id task-id bulk-update-params headers]
   {:action :bulk-update
    :provider-id provider-id
    :task-id task-id
-   :bulk-update-params bulk-update-params})
+   :bulk-update-params bulk-update-params
+   :headers headers})
 
 (defn ingest-collection-bulk-update-event
-  [provider-id task-id concept-id bulk-update-params]
+  [provider-id task-id concept-id bulk-update-params headers]
   {:action :collection-bulk-update
    :provider-id provider-id
    :task-id task-id
    :concept-id concept-id
-   :bulk-update-params bulk-update-params})
+   :bulk-update-params bulk-update-params
+   :headers headers})

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -7,6 +7,7 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.validations.json-schema :as js]
+   [cmr.ingest.api.core :as api-core]
    [cmr.ingest.config :as config]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
@@ -94,7 +95,7 @@
   "Validate the bulk update POST parameters, save rows to the db for task
   and collection statuses, and queueu bulk update. Return task id, which comes
   from the db save."
-  [context provider-id json]
+  [context provider-id json headers]
   (validate-bulk-update-post-params json)
   (let [bulk-update-params (json/parse-string json true)
         {:keys [concept-ids]} bulk-update-params
@@ -104,12 +105,12 @@
     ;; Queue the bulk update event
     (ingest-events/publish-ingest-event
       context
-      (ingest-events/ingest-bulk-update-event provider-id task-id bulk-update-params))
+      (ingest-events/ingest-bulk-update-event provider-id task-id bulk-update-params headers))
     task-id))
 
 (defn handle-bulk-update-event
   "For each concept-id, queueu collection bulk update messages"
-  [context provider-id task-id bulk-update-params]
+  [context provider-id task-id bulk-update-params headers]
   (let [{:keys [concept-ids]} bulk-update-params]
     (doseq [concept-id concept-ids]
      (ingest-events/publish-ingest-event
@@ -118,11 +119,12 @@
        provider-id
        task-id
        concept-id
-       bulk-update-params)))))
+       bulk-update-params
+       headers)))))
 
 (defn- update-collection-concept
   "Perform the update on the collection and update the concept"
-  [context concept bulk-update-params]
+  [context concept bulk-update-params headers]
   (let [{:keys [update-type update-field find-value update-value]} bulk-update-params
         update-type (csk/->kebab-case-keyword update-type)
         update-field (csk/->PascalCaseKeyword update-field)]
@@ -132,7 +134,8 @@
                                                       update-format))
         (assoc :format update-format)
         (update :revision-id inc)
-        (assoc :revision-date (time-keeper/now)))))
+        (assoc :revision-date (time-keeper/now))
+        (api-core/set-user-id-for-bulk-update context headers))))
 
 (defn- validate-and-save-collection
   "Put concept through ingest validation. Attempt save to
@@ -171,10 +174,10 @@
 (defn handle-collection-bulk-update-event
   "Perform update for the given concept id. Log an error status if the concept
   cannot be found."
-  [context provider-id task-id concept-id bulk-update-params]
+  [context provider-id task-id concept-id bulk-update-params headers]
   (try
     (if-let [concept (mdb2/get-latest-concept context concept-id)]
-      (let [updated-concept (update-collection-concept context concept bulk-update-params)
+      (let [updated-concept (update-collection-concept context concept bulk-update-params headers)
             warnings (validate-and-save-collection context updated-concept)]
         (data-bulk-update/update-bulk-update-task-collection-status
          context task-id concept-id complete-status (create-success-status-message warnings)))
@@ -188,7 +191,8 @@
          (ingest-events/ingest-collection-bulk-update-event provider-id
                                                             task-id
                                                             concept-id
-                                                            bulk-update-params))
+                                                            bulk-update-params
+                                                            headers))
         (data-bulk-update/update-bulk-update-task-collection-status
           context task-id concept-id failed-status (.getMessage ex-info))))
     (catch Exception e

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -16,7 +16,7 @@
    (:provider-id msg)
    (:task-id msg)
    (:bulk-update-params msg)
-   (:headers msg)))
+   (:user-id msg)))
 
 (defmethod handle-provider-event :collection-bulk-update
   [context msg]
@@ -26,7 +26,7 @@
    (:task-id msg)
    (:concept-id msg)
    (:bulk-update-params msg)
-   (:headers msg)))
+   (:user-id msg)))
 
 ;; Default ignores the provider event. There may be provider events we don't care about.
 (defmethod handle-provider-event :default

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -15,7 +15,8 @@
    context
    (:provider-id msg)
    (:task-id msg)
-   (:bulk-update-params msg)))
+   (:bulk-update-params msg)
+   (:headers msg)))
 
 (defmethod handle-provider-event :collection-bulk-update
   [context msg]
@@ -24,7 +25,8 @@
    (:provider-id msg)
    (:task-id msg)
    (:concept-id msg)
-   (:bulk-update-params msg)))
+   (:bulk-update-params msg)
+   (:headers msg)))
 
 ;; Default ignores the provider event. There may be provider events we don't care about.
 (defmethod handle-provider-event :default

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -495,13 +495,18 @@
  ([provider-id request-body options]
   (let [accept-format (get options :accept-format :xml)
         token (:token options)
+        user-id (:user-id options)
+        headers (when (or user-id token)
+                  (util/remove-nil-keys
+                    {transmit-config/token-header token
+                     "user-id" user-id}))
         params {:method :post
                 :url (url/ingest-collection-bulk-update-url provider-id)
                 :body (json/generate-string request-body)
                 :connection-manager (s/conn-mgr)
                 :throw-exceptions false}
         params (merge params (when accept-format {:accept accept-format}))
-        params (merge params (when token {:headers {transmit-config/token-header token}}))
+        params (merge params (when headers {:headers headers})) 
         response (client/request params)]
    (parse-bulk-update-response response options))))
 

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -40,6 +40,9 @@
 (def token-header
   "echo-token")
 
+(def user-id-header
+  "user-id")
+
 (defmacro def-app-conn-config
   "Defines the following configuration entries for an application:
   * protocol


### PR DESCRIPTION
Turns out bulk update and regular ingest/update are not going through the same ingest-collection function, in which the user-id is set.  
Bulk update doesn't contain the functionality to set the user id. It just makes use of the user-id from the previous revision.  This is why the regular update will set the user-id, while the bulk update just carries  on whatever the user-id is from the previous revision.