### PR TITLE
CMR-4708: Exclude deleted collections for bulk update.

### DIFF
--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -118,7 +118,7 @@
       (map :concept-id collections)
       (errors/throw-service-errors
         :bad-request
-        [(format "There are no un-deleted collections for provider-id [%s]." provider-id)]))))
+        [(format "There are no collections that have not been deleted for provider [%s]." provider-id)]))))
 
 (defn- get-collection-concept-id-validation-err-msgs
   "Returns the concept-id validation msgs"

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -267,7 +267,11 @@
         context task-id concept-id failed-status 
         (format "Concept-id [%s] is not associated with provider-id [%s]." concept-id provider-id))
       (if-let [concept (mdb2/get-latest-concept context concept-id)]
-        (update-concept-and-status context task-id concept concept-id bulk-update-params user-id)
+        (if (:deleted concept)
+          (data-bulk-update/update-bulk-update-task-collection-status
+            context task-id concept-id failed-status 
+            (format "Collection with concept-id [%s] is deleted. Can not be updated." concept-id))   
+          (update-concept-and-status context task-id concept concept-id bulk-update-params user-id))
         (data-bulk-update/update-bulk-update-task-collection-status
           context task-id concept-id failed-status (format "Concept-id [%s] does not exist." concept-id))))
     (catch clojure.lang.ExceptionInfo ex-info

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -87,7 +87,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["There are no collections that have not been deleted for provider."]
+            ["There are no collections that have not been deleted for provider [PROV1]."]
 
             "Mix of all, valid and invalid concept-ids"
             {:concept-ids ["all" "S1111-PROV1" "C12345-PROV1" "invalid-id"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_endpoint_test.clj
@@ -87,7 +87,7 @@
                             :Term "SURFACE RADIATIVE PROPERTIES"
                             :VariableLevel1 "REFLECTANCE"}}
             400
-            ["There are no un-deleted collections for provider-id [PROV1]."]
+            ["There are no collections that have not been deleted for provider."]
 
             "Mix of all, valid and invalid concept-ids"
             {:concept-ids ["all" "S1111-PROV1" "C12345-PROV1" "invalid-id"]

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -190,7 +190,7 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:concept-ids concept-ids 
+        bulk-update-body {:concept-ids ["all"] 
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -198,7 +198,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids concept-ids 
+        duplicate-body {:concept-ids ["ALL"] 
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -888,12 +888,13 @@
                                           :Topic "ATMOSPHERE"
                                           :Term "AIR QUALITY"
                                           :VariableLevel1 "EMISSIONS"}}]
-    ;; perform bulk update, verify that one collection is skipped because find-value is not found.
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
-          _ (index/wait-until-indexed)
-          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
-      (is (= "COMPLETE" (:task-status collection-response)))
-      (is (= "Task completed with 2 SKIPPED out of 2 total collection update(s)." (:status-message collection-response))))
+    ;; perform bulk update, verify that both collections are skipped because find-value is not found.
+    (testing "all the non-deleted collections are included in update all case."
+      (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
+            _ (index/wait-until-indexed)
+            collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
+        (is (= "COMPLETE" (:task-status collection-response)))
+        (is (= "Task completed with 2 SKIPPED out of 2 total collection update(s)." (:status-message collection-response)))))
   
     ;; delete the collection
     (is (= 200 (:status (ingest/delete-concept (data2-core/umm-c-collection->concept coll1 :echo10)))))
@@ -901,21 +902,22 @@
    
     ;; perform another bulk update, verify that the deleted collection is not included when getting all 
     ;; collections from the provider. 
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
-          _ (index/wait-until-indexed)
-          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]  
-      (is (= "Task completed with 1 SKIPPED out of 1 total collection update(s)." (:status-message collection-response))))       
+    (testing "Deleted collection is excluded in update all case."
+      (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
+            _ (index/wait-until-indexed)
+            collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]  
+        (is (= "Task completed with 1 SKIPPED out of 1 total collection update(s)." (:status-message collection-response)))))       
     ;; perform a bulk update with the deleted collection's concept-id and a non-deleted collection's concept-id
     ;; The deleted one should fail the update. 
-    ;; https://bugs.earthdata.nasa.gov/browse/CMR-4708 
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body2)
-          _ (index/wait-until-indexed)
-          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))
-          collection-statuses (:collection-statuses collection-response)]
-      (is (= "COMPLETE" (:task-status collection-response)))
-      (is (= "Collection with concept-id [C1200000009-PROV1] is deleted. Can not be updated."  
-             (get (first collection-statuses) :status-message)))
-      (is (= "Task completed with 1 FAILED and 1 SKIPPED out of 2 total collection update(s)." (:status-message collection-response))))
+    (testing "Deleted collection is failed in update concept-id case."
+      (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body2)
+            _ (index/wait-until-indexed)
+            collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))
+            collection-statuses (:collection-statuses collection-response)]
+        (is (= "COMPLETE" (:task-status collection-response)))
+        (is (= "Collection with concept-id [C1200000009-PROV1] is deleted. Can not be updated."  
+               (get (first collection-statuses) :status-message)))
+        (is (= "Task completed with 1 FAILED and 1 SKIPPED out of 2 total collection update(s)." (:status-message collection-response)))))
 
     ;; delete the second collection
     (is (= 200 (:status (ingest/delete-concept (data2-core/umm-c-collection->concept coll2 :echo10)))))
@@ -923,10 +925,11 @@
   
     ;; perform another bulk update, verify that the deleted collections are not included when getting all
     ;; collections from the provider.
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
-          _ (index/wait-until-indexed)] 
-      (is (= ["There are no collections that have not been deleted for provider [PROV1]."]
-             (:errors response))))))
+    (testing "All collections are deleted in update all case."
+      (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
+            _ (index/wait-until-indexed)] 
+        (is (= ["There are no collections that have not been deleted for provider [PROV1]."]
+               (:errors response)))))))
           
 (deftest bulk-update-default-name-test
   (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -198,7 +198,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids ["ALL"] 
+        duplicate-body {:concept-ids ["ALL" ] 
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_update_test.clj
@@ -190,7 +190,7 @@
         bulk-update-options1 {:token (e/login (s/context) "user1") :user-id "user2"}
         bulk-update-options2 {:token (e/login (s/context) "user1")}
         bulk-update-options3 {:user-id "user2"}
-        bulk-update-body {:concept-ids ["all"] 
+        bulk-update-body {:concept-ids concept-ids 
                           :update-type "ADD_TO_EXISTING"
                           :update-field "SCIENCE_KEYWORDS"
                           :update-value {:Category "EARTH SCIENCE"
@@ -198,7 +198,7 @@
                                          :Term "ENVIRONMENTAL IMPACTS"
                                          :VariableLevel1 "HEAVY METALS CONCENTRATION"}}
         ;; CMR-4570 tests that no duplicate science keywords are created.
-        duplicate-body {:concept-ids ["ALL" ] 
+        duplicate-body {:concept-ids concept-ids 
                         :update-type "ADD_TO_EXISTING"
                         :update-field "SCIENCE_KEYWORDS"
                         :update-value {:Category "EARTH SCIENCE"
@@ -864,36 +864,58 @@
       ;; revision-id not changed, format not changed, it's identical to the original-concepts.
       (is (= new-concepts original-concepts)))) 
 
-(deftest bulk-update-update-all-tombstone-test
+(deftest bulk-update-update-all-tomb-stone-test
   (let [coll1 (data2-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
                                                                                      :ShortName "S1"}))
         _ (index/wait-until-indexed)
-        bulk-update-body {:concept-ids ["ALL"] 
-                          :update-type "FIND_AND_UPDATE"
-                          :update-field "SCIENCE_KEYWORDS"
-                          ;; Note: find-value is case-sensitive.
-                          :find-value {:Topic "aTmoSPHERE"}
-                          :update-value {:Category "EARTH SCIENCE"
-                                         :Topic "ATMOSPHERE"
-                                         :Term "AIR QUALITY"
-                                         :VariableLevel1 "EMISSIONS"}}]
+        bulk-update-body1 {:concept-ids ["ALL"] 
+                           :update-type "FIND_AND_UPDATE"
+                           :update-field "SCIENCE_KEYWORDS"
+                           ;; Note: find-value is case-sensitive.
+                           :find-value {:Topic "aTmoSPHERE"}
+                           :update-value {:Category "EARTH SCIENCE"
+                                          :Topic "ATMOSPHERE"
+                                          :Term "AIR QUALITY"
+                                          :VariableLevel1 "EMISSIONS"}}
+        bulk-update-body2 {:concept-ids [(:concept-id coll1)] 
+                           :update-type "FIND_AND_UPDATE"
+                           :update-field "SCIENCE_KEYWORDS"
+                           ;; Note: find-value is case-sensitive.
+                           :find-value {:Topic "aTmoSPHERE"}
+                           :update-value {:Category "EARTH SCIENCE"
+                                          :Topic "ATMOSPHERE"
+                                          :Term "AIR QUALITY"
+                                          :VariableLevel1 "EMISSIONS"}}]
     ;; perform bulk update, verify that one collection is skipped because find-value is not found.
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
           _ (index/wait-until-indexed)
           collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))]
       (is (= "COMPLETE" (:task-status collection-response)))
       (is (= "Task completed with 1 SKIPPED out of 1 total collection update(s)." (:status-message collection-response))))
+  
     ;; delete the collection
     (is (= 200 (:status (ingest/delete-concept (data2-core/umm-c-collection->concept coll1 :echo10)))))
     (index/wait-until-indexed)
-    
+   
     ;; perform another bulk update, verify that the deleted collection is not included when getting all 
     ;; collections from the provider. 
-    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body)
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body1)
           _ (index/wait-until-indexed)]  
       (is (= ["There are no un-deleted collections for provider-id [PROV1]."]
-             (:errors response))))))
-              
+             (:errors response))))
+
+    ;; perform a bulk update with the deleted collection's concept-id. It doesn't exclude tomb-stone one.
+    ;; Looks like when updating the tomb stone one it will cause error
+    ;; https://bugs.earthdata.nasa.gov/browse/CMR-4708 
+    (let [response (ingest/bulk-update-collections "PROV1" bulk-update-body2)
+          _ (index/wait-until-indexed)
+          collection-response (ingest/bulk-update-task-status "PROV1" (:task-id response))
+          collection-statuses (:collection-statuses collection-response)]
+      (is (= "COMPLETE" (:task-status collection-response)))
+      (is (= "Collection with concept-id [C1200000009-PROV1] is deleted. Can not be updated."  
+             (get (first collection-statuses) :status-message)))
+      (is (= "Task completed with 1 FAILED out of 1 total collection update(s)." (:status-message collection-response))))))
+          
 (deftest bulk-update-default-name-test
   (let [concept-ids (ingest-collection-in-each-format find-update-keywords-umm)
         _ (index/wait-until-indexed)


### PR DESCRIPTION
1. Verified that all the collections that failed the bulkupdate are the deleted collections. 
2. The error happens at spec-core/parse-metadata (xpath/context metadata) 
3. Since the deleted collections  are already excluded in the update "ALL" case, we should exclude them in individual concept-id case as well, which will get rid of the error.  Still don't understand why the error only happens on the deleted collections.