### PR TITLE
CMR-4720: Don't use alias for building Ruby gems.

### DIFF
--- a/dev-system/support/build.sh
+++ b/dev-system/support/build.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ] ; then
 fi
 # The library is reinstalled after installing gems so that it will contain the gem code.
 date && echo "Installing collection renderer gems and reinstalling library" &&
-(cd ../collection-renderer-lib && lein 'install!')
+(cd ../collection-renderer-lib && lein do install-gems, install, clean)
 if [ $? -ne 0 ] ; then
   echo "Failed to install gems" >&2
   exit 1


### PR DESCRIPTION
This is to fix an issue that Chris as seen in the Heritage build.