### PR TITLE
CMR-4683: Add navigation links to granule year facets

### DIFF
--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
@@ -54,8 +54,7 @@
       (hv2/nested-facet (get (facets-v2-params->elastic-fields concept-type) facet-field) size depth))
 
     :start-date
-    (temporal-facets/temporal-facet (get (facets-v2-params->elastic-fields concept-type) facet-field)
-                                    size)
+    (temporal-facets/temporal-facet size)
     ;; else
     (v2h/prioritized-facet (get (facets-v2-params->elastic-fields concept-type) facet-field) size)))
 

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -76,8 +76,8 @@
                           (filter (fn [[k v]] (re-matches field-reg-ex k)))
                           seq
                           some?)
-            subfacets-missing-label? (nil? (:title subfacets))
-            updated-subfacets (if subfacets-missing-label?
+            subfacets-missing-title? (nil? (:title subfacets))
+            updated-subfacets (if subfacets-missing-title?
                                 (v2h/generate-group-node "Year" applied?
                                                          (:children subfacets))
                                 (assoc subfacets :applied applied?))

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -2,10 +2,12 @@
   "Functions for generating v2 granule facets. Similar structure as v2 collection facets, but
   granule fields. First major use case is supporting OPeNDAP virutal directories capability."
   (:require
+   [camel-snake-kebab.core :as csk]
    [cmr.common-app.services.search.query-to-elastic :as q2e]
    [cmr.common.util :as util]
    [cmr.search.services.query-execution.facets.facets-v2-helper :as v2h]
    [cmr.search.services.query-execution.facets.facets-v2-results-feature :as v2-facets]
+   [cmr.search.services.query-execution.facets.hierarchical-v2-facets :as hv2]
    [cmr.search.services.query-execution.facets.temporal-facets :as temporal-facets]))
 
 (def granule-facet-params->elastic-fields
@@ -63,18 +65,24 @@
 
 (defmethod v2-facets/create-v2-facets-by-concept-type :granule
   [concept-type base-url query-params aggs _]
-  (let [temporal-facets (temporal-facets/parse-temporal-buckets
-                         (-> aggs :start-date-doc-values :buckets)
-                         :year)
-        year-node (when (seq temporal-facets)
-                    (v2h/generate-group-node "Year"
-                                              false
-                                              temporal-facets))
-        ;; Will be added by CMR-4683 and CMR-4684
-        year-node (dissoc year-node :applied :type)
-        temporal-node (when year-node
-                        (v2h/generate-group-node (v2h/fields->human-readable-label :temporal)
-                                                 false
-                                                 [year-node]))
-        temporal-node (dissoc temporal-node :applied :type)]
-     [temporal-node]))
+  (let [subfacets (hv2/hierarchical-bucket-map->facets-v2
+                   :temporal-facet
+                   (:start-date-doc-values aggs)
+                   base-url
+                   query-params)]
+    (when (seq subfacets)
+      (let [field-reg-ex (re-pattern "temporal_facet.*")
+            applied? (->> query-params
+                          (filter (fn [[k v]] (re-matches field-reg-ex k)))
+                          seq
+                          some?)
+            subfacets-missing-label? (nil? (:title subfacets))
+            updated-subfacets (if subfacets-missing-label?
+                                (v2h/generate-group-node "Year" applied?
+                                                         (:children subfacets))
+                                (assoc subfacets :applied applied?))
+            ;; Return facets in reverse chronological order
+            updated-subfacets (update updated-subfacets :children reverse)]
+        [(merge v2h/sorted-facet-map
+                (v2h/generate-group-node "Temporal" applied?
+                                         [updated-subfacets]))]))))

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -2,7 +2,6 @@
   "Functions for generating v2 granule facets. Similar structure as v2 collection facets, but
   granule fields. First major use case is supporting OPeNDAP virutal directories capability."
   (:require
-   [camel-snake-kebab.core :as csk]
    [cmr.common-app.services.search.query-to-elastic :as q2e]
    [cmr.common.util :as util]
    [cmr.search.services.query-execution.facets.facets-v2-helper :as v2h]

--- a/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -11,14 +11,19 @@
    [cmr.common-app.services.search.parameters.converters.nested-field :as nested-field]
    [cmr.search.services.query-execution.facets.facets-results-feature :as frf]
    [cmr.search.services.query-execution.facets.facets-v2-helper :as v2h]
-   [cmr.search.services.query-execution.facets.hierarchical-links-helper :as hlh]))
+   [cmr.search.services.query-execution.facets.hierarchical-links-helper :as hlh]
+   [cmr.search.services.query-execution.facets.temporal-facets :as temporal-facets]))
 
 (defn- nested-fields-mappings
   "Returns nested field mappings for the given field, ignoring humanizer suffixes"
   [field]
   (let [stripped-field (string/replace (string/replace (name field) #"-h$" "") #"\.humanized$" "")]
-    (if (= "variables" stripped-field)
-      nested-field/variable-subfields
+    (condp = stripped-field
+      "variables" nested-field/variable-subfields
+      "temporal" nested-field/temporal-facet-subfields
+      "temporal-facet" nested-field/temporal-facet-subfields
+      "start-date-doc-values" nested-field/temporal-facet-subfields
+      ;; else
       (kms-fetcher/nested-fields-mappings (keyword stripped-field)))))
 
 (defn- get-max-subfield-index
@@ -39,13 +44,15 @@
   depth of 3 levels (e.g. Category, Topic, and Term for science keywords) for science keywords,
   and 2 for variables."
   {:science-keywords-h 3
-   :variables-h 2})
+   :variables-h 2
+   :temporal 2})
 
 (def num-levels-below-subfield
   "Number of levels below the lowest level subfield to request for hierarchical aggregations queries
   from elastic."
   {:science-keywords-h 2
-   :variables-h 1})
+   :variables-h 1
+   :temporal 1})
 
 (defn get-depth-for-hierarchical-field
   "Returns what depth should be used when requesting aggregations for facets for a hierarchical
@@ -167,13 +174,19 @@
                          the part of the facets v2 response related to the passed in field."
   [recursive-parse-fn has-siblings-fn generate-links-fn field field-hierarchy elastic-aggregations]
   ;; Each value for this field has its own bucket in the elastic aggregations response
-  (for [bucket (get-in elastic-aggregations [field :buckets])
-        :let [value (:key bucket)
+  ;; Top level could be a field
+  (for [bucket (or (get-in elastic-aggregations [field :buckets] (get elastic-aggregations :buckets)))
+        :let [temporal? (some? (:key_as_string bucket))
+              value (if temporal?
+                      (temporal-facets/parse-date (:key_as_string bucket) field)
+                      (:key bucket))
               count (get-in bucket [:coll-count :doc_count] (:doc_count bucket))
               sub-facets (recursive-parse-fn value bucket)
               ;; Sort alphabetically
               sub-facets (when (seq (:children sub-facets))
                            (update sub-facets :children
+                                  ;  #(if temporal?
+                                  ;     (reverse (sort-by :title util/compare-natural-strings %))
                                    #(sort-by :title util/compare-natural-strings %)))
               children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
               has-siblings? (has-siblings-fn value)
@@ -237,7 +250,9 @@
                                                     generate-links-fn subfield field-hierarchy
                                                     elastic-aggs)]
        (when (seq children)
-         (v2h/generate-group-node (csk/->snake_case_string subfield) true children))))))
+         (v2h/generate-group-node (string/capitalize (csk/->snake_case_string subfield))
+                                  true
+                                  children))))))
 
 (defn- get-search-terms-for-hierarchical-field
   "Returns all of the search terms applied in the passed in query params for the provided
@@ -337,7 +352,7 @@
         (assoc updated-facet :children (:children earth-science-facets))))
     hierarchical-facet))
 
-(defn- hierarchical-bucket-map->facets-v2
+(defn hierarchical-bucket-map->facets-v2
   "Takes a map of elastic aggregation results for a nested field. Returns a hierarchical facet for
   that field."
   [field bucket-map base-url query-params]

--- a/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -20,9 +20,7 @@
   (let [stripped-field (string/replace (string/replace (name field) #"-h$" "") #"\.humanized$" "")]
     (condp = stripped-field
       "variables" nested-field/variable-subfields
-      "temporal" nested-field/temporal-facet-subfields
       "temporal-facet" nested-field/temporal-facet-subfields
-      "start-date-doc-values" nested-field/temporal-facet-subfields
       ;; else
       (kms-fetcher/nested-fields-mappings (keyword stripped-field)))))
 

--- a/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -183,8 +183,6 @@
               ;; Sort alphabetically
               sub-facets (when (seq (:children sub-facets))
                            (update sub-facets :children
-                                  ;  #(if temporal?
-                                  ;     (reverse (sort-by :title util/compare-natural-strings %))
                                    #(sort-by :title util/compare-natural-strings %)))
               children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
               has-siblings? (has-siblings-fn value)

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -25,19 +25,8 @@
 
 (defn temporal-facet
   "Creates a temporal facet for the provided field."
-  [field interval-granularity]
+  [interval-granularity]
   (let [interval-granularity :year]
     {:date_histogram
-     {:field field
+     {:field :start-date-doc-values
       :interval interval-granularity}}))
-
-(defn parse-temporal-buckets
-  "Parses the Elasticsearch aggregations response to return a map of the value for the current
-  interval and count of the number of documents for that interval."
-  [buckets interval]
-  (reverse
-   (map (fn [bucket]
-          (let [value (parse-date (:key_as_string bucket) interval)]
-            {:title value
-             :count (:doc_count bucket)}))
-        buckets)))

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
@@ -183,3 +183,19 @@
           "2010" "2010" 2
           "2011" "2011" 1
           "2012" "2012" 1)))))
+      ; (testing "All of the years include a link to apply that year to the search."
+      ;   (let [links (get-links year-facets)]
+      ;     (is (= 4 (count links)))
+      ;     (doseq [[link-type url] (map :links year-facets)]
+      ;       (is (= :apply link-type)))))
+      ; (testing "When selecting a link the search results only contain granules for that year."
+      ;   (let [response (traverse-link "2011" year-facets)
+      ;         updated-year-facets (get-in response [:results :facets])]
+      ;     (is (= gran2011-1 (get-gran-from-json-response response)))
+      ;     (is (= :remove (get-link-type "2011" updated-year-facets)))))
+      ; (testing "When multiple years are selected the search results contain granules from either year."
+      ;     (let [response (traverse-link "1999" updated-year-facets)
+      ;           updated-year-facets (get-in response [:results :facets])]
+      ;       (is (= [gran1999-1 gran2011-1] (get-gran-from-json-response response)))
+      ;       (is (= :remove (get-link-type "2011" updated-year-facets)))
+      ;       (is (= :remove (get-link-type "1999" updated-year-facets))))))))


### PR DESCRIPTION
The facet response after this pull request includes links to add or remove years from the granule search. It looks like:

```
"facets" : {
  "title" : "Browse Granules",
  "has_children" : true,
  "children" : [ {
    "title" : "Temporal",
    "type" : "group",
    "applied" : false,
    "has_children" : true,
    "children" : [ {
      "title" : "Year",
      "type" : "group",
      "applied" : false,
      "has_children" : true,
      "children" : [ {
        "title" : "2012",
        "type" : "filter",
        "applied" : false,
        "count" : 1,
        "links" : {
          "apply" : "http://localhost:3003/granules.json?page_size=0&include_facets=v2&collection_concept_id=C1-PROV1&pretty=true&temporal_facet%5B0%5D%5Byear%5D=2012"
        },
        "has_children" : false
      }, {
        "title" : "2011",
        "type" : "filter",
        "applied" : false,
        "count" : 1,
        "links" : {
          "apply" : "http://localhost:3003/granules.json?page_size=0&include_facets=v2&collection_concept_id=C1-PROV1&pretty=true&temporal_facet%5B0%5D%5Byear%5D=2011"
        },
        "has_children" : false
      }, {
        "title" : "2010",
        "type" : "filter",
        "applied" : false,
        "count" : 2,
        "links" : {
          "apply" : "http://localhost:3003/granules.json?page_size=0&include_facets=v2&collection_concept_id=C1-PROV1&pretty=true&temporal_facet%5B0%5D%5Byear%5D=2010"
        },
        "has_children" : false
      }, {
        "title" : "1999",
        "type" : "filter",
        "applied" : false,
        "count" : 1,
        "links" : {
          "apply" : "http://localhost:3003/granules.json?page_size=0&include_facets=v2&collection_concept_id=C1-PROV1&pretty=true&temporal_facet%5B0%5D%5Byear%5D=1999"
        },
        "has_children" : false
      } ]
    } ]
  } ]
}
```