### PR TITLE
CMR-4404: Cache the search-params to improve granule scroll search performance.

### DIFF
--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -64,7 +64,8 @@
                         (rfh/printable-result-format result-format) (pr-str params)))
         search-params (lp/process-legacy-psa params)
         search-params (if cached-search-params
-                        (assoc cached-search-params :result-format (:result-format search-params))
+                        (assoc cached-search-params :result-format (:result-format search-params)
+                                                    :include_facets (:include_facets search-params))
                         search-params)
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)    

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -53,16 +53,22 @@
   [ctx path-w-extension params headers body]
   (let [concept-type (concept-type-path-w-extension->concept-type path-w-extension)
         short-scroll-id (get headers (string/lower-case common-routes/SCROLL_ID_HEADER))
-        scroll-id (core-api/get-scroll-id-from-cache ctx short-scroll-id)
+        scroll-id-and-search-params (core-api/get-scroll-id-and-search-params-from-cache ctx short-scroll-id)
+        scroll-id (:scroll-id scroll-id-and-search-params)
+        cached-search-params (:search-params scroll-id-and-search-params)
         ctx (assoc ctx :query-string body :scroll-id scroll-id)
         params (core-api/process-params concept-type params path-w-extension headers mt/xml)
         result-format (:result-format params)
         _ (info (format "Searching for %ss from client %s in format %s with params %s."
                         (name concept-type) (:client-id ctx)
                         (rfh/printable-result-format result-format) (pr-str params)))
-        search-params (lp/process-legacy-psa params)
+        search-params (if cached-search-params
+                        cached-search-params 
+                        (lp/process-legacy-psa params))
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
-    (core-api/search-response ctx results)))
+    (if (:scroll-id results)    
+      (core-api/search-response ctx results search-params)
+      (core-api/search-response ctx results))))
 
 (defn- find-concepts
   "Invokes query service to find results and returns the response.

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -62,10 +62,9 @@
         _ (info (format "Searching for %ss from client %s in format %s with params %s."
                         (name concept-type) (:client-id ctx)
                         (rfh/printable-result-format result-format) (pr-str params)))
-        search-params (lp/process-legacy-psa params)
         search-params (if cached-search-params
                         cached-search-params
-                        search-params)
+                        (lp/process-legacy-psa params))
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)    
       (core-api/search-response ctx results search-params)

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -64,8 +64,7 @@
                         (rfh/printable-result-format result-format) (pr-str params)))
         search-params (lp/process-legacy-psa params)
         search-params (if cached-search-params
-                        (assoc cached-search-params :result-format (:result-format search-params)
-                                                    :include_facets (:include_facets search-params))
+                        cached-search-params
                         search-params)
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)    

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -62,9 +62,10 @@
         _ (info (format "Searching for %ss from client %s in format %s with params %s."
                         (name concept-type) (:client-id ctx)
                         (rfh/printable-result-format result-format) (pr-str params)))
+        search-params (lp/process-legacy-psa params)
         search-params (if cached-search-params
-                        cached-search-params 
-                        (lp/process-legacy-psa params))
+                        (assoc cached-search-params :result-format (:result-format search-params))
+                        search-params)
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)    
       (core-api/search-response ctx results search-params)

--- a/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
@@ -85,7 +85,7 @@
       (let [result (search/find-concepts-in-format
                      mime-types/xml
                      :granule
-                     {:provider "PROV1" :scroll true :page-size 2 :result-format mime-types/xml})
+                     {:provider "PROV1" :scroll true :page-size 2})
             format (get-in result [:headers :Content-Type])
             hits (get-in result [:headers :CMR-Hits])
             scroll-id (get-in result [:headers :CMR-Scroll-Id])

--- a/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
@@ -88,17 +88,18 @@
                      {:provider "PROV1" :scroll true :page-size 2 :result-format mime-types/xml})
             format (get-in result [:headers :Content-Type])
             hits (get-in result [:headers :CMR-Hits])
-            scroll-id (get-in result [:headers :CMR-Scroll-Id])]
-        (testing "Subsequent searches with different search params still returns the same hits and format."
-          (let [result (search/find-concepts-in-format
-                         mime-types/json
-                         :granule
-                         {:provider "PROV2" :scroll false :page-size 10}
-                         {:headers {routes/SCROLL_ID_HEADER scroll-id}})
-                subsequent-hits (get-in result [:headers :CMR-Hits])
-                subsequent-format (get-in result [:headers :Content-Type])]
-            (is (= hits subsequent-hits))
-            (is (= format subsequent-format))))))
+            scroll-id (get-in result [:headers :CMR-Scroll-Id])
+            ;; Do a subsequent scroll search with different format, provider, scroll and page-size.
+            ;; Verify the new search params are ignored. It still returns the same xml format.
+            subsequent-result (search/find-concepts-in-format
+                                mime-types/json
+                                :granule
+                                {:provider "PROV2" :scroll false :page-size 10}
+                                {:headers {routes/SCROLL_ID_HEADER scroll-id}})
+            subsequent-format (get-in subsequent-result [:headers :Content-Type])
+            subsequent-hits (get-in subsequent-result [:headers :CMR-Hits])]
+         (is (= hits subsequent-hits))
+         (is (= format subsequent-format))))
 
     ;; The following test is included for completeness to test session timeouts, but it
     ;; cannot be run regularly because it is impossible to predict how long it will take

--- a/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as string]
    [clojure.test :refer :all]
    [cmr.common-app.api.routes :as routes]
+   [cmr.common.mime-types :as mime-types]
    [cmr.common.util :as util :refer [are3]]
    [cmr.elastic-utils.config :as es-config]
    [cmr.system-int-test.data2.core :as data2-core]
@@ -79,6 +80,25 @@
                                          {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
             (is (= (count all-grans) hits))
             (is (data2-core/refs-match? [] result))))))
+    
+    (testing "Scrolling with different search params from the original"
+      (let [result (search/find-concepts-in-format
+                     mime-types/xml
+                     :granule
+                     {:provider "PROV1" :scroll true :page-size 2 :result-format mime-types/xml})
+            format (get-in result [:headers :Content-Type])
+            hits (get-in result [:headers :CMR-Hits])
+            scroll-id (get-in result [:headers :CMR-Scroll-Id])]
+        (testing "Subsequent searches with different search params still returns the same hits and format."
+          (let [result (search/find-concepts-in-format
+                         mime-types/json
+                         :granule
+                         {:provider "PROV2" :scroll false :page-size 10}
+                         {:headers {routes/SCROLL_ID_HEADER scroll-id}})
+                subsequent-hits (get-in result [:headers :CMR-Hits])
+                subsequent-format (get-in result [:headers :Content-Type])]
+            (is (= hits subsequent-hits))
+            (is (= format subsequent-format))))))
 
     ;; The following test is included for completeness to test session timeouts, but it
     ;; cannot be run regularly because it is impossible to predict how long it will take


### PR DESCRIPTION
1. Issue:
If you do the following granule scroll search:
curl -i "http://localhost:3003/granules?provider=PROV&page_size=1&scroll=true"
and then do a subsequent granule scroll search using the scroll-id returned:
curl -i -H "CMR-Scroll-Id: -1261131662" "http://localhost:3003/granules?scroll=true"
The search-params with the provider=PROV info is lost for the subsequent scroll search, which results in the query search against all the indexes.  

2. Solution:
Cache the search-params together with the scroll-id in the cache and use the cached search-params if it's not nil.

3. Integration test issue:
Since the search-params doesn't affect the subsequent scroll search result, only impacts the performance, not sure how to test this. The only thing I could think of is to add the search-params to the search response so that the end-user can use the info to test.

