### PR TITLE
CMR-4533 implements DOI warning validation for DOI formatting

### DIFF
--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
@@ -243,7 +243,6 @@
      :EntryTitle (str "Entry Title " index)}
     attribs)))
 
-
 (defn collection
   "Returns a UmmCollection from the given attribute map."
   ([]

--- a/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_collection_validation.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_collection_validation.clj
@@ -27,8 +27,9 @@
 (defn doi-format-warning-validation
   "Validates that DOI is properly formatted."
   [field-path value]
-  (when-not (re-matches #"\d\d\.\d\d\d\d(\.\d+)*\/.+" value)
-    {field-path [(format "DOI [%s] is improperly formatted." value)]}))
+  (when (seq value)
+    (when-not (re-matches #"\d\d\.\d\d\d\d(\.\d+)*\/.+" value)
+      {field-path [(format "DOI [%s] is improperly formatted." value)]})))
 
 (def tiling-identification-system-coordinate-validations
   "Defines the tiling identification system coordinate validations for collections"

--- a/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_collection_validation.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/umm_spec_collection_validation.clj
@@ -24,6 +24,12 @@
       {field-path [(format "%%s minimum [%s] must be less than or equal to the maximum [%s]."
                            (str MinimumValue) (str MaximumValue))]})))
 
+(defn doi-format-warning-validation
+  "Validates that DOI is properly formatted."
+  [field-path value]
+  (when-not (re-matches #"\d\d\.\d\d\d\d(\.\d+)*\/.+" value)
+    {field-path [(format "DOI [%s] is improperly formatted." value)]}))
+
 (def tiling-identification-system-coordinate-validations
   "Defines the tiling identification system coordinate validations for collections"
   {:Coordinate1 coordinate-validator
@@ -63,4 +69,5 @@
   :ContactPersons (v/every url/contact-persons-groups-contact-information-validations)
   :ContactGroups (v/every url/contact-persons-groups-contact-information-validations)
   :DataDates data-date/data-dates-warning-validation
-  :MetadataDates data-date/data-dates-warning-validation})
+  :MetadataDates data-date/data-dates-warning-validation
+  :DOI {:DOI doi-format-warning-validation}})

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_collection_validation_tests.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_collection_validation_tests.clj
@@ -212,3 +212,20 @@
              {:path [:TilingIdentificationSystems 3 :Coordinate2],
               :errors
               ["Coordinate 2 minimum [50.0] must be less than or equal to the maximum [26.0]."]}]))))))
+
+(deftest collection-doi-format-validation
+  (let [doi1 (c/map->DoiType {:DOI "10.1451/DOIID"
+                              :test "Test"
+                              :Authority "Data Center or Creator of the DOI - not the DOI registration service"})
+        doi2 (c/map->DoiType {:DOI "incorrect doi"
+                              :Authority "Data Center or Creator of the DOI - not the DOI registration service"})]
+    
+    (testing "valid doi format"
+      (h/assert-warnings-valid (coll/map->UMM-C {:DOI doi1})))
+
+    (testing "invalid doi format"
+      (let [coll (coll/map->UMM-C {:DOI doi2})]
+        (h/assert-warnings-invalid
+          coll
+          [:DOI :DOI]
+          ["DOI [incorrect doi] is improperly formatted."])))))


### PR DESCRIPTION
This PR adds validation on DOI formatting, the DOI should have a normal format of prefix/suffix where the prefix normally is dd.dddd, where d is a digit and the suffix is a string .