### PR TITLE
CMR-4128

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
@@ -33,7 +33,8 @@
 
   (get-granule-concept-ids
     [db provider native-id]
-    "Return the granule concept-id and parent collection concept-id for the given granule native id.")
+    "Return the granule concept-id, parent collection concept-id and deleted flag
+    for the given granule native id.")
 
   (get-concept
     [db concept-type provider concept-id revision-id]

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -202,15 +202,16 @@
   (get-granule-concept-ids
    [this provider native-id]
    (let [provider-id (:provider-id provider)
-         concept-ids-fn (fn [gran]
-                          [(:concept-id gran) (get-in gran [:extra-fields :parent-collection-id])])]
-     (->> @concepts-atom
-          (filter (fn [c]
-                    (and (= :granule (:concept-type c))
-                         (= provider-id (:provider-id c))
-                         (= native-id (:native-id c)))))
-          first
-          concept-ids-fn)))
+         matched-gran (->> @concepts-atom
+                           (filter (fn [c]
+                                     (and (= :granule (:concept-type c))
+                                          (= provider-id (:provider-id c))
+                                          (= native-id (:native-id c)))))
+                           (sort-by :revisoin-id)
+                           last)
+         {:keys [concept-id deleted]} matched-gran
+         parent-collection-id (get-in matched-gran [:extra-fields :parent-collection-id])]
+     [concept-id parent-collection-id deleted]))
 
   (get-concept
    [db concept-type provider concept-id]

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -79,14 +79,12 @@
                  (dg/granule-with-umm-spec-collection
                   coll1
                   (:concept-id coll1)
-                  {:granule-ur "gran1"
-                   :native-id "gran-native1-1"}))
+                  {:native-id "gran-native1-1"}))
           gran2 (d/item->concept
                  (dg/granule-with-umm-spec-collection
                   coll2
                   (:concept-id coll2)
-                  {:granule-ur "gran1"
-                   :native-id "gran-native1-1"}))
+                  {:native-id "gran-native1-1"}))
           {:keys [concept-id revision-id]} (ingest/ingest-concept gran1)
           {:keys [status errors]} (ingest/ingest-concept gran2 {:allow-failure? true})]
       (is (= 422 status))


### PR DESCRIPTION
Make the native id of granule tombstone reusable to reference a different parent collection.