### PR TITLE
CMR-4683: Add support for temporal_facet[0][year]... search parameter

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/parameter_validation.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/parameter_validation.clj
@@ -175,7 +175,7 @@
                (not (scrolling-enabled)))
       ["Scrolling is disabled."])))
 
-(defn scroll-validation 
+(defn scroll-validation
   "Validates the the scroll parameter (if present) is boolean."
   [concept-type params]
   (validate-boolean-param :scroll concept-type params))

--- a/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
@@ -7,18 +7,29 @@
    [cmr.common-app.services.search.query-model :as qm]
    [cmr.transmit.kms :as kms]))
 
-(def variable-sub-fields
+(def variable-subfields
   "The subfields of variable nested field."
   [:measurement :variable])
+
+(def temporal-facet-subfields
+  "The subfields of the granule temporal facet nested field."
+  [:year])
 
 (defn get-subfield-names
   "Returns all of the subfields for the provided nested field. All nested field queries also support
   'any'."
   [parent-field]
   ;; Remove any modifiers from parent field, e.g. :science-keyword.humanized -> :science-keyword
-  (let [base-parent-field (keyword (str/replace (name parent-field) #"\..*$" ""))]
-    (if (= :variables base-parent-field)
-      variable-sub-fields
+  ;; and :science-keywords-h to :science-keywords
+  (let [base-parent-field (-> parent-field
+                              name
+                              (str/replace #"\..*$" "")
+                              (str/replace #"-h$" "")
+                              keyword)]
+    (condp = base-parent-field
+      :variables variable-subfields
+      :temporal-facet temporal-facet-subfields
+      ;; else
       (conj (kms/keyword-scheme->field-names
              (kms/translate-keyword-scheme-to-gcmd base-parent-field))
             :any))))

--- a/search-app/src/cmr/search/services/json_parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/json_parameters/conversion.clj
@@ -80,8 +80,8 @@
   (when-let [errors (seq (js/validate-json json-query-schema json-query))]
     (errors/throw-service-errors :bad-request errors)))
 
-(def ^:private tag-sub-fields
-  "Defines a map of :tag to its sub-fields for nested condition."
+(def ^:private tag-subfields
+  "Defines a map of :tag to its subfields for nested condition."
   {:tag [:tag-key :originator-id]})
 
 (defn- validate-nested-condition
@@ -92,7 +92,7 @@
   (when-not (seq (set/intersection
                    (set (keys value))
                    (set (concat (nf/get-subfield-names (inf/plural condition-name))
-                                (tag-sub-fields condition-name)))))
+                                (tag-subfields condition-name)))))
     (errors/throw-service-error
       :bad-request (msg/invalid-nested-json-query-condition condition-name value))))
 

--- a/search-app/src/cmr/search/services/messages/common_messages.clj
+++ b/search-app/src/cmr/search/services/messages/common_messages.clj
@@ -20,6 +20,12 @@
        "should be in the format of variables[0/group number (if multiple groups are present)]"
        "[measurement/variable]."))
 
+(defn temporal-facets-invalid-format-msg
+  []
+  (str "Parameter temporal_facet is invalid, "
+       "should be in the format of temporal_facet[0/group number (if multiple groups are present)]"
+       "[year]."))
+
 (defn invalid-exclude-param-msg
   "Creates a message saying supplied parameter(s) are not in exclude params set."
   [params-set]

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -109,6 +109,7 @@
    :sensor :inheritance
    :short-name :collection-query
    :temporal :temporal
+   :temporal-facet :temporal-facet
    :two-d-coordinate-system :two-d-coordinate-system
    :updated-since :updated-since
    :version :collection-query})

--- a/search-app/src/cmr/search/services/parameters/converters/temporal_facet.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/temporal_facet.clj
@@ -1,0 +1,58 @@
+(ns cmr.search.services.parameters.converters.temporal-facet
+  "Contains functions for converting temporal facets query parameters to conditions"
+  (:require
+   [clj-time.core :as clj-time]
+   [clojure.string :as str]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]
+   [cmr.common-app.services.search.params :as p]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common.date-time-parser :as parser]))
+
+(defn- temporal-facet-map->clj-time-interval
+  "Returns the next temporal interval based on the values in the map."
+  [temporal-facet-map]
+  (let [all-keys (set (keys temporal-facet-map))]
+    (if-not (contains? all-keys :year)
+      nil
+      (if-not (contains? all-keys :month)
+        (clj-time/years 1)
+        (if-not (contains? all-keys :day)
+          (clj-time/months 1)
+          (if-not (contains? all-keys :hour)
+            (clj-time/days 1)
+            (clj-time/hours 1)))))))
+
+(defn- get-date-ranges
+  "Returns a tuple of start date and end date based on the passed in time range map."
+  [{:keys [year month day hour] :as temporal-facet-map}]
+  (let [start-date-string (when year
+                            (format "%s-%s-%sT%s:00:00.000Z"
+                                    year (or month "01") (or day "01") (or hour "00")))
+        start-date (when start-date-string (parser/parse-datetime start-date-string))
+        interval (temporal-facet-map->clj-time-interval temporal-facet-map)
+        end-date (when start-date
+                   (clj-time/minus (clj-time/plus start-date interval) (clj-time/millis 1)))]
+    [start-date end-date]))
+
+(defn- parse-temporal-facet-condition
+  "Converts a temporal facet parameter into a query model condition."
+  [temporal-facet-map]
+  (let [[start-date end-date] (get-date-ranges temporal-facet-map)]
+    (qm/map->DateRangeCondition {:field :start-date
+                                 :start-date start-date
+                                 :end-date end-date})))
+
+(defmethod p/parameter->condition :temporal-facet
+  [context concept-type param temporal-facet options]
+  (let [group-operation (p/group-operation param options :or)]
+    (if (map? (first (vals temporal-facet)))
+      ;; If multiple temporal facets are passed in like the following
+      ;;  -> temporal_facet[0][year]=2009&temporal_facet[1][year]=2010
+      ;; then this recurses back into this same function to handle each separately
+      (gc/group-conds
+        group-operation
+        (map #(p/parameter->condition context concept-type param % options)
+             (vals temporal-facet)))
+      ;; Creates the temporal facet condition for a group of temporal facet fields and temporal-facet-maps.
+      (parse-temporal-facet-condition temporal-facet))))

--- a/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -18,7 +18,7 @@
   [field]
   (let [stripped-field (string/replace (string/replace (name field) #"-h$" "") #"\.humanized$" "")]
     (if (= "variables" stripped-field)
-      nested-field/variable-sub-fields
+      nested-field/variable-subfields
       (kms-fetcher/nested-fields-mappings (keyword stripped-field)))))
 
 (defn- get-max-subfield-index

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -23,6 +23,16 @@
   [datetime interval]
   (second (re-find #"^\d{4}-\d{2}-\d{2}T(\d{2}):\d{2}:\d{2}\+\d+$" datetime)))
 
+; (defn validate-year
+;   "Validates a given value is a valid year."
+;   [year]
+;   (let [parsed-year]
+;     (try
+;       (java.lang.Double. value)
+;       nil
+;       (catch NumberFormatException e
+;         (msg/invalid-msg Double value)))))
+
 (defn temporal-facet
   "Creates a temporal facet for the provided field."
   [field interval-granularity]

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -23,16 +23,6 @@
   [datetime interval]
   (second (re-find #"^\d{4}-\d{2}-\d{2}T(\d{2}):\d{2}:\d{2}\+\d+$" datetime)))
 
-; (defn validate-year
-;   "Validates a given value is a valid year."
-;   [year]
-;   (let [parsed-year]
-;     (try
-;       (java.lang.Double. value)
-;       nil
-;       (catch NumberFormatException e
-;         (msg/invalid-msg Double value)))))
-
 (defn temporal-facet
   "Creates a temporal facet for the provided field."
   [field interval-granularity]

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -69,6 +69,7 @@
     cmr.search.services.parameters.converters.science-keyword
     cmr.search.services.parameters.converters.spatial
     cmr.search.services.parameters.converters.temporal
+    cmr.search.services.parameters.converters.temporal-facet
     cmr.search.services.parameters.converters.two-d-coordinate-system
     cmr.search.services.query-execution
     cmr.search.services.query-execution.facets.collection-v2-facets

--- a/search-app/test/cmr/search/test/services/parameter_validation.clj
+++ b/search-app/test/cmr/search/test/services/parameter_validation.clj
@@ -1,12 +1,14 @@
 (ns cmr.search.test.services.parameter-validation
-  (:require [clojure.test :refer :all]
-            [cmr.search.services.parameters.parameter-validation :as pv]
-            [cmr.common-app.services.search.parameter-validation :as cpv]
-            [cmr.search.services.messages.attribute-messages :as attrib-msg]
-            [cmr.search.services.messages.orbit-number-messages :as on-msg]
-            [cmr.common.services.messages :as com-msg]
-            [cmr.search.services.messages.common-messages :as msg]
-            [cmr.common-app.services.search.messages :as cmsg]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util]
+   [cmr.search.services.parameters.parameter-validation :as pv]
+   [cmr.common-app.services.search.parameter-validation :as cpv]
+   [cmr.search.services.messages.attribute-messages :as attrib-msg]
+   [cmr.search.services.messages.orbit-number-messages :as on-msg]
+   [cmr.common.services.messages :as com-msg]
+   [cmr.search.services.messages.common-messages :as msg]
+   [cmr.common-app.services.search.messages :as cmsg]))
 
 (def valid-params
   "Example valid parameters"
@@ -243,10 +245,10 @@
        :variable-level-2
        :variable-level-3
        :detailed-variable)
-  (is (= ["parameter [categories] is not a valid science keyword search term."]
+  (is (= ["parameter [categories] is not a valid [science_keywords] search term."]
          (pv/science-keywords-validation-for-field :science-keywords :collection {:science-keywords {:0 {:categories "Cat1"}}})))
-  (is (= ["parameter [categories] is not a valid science keyword search term."
-          "parameter [topics] is not a valid science keyword search term."]
+  (is (= ["parameter [categories] is not a valid [science_keywords] search term."
+          "parameter [topics] is not a valid [science_keywords] search term."]
          (pv/science-keywords-validation-for-field :science-keywords :collection {:science-keywords {:0 {:categories "Cat1"
                                                                                                          :topics "Topic1"}}}))))
 
@@ -342,3 +344,18 @@
                                               {:collection-concept-id ["C1234-Invalid'"
                                                                        "C5678-Invalid'"
                                                                        "C5678-Valid"]}))))
+
+(deftest valid-year-test
+  (testing "Valid years"
+    (doseq [year (map inc (range 9999))]
+      (is (= true (pv/valid-year? year)))))
+  (testing "Invalid years"
+    (util/are3
+      [year]
+      (is (= false (pv/valid-year? year)))
+
+      "foo" "foo"
+      -5 -5
+      2010.2 2010.2
+      0 0
+      10000 10000)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_science_keyword_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_science_keyword_search_test.clj
@@ -1,6 +1,6 @@
 (ns cmr.system-int-test.search.collection-science-keyword-search-test
   "Integration test for CMR collection search by science keyword terms"
-  (:require 
+  (:require
     [clojure.test :refer :all]
     [cmr.system-int-test.data2.collection :as dc]
     [cmr.system-int-test.data2.core :as d]
@@ -261,4 +261,7 @@
   (testing "search by invalid format."
     (let [{:keys [status errors]} (search/find-refs :collection {:science-keywords {:0 {:and "true"}}})]
       (is (= 400 status))
-      (is (re-find #"parameter \[and\] is not a valid science keyword search term." (first errors))))))
+      (is (re-find #"parameter \[and\] is not a valid \[science_keywords\] search term." (first errors))))
+    (let [{:keys [status errors]} (search/find-refs :collection {:science-keywords-h {:0 {:and "true"}}})]
+      (is (= 400 status))
+      (is (re-find #"parameter \[and\] is not a valid \[science_keywords_h\] search term." (first errors))))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
@@ -1,0 +1,89 @@
+(ns cmr.system-int-test.search.granule-temporal-facet-search-test
+  "Integration test for CMR granule temporal search"
+  (:require
+    [clojure.test :refer :all]
+    [cmr.common.util :as util]
+    [cmr.system-int-test.data2.core :as d]
+    [cmr.system-int-test.data2.granule :as dg]
+    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
+    [cmr.system-int-test.utils.index-util :as index]
+    [cmr.system-int-test.utils.ingest-util :as ingest]
+    [cmr.system-int-test.utils.search-util :as search]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(defn- ingest-granule
+  "Helper to ingest a granule"
+  [provider collection granule-map]
+  (d/ingest provider
+            (dg/granule-with-umm-spec-collection collection (:concept-id collection) granule-map)))
+
+(deftest search-by-temporal-facet
+  (let [coll1 (d/ingest-umm-spec-collection
+               "PROV1" (data-umm-c/collection {:TemporalExtents
+                                                [(data-umm-cmn/temporal-extent
+                                                  {:beginning-date-time "1370-01-01T00:00:00Z"})]}))
+        ingest-granule-fn (partial ingest-granule "PROV1" coll1)
+        gran1 (ingest-granule-fn {:granule-ur "Granule1"
+                                  :beginning-date-time "1501-01-01T12:00:00Z"
+                                  :ending-date-time "2010-01-11T12:00:00Z"})
+        gran2 (ingest-granule-fn {:granule-ur "Granule2"
+                                  :beginning-date-time "1888-01-31T12:00:00Z"
+                                  :ending-date-time "2010-12-12T12:00:00Z"})
+        gran3 (ingest-granule-fn {:granule-ur "Granule3"
+                                  :beginning-date-time "1924-12-03T12:00:00Z"
+                                  :ending-date-time "2010-12-20T12:00:00Z"})
+        gran4 (ingest-granule-fn {:granule-ur "Granule4"
+                                  :beginning-date-time "1924-12-12T12:00:00Z"
+                                  :ending-date-time "2011-01-03T12:00:00Z"})
+        gran5 (ingest-granule-fn {:granule-ur "Granule5"
+                                  :beginning-date-time "1946-02-01T12:00:00Z"
+                                  :ending-date-time "2011-03-01T12:00:00Z"})
+        gran6 (ingest-granule-fn {:granule-ur "Granule6"
+                                  :beginning-date-time "1952-01-30T12:00:00Z"})
+        gran7 (ingest-granule-fn {:granule-ur "Granule7"
+                                  :beginning-date-time "1983-12-12T12:00:00Z"})
+        gran8 (ingest-granule-fn {:granule-ur "Granule8"
+                                  :beginning-date-time "2011-12-13T12:00:00Z"})
+        gran9 (ingest-granule-fn {:granule-ur "Granule9"})]
+    (index/wait-until-indexed)
+
+    (util/are3
+      [params expected]
+      (d/assert-refs-match expected (search/find-refs :granule params))
+
+      "Finds single granule."
+      {"temporal_facet[0][year]" 1501} [gran1]
+
+      "Index does not need to start at 0."
+      {"temporal_facet[1536][year]" 1501} [gran1]
+
+      "Multiple grans in one year."
+      {"temporal_facet[0][year]" 1924} [gran3 gran4]
+
+      "Ending date is not matched against for temporal_facet searches."
+      {"temporal_facet[0][year]" 2010} []
+
+      "Multiple years are OR'ed together."
+      {"temporal_facet[0][year]" 1501
+       "temporal_facet[1][year]" 1924}
+      [gran1 gran3 gran4]
+
+      "Multiple years with non-consecutive indexes are OR'ed together."
+      {"temporal_facet[0][year]" 1501
+       "temporal_facet[3][year]" 1924
+       "temporal_facet[11][year]" 1946}
+      [gran1 gran3 gran4 gran5])))
+
+;; TODO - figure out where the validation functions are going to go and then write unit tests
+;; Just some symbolic invalid temporal testing, more complete test coverage is in unit tests
+; (deftest search-temporal-facet-error-scenarios
+;   (testing "search by invalid temporal format."
+;     (let [{:keys [status errors]} (search/find-refs :granule {"temporal[]" "2010-13-12T12:00:00,"})]
+;       (is (= 400 status))
+;       (is (re-find #"temporal start datetime is invalid: \[2010-13-12T12:00:00\] is not a valid datetime" (first errors)))))
+;   (testing "search by invalid temporal start-date after end-date."
+;     (let [{:keys [status errors]} (search/find-refs :granule {"temporal[]" "2011-01-01T10:00:00Z,2010-01-10T12:00:00Z"})]
+;       (is (= 400 status))
+;       (is (re-find #"start_date \[2011-01-01T10:00:00Z\] must be before end_date \[2010-01-10T12:00:00Z\]" (first errors))))))

--- a/system-int-test/test/cmr/system_int_test/search/variable/collection_variable_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/collection_variable_search_test.clj
@@ -311,7 +311,7 @@
     (let [{:keys [status errors]} (search/find-refs :collection
                                                     {:variables-h {:0 {:and "true"}}})]
       (is (= 400 status))
-      (is (re-find #"parameter \[and\] is not a valid variable search term." (first errors)))))
+      (is (re-find #"parameter \[and\] is not a valid \[variables_h\] search term." (first errors)))))
   (testing "search variable concept id does not support ignore-case options"
     (let [{:keys [status errors]} (search/find-refs
                                    :collection


### PR DESCRIPTION
`"http://localhost:3003/granules?temporal_facet[0][year]=1924&temporal_facet[1][year]=1946"` will return any granules which have starting date temporal values in the years 1924 or 1946. That's what this PR adds. I will have a subsequent PR for this ticket to construct and provide the appropriate links for temporal facets within the granule facets.

I did not update the API docs to document this search parameter because it is not intended to be used outside of facet links. For v2 facet links we explicitly state that the links are treated as opaque strings and the parameters used in those links are not guaranteed to stay from release to release.

