### PR TITLE
CMR-4630: Modified the indication of all collection update.

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -645,7 +645,7 @@ The following update types are supported:
 
 Bulk update post request takes the following parameters:
 
-  * Concept-ids (optional) - a list of concept ids to update, which need to be associated with the provider the bulk update is initiated with. If not provided, all the collections for the provider will be updated.
+  * Concept-ids (required) - a list of concept ids to update, which need to be associated with the provider the bulk update is initiated with. If it is equal to ["ALL"], case insensitive, all the collections for the provider will be updated.
   * Name (optional) - a name used to identify a bulk update task. It needs to be unique within a provider. 
   * Update type (required) - choose from the enumeration: `ADD_TO_EXISTING`, `CLEAR_ALL_AND_REPLACE`, `FIND_AND_REPLACE`, `FIND_AND_REMOVE`, `FIND_AND_UPDATE`, `FIND_AND_UPDATE_HOME_PAGE_URL`
   * Update field (required) - choose from the enumeration: `SCIENCE_KEYWORDS`, `LOCATION_KEYWORDS`, `DATA_CENTERS`, `PLATFORMS`, `INSTRUMENTS`

--- a/ingest-app/resources/bulk_update_schema.json
+++ b/ingest-app/resources/bulk_update_schema.json
@@ -57,5 +57,5 @@
           "type": "object"
         }
     },
-    "required": ["update-type", "update-field"]
+    "required": ["update-type", "update-field", "concept-ids"]
 }

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -134,15 +134,14 @@
     err-msg))
 
 (defn- validate-concept-ids
-  "Throws exception if there exists invalid
-   concept-ids."
+  "Validate concept-ids. Raise error if there exist invalid concept-ids."
   [concept-ids]
   (when-not (= ["ALL"] (map string/upper-case concept-ids))
     (let [err-msgs (get-collection-concept-id-validation-err-msgs concept-ids)]
       (when (seq err-msgs)
         (errors/throw-service-errors
           :bad-request
-          [(string/join "; " err-msgs)])))))
+          [(string/join ", " err-msgs)])))))
 
 (defn- get-concept-ids
   "Get the concept-ids from either the concept-ids passed in or

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -108,18 +108,17 @@
 
 (defn- get-provider-collection-concept-ids
   "Returns a list of collection concept ids for a given provider-id.
-   Throws exception if non are returned."
+   Raise error if no collections are found."
   [context provider-id]
-  (let [concepts (mdb/find-concepts context 
-                                    {:provider-id provider-id
-                                     :latest "true"} 
-                                    :collection)
-        concepts (remove :deleted concepts)]
-    (if (seq concepts)
-      (distinct (map :concept-id concepts))
+  (let [collections (mdb/find-collections context 
+                                          {:provider-id provider-id
+                                           :latest true})
+        collections (remove :deleted collections)]
+    (if (seq collections)
+      (map :concept-id collections)
       (errors/throw-service-errors
         :bad-request
-        ["No concept-ids are associated with the provider-id."]))))
+        [(format "There are no un-deleted collections for provider-id [%s]." provider-id)]))))
 
 (defn- get-collection-concept-id-validation-err-msgs
   "Returns the concept-id validation msgs"

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -118,9 +118,9 @@
   "Get the concept-ids from either the concept-ids passed in or 
    from the provider. If both are empty, throws exception." 
   [context concept-ids provider-id]
-  (if-let [concept-ids (if (seq concept-ids)
-                         concept-ids
-                         (get-provider-concept-ids context provider-id))]
+  (if-let [concept-ids (if (= "[\"ALL\"]" (string/trim (string/upper-case concept-ids)))
+                         (get-provider-concept-ids context provider-id)
+                         concept-ids)]
     concept-ids
     (errors/throw-service-errors
       :bad-request

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -130,7 +130,9 @@
                        err-msg (if err-msg
                                  err-msg
                                  (when-not (string/starts-with? id "C")
-                                   [(str "Collection concept-id " id " does not start with C")]))]
+                                   [(str "Concept-id [" id 
+                                         "] is not a valid collection concept id, "
+                                         "must start with C")]))]
                  :when err-msg]
              err-msg)]
       (when (seq err-msgs)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -65,9 +65,21 @@
                   {:keys [status errors]} response]
               (is (= status-code status))
               (is (= error-messages errors)))
-
+    
             "Missing concept-ids"
             {:name "TEST NAME 1"
+             :update-field "SCIENCE_KEYWORDS"
+             :update-type "ADD_TO_EXISTING"
+             :update-value {:Category "EARTH SCIENCE"
+                            :Topic "LAND SURFACE"
+                            :Term "SURFACE RADIATIVE PROPERTIES"
+                            :VariableLevel1 "REFLECTANCE"}}
+            400
+            ["object has missing required properties ([\"concept-ids\"])"]
+
+            "All concept-ids"
+            {:concept-ids ["all" ]
+             :name "TEST NAME 1"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "ADD_TO_EXISTING"
              :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -99,7 +99,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["[\"Concept-id [all] is not valid.\"], [\"Collection concept-id S1111-PROV1 does not start with C\"], [\"Concept-id [invalid-id] is not valid.\"]"] 
+            ["[\"Concept-id [all] is not valid.\"], [\"Concept-id [S1111-PROV1] is not a valid collection concept id, must start with C\"], [\"Concept-id [invalid-id] is not valid.\"]"]
 
             "0 concept-ids"
             {:concept-ids []

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -99,7 +99,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["[\"Concept-id [all] is not valid.\"]; [\"Collection concept-id [S1111-PROV1] is invalid, must start with C\"]; [\"Concept-id [invalid-id] is not valid.\"]"]
+            ["[\"Concept-id [all] is not valid.\"], [\"Collection concept-id [S1111-PROV1] is invalid, must start with C\"], [\"Concept-id [invalid-id] is not valid.\"]"]
 
             "0 concept-ids"
             {:concept-ids []

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -99,7 +99,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["[\"Concept-id [all] is not valid.\"], [\"Concept-id [S1111-PROV1] is not a valid collection concept id, must start with C\"], [\"Concept-id [invalid-id] is not valid.\"]"]
+            ["[\"Concept-id [all] is not valid.\"]; [\"Collection concept-id [S1111-PROV1] is invalid, must start with C\"]; [\"Concept-id [invalid-id] is not valid.\"]"]
 
             "0 concept-ids"
             {:concept-ids []

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -78,7 +78,7 @@
             ["object has missing required properties ([\"concept-ids\"])"]
 
             "All concept-ids"
-            {:concept-ids ["all" ]
+            {:concept-ids ["all"]
              :name "TEST NAME 1"
              :update-field "SCIENCE_KEYWORDS"
              :update-type "ADD_TO_EXISTING"
@@ -88,6 +88,18 @@
                             :VariableLevel1 "REFLECTANCE"}}
             400
             ["Concept-ids not found - None provided in the request, and none are associated with the provider-id either."]
+
+            "Mix of all, valid and invalid concept-ids"
+            {:concept-ids ["all" "S1111-PROV1" "C12345-PROV1" "invalid-id"]
+             :name "TEST NAME 1"
+             :update-field "SCIENCE_KEYWORDS"
+             :update-type "ADD_TO_EXISTING"
+             :update-value {:Category "EARTH SCIENCE"
+                            :Topic "LAND SURFACE"
+                            :Term "SURFACE RADIATIVE PROPERTIES"
+                            :VariableLevel1 "REFLECTANCE"}}
+            400
+            ["[\"Concept-id [all] is not valid.\"], [\"Collection concept-id S1111-PROV1 does not start with C\"], [\"Concept-id [invalid-id] is not valid.\"]"] 
 
             "0 concept-ids"
             {:concept-ids []

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -87,7 +87,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["No concept-ids are associated with the provider-id."]
+            ["There are no un-deleted collections for provider-id [PROV1]."]
 
             "Mix of all, valid and invalid concept-ids"
             {:concept-ids ["all" "S1111-PROV1" "C12345-PROV1" "invalid-id"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -87,7 +87,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["Concept-ids not found - None provided in the request, and none are associated with the provider-id either."]
+            ["No concept-ids are associated with the provider-id."]
 
             "Mix of all, valid and invalid concept-ids"
             {:concept-ids ["all" "S1111-PROV1" "C12345-PROV1" "invalid-id"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -190,7 +190,7 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:concept-ids concept-ids 
+        bulk-update-body {:concept-ids ["all"] 
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -198,7 +198,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids concept-ids 
+        duplicate-body {:concept-ids ["ALL" ] 
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -188,7 +188,7 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:concept-ids ["ALL" ]
+        bulk-update-body {:concept-ids ["ALL"]
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -196,7 +196,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids ["aLL"  ]
+        duplicate-body {:concept-ids ["aLL" ]
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -864,7 +864,7 @@
       ;; revision-id not changed, format not changed, it's identical to the original-concepts.
       (is (= new-concepts original-concepts)))) 
 
-(deftest bulk-update-update-all-tomb-stone-test
+(deftest bulk-update-update-all-tombstone-test
   (let [coll1 (data2-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
                                                                                      :ShortName "S1"}))
         _ (index/wait-until-indexed)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -891,7 +891,7 @@
     ;; collections from the provider. 
     (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
           _ (index/wait-until-indexed)]  
-      (is (= ["No concept-ids are associated with the provider-id."]
+      (is (= ["There are no un-deleted collections for provider-id [PROV1]."]
              (:errors response))))))
               
 (deftest bulk-update-default-name-test

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -188,14 +188,16 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:update-type "ADD_TO_EXISTING"
+        bulk-update-body {:concept-ids ["ALL" ]
+                          :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
                                          :Topic "HUMAN DIMENSIONS"
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:update-type "ADD_TO_EXISTING"
+        duplicate-body {:concept-ids ["aLL"  ]
+                        :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"
                                        :Term "MARINE SEDIMENTS"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -10,7 +10,9 @@
    [cmr.ingest.config :as ingest-config]
    [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
    [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.core :as data2-core]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn] 
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
@@ -188,7 +190,7 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:concept-ids ["ALL"]
+        bulk-update-body {:concept-ids concept-ids 
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -196,7 +198,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids ["aLL" ]
+        duplicate-body {:concept-ids concept-ids 
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"
@@ -862,6 +864,36 @@
       ;; revision-id not changed, format not changed, it's identical to the original-concepts.
       (is (= new-concepts original-concepts)))) 
 
+(deftest bulk-update-update-all-tomb-stone-test
+  (let [coll1 (data2-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
+                                                                                     :ShortName "S1"}))
+        _ (index/wait-until-indexed)
+        bulk-update-body {:concept-ids ["ALL"] 
+                          :update-type "FIND_AND_UPDATE"
+                          :update-field "SCIENCE_KEYWORDS"
+                          ;; Note: find-value is case-sensitive.
+                          :find-value {:Topic "aTmoSPHERE"}
+                          :update-value {:Category "EARTH SCIENCE"
+                                         :Topic "ATMOSPHERE"
+                                         :Term "AIR QUALITY"
+                                         :VariableLevel1 "EMISSIONS"}}]
+    ;; perform bulk update, verify that one collection is skipped because find-value is not found.
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+          _ (index/wait-until-indexed)
+          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
+      (is (= "COMPLETE" (:task-status collection-response)))
+      (is (= "Task completed with 1 SKIPPED out of 1 total collection update(s)." (:status-message collection-response))))
+    ;; delete the collection
+    (is (= 200 (:status (ingest/delete-concept (data2-core/umm-c-collection->concept coll1 :echo10)))))
+    (index/wait-until-indexed)
+    
+    ;; perform another bulk update, verify that the deleted collection is not included when getting all 
+    ;; collections from the provider. 
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+          _ (index/wait-until-indexed)]  
+      (is (= ["No concept-ids are associated with the provider-id."]
+             (:errors response))))))
+              
 (deftest bulk-update-default-name-test
   (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)
         _ (index/wait-until-indexed)


### PR DESCRIPTION
In bulk update body, pass in :concept-ids ["ALL"] to indicate all the collections for the provider will be updated, rather than not passing any concept-ids in the previous implementation.