### PR TITLE
CMR-4678 - new version of metadata preview gem developed for CMR-4678…

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -14,7 +14,7 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-      "5d0905f8cec"))
+      "a931085"))
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
… - handle duplicate urls with schema.org sameAs value