### PR TITLE
CMR-4679: Added analyze-test task.

### DIFF
--- a/search-app/src/cmr/search/data/keywords_to_elastic.clj
+++ b/search-app/src/cmr/search/data/keywords_to_elastic.clj
@@ -51,7 +51,7 @@
   "Field boosts to use if not provided."
   {:short-name 1.4
    :entry-id 1.4
-   :project 1.3
+   :project 1.0
    :platform 1.3
    :instrument 1.2
    :science-keywords 1.2

--- a/search-relevancy-test/README.md
+++ b/search-relevancy-test/README.md
@@ -14,6 +14,7 @@ The tasks supported by this project are:
 * download-collections
 * relevancy-tests
 * boost-tests
+* analyze-test
 
 ### Download collections
 
@@ -49,6 +50,17 @@ Arguments:
 * -field - (required) the field for which to configure the boost
 * -min-value (optional) - the smallest boost value, defaults to 1.0
 * -max-value (optional) - the highest boost value, defaults to 4.0
+
+### analyze-test
+
+`lein run analyze-test <anomaly-number> <anomaly-filename>`
+
+This task will help analyze the failure of a test with the anomaly-number in the anomaly file with the anomaly-filename. 
+If anomaly-filename is not provided, anomaly_tests.csv will be used.
+
+For example, if you run `lein run analyze-test 5`, it will analyze test number 5 in anomaly_tests.csv and give you the
+following information, which helps explain why C1237114139-GES_DISC appears above C1239966794-GES_DISC: 
+Filtered search result is:  ({:id C1237114139-GES_DISC, :score 1.3104, :version_id 003, :short_name OMDOAO3, :processing_level_id 2} {:id C1239966794-GES_DISC, :score 1.008, :version_id 008, :short_name TOMSEPL2, :processing_level_id 2})
 
 ## License
 

--- a/search-relevancy-test/README.md
+++ b/search-relevancy-test/README.md
@@ -60,7 +60,7 @@ If anomaly-filename is not provided, anomaly_tests.csv will be used.
 
 For example, if you run `lein run analyze-test 5`, it will analyze test number 5 in anomaly_tests.csv and give you the
 following information, which helps explain why C1237114139-GES_DISC appears above C1239966794-GES_DISC: 
-Filtered search result is:  ({:id C1237114139-GES_DISC, :score 1.3104, :version_id 003, :short_name OMDOAO3, :processing_level_id 2} {:id C1239966794-GES_DISC, :score 1.008, :version_id 008, :short_name TOMSEPL2, :processing_level_id 2})
+Filtered search result is:  ({:id C1237114193-GES_DISC, :score 1.3104, :version_id 008, :short_name TOMSEPL2, :processing_level_id 2} {:id C1239966794-GES_DISC, :score 1.008, :version_id 003, :short_name OMDOAO3, :processing_level_id 2})
 
 ## License
 

--- a/search-relevancy-test/src/search_relevancy_test/anomaly_analyzer.clj
+++ b/search-relevancy-test/src/search_relevancy_test/anomaly_analyzer.clj
@@ -11,8 +11,8 @@
   "Get the test data from the CSV file - need the concept ids we want to look at
   and the search params. If the anomaly has multiple tests, we get the data for
   all of the tests."
-  [anomaly-number]
-  (let [csv-data (core/read-anomaly-test-csv)
+  [anomaly-number file-name]
+  (let [csv-data (core/read-anomaly-test-csv file-name)
         tests (filter #(= (str anomaly-number) (:anomaly %))
                       csv-data)
         concept-ids (distinct
@@ -37,10 +37,12 @@
 (defn analyze-test
  "Get relevancy-related data for concepts in the test by performing the search
  and filtering by concept"
- [anomaly-number]
- (let [test (get-test-data anomaly-number)
-       search-results (relevancy-test/perform-search test nil)]
-   (filter-search-results search-results test)))
+ ([anomaly-number]
+  (analyze-test anomaly-number core/provider-anomaly-filename))
+ ([anomaly-number file-name]
+  (let [test (get-test-data anomaly-number file-name)
+        search-results (relevancy-test/perform-search test nil)]
+    (println "Filtered search result is: " (filter-search-results search-results test)))))
 
 (comment
  (analyze-test 39))

--- a/search-relevancy-test/src/search_relevancy_test/anomaly_fetcher.clj
+++ b/search-relevancy-test/src/search_relevancy_test/anomaly_fetcher.clj
@@ -42,7 +42,7 @@
                  {:form-params {:concept-id concept-ids
                                 :page-size 2000}
                   :headers {:echo-token (System/getenv "CMR_SYSTEM_TOKEN")}})
-        response (client/post url)
+        response (client/post url options)
         items (:items (json/parse-string (:body response) true))]
     (into {}
           (for [item items

--- a/search-relevancy-test/src/search_relevancy_test/relevancy_test.clj
+++ b/search-relevancy-test/src/search_relevancy_test/relevancy_test.clj
@@ -20,8 +20,10 @@
 
 (defn- add-concept-ids-to-search
   "Takes a search string and adds concept-ids to the search."
-  [query-string concept-ids-string]
-  (let [concept-ids (string/split concept-ids-string #",")
+  [query-string concept-ids]
+  (let [concept-ids (if (string? concept-ids)
+                      (string/split concept-ids #",")
+                      concept-ids)
         concept-ids-query-string (string/join "&concept_id[]=" concept-ids)]
     (format "%s&concept_id[]=%s" query-string concept-ids-query-string)))
 

--- a/search-relevancy-test/src/search_relevancy_test/runner.clj
+++ b/search-relevancy-test/src/search_relevancy_test/runner.clj
@@ -5,12 +5,13 @@
    [cheshire.core :as json]
    [clojure.string :as string]
    [search-relevancy-test.anomaly-fetcher :as anomaly-fetcher]
+   [search-relevancy-test.anomaly-analyzer :as anomaly-analyzer]
    [search-relevancy-test.boost-test :as boost-test]
    [search-relevancy-test.relevancy-test :as relevancy-test]))
 
 (def tasks
   "List of available tasks"
-  ["download-collections" "relevancy-tests" "boost-tests"])
+  ["download-collections" "relevancy-tests" "boost-tests" "analyze-test"])
 
 (defn- usage
  "Prints the list of available tasks."
@@ -21,6 +22,9 @@
   "Runs search relevancy tasks."
   [task-name & args]
   (case task-name
+        "analyze-test" (if (some? (second args))
+                         (anomaly-analyzer/analyze-test (first args) (second args))
+                         (anomaly-analyzer/analyze-test (first args)))
         "download-collections" (anomaly-fetcher/download-and-save-all-collections)
         "relevancy-tests" (relevancy-test/relevancy-test args)
         "edsc-relevancy-tests" (relevancy-test/edsc-relevancy-test args)

--- a/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_usage_relevancy.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_usage_relevancy.clj
@@ -98,7 +98,7 @@
                                                         :Version "2"}))
   (index/wait-until-indexed)
   (let [results (:refs (search/find-refs :collection {:keyword "Relevancy"}))]
-    (is (= ["Relevancy 1" "AST_05" "Relevancy 2" "Relevancy 3"] (map :name results))))
+    (is (= ["Relevancy 1" "Relevancy 2" "Relevancy 3" "AST_05"] (map :name results))))
 
   (testing "Usage sort takes precedence over keyword Relevancy"
     (let [results (:refs (search/find-refs :collection {:keyword "Relevancy" :sort-key "-usage-score"}))]


### PR DESCRIPTION
1. Added a comment to the ticket to explain why the keyword score is higher for TOMS products over OMI products: https://bugs.earthdata.nasa.gov/browse/CMR-4679

2. Added analyze-test task and modify the existing code to make it work so that we could use it to help analyzing the test failures.

3. Changed the default boost value of project to 1.0.  This change will make 2 more tests pass, including the one in this ticket, without failing any of the tests that passed previously.  