### PR TITLE
CMR-4583: Removed EDSC stubbed data support for previous PI testing tasks

### DIFF
--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -14,39 +14,6 @@
     [clj-time "0.14.2"]
     [com.github.fge/json-schema-validator "2.2.6"]
     [commons-codec/commons-codec "1.11"]
-    ;; XXX REMOVE the following deps when the stubbed
-    ;;     responses are replaced with the real ones
-    ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
-    [clojusc/ltest "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"
-     :exclusions [cljs-http
-                  clj-http
-                  clojusc/ltest
-                  com.google.code.findbugs/jsr305
-                  gov.nasa.earthdata/cmr-client
-                  instaparse
-                  org.clojure/clojurescript
-                  org.clojure/core.async
-                  org.clojure/data.xml
-                  org.clojure/tools.analyzer.jvm
-                  org.clojure/tools.reader
-                  org.clojure/java.jdbc
-                  ring/ring-codec]]
-    [gov.nasa.earthdata/cmr-edsc-stubs "0.2.0-SNAPSHOT"
-     :exclusions [cljs-http
-                  clj-http
-                  clojusc/ltest
-                  com.google.code.findbugs/jsr305
-                  gov.nasa.earthdata/cmr-client
-                  instaparse
-                  org.clojure/clojurescript
-                  org.clojure/core.async
-                  org.clojure/data.xml
-                  org.clojure/tools.analyzer.jvm
-                  org.clojure/tools.reader
-                  org.clojure/java.jdbc
-                  ring/ring-codec]]
-    ;; XXX end REMOVE
     [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]

--- a/search-app/src/cmr/search/api/concepts_lookup.clj
+++ b/search-app/src/cmr/search/api/concepts_lookup.clj
@@ -1,12 +1,6 @@
 (ns cmr.search.api.concepts-lookup
   "Defines the API for concepts lookup in the CMR."
   (:require
-   ;; XXX REMOVE the next three requires once the service and associations work is complete
-   ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
-   [clojure.string :as string]
-   [cmr-edsc-stubs.core :as stubs]
-   [cmr.common.util :as util]
-   ;; end XXX
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common.concepts :as concepts]
    [cmr.common.log :refer (debug info warn error)]
@@ -121,12 +115,4 @@
     (OPTIONS "/" req common-routes/options-response)
     (GET "/"
       {params :params headers :headers ctx :request-context}
-      ;; XXX REMOVE this check and the stubs once the service and
-      ;;     the associations work is complete
-      ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
-      (if (= "true" (util/safe-lowercase (headers "cmr-prototype-umm")))
-        (core-api/search-response
-         ctx
-         {:results (stubs/handle-prototype-request path-w-extension params headers)
-          :result-format :umm-json})
-        (find-concept-by-cmr-concept-id ctx path-w-extension params headers)))))
+      (find-concept-by-cmr-concept-id ctx path-w-extension params headers))))

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -2,12 +2,6 @@
   "Defines the API for search-by-concept in the CMR."
   (:require
    [clojure.string :as string]
-   ;; XXX REMOVE the next three requires once the service and associations work is complete
-   ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
-   [clojure.string :as string]
-   [cmr-edsc-stubs.core :as stubs]
-   [cmr.common.util :as util]
-   ;; end XXX
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
    [cmr.common.cache :as cache]
@@ -150,19 +144,7 @@
     (OPTIONS "/" req common-routes/options-response)
     (GET "/"
       {params :params headers :headers ctx :request-context query-string :query-string}
-      ;; XXX REMOVE this check and the stubs once the service and
-      ;;     the associations work is complete
-      ;;     See https://bugs.earthdata.nasa.gov/browse/CMR-4583
-      (if (= "true" (util/safe-lowercase (headers "cmr-prototype-umm")))
-        (core-api/search-response
-         ctx
-         {:results (stubs/handle-prototype-request
-                    path-w-extension
-                    params
-                    (assoc headers "CMR-Hits" 42 "CMR-Took" 42)
-                    query-string)
-          :result-format :json})
-        (find-concepts ctx path-w-extension params headers query-string)))
+      (find-concepts ctx path-w-extension params headers query-string))
     ;; Find concepts - form encoded or JSON
     (POST "/"
       {params :params headers :headers ctx :request-context body :body-copy}


### PR DESCRIPTION
This is also blocking some changes we want to make to support the local nexus jar repo in CI/CD (it can't currently handle SNAPSHOTS from Clojars).