### PR TITLE
CMR-4279, CMR-4674

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -86,7 +86,12 @@
   [context service-associations]
   (let [service-concepts (remove nil?
                                  (map #(service-association->service-concept context %)
-                                      service-associations))]
-    {:has-formats (boolean (some #(has-formats? context %) service-concepts))
+                                      service-associations))
+        service-names (map #(get-in % [:extra-fields :service-name]) service-concepts)
+        service-concept-ids (map :concept-id service-concepts)]
+    {:service-names service-names
+     :service-names.lowercase (map string/lower-case service-names)
+     :service-concept-ids service-concept-ids
+     :has-formats (boolean (some #(has-formats? context %) service-concepts))
      :has-spatial-subsetting (boolean (some #(has-spatial-subsetting? context %) service-concepts))
      :has-transforms (boolean (some #(has-transforms? context %) service-concepts))}))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -447,6 +447,11 @@
           :measurements.lowercase m/string-field-mapping
           :variables variables-mapping
 
+          ;; associated services
+          :service-names (m/doc-values m/string-field-mapping)
+          :service-names.lowercase (m/doc-values m/string-field-mapping)
+          :service-concept-ids (m/doc-values m/string-field-mapping)
+
           ;; associations with the collection stored as EDN gzipped and base64 encoded for retrieving purpose
           :associations-gzip-b64 (m/not-indexed (m/stored m/string-field-mapping))
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -65,6 +65,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Tag parameters](#c-tag-parameters)
     * [Variable parameters](#c-variable-parameters)
     * [Variables](#c-variables)
+    * [Service parameters](#c-service-parameters)
     * [Spatial](#c-spatial)
         * [Polygon](#c-polygon)
         * [Bounding Box](#c-bounding-box)
@@ -1521,6 +1522,23 @@ Find collections matching 'variables-h' param value
 Find collections matching multiple 'variables-h' param values, default is :and
 
      curl "%CMR-ENDPOINT%/collections?variables-h\[0\]\[measurement\]=M1&variables-h\[0\]\[variable\]=Var1&variables-h\[1\]\[measurement\]=M2"
+
+#### <a name="c-service-parameters"></a> Find collections by service parameters
+
+Collections can be found by searching for associated services. The following service parameters are supported.
+
+* service_name
+  * supports `pattern`, `ignore_case` and option `and`
+* service_concept_id
+  * supports option `and`
+
+Find collections matching service name.
+
+    curl "%CMR-ENDPOINT%/collections?service_name=AtlasNorth"
+
+Find collections matching service concept id.
+
+    curl "%CMR-ENDPOINT%/collections?service_concept_id\[\]=S100000-PROV1&service_concept_id\[\]=S12345-PROV1"
 
 #### <a name="c-spatial"></a> Find collections by Spatial
 

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -59,7 +59,9 @@
                           :variable-native-id :variable-native-ids
                           :measurement :measurements
                           :author :authors
-                          :doi :doi-stored}]
+                          :doi :doi-stored
+                          :service-name :service-names
+                          :service-concept-id :service-concept-ids}]
     (if (use-doc-values-fields)
       (merge default-mappings spatial-doc-values-field-mappings)
       default-mappings)))
@@ -125,7 +127,9 @@
    :variable-concept-ids :variable-concept-id
    :variable-native-ids :variable-native-id
    :measurements :measurement
-   :authors :author})
+   :authors :author
+   :service-names :service-name
+   :service-concept-ids :service-concept-id})
 
 (defmethod q2e/elastic-field->query-field-mappings :granule
   [_]
@@ -152,7 +156,8 @@
    :variable-name "variable-names.lowercase"
    :variable-native-id "variable-native-ids.lowercase"
    :measurement "measurements.lowercase"
-   :author "authors.lowercase"})
+   :author "authors.lowercase"
+   :service-name "service-names.lowercase"})
 
 (defmethod q2e/field->lowercase-field-mappings :variable
   [_]

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -72,7 +72,11 @@
    :variable-name :string
    :variable-concept-id :string
    :variable-native-id :string
-   :variables-h :variables-h})
+   :variables-h :variables-h
+
+   ;; service parameters
+   :service-name :string
+   :service-concept-id :string})
 
 (defmethod common-params/param-mappings :granule
   [_]
@@ -133,7 +137,7 @@
 
 (defmethod common-params/always-case-sensitive-fields :collection
   [_]
-  #{:concept-id :variable-concept-id})
+  #{:concept-id :variable-concept-id :service-concept-id})
 
 (defmethod common-params/always-case-sensitive-fields :granule
   [_]

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -41,7 +41,8 @@
                        :collection-data-type :project :project-h :entry-id :version :provider
                        :entry-title :doi :native-id :platform :platform-h :processing-level-id
                        :processing-level-id-h :sensor :data-center-h :measurement :variable-name
-                       :variable-concept-id :variable-native-id :author}
+                       :variable-concept-id :variable-native-id :author :service-name
+                       :service-concept-id}
      :always-case-sensitive #{:echo-collection-id}
      :disallow-pattern #{:echo-collection-id}}))
 
@@ -139,7 +140,11 @@
    :variable-concept-id cpv/and-option
    :variable-native-id cpv/string-plus-and-options
    :measurement cpv/string-plus-and-options
-   :variables-h cpv/string-plus-or-options})
+   :variables-h cpv/string-plus-or-options
+
+   ;; service related parameters
+   :service-name cpv/string-plus-and-options
+   :service-concept-id cpv/and-option})
 
 (defmethod cpv/valid-parameter-options :granule
   [_]

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -506,7 +506,7 @@
                 :connection-manager (s/conn-mgr)
                 :throw-exceptions false}
         params (merge params (when accept-format {:accept accept-format}))
-        params (merge params (when headers {:headers headers})) 
+        params (merge params (when headers {:headers headers}))
         response (client/request params)]
    (parse-bulk-update-response response options))))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -207,6 +207,9 @@
     (let [response (ingest/bulk-update-collections "PROV1" duplicate-body)
           _ (index/wait-until-indexed)
           {:keys [task-id]} response
+          ;; I am surprised to find out that the task-id returned in the response is a string
+          ;; Here I am just blindly patch this test to work with a string.
+          next-task-id (+ 1 (Integer/parseInt task-id))
           collection-response (ingest/bulk-update-task-status "PROV1" task-id)]
       (is (= "COMPLETE" (:task-status collection-response)))
 
@@ -215,9 +218,10 @@
       (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)]
         (is (= 400 (:status response)))
         (is (= ["Bulk update is disabled."] (:errors response))))
-      (let [collection-response (ingest/bulk-update-task-status "PROV1" 2)]
+      (let [collection-response (ingest/bulk-update-task-status "PROV1" next-task-id)]
         (is (= 404 (:status collection-response)))
-        (is (= ["Bulk update task with task id [2] could not be found for provider id [PROV1]."]
+        (is (= [(format "Bulk update task with task id [%s] could not be found for provider id [PROV1]."
+                        next-task-id)]
                (:errors collection-response))))
       (let [collection-response (ingest/bulk-update-task-status "PROV1" task-id)]
         (is (= 200 (:status collection-response))))

--- a/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
@@ -99,7 +99,7 @@
    (assert-collection-atom-json-result coll expected-fields serv-concept-ids var-concept-ids)
    (assert-collection-umm-json-result coll expected-fields serv-concept-ids var-concept-ids)))
 
-(deftest collection-service-search-test
+(deftest collection-service-search-result-fields-test
   (let [token (e/login (s/context) "user1")
         coll1 (d/ingest "PROV1" (dc/collection {:entry-title "ET1"
                                                 :short-name "S1"


### PR DESCRIPTION
As a client, I want to search collections by its associated services through the service unique identifier.
Fixed bulk-update-science-keywords test which fails intermittently in CI and local dev env.