### PR TITLE
CMR-4648. Remove Originating_Center Translation between DIF and UMM.

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -202,8 +202,7 @@
 (defn- expected-dif-data-centers
   "Returns the expected DIF parsed data centers for the given UMM collection."
   [centers]
-  (let [originating-center (first (filter #(.contains (:Roles %) "ORIGINATOR") centers))
-        processing-centers (for [center centers
+  (let [processing-centers (for [center centers
                                  :let [long-name (:LongName center)]
                                  :when (and (.contains (:Roles center) "PROCESSOR")
                                             (or (nil? long-name) (.endsWith ".processor" long-name)))]

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -203,10 +203,6 @@
   "Returns the expected DIF parsed data centers for the given UMM collection."
   [centers]
   (let [originating-center (first (filter #(.contains (:Roles %) "ORIGINATOR") centers))
-        originating-centers (when originating-center
-                              [(cmn/map->DataCenterType
-                                 {:Roles ["ORIGINATOR"]
-                                  :ShortName (:ShortName originating-center)})])
         processing-centers (for [center centers
                                  :let [long-name (:LongName center)]
                                  :when (and (.contains (:Roles center) "PROCESSOR")
@@ -235,7 +231,7 @@
                            :ContactPersons [(cmn/map->ContactPersonType
                                               {:Roles ["Data Center Contact"]
                                                :LastName su/not-provided})]})])]
-    (seq (concat originating-centers data-centers processing-centers))))
+    (seq (concat data-centers processing-centers))))
 
 (defn- expected-dif-additional-attribute
   [attribute]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
@@ -160,7 +160,6 @@
     [:Access_Constraints (-> c :AccessConstraints :Description)]
     [:Use_Constraints (:UseConstraints c)]
     (dif-util/generate-dataset-language :Data_Set_Language (:DataLanguage c))
-    (center/generate-originating-center c)
     (center/generate-data-centers c)
     (for [distribution (:Distributions c)]
       [:Distribution

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9/data_center.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9/data_center.clj
@@ -12,13 +12,6 @@
   "Value to use as the Group for the Metadata entry for a processing center"
   "gov.nasa.esdis.cmr.processor")
 
-(defn generate-originating-center
-  "Returns the DIF9 originating center element from the given umm collection"
-  [c]
-  (when-let [originating-center (first (filter #(.contains (:Roles %) "ORIGINATOR")
-                                               (:DataCenters c)))]
-    [:Originating_Center (:ShortName originating-center)]))
-
 (defn generate-processing-centers
   "Returns the dif9 processing centers as extended metadata elements. Can have multiple processing
   centers."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
@@ -214,8 +214,7 @@
      :MetadataAssociations (for [parent-dif (values-at doc "/DIF/Parent_DIF")]
                              {:EntryId parent-dif})
      :ContactPersons (contact/parse-contact-persons (select doc "/DIF/Personnel"))
-     :DataCenters (concat (center/parse-originating-centers doc)
-                          (center/parse-data-centers doc sanitize?)
+     :DataCenters (concat (center/parse-data-centers doc sanitize?)
                           (center/parse-processing-centers doc))}))
 
 (defn dif9-xml-to-umm-c

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9/data_center.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9/data_center.clj
@@ -13,15 +13,6 @@
   do not map to Data Center Contact which is our default."
   (set/map-invert center/umm-contact-role->dif9-data-center-contact-role))
 
-(defn parse-originating-centers
-  "Returns the UMM data centers from parsing the DIF9 Originating_Center in the given xml document.
-  There can only be one originating center, but we retun it in a vector anyways for better handling
-  in the caller."
-  [doc]
-  (when-let [originating-center (value-of doc "/DIF/Originating_Center")]
-    [{:Roles ["ORIGINATOR"]
-      :ShortName originating-center}]))
-
 (defn parse-processing-centers
   "Returns the UMM data centers from parsing DIF9 Extended_Metadata for Metadata with name
   'Processor'"


### PR DESCRIPTION
1. The ticket asked for the removal of Originating_Center translation between UMM and DIF9, DIF10.
   Turns out only there's no such translation for DIF10, so only need to remove it for DIF9.
2. We have the Originating_Center in the example_data under DIF9 and DIF10. I removed the "ORIGINATOR" DataCenter from the expected. With all that, the generate_and_parse.clj should cover all the necessary testings. 