### PR TITLE
CMR-4632: When making bulk update status calls, the task-id and provi…

### DIFF
--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -123,7 +123,7 @@
   (let [{:keys [headers request-context]} request]
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :read :provider-object provider-id)
-    (let [task-status (data-bulk-update/get-bulk-update-task-status-for-provider request-context task-id)
+    (let [task-status (data-bulk-update/get-bulk-update-task-status-for-provider request-context task-id provider-id)
           collection-statuses (data-bulk-update/get-bulk-update-collection-statuses-for-task request-context task-id)]
       (when (or (nil? task-status) (nil? (:status task-status)))
         (srvc-errors/throw-service-error

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -127,7 +127,7 @@
           collection-statuses (data-bulk-update/get-bulk-update-collection-statuses-for-task request-context task-id)]
       (when (or (nil? task-status) (nil? (:status task-status)))
         (srvc-errors/throw-service-error
-          :not-found (format "Bulk update task with task id [%s] could not be found." task-id)))
+          :not-found (format "Bulk update task with task id [%s] could not be found for provider id [%s]." task-id provider-id)))
       (generate-provider-task-status-response
        headers
        {:status 200

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -36,9 +36,10 @@
              (map #(select-keys % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-bulk-update-task-status
-    [this task-id]
+    [this task-id provider-id]
     (let [task-status (some->> @task-status-atom
-                               (some #(when (= task-id (str (:task-id %)))
+                               (some #(when (and (= provider-id (str (:provider-id %)))
+                                                 (= task-id (str (:task-id %))))
                                             %)))]
       (select-keys task-status [:created-at :name :task-id :status :status-message :request-json-body])))
 

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -169,7 +169,7 @@
   "Check if the overall bulk update operation is complete and if so, re-index
   provider collections"
   [context provider-id task-id]
-  (let [task-status (data-bulk-update/get-bulk-update-task-status-for-provider context task-id)]
+  (let [task-status (data-bulk-update/get-bulk-update-task-status-for-provider context task-id provider-id)]
     (when (= complete-status (:status task-status))
       (ingest-events/publish-ingest-event
        context

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -248,5 +248,5 @@
           response (ingest/bulk-update-task-status "PROV1" 12 {:token token})
           {:keys [status errors]} response]
       (is (= 404 status))
-      (is (= ["Bulk update task with task id [12] could not be found."]
+      (is (= ["Bulk update task with task id [12] could not be found for provider id [PROV1]."]
              errors)))))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -218,13 +218,13 @@
     (index/wait-until-indexed)
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 2)]
       (is (= 404 (:status collection-response)))
-      (is (= ["Bulk update task with task id [2] could not be found."]
+      (is (= ["Bulk update task with task id [2] could not be found for provider id [PROV1]."]
              (:errors collection-response))))
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
       (is (= 200 (:status collection-response))))
     (let [collection-response (ingest/bulk-update-task-status "PROV2" 1)]
       (is (= 404 (:status collection-response)))
-      (is (= ["Bulk update task with task id [1] could not be found."]
+      (is (= ["Bulk update task with task id [1] could not be found for provider id [PROV2]."]
              (:errors collection-response))))
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -17,7 +17,7 @@
    [cmr.system-int-test.utils.search-util :as search]))
 
 (use-fixtures :each (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"})
+                      [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
                        (search/freeze-resume-time-fixture)]))
 
 (def collection-formats
@@ -219,6 +219,12 @@
     (let [collection-response (ingest/bulk-update-task-status "PROV1" 2)]
       (is (= 404 (:status collection-response)))
       (is (= ["Bulk update task with task id [2] could not be found."]
+             (:errors collection-response))))
+    (let [collection-response (ingest/bulk-update-task-status "PROV1" 1)]
+      (is (= 200 (:status collection-response))))
+    (let [collection-response (ingest/bulk-update-task-status "PROV2" 1)]
+      (is (= 404 (:status collection-response)))
+      (is (= ["Bulk update task with task id [1] could not be found."]
              (:errors collection-response))))
     (side/eval-form `(ingest-config/set-bulk-update-enabled! true))
 


### PR DESCRIPTION
…der-id need to match in bulk_update_task_status table.