### PR TITLE
CMR-4680: Add initial support for the include_facets=v2 parameter

### DIFF
--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -10,7 +10,7 @@
    [cmr.common.concepts :as cc]
    [cmr.common.date-time-parser :as parser]
    [cmr.common.services.errors :as errors]
-   [cmr.common.util :as u]
+   [cmr.common.util :as util]
    [cmr.search.models.query :as qm]
    [cmr.search.services.parameters.legacy-parameters :as lp]))
 
@@ -349,7 +349,7 @@
                                   (if (= "true" (:hierarchical-facets params))
                                     [:hierarchical-facets]
                                     [:facets]))
-                                (when (= (:include-facets params) "v2")
+                                (when (= "v2" (util/safe-lowercase (:include-facets params)))
                                     [:facets-v2])
                                 (when (= (:include-highlights params) "true")
                                   [:highlights])
@@ -381,14 +381,18 @@
                                             :end-tag end-tag
                                             :snippet-length (when snippet-length (Integer. snippet-length))
                                             :num-snippets (when num-snippets (Integer. num-snippets))}}))})
-         u/remove-nil-keys)]))
+         util/remove-nil-keys)]))
 
 (defmethod common-params/parse-query-level-params :granule
   [concept-type params]
   (let [[params query-attribs] (common-params/default-parse-query-level-params
-                                 :granule params lp/param-aliases)]
-    [(dissoc params :echo-compatible)
-     (merge query-attribs {:echo-compatible? (= "true" (:echo-compatible params))})]))
+                                 :granule params lp/param-aliases)
+        result-features (when (= "v2" (util/safe-lowercase (:include-facets params)))
+                          [:facets-v2])]
+    [(dissoc params :echo-compatible :include-facets)
+     (merge query-attribs
+            {:echo-compatible? (= "true" (:echo-compatible params))
+             :result-features result-features})]))
 
 (defmethod common-params/parse-query-level-params :variable
   [concept-type params]

--- a/search-app/src/cmr/search/services/query_execution/facets/collection_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/collection_v2_facets.clj
@@ -1,0 +1,51 @@
+(ns cmr.search.services.query-execution.facets.collection-v2-facets
+  "Returns facets v2 along with collection search results. See
+  https://wiki.earthdata.nasa.gov/display/CMR/Updated+facet+response"
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [cmr.common-app.services.search.query-execution :as query-execution]
+   [cmr.common.config :refer [defconfig]]
+   [cmr.common.util :as util]
+   [cmr.search.services.query-execution.facets.facets-results-feature :as frf]
+   [cmr.search.services.query-execution.facets.facets-v2-helper :as v2h]
+   [cmr.search.services.query-execution.facets.hierarchical-v2-facets :as hv2]
+   [cmr.search.services.query-execution.facets.links-helper :as lh]
+   [cmr.transmit.connection :as conn]
+   [ring.util.codec :as codec]))
+
+(def facets-v2-params->elastic-fields
+  "Defines the mapping of the base search parameters for the v2 facets fields to its field names
+   in elasticsearch."
+  {:science-keywords :science-keywords.humanized
+   :platform :platform-sn.humanized2
+   :instrument :instrument-sn.humanized2
+   :data-center :organization.humanized2
+   :project :project-sn.humanized2
+   :processing-level-id :processing-level-id.humanized2
+   :variables :variables})
+
+(def facets-v2-params
+  "Facets query params by concept-type"
+  (keys facets-v2-params->elastic-fields))
+
+(def facet-fields->aggregation-fields
+  "Defines the mapping between facet fields to aggregation fields."
+  (into {}
+        (map (fn [field] [field (keyword (str (name field) "-h"))]) facets-v2-params)))
+
+(def v2-facets-result-field-in-order
+  "Defines the v2 facets result field in order"
+  ["Keywords" "Platforms" "Instruments" "Organizations" "Projects" "Processing levels"
+   "Measurements" "Output File Formats" "Reprojections"])
+
+(def collection-v2-facets-root
+  "Root element for the facet response"
+  {:title "Browse Collections"
+   :type :group})
+
+(defconfig include-variable-facets
+  "Controls whether or not to display variable facets. Feature toggle needed while prototyping
+  with EDSC in certain environments."
+  {:type Boolean :default false})

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -1,0 +1,22 @@
+(ns cmr.search.services.query-execution.facets.granule-v2-facets
+  "Functions for generating v2 granule facets. Similar structure as v2 collection facets, but
+  granule fields. First major use case is supporting OPeNDAP virutal directories capability.")
+
+(def granule-facet-params->elastic-fields
+  {})
+
+(def granule-facet-fields
+  "Faceted fields for granules."
+  (keys granule-facet-params->elastic-fields))
+
+(def granule-fields->aggregation-fields
+  "Defines the mapping of granule parameter names to the aggregation parameter names."
+  {})
+
+(def granule-v2-facets-root
+  "Root element for the facet response"
+  {:title "Browse Granules"})
+
+(def v2-facets-result-field-in-order
+  "Defines the v2 facets result field in order"
+  [])

--- a/search-app/src/cmr/search/services/query_walkers/facet_condition_resolver.clj
+++ b/search-app/src/cmr/search/services/query_walkers/facet_condition_resolver.clj
@@ -14,7 +14,9 @@
             ;; The first check handles the data-center-h field since its query condition field
             ;; :organization.humanized2.value does not match the regex on the second check
             ;; The first check alone will not work for science-keywords
-            (= (str (fvrf/facets-v2-params->elastic-fields field-key) ".value") (str (:field c)))
+            ;; Note that this check only applies for collection facets and not granule facets
+            (= (str (-> fvrf/facets-v2-params->elastic-fields :collection field-key) ".value")
+               (str (:field c)))
             (re-matches (re-pattern (str field-key ".*")) (str (:field c))))))
 
 (defprotocol AdjustFacetQuery

--- a/search-app/src/cmr/search/validators/validation.clj
+++ b/search-app/src/cmr/search/validators/validation.clj
@@ -83,7 +83,8 @@
   [lwv/limit-number-of-leading-wildcard-patterns
    all-granule-validation/no-all-granules-with-spatial
    all-granule-validation/all-granules-exceeds-page-depth-limit
-   all-granule-validation/no-all-granules-with-scroll])
+   all-granule-validation/no-all-granules-with-scroll
+   validate-facets-v2-format])
 
 (extend-protocol cqv/Validator
   cmr.search.models.query.SpatialCondition

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_search_test.clj
@@ -317,10 +317,8 @@
     (index/wait-until-indexed)
 
    (testing "invalid include-facets"
-     (is (= {:errors ["Parameter include_facets must take value of true, false, or v2, but was [foo]"] :status 400}
-            (search/find-refs :collection {:include-facets "foo"})))
-     (is (= {:errors ["Parameter [include_facets] was not recognized."] :status 400}
-            (search/find-refs :granule {:include-facets true}))))
+     (is (= {:errors ["Collection parameter include_facets must take value of true, false, or v2, but was [foo]"] :status 400}
+            (search/find-refs :collection {:include-facets "foo"}))))
 
    (testing "retreving all facets in different formats"
      (let [expected-facets [{:field "data_center"

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer :all]
    [cmr.common.mime-types :as mt]
    [cmr.mock-echo.client.echo-util :as e]
-   [cmr.search.services.query-execution.facets.facets-v2-results-feature :as frf2]
+   [cmr.search.services.query-execution.facets.collection-v2-facets :as frf2]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-spec]
@@ -69,7 +69,7 @@
 
 (deftest all-facets-v2-test
   (dev-sys-util/eval-in-dev-sys
-   `(cmr.search.services.query-execution.facets.facets-v2-results-feature/set-include-variable-facets!
+   `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
      true))
   (let [token (e/login (s/context) "user1")
         coll1 (fu/make-coll 1 "PROV1"
@@ -129,7 +129,7 @@
         (is (fu/applied? response :instrument-h))
         (is (fu/applied? response :processing-level-id-h)))))
   (dev-sys-util/eval-in-dev-sys
-   `(cmr.search.services.query-execution.facets.facets-v2-results-feature/set-include-variable-facets!
+   `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
      false)))
 
 (def science-keywords-all-applied
@@ -676,7 +676,7 @@
 
     (testing "variable facets enabled"
       (dev-sys-util/eval-in-dev-sys
-       `(cmr.search.services.query-execution.facets.facets-v2-results-feature/set-include-variable-facets!
+       `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
          true))
       ;; We only check the top level variables facet for convenience since the whole
       ;; hierarchical structure of variables facet has been covered in all facets test.
@@ -709,7 +709,7 @@
           (assert-facet-field-not-exist facets-result "Measurements" "Measurement2")
           (assert-facet-field-not-exist facets-result "Platforms" "P3")))
       (dev-sys-util/eval-in-dev-sys
-       `(cmr.search.services.query-execution.facets.facets-v2-results-feature/set-include-variable-facets!
+       `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
          false)))))
 
 (comment

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_facets_v2_search_test.clj
@@ -22,12 +22,13 @@
       (is (= "Browse Granules" (:title facets)))))
 
   (testing "Only the json format supports V2 granule facets."
-    (let [unsupported-formats (remove #(or (= :timeline %) (= :json %))
-                                      (cqv/supported-result-formats :granule))
-          xml-error-string (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?><errors><error>"
+    (let [xml-error-string (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?><errors><error>"
                                 "V2 facets are only supported in the JSON format.</error></errors>")
           json-error-string "{\"errors\":[\"V2 facets are only supported in the JSON format.\"]}"]
-      (doseq [fmt unsupported-formats
+      (doseq [fmt (cqv/supported-result-formats :granule)
+              ;; timeline is not supported on the granule search route and json is valid, so we
+              ;; do not test those.
+              :when (not (#{:timeline :json} fmt))
               :let [expected-body (if (= :csv fmt) json-error-string xml-error-string)]]
         (testing (str "format" fmt)
           (let [response (search/find-concepts-in-format fmt :granule {:include-facets "v2"}

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_facets_v2_search_test.clj
@@ -1,0 +1,56 @@
+(ns cmr.system-int-test.search.facets.granule-facets-v2-search-test
+  "This tests retrieving v2 facets when searching for granules."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util]
+   [cmr.common-app.services.search.query-validation :as cqv]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+(defn- search-and-return-v2-facets
+  "Returns only the facets from a v2 granule facets search request."
+  ([]
+   (search-and-return-v2-facets {}))
+  ([search-params]
+   (index/wait-until-indexed)
+   (let [query-params (merge search-params {:page-size 0 :include-facets "v2"})]
+     (get-in (search/find-concepts-json :granule query-params) [:results :facets]))))
+
+(deftest granule-facet-tests
+  (testing "Granule facets are returned when requesting V2 facets in JSON format."
+    (let [facets (search-and-return-v2-facets)]
+      (is (= "Browse Granules" (:title facets)))))
+
+  (testing "Only the json format supports V2 granule facets."
+    (let [unsupported-formats (remove #(or (= :timeline %) (= :json %))
+                                      (cqv/supported-result-formats :granule))
+          xml-error-string (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?><errors><error>"
+                                "V2 facets are only supported in the JSON format.</error></errors>")
+          json-error-string "{\"errors\":[\"V2 facets are only supported in the JSON format.\"]}"]
+      (doseq [fmt unsupported-formats
+              :let [expected-body (if (= :csv fmt) json-error-string xml-error-string)]]
+        (testing (str "format" fmt)
+          (let [response (search/find-concepts-in-format fmt :granule {:include-facets "v2"}
+                                                         {:url-extension (name fmt)
+                                                          :throw-exceptions false})]
+            (is (= {:status 400
+                    :body expected-body}
+                   (select-keys response [:status :body]))))))))
+
+  (testing "The value for include_facets must be v2 case insensitive."
+    (testing "Case insensitive"
+      (let [facets (get-in (search/find-concepts-json :granule {:include-facets "V2"})
+                           [:results :facets])]
+        (is (= "Browse Granules" (:title facets)))))
+    (testing "Invalid values"
+      (util/are3
+        [param-value]
+        (is (= {:status 400
+                :errors [(str "Granule parameter include_facets only supports the value v2, but "
+                              "was [" param-value "]")]}
+               (search/find-concepts-json :granule {:include-facets param-value})))
+
+        "foo" "foo"
+        "V22" "V22"
+        "true" true
+        "false" false))))


### PR DESCRIPTION
This is the first step to supporting granule facets. Returns an empty facets object for the JSON format, and a 400 error when requesting v2 facets in any other format.

Subsequent tickets CMR-4681 through CMR-4687 will add the remaining functionality.

In addition to adding support for the parameter for granule searches, this PR separated out collection and granule specific logic from the main V2 facets capability so that we can reuse as much as possible from the collection V2 facets implementation when adding similar support for granules.