### PR TITLE
CMR-4537: Update version of AWS java SDK to fix problem socket exception in SIT

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -10,7 +10,7 @@
   :dependencies [
     [cheshire "5.8.0"]
     [clj-time "0.14.2"]
-    [com.amazonaws/aws-java-sdk "1.10.60"]
+    [com.amazonaws/aws-java-sdk "1.11.261"]
     [com.novemberain/langohr "3.4.0"]
     [commons-logging "1.2"]
     [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]


### PR DESCRIPTION
No more socket exception locally:

18-Jan-10 13:53:34 ... DEBUG [cmr.message-queue.queue.sqs] - Configuring client com.amazonaws.services.sqs.AmazonSQSClient@2f947370
18-Jan-10 13:53:34 ... DEBUG [cmr.message-queue.queue.sqs] - Configuring client com.amazonaws.services.sns.AmazonSNSClient@7b239692
18-Jan-10 13:53:37 ... INFO [cmr.message-queue.queue.sqs] - Calling SNS to get topic  gsfc-eosdis-cmr-local-jn_test_exchangeA5
18-Jan-10 13:53:40 ... INFO [cmr.message-queue.queue.sqs] - Calling SNS to get topic  gsfc-eosdis-cmr-local-jn_test_exchangeB5
cmr.message-queue.queue.sqs=>
#'cmr.message-queue.queue.sqs/broker