### PR TITLE
CMR-4713 As a Client User, I would like to be able to constrain collection results to collections that have granules or that have been tagged as a CWIC collection

### DIFF
--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -320,6 +320,7 @@
           :granule-end-date               m/date-field-mapping
 
           :has-granules (m/stored m/bool-field-mapping)
+          :has-granules-or-cwic (m/stored m/bool-field-mapping)
           :has-variables (m/stored m/bool-field-mapping)
           :has-formats (m/stored m/bool-field-mapping)
           :has-transforms (m/stored m/bool-field-mapping)

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1612,6 +1612,12 @@ When `has_granules` is set to "true" or "false", results will be restricted to c
 
     curl "%CMR-ENDPOINT%/collections?has_granules=true"
 
+#### <a name="c-has-granules-or-cwic"></a> Find collections with or without granules, or the collection is tagged with the configured CWIC tag.
+
+When `has_granules_or_cwic` is set to "true" or "false", results will be restricted to collections with or without granules or with or without the configured CWIC tag, respectively.
+
+    curl "%CMR-ENDPOINT%/collections?has_granules_or_cwic=true"
+
 #### <a name="sorting-collection-results"></a> Sorting Collection Results
 
 Collection results are sorted by ascending entry title by default when a search does not result in a score.

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1614,7 +1614,7 @@ When `has_granules` is set to "true" or "false", results will be restricted to c
 
 #### <a name="c-has-granules-or-cwic"></a> Find collections with or without granules, or the collection is tagged with the configured CWIC tag.
 
-When `has_granules_or_cwic` is set to "true" or "false", results will be restricted to collections with or with the configured CWIC tag when true.  When false, results will be restricted to collections without granules.
+When `has_granules_or_cwic` can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured CWIC tag.  When false, results will be restricted to collections without granules.
 
     curl "%CMR-ENDPOINT%/collections?has_granules_or_cwic=true"
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1614,7 +1614,7 @@ When `has_granules` is set to "true" or "false", results will be restricted to c
 
 #### <a name="c-has-granules-or-cwic"></a> Find collections with or without granules, or the collection is tagged with the configured CWIC tag.
 
-When `has_granules_or_cwic` is set to "true" or "false", results will be restricted to collections with or without granules or with or without the configured CWIC tag, respectively.
+When `has_granules_or_cwic` is set to "true" or "false", results will be restricted to collections with or with the configured CWIC tag when true.  When false, results will be restricted to collections without granules.
 
     curl "%CMR-ENDPOINT%/collections?has_granules_or_cwic=true"
 

--- a/search-app/resources/schema/swagger.json
+++ b/search-app/resources/schema/swagger.json
@@ -384,6 +384,13 @@
           },
           {
             "in": "query",
+            "name": "has_granules_or_cwic",
+            "description": "When <code>has_granules_or_cwic</code> is set to \"true\" or \"false\", results will be restricted to collections with or without granules, respectively. Or they are CWIC tagged collections.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "in": "query",
             "name": "collection_data_type[]",
             "description": "Matches collections by the collection data type. The following are aliases for \"NEAR_REAL_TIME\": \"near_real_time\", \"nrt\", \"NRT\", \"near real time\", \"near-real time\", \"near-real-time\", \"near real-time\".",
             "required": false,

--- a/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules.clj
+++ b/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules.clj
@@ -1,8 +1,9 @@
 (ns cmr.search.data.complex-to-simple-converters.has-granules
-  (:require [cmr.search.services.query-execution.has-granules-results-feature :as has-granules-base]
-            [cmr.common-app.services.search.complex-to-simple :as c2s]
-            [cmr.search.models.query :as qm]
-            [cmr.common-app.services.search.query-model :as cqm]))
+  (:require
+   [cmr.common-app.services.search.complex-to-simple :as c2s]
+   [cmr.common-app.services.search.query-model :as cqm]
+   [cmr.search.models.query :as qm]
+   [cmr.search.services.query-execution.has-granules-results-feature :as has-granules-base]))
 
 ;; The following protocol implementation ensures that a c.s.m.q.HasGranulesCondition record in our
 ;; query model will be expanded into a form which can, in turn, be converted into another structure

--- a/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_cwic.clj
+++ b/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_cwic.clj
@@ -1,0 +1,21 @@
+(ns cmr.search.data.complex-to-simple-converters.has-granules-or-cwic
+  (:require [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as has-granules-or-cwic-base]
+            [cmr.common-app.services.search.complex-to-simple :as c2s]
+            [cmr.search.models.query :as qm]
+            [cmr.common-app.services.search.query-model :as cqm]))
+
+;; The following protocol implementation ensures that a c.s.m.q.HasGranulesCondition record in our
+;; query model will be expanded into a form which can, in turn, be converted into another structure
+;; in our query model which can, once again, be converted into an Elasticsearch query.
+
+(extend-protocol c2s/ComplexQueryToSimple
+  cmr.search.models.query.HasGranulesOrCwicCondition
+  (c2s/reduce-query-condition [this context]
+    ;; We need to limit the query to collections which have granules, so we will use the
+    ;; has-granules-map and get the keys (concept IDs) of entries with true values.
+    (let [has-granules-map (has-granules-or-cwic-base/get-has-granules-or-cwic-map context)
+          concept-ids (map key (filter val has-granules-map))
+          condition (cqm/string-conditions :concept-id concept-ids true)]
+      (if (:has-granules-or-cwic this)
+        condition
+        (cqm/negated-condition condition)))))

--- a/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_cwic.clj
+++ b/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_cwic.clj
@@ -1,8 +1,10 @@
 (ns cmr.search.data.complex-to-simple-converters.has-granules-or-cwic
-  (:require [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as has-granules-or-cwic-base]
-            [cmr.common-app.services.search.complex-to-simple :as c2s]
-            [cmr.search.models.query :as qm]
-            [cmr.common-app.services.search.query-model :as cqm]))
+  (:require
+   [cmr.common-app.services.search.complex-to-simple :as c2s]
+   [cmr.common-app.services.search.query-model :as cqm]
+   [cmr.search.models.query :as qm]
+   [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as has-granules-or-cwic-base]
+   [cmr.search.services.query-execution.has-granules-results-feature :as has-granules-base]))
 
 ;; The following protocol implementation ensures that a c.s.m.q.HasGranulesCondition record in our
 ;; query model will be expanded into a form which can, in turn, be converted into another structure
@@ -13,9 +15,12 @@
   (c2s/reduce-query-condition [this context]
     ;; We need to limit the query to collections which have granules, so we will use the
     ;; has-granules-map and get the keys (concept IDs) of entries with true values.
-    (let [has-granules-map (has-granules-or-cwic-base/get-has-granules-or-cwic-map context)
+    (let [has-granules-or-cwic-map (has-granules-or-cwic-base/get-has-granules-or-cwic-map context)
+          has-granules-map (has-granules-base/get-has-granules-map context)
           concept-ids (map key (filter val has-granules-map))
-          condition (cqm/string-conditions :concept-id concept-ids true)]
+          condition (cqm/string-conditions :concept-id concept-ids true)
+          or-cwic-concept-ids (map key (filter val has-granules-or-cwic-map))
+          or-cwic-condition (cqm/string-conditions :concept-id or-cwic-concept-ids true)]
       (if (:has-granules-or-cwic this)
-        condition
+        or-cwic-condition
         (cqm/negated-condition condition)))))

--- a/search-app/src/cmr/search/models/query.clj
+++ b/search-app/src/cmr/search/models/query.clj
@@ -144,6 +144,7 @@
 ;; The HasGranulesCondition type represents a condition that restricts a query to collection that
 ;; are known to have granules.
 (defrecord HasGranulesCondition [has-granules])
+(defrecord HasGranulesOrCwicCondition [has-granules-or-cwic])
 
 (defmethod common-qm/default-sort-keys :granule
   [_]

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -290,9 +290,7 @@
 
 (defmethod common-params/parameter->condition :has-granules-or-cwic
   [_ _ _ value _]
-  (if (= "unset" value)
-    cqm/match-all
-    (qm/->HasGranulesOrCwicCondition (= "true" value))))
+  (qm/->HasGranulesOrCwicCondition (= "true" value)))
 
 (defn- collection-data-type-matches-science-quality?
   "Convert the collection-data-type parameter with wildcards to a regex. This function

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -34,6 +34,7 @@
    :entry-title :string
    :exclude :exclude
    :has-granules :has-granules
+   :has-granules-or-cwic :has-granules-or-cwic
    :has-granules-created-at :multi-date-range
    :has-granules-revised-at :multi-date-range
    :instrument :string
@@ -286,6 +287,12 @@
   (if (= "unset" value)
     cqm/match-all
     (qm/->HasGranulesCondition (= "true" value))))
+
+(defmethod common-params/parameter->condition :has-granules-or-cwic
+  [_ _ _ value _]
+  (if (= "unset" value)
+    cqm/match-all
+    (qm/->HasGranulesOrCwicCondition (= "true" value))))
 
 (defn- collection-data-type-matches-science-quality?
   "Convert the collection-data-type parameter with wildcards to a regex. This function

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -226,6 +226,7 @@
     :revision-date
     :score
     :has-granules
+    :has-granules-or-cwic
     :usage-score})
 
 (defmethod cpv/valid-sort-keys :granule

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -73,11 +73,6 @@
                          (idx/get-collection-granule-counts context nil)
                          (get-cwic-collections context nil)))))))
 
-;; This returns a boolean flag with collection results if a collection has any granules in provider holdings
-(defmethod query-execution/post-process-query-result-feature :has-granules-or-cwic
-  [context query elastic-results query-results feature]
-  (assoc query-results :has-granules-or-cwic-map (get-has-granules-or-cwic-map context)))
-
 (defjob RefreshHasGranulesOrCwicMapJob
   [ctx system]
   (refresh-has-granules-or-cwic-map {:system system}))

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -1,0 +1,87 @@
+(ns cmr.search.services.query-execution.has-granules-or-cwic-results-feature
+  "This enables the :has-granules-or-cwic feature for collection search results. When it is enabled
+  collection search results will include a boolean flag indicating whether the collection has
+  any granules at all as indicated by provider holdings."
+  (:require
+   [cmr.common-app.services.search.elastic-search-index :as common-esi]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]
+   [cmr.common-app.services.search.query-execution :as query-execution]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common.cache :as cache]
+   [cmr.common.cache.in-memory-cache :as mem-cache]
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.jobs :refer [defjob]]
+   [cmr.search.data.elastic-search-index :as idx]))
+
+(def REFRESH_HAS_GRANULES_OR_CWIC_MAP_JOB_INTERVAL
+  "The frequency in seconds of the refresh-has-granules-or-cwic-map-job"
+  ;; default to 1 hour
+  3600)
+
+(def has-granule-cache-key
+  :has-granules-or-cwic-map)
+
+(defconfig cwic-tag
+  "has-granules-or-cwic should also return any collection with configured cwic-tag"
+  {:default "CWIC"})
+
+(defn create-has-granules-or-cwic-map-cache
+  "Returns a 'cache' which will contain the cached has granules map."
+  []
+  (mem-cache/create-in-memory-cache))
+
+(defn get-cwic-collections
+  "Returns the collection granule count by searching elasticsearch by aggregation"
+  [context provider-ids]
+  (let [condition (nf/parse-nested-condition :tags {:tag-key (cwic-tag)} false true)
+        query (qm/query {:concept-type :collection
+                         :condition condition})
+        results (common-esi/execute-query context query)]
+    (into {}
+          (for [coll-id (map :_id (get-in results [:hits :hits]))]
+            [coll-id 1]))))
+
+(defn- collection-granule-counts->has-granules-or-cwic-map
+  "Converts a map of collection ids to granule counts to a map of collection ids to true or false
+  of whether the collection has any granules"
+  [coll-gran-counts]
+  (into {} (for [[coll-id num-granules] coll-gran-counts]
+             [coll-id (> num-granules 0)])))
+
+(defn refresh-has-granules-or-cwic-map
+  "Gets the latest provider holdings and updates the has-granules-or-cwic-map stored in the cache."
+  [context]
+  (let [has-granules-or-cwic-map (collection-granule-counts->has-granules-or-cwic-map
+                                  (merge
+                                   (idx/get-collection-granule-counts context nil)
+                                   (get-cwic-collections context nil)))]
+    (cache/set-value (cache/context->cache context has-granule-cache-key)
+                     :has-granules-or-cwic has-granules-or-cwic-map)))
+
+(defn get-has-granules-or-cwic-map
+  "Gets the cached has granules map from the context which contains collection ids to true or false
+  of whether the collections have granules or not. If the has-granules-or-cwic-map has not yet been cached
+  it will retrieve it and cache it."
+  [context]
+  (let [has-granules-or-cwic-map-cache (cache/context->cache context has-granule-cache-key)]
+    (cache/get-value has-granules-or-cwic-map-cache
+                     :has-granules-or-cwic
+                     (fn []
+                       (collection-granule-counts->has-granules-or-cwic-map
+                        (merge
+                         (idx/get-collection-granule-counts context nil)
+                         (get-cwic-collections context nil)))))))
+
+;; This returns a boolean flag with collection results if a collection has any granules in provider holdings
+(defmethod query-execution/post-process-query-result-feature :has-granules-or-cwic
+  [context query elastic-results query-results feature]
+  (assoc query-results :has-granules-or-cwic-map (get-has-granules-or-cwic-map context)))
+
+(defjob RefreshHasGranulesOrCwicMapJob
+  [ctx system]
+  (refresh-has-granules-or-cwic-map {:system system}))
+
+(def refresh-has-granules-or-cwic-map-job
+  {:job-type RefreshHasGranulesOrCwicMapJob
+   :interval REFRESH_HAS_GRANULES_OR_CWIC_MAP_JOB_INTERVAL})

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -24,7 +24,7 @@
 
 (defconfig cwic-tag
   "has-granules-or-cwic should also return any collection with configured cwic-tag"
-  {:default "CWIC"})
+  {:default "org.ceos.wgiss.cwic.granules.prod"})
 
 (defn create-has-granules-or-cwic-map-cache
   "Returns a 'cache' which will contain the cached has granules map."

--- a/search-app/src/cmr/search/services/query_execution/has_granules_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_results_feature.clj
@@ -60,4 +60,3 @@
 (def refresh-has-granules-map-job
   {:job-type RefreshHasGranulesMapJob
    :interval REFRESH_HAS_GRANULES_MAP_JOB_INTERVAL})
-

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -48,6 +48,7 @@
   (:require
     cmr.search.data.complex-to-simple-converters.attribute
     cmr.search.data.complex-to-simple-converters.has-granules
+    cmr.search.data.complex-to-simple-converters.has-granules-or-cwic
     cmr.search.data.complex-to-simple-converters.orbit
     cmr.search.data.complex-to-simple-converters.spatial
     cmr.search.data.complex-to-simple-converters.temporal
@@ -78,6 +79,7 @@
     cmr.search.services.query-execution.granule-counts-results-feature
     cmr.search.services.query-execution.has-granules-created-at-feature
     cmr.search.services.query-execution.has-granules-results-feature
+    cmr.search.services.query-execution.has-granules-or-cwic-results-feature
     cmr.search.services.query-execution.has-granules-revised-at-feature
     cmr.search.services.query-execution.highlight-results-feature
     cmr.search.services.query-execution.tags-results-feature

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -140,6 +140,7 @@
                          [(af/refresh-acl-cache-job "search-acl-cache-refresh")
                           idx/refresh-index-names-cache-job
                           hgrf/refresh-has-granules-map-job
+                          hgrf/refresh-has-granules-or-cwic-map-job
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           coll-cache/refresh-collections-cache-for-granule-acls-job
                           jvm-info/log-jvm-statistics-job

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -30,6 +30,7 @@
    [cmr.search.services.acls.collections-cache :as coll-cache]
    [cmr.search.services.humanizers.humanizer-report-service :as hrs]
    [cmr.search.services.query-execution.has-granules-results-feature :as hgrf]
+   [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as hgocrf]
    [cmr.transmit.config :as transmit-config]))
 
 ;; Design based on http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts
@@ -116,6 +117,7 @@
                       context-augmenter/token-sid-cache-name (context-augmenter/create-token-sid-cache)
                       context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)
                       :has-granules-map (hgrf/create-has-granules-map-cache)
+                      :has-granules-or-cwic-map (hgocrf/create-has-granules-or-cwic-map-cache)
                       coll-cache/cache-key (coll-cache/create-cache)
                       metadata-transformer/xsl-transformer-cache-name (mem-cache/create-in-memory-cache)
                       acl/token-imp-cache-key (acl/create-token-imp-cache)

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -140,7 +140,7 @@
                          [(af/refresh-acl-cache-job "search-acl-cache-refresh")
                           idx/refresh-index-names-cache-job
                           hgrf/refresh-has-granules-map-job
-                          hgrf/refresh-has-granules-or-cwic-map-job
+                          hgocrf/refresh-has-granules-or-cwic-map-job
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           coll-cache/refresh-collections-cache-for-granule-acls-job
                           jvm-info/log-jvm-statistics-job

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -100,8 +100,8 @@
         {:keys [id title short-name version-id summary updated dataset-id collection-data-type
                 processing-level-id original-format data-center archive-center time-start time-end
                 links dif-ids online-access-flag browse-flag coordinate-system score
-                shapes points boxes polygons lines granule-count has-granules has-variables
-                has-formats has-transforms has-spatial-subsetting orbit-parameters
+                shapes points boxes polygons lines granule-count has-granules has-granules-or-cwic
+                has-variables has-formats has-transforms has-spatial-subsetting orbit-parameters
                 highlighted-summary-snippets organizations associations]} json-entry]
     (util/remove-nil-keys
       {:id id

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -111,6 +111,7 @@
          "acls"
          "collections-for-gran-acls"
          "has-granules-map"
+         "has-granules-or-cwic-map"
          "health"
          "humanizer-report-cache"
          "index-names"

--- a/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
@@ -351,7 +351,7 @@
                :atom (search/find-concepts-atom :collection {:include-has-granules true :include-granule-counts true})
                :atom (search/find-concepts-json :collection {:include-has-granules true :include-granule-counts true})))))))
 
-(deftest search-collections-include-cwic-collections-test
+(deftest search-collections-has-granules-or-cwic-test
   (let [coll1 (make-coll 1 m/whole-world nil)
         coll2 (make-coll 2 m/whole-world nil)
         coll3 (make-coll 3 m/whole-world nil)
@@ -368,8 +368,8 @@
         tag2 (tags/save-tag
                user1-token
                (tags/make-tag {:tag-key "CWIC"})
-               [coll2 coll6])
-        _ (index/wait-until-indexed)]
+               [coll2 coll6])]
+    (index/wait-until-indexed)
 
     ;; coll1
     ;; non-cwic tagged with granule

--- a/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
@@ -1,22 +1,26 @@
 (ns cmr.system-int-test.search.granule-counts-search-test
   "This tests the granule counts search feature which allows retrieving counts of granules per collection."
   (:require
-    [clojure.test :refer :all]
-    [cmr.common.util :as util]
-    [cmr.spatial.codec :as codec]
-    [cmr.spatial.mbr :as m]
-    [cmr.spatial.point :as p]
-    [cmr.system-int-test.data2.collection :as dc]
-    [cmr.system-int-test.data2.core :as d]
-    [cmr.system-int-test.data2.granule :as dg]
-    [cmr.system-int-test.data2.granule-counts :as gran-counts]
-    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-    [cmr.system-int-test.utils.index-util :as index]
-    [cmr.system-int-test.utils.ingest-util :as ingest]
-    [cmr.system-int-test.utils.search-util :as search]))
+   [clojure.test :refer :all]
+   [cmr.common.util :as util]
+   [cmr.spatial.codec :as codec]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.point :as p]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.granule-counts :as gran-counts]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.tag-util :as tags]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
-
+(use-fixtures :each (join-fixtures
+                      [(ingest/reset-fixture {"provguid1" "PROV1"})
+                       tags/grant-all-tag-fixture]))
 (defn temporal-range
   "Creates attributes for collection or granule defining a temporal range between start and stop
   which should be single digit integers."
@@ -346,3 +350,51 @@
                :echo10 (search/find-metadata :collection :echo10 {:include-has-granules true :include-granule-counts true})
                :atom (search/find-concepts-atom :collection {:include-has-granules true :include-granule-counts true})
                :atom (search/find-concepts-json :collection {:include-has-granules true :include-granule-counts true})))))))
+
+(deftest search-collections-include-cwic-collections-test
+  (let [coll1 (make-coll 1 m/whole-world nil)
+        coll2 (make-coll 2 m/whole-world nil)
+        coll3 (make-coll 3 m/whole-world nil)
+        coll4 (make-coll 4 m/whole-world nil)
+        coll5 (make-coll 5 m/whole-world nil)
+        coll6 (make-coll 6 m/whole-world nil)
+
+        _ (index/wait-until-indexed)
+        user1-token (e/login (s/context) "user1")
+        tag1 (tags/save-tag
+               user1-token
+               (tags/make-tag {:tag-key "NON-CWIC"})
+               [coll1 coll5])
+        tag2 (tags/save-tag
+               user1-token
+               (tags/make-tag {:tag-key "CWIC"})
+               [coll2 coll6])
+        _ (index/wait-until-indexed)]
+
+    ;; coll1
+    ;; non-cwic tagged with granule
+    (make-gran coll1 (p/point 0 0) nil)
+
+    ;; coll2
+    ;; cwic tagged with granule
+    (make-gran coll2 (p/point 0 0) nil)
+
+    ;; coll 3
+    ;; no tag with granule
+    (make-gran coll3 (p/point 0 0) nil)
+
+    ;; coll 4
+    ;; no tag without granule
+
+    ;; coll 5
+    ;; non-cwic tagged no granule
+
+    ;; coll 6
+    ;; cwic tagged no granule
+
+    (index/wait-until-indexed)
+    (testing "Search with has-granules-or-cwic feature"
+      (d/refs-match? [coll1 coll3 coll6 coll2]
+                     (search/find-refs :collection
+                                       {:has_granules_or_cwic true}
+                                       {:snake-kebab? false})))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
@@ -397,4 +397,10 @@
       (d/refs-match? [coll1 coll3 coll6 coll2]
                      (search/find-refs :collection
                                        {:has_granules_or_cwic true}
+                                       {:snake-kebab? false})))
+
+    (testing "Search with has-granules-or-cwic feature"
+      (d/refs-match? [coll4 coll5 coll6]
+                     (search/find-refs :collection
+                                       {:has_granules_or_cwic false}
                                        {:snake-kebab? false})))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
@@ -367,7 +367,7 @@
                [coll1 coll5])
         tag2 (tags/save-tag
                user1-token
-               (tags/make-tag {:tag-key "CWIC"})
+               (tags/make-tag {:tag-key "org.ceos.wgiss.cwic.granules.prod"})
                [coll2 coll6])]
     (index/wait-until-indexed)
 

--- a/system-int-test/test/cmr/system_int_test/search/tagging/collection_tag_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/collection_tag_search_test.clj
@@ -1,17 +1,20 @@
 (ns cmr.system-int-test.search.tagging.collection-tag-search-test
   "This tests searching for collections by tag parameters"
-  (:require [clojure.test :refer :all]
-            [clojure.string :as str]
-            [cmr.common.util :as util :refer [are2]]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.search-util :as search]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.system-int-test.utils.tag-util :as tags]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.system-int-test.data2.collection :as dc]
-            [cmr.system-int-test.data2.atom :as da]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.system-int-test.system :as s]))
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are2]]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.spatial.point :as p]
+   [cmr.system-int-test.data2.atom :as da]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.tag-util :as tags]))
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})


### PR DESCRIPTION
This pull request implements new search feature to include CWIC collections in a has_granules=true search, using has_granules_or_cwic parameter.