### PR TITLE
CMR-4686: Add months to temporal facets within granule V2 facets

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
@@ -13,7 +13,7 @@
 
 (def temporal-facet-subfields
   "The subfields of the granule temporal facet nested field."
-  [:year])
+  [:year :month])
 
 (defn get-subfield-names
   "Returns all of the subfields for the provided nested field. All nested field queries also support

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -423,7 +423,7 @@
 (defn doall-recursive
   "Recursively forces evaluation of any nested sequences. The regular doall
   will force evaluation of a sequence but if elements of those sequences are
-  things like maps which also contain lazy  sequences they would not be
+  things like maps which also contain lazy sequences they would not be
   realized. This function will force all of them to be realized."
   [v]
   (w/postwalk identity v))

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -415,6 +415,16 @@
     (and (not (nil? parsed-year))
          (<= 1 parsed-year 9999))))
 
+(defn valid-month?
+  "Returns true if the provided value is a valid month and false otherwise."
+  [month]
+  (let [parsed-month (try
+                       (Long. month)
+                       (catch Exception e
+                         nil))]
+    (and (not (nil? parsed-month))
+         (<= 1 parsed-month 12))))
+
 (defn temporal-facet-year-validation
   "Validates that the years provided in all temporal-facet parameters are valid."
   [concept-type params]
@@ -431,6 +441,23 @@
               errors))
           []
           years)))))
+
+(defn temporal-facet-month-validation
+  "Validates that the months provided in all temporal-facet parameters are valid."
+  [concept-type params]
+  (when-let [param-values (:temporal-facet params)]
+    (when (map? param-values)
+      (let [temporal-facet-maps (vals param-values)
+            months (keep :month temporal-facet-maps)]
+        (reduce
+          (fn [errors month]
+            (if-not (valid-month? month)
+              (conj errors (format (str "Month [%s] within [temporal_facet] is not a valid month. "
+                                        "Months must be between 1 and 12.")
+                                   month))
+              errors))
+          []
+          months)))))
 
 ;; This method is for processing legacy numeric ranges in the form of
 ;; param_nam[value], param_name[minValue], and param_name[maxValue].
@@ -703,7 +730,8 @@
               collection-concept-id-validation
               granule-include-facets-validation
               temporal-facets-subfields-validation
-              temporal-facet-year-validation])
+              temporal-facet-year-validation
+              temporal-facet-month-validation])
    :tag cpv/common-validations
    :variable (concat cpv/common-validations
                      [boolean-value-validation])

--- a/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/facets_v2_results_feature.clj
@@ -54,7 +54,7 @@
       (hv2/nested-facet (get (facets-v2-params->elastic-fields concept-type) facet-field) size depth))
 
     :start-date
-    (temporal-facets/temporal-facet size)
+    (temporal-facets/temporal-facet query-params)
     ;; else
     (v2h/prioritized-facet (get (facets-v2-params->elastic-fields concept-type) facet-field) size)))
 

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -66,100 +66,17 @@
 (def group-nodes-in-order
   "The titles of temporal facet group nodes in order."
   ["Year" "Month" "Day"])
-;
-; (defn get-children-depth
-;   "Returns how many levels of children the facets contain."
-;   [facets]
-;   (loop [facets facets
-;          level 1]
-;     (if facets
-;       (recur (:children facets) (inc level))
-;       level)))
-;
-;
-
-(comment
-   (some? (some identity [false true false true]))
-   (some? (some true? [false true false]))
-   (any? #(= true %) [false false])
-   (not (apply = [false true false]))
-   (not (apply = [true true]))
-
-   (some? #{true} [false false]))
 
 (defn add-group-nodes-to-facets
   "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
   [facets remaining-levels]
-  ; (let [num-levels (get-children-depth subfacets)]
-    ; (loop [updated-facets subfacets
-    ;        level 1
-    ;        remaining-levels group-nodes-in-order]
-  ; (println "Facets are:" facets)
-  (println remaining-levels)
-  (let [applied? (some? (some true? (map :applied (:children facets))))
-        years (:children facets)
-        ; _ (println "Applied" applied?)
-        updated-facets (v2h/generate-group-node (first remaining-levels) applied?
-                                                (:children facets))
-        ; _ (println "Updated-facets" updated-,ffacets)
-        children-facets (doall
-                         (for [child (reverse (:children facets))]
-                          (if (some? (:children child))
-                            (add-group-nodes-to-facets child (rest remaining-levels))
-                            child)))
-
-        ; _ (println "Children facets" children-facets)
-        parent-to-children (-> updated-facets :children first)
-        ; _ (println "Parent to children" parent-to-children)
-        updated-parent-to-children (assoc parent-to-children :children children-facets)]
-        ; parent (-> updated-facets :children first)
-        ; updated-parent]
-
-    ; (v2h/generate-group-node (first remaining-levels) applied? (assoc facets :children children-facets))))
-    (if (some? (-> facets :children first :children))
-      (assoc updated-facets :children [updated-parent-to-children])
-      (assoc updated-facets :children children-facets))))
-    ; (cmr.common.util/update-in-each updated-facets [:children] children-facets)))
-
-(defn add-group-nodes-to-facets2
-  "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
-  [facets remaining-levels]
-  ; (let [num-levels (get-children-depth subfacets)]
-    ; (loop [updated-facets subfacets
-    ;        level 1
-    ;        remaining-levels group-nodes-in-order]
-  ; (println "Facets are:" facets)
-  (println remaining-levels)
-  (println "Facets" facets)
   (let [applied? (some? (some true? (map :applied facets)))
-        ; _ (println "Applied" applied?)
-        ; updated-facets (v2h/generate-group-node (first remaining-levels) applied?
-        ;                                         facets)
-        ; _ (println "Updated-facets" updated-,ffacets)
-        children-facets (doall
-                         (for [facet (reverse facets)]
-                          (if (:has_children facet)
-                            (assoc facet :children [(add-group-nodes-to-facets2 (:children facet) (rest remaining-levels))])
-                            facet)))]
-
-        ; _ (println "Children facets" children-facets)
-        ; parent-to-children (-> updated-facets :children first)
-        ; ; _ (println "Parent to children" parent-to-children)
-        ; updated-parent-to-children (assoc parent-to-children :children children-facets)]
-        ; parent (-> updated-facets :children first)
-        ; updated-parent]
-
-    ; (v2h/generate-group-node (first remaining-levels) applied? (assoc facets :children children-facets))))
-    ; (if (some? (-> facets :children first :children))
-      ; (assoc updated-facets :children [updated-parent-to-children])
-      ; (assoc updated-facets :children children-facets)))
-
+        children-facets (for [facet (reverse facets)]
+                          (if (seq (:children facet))
+                            (assoc facet :children [(add-group-nodes-to-facets
+                                                     (:children facet) (rest remaining-levels))])
+                            facet))]
     (v2h/generate-group-node (first remaining-levels) applied? children-facets)))
-; (defn add-group-nodes-to-facets
-;   "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
-;   [facets]
-;   (let [years facets
-;         months (:children facets)]))
 
 (defmethod v2-facets/create-v2-facets-by-concept-type :granule
   [concept-type base-url query-params aggs _]
@@ -174,17 +91,7 @@
                           (filter (fn [[k v]] (re-matches field-reg-ex k)))
                           seq
                           some?)
-            _ (println "Starting subfacets" subfacets)
-            updated-subfacets (add-group-nodes-to-facets2 (:children subfacets) group-nodes-in-order)]
-            ; updated-subfacets (add-group-nodes-to-facets subfacets group-nodes-in-order)]
-            ; subfacets-missing-title? (nil? (:title subfacets))
-            ; updated-subfacets (if subfacets-missing-title?
-            ;                     (v2h/generate-group-node "Year" applied?
-            ;                                              (:children subfacets))
-            ;                     (assoc subfacets :applied applied?))
-            ; ;; Return facets in reverse chronological order
-            ; updated-subfacets (update updated-subfacets :children reverse)]
+            updated-subfacets (add-group-nodes-to-facets (:children subfacets) group-nodes-in-order)]
         [(merge v2h/sorted-facet-map
                 (v2h/generate-group-node "Temporal" applied?
-                                        ;  [subfacets]))]))))
                                          [updated-subfacets]))]))))

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -63,6 +63,104 @@
   [_]
   (util/build-validator :bad-request validations))
 
+(def group-nodes-in-order
+  "The titles of temporal facet group nodes in order."
+  ["Year" "Month" "Day"])
+;
+; (defn get-children-depth
+;   "Returns how many levels of children the facets contain."
+;   [facets]
+;   (loop [facets facets
+;          level 1]
+;     (if facets
+;       (recur (:children facets) (inc level))
+;       level)))
+;
+;
+
+(comment
+   (some? (some identity [false true false true]))
+   (some? (some true? [false true false]))
+   (any? #(= true %) [false false])
+   (not (apply = [false true false]))
+   (not (apply = [true true]))
+
+   (some? #{true} [false false]))
+
+(defn add-group-nodes-to-facets
+  "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
+  [facets remaining-levels]
+  ; (let [num-levels (get-children-depth subfacets)]
+    ; (loop [updated-facets subfacets
+    ;        level 1
+    ;        remaining-levels group-nodes-in-order]
+  ; (println "Facets are:" facets)
+  (println remaining-levels)
+  (let [applied? (some? (some true? (map :applied (:children facets))))
+        years (:children facets)
+        ; _ (println "Applied" applied?)
+        updated-facets (v2h/generate-group-node (first remaining-levels) applied?
+                                                (:children facets))
+        ; _ (println "Updated-facets" updated-,ffacets)
+        children-facets (doall
+                         (for [child (reverse (:children facets))]
+                          (if (some? (:children child))
+                            (add-group-nodes-to-facets child (rest remaining-levels))
+                            child)))
+
+        ; _ (println "Children facets" children-facets)
+        parent-to-children (-> updated-facets :children first)
+        ; _ (println "Parent to children" parent-to-children)
+        updated-parent-to-children (assoc parent-to-children :children children-facets)]
+        ; parent (-> updated-facets :children first)
+        ; updated-parent]
+
+    ; (v2h/generate-group-node (first remaining-levels) applied? (assoc facets :children children-facets))))
+    (if (some? (-> facets :children first :children))
+      (assoc updated-facets :children [updated-parent-to-children])
+      (assoc updated-facets :children children-facets))))
+    ; (cmr.common.util/update-in-each updated-facets [:children] children-facets)))
+
+(defn add-group-nodes-to-facets2
+  "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
+  [facets remaining-levels]
+  ; (let [num-levels (get-children-depth subfacets)]
+    ; (loop [updated-facets subfacets
+    ;        level 1
+    ;        remaining-levels group-nodes-in-order]
+  ; (println "Facets are:" facets)
+  (println remaining-levels)
+  (println "Facets" facets)
+  (let [applied? (some? (some true? (map :applied facets)))
+        ; _ (println "Applied" applied?)
+        ; updated-facets (v2h/generate-group-node (first remaining-levels) applied?
+        ;                                         facets)
+        ; _ (println "Updated-facets" updated-,ffacets)
+        children-facets (doall
+                         (for [facet (reverse facets)]
+                          (if (:has_children facet)
+                            (assoc facet :children [(add-group-nodes-to-facets2 (:children facet) (rest remaining-levels))])
+                            facet)))]
+
+        ; _ (println "Children facets" children-facets)
+        ; parent-to-children (-> updated-facets :children first)
+        ; ; _ (println "Parent to children" parent-to-children)
+        ; updated-parent-to-children (assoc parent-to-children :children children-facets)]
+        ; parent (-> updated-facets :children first)
+        ; updated-parent]
+
+    ; (v2h/generate-group-node (first remaining-levels) applied? (assoc facets :children children-facets))))
+    ; (if (some? (-> facets :children first :children))
+      ; (assoc updated-facets :children [updated-parent-to-children])
+      ; (assoc updated-facets :children children-facets)))
+
+    (v2h/generate-group-node (first remaining-levels) applied? children-facets)))
+; (defn add-group-nodes-to-facets
+;   "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
+;   [facets]
+;   (let [years facets
+;         months (:children facets)]))
+
 (defmethod v2-facets/create-v2-facets-by-concept-type :granule
   [concept-type base-url query-params aggs _]
   (let [subfacets (hv2/hierarchical-bucket-map->facets-v2
@@ -76,13 +174,17 @@
                           (filter (fn [[k v]] (re-matches field-reg-ex k)))
                           seq
                           some?)
-            subfacets-missing-title? (nil? (:title subfacets))
-            updated-subfacets (if subfacets-missing-title?
-                                (v2h/generate-group-node "Year" applied?
-                                                         (:children subfacets))
-                                (assoc subfacets :applied applied?))
-            ;; Return facets in reverse chronological order
-            updated-subfacets (update updated-subfacets :children reverse)]
+            _ (println "Starting subfacets" subfacets)
+            updated-subfacets (add-group-nodes-to-facets2 (:children subfacets) group-nodes-in-order)]
+            ; updated-subfacets (add-group-nodes-to-facets subfacets group-nodes-in-order)]
+            ; subfacets-missing-title? (nil? (:title subfacets))
+            ; updated-subfacets (if subfacets-missing-title?
+            ;                     (v2h/generate-group-node "Year" applied?
+            ;                                              (:children subfacets))
+            ;                     (assoc subfacets :applied applied?))
+            ; ;; Return facets in reverse chronological order
+            ; updated-subfacets (update updated-subfacets :children reverse)]
         [(merge v2h/sorted-facet-map
                 (v2h/generate-group-node "Temporal" applied?
+                                        ;  [subfacets]))]))))
                                          [updated-subfacets]))]))))

--- a/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -168,6 +168,32 @@
     (temporal-facets/parse-date (:key_as_string bucket) field)
     (:key bucket)))
 
+(defn- generate-temporal-hierarchical-children
+  "Generate children nodes for a hierarchical facet v2 response.
+  recursive-parse-fn - function to call to recursively generate any children filter nodes.
+  has-siblings-fn - function to call to check whether the given value has any sibling nodes.
+  generate-links-fn - function to call to generate the links field in the facets v2 response for
+                      the passed in field.
+  field - the hierarchical subfield to generate the filter nodes for in the v2 response.
+  elastic-aggregations - the portion of the elastic aggregations response to parse to generate
+                         the part of the facets v2 response related to the passed in field."
+  [recursive-parse-fn has-siblings-fn generate-links-fn field field-hierarchy elastic-aggregations]
+  (let [bucket (first (get elastic-aggregations :buckets))
+        ; _ (println "Elastic aggs" elastic-aggregations)
+        value (temporal-facets/parse-date (:key_as_string bucket) field)
+        sub-facets (recursive-parse-fn value elastic-aggregations)
+        ; _ (println "The subfacets are:" sub-facets)
+        count (reduce + (map :count (:children sub-facets)))
+        ;; Sort alphabetically
+        sub-facets (when (seq (:children sub-facets))
+                     (update sub-facets :children
+                             #(sort-by :title util/compare-natural-strings %)))
+        children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
+        has-siblings? (has-siblings-fn value)
+        links (generate-links-fn value has-siblings? children-values-to-remove)]
+        ; links (generate-links-fn value false nil)]
+    [(v2h/generate-hierarchical-filter-node value count links sub-facets)]))
+
 (defn- generate-hierarchical-children
   "Generate children nodes for a hierarchical facet v2 response.
   recursive-parse-fn - function to call to recursively generate any children filter nodes.
@@ -178,22 +204,54 @@
   elastic-aggregations - the portion of the elastic aggregations response to parse to generate
                          the part of the facets v2 response related to the passed in field."
   [recursive-parse-fn has-siblings-fn generate-links-fn field field-hierarchy elastic-aggregations]
-  ;; Each value for this field has its own bucket in the elastic aggregations response
-  ;; Top level could be a field
-  (let [buckets (or (get-in elastic-aggregations [field :buckets])
-                    (get elastic-aggregations :buckets))]
-    (for [bucket buckets
-          :let [value (extract-value-from-bucket bucket field)
-                count (get-in bucket [:coll-count :doc_count] (:doc_count bucket))
-                sub-facets (recursive-parse-fn value bucket)
-                ;; Sort alphabetically
-                sub-facets (when (seq (:children sub-facets))
-                             (update sub-facets :children
-                                     #(sort-by :title util/compare-natural-strings %)))
-                children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
-                has-siblings? (has-siblings-fn value)
-                links (generate-links-fn value has-siblings? children-values-to-remove)]]
-      (v2h/generate-hierarchical-filter-node value count links sub-facets))))
+  ; (println "gen-hierarchical-children - field, field-hierarchy" field field-hierarchy)
+  (let [temporal-case? (some? (get elastic-aggregations :buckets))]
+    (if (and temporal-case? (not= 1 (count field-hierarchy)))
+      (generate-temporal-hierarchical-children recursive-parse-fn has-siblings-fn generate-links-fn
+                                               field field-hierarchy elastic-aggregations)
+      (let [buckets (or (get-in elastic-aggregations [field :buckets])
+                        (get elastic-aggregations :buckets))]
+        (for [bucket buckets
+              :let [value (extract-value-from-bucket bucket field)
+                    count (get-in bucket [:coll-count :doc_count] (:doc_count bucket))
+                    sub-facets (recursive-parse-fn value bucket)
+                    ;; Sort alphabetically
+                    sub-facets (when (seq (:children sub-facets))
+                                 (update sub-facets :children
+                                         #(sort-by :title util/compare-natural-strings %)))
+                    children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
+                    has-siblings? (has-siblings-fn value)
+                    links (generate-links-fn value has-siblings? children-values-to-remove)]]
+          ; (if temporal-case?
+            ; (v2h/generate-hierarchical-group-and-filter-node value count links sub-facets)
+          (v2h/generate-hierarchical-filter-node value count links sub-facets))))))
+
+; (defn- generate-hierarchical-children
+;   "Generate children nodes for a hierarchical facet v2 response.
+;   recursive-parse-fn - function to call to recursively generate any children filter nodes.
+;   has-siblings-fn - function to call to check whether the given value has any sibling nodes.
+;   generate-links-fn - function to call to generate the links field in the facets v2 response for
+;                       the passed in field.
+;   field - the hierarchical subfield to generate the filter nodes for in the v2 response.
+;   elastic-aggregations - the portion of the elastic aggregations response to parse to generate
+;                          the part of the facets v2 response related to the passed in field."
+;   [recursive-parse-fn has-siblings-fn generate-links-fn field field-hierarchy elastic-aggregations]
+;   ;; Each value for this field has its own bucket in the elastic aggregations response
+;   ;; Top level could be a field
+;   (let [buckets (or (get-in elastic-aggregations [field :buckets])
+;                     (get elastic-aggregations :buckets))]
+;     (for [bucket buckets
+;           :let [value (extract-value-from-bucket bucket field)
+;                 count (get-in bucket [:coll-count :doc_count] (:doc_count bucket))
+;                 sub-facets (recursive-parse-fn value bucket)
+;                 ;; Sort alphabetically
+;                 sub-facets (when (seq (:children sub-facets))
+;                              (update sub-facets :children
+;                                      #(sort-by :title util/compare-natural-strings %)))
+;                 children-values-to-remove (find-applied-children sub-facets field-hierarchy false)
+;                 has-siblings? (has-siblings-fn value)
+;                 links (generate-links-fn value has-siblings? children-values-to-remove)]]
+;       (v2h/generate-hierarchical-filter-node value count links sub-facets))))
 
 (defn- parse-hierarchical-bucket-v2
   "Recursively parses the elasticsearch aggregations response and generates version 2 facets.
@@ -354,11 +412,27 @@
         (assoc updated-facet :children (:children earth-science-facets))))
     hierarchical-facet))
 
+(defn get-field-hierarchy
+  "Returns the field hierarchy for the given field and passed in query parameters."
+  [field query-params]
+  ; (println "In get-field-hierarchy field is" field)
+  (let [field-hierarchy (nested-fields-mappings field)]
+    (if (not= :temporal-facet field)
+      field-hierarchy
+      (let [lowest-field (temporal-facets/query-params->time-interval query-params)
+            relevant-fields (concat
+                              (for [a-field field-hierarchy
+                                    :while (not= lowest-field a-field)]
+                                a-field)
+                              [lowest-field])]
+        ; (println "relevant-fields" relevant-fields)
+        relevant-fields))))
+
 (defn hierarchical-bucket-map->facets-v2
   "Takes a map of elastic aggregation results for a nested field. Returns a hierarchical facet for
   that field."
   [field bucket-map base-url query-params]
-  (let [field-hierarchy (nested-fields-mappings field)
+  (let [field-hierarchy (get-field-hierarchy field query-params)
         hierarchical-facet (-> (parse-hierarchical-bucket-v2 field field-hierarchy base-url
                                                              query-params bucket-map)
                                (prune-hierarchical-facet field true)

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -26,15 +26,13 @@
 (defn- time-intervals->next-interval
   "Returns the next interval based on the values in the map."
   [time-intervals]
-  ; (println "My time intervals are" time-intervals)
   (if-not (contains? (set time-intervals) :year)
     :year
     :month))
 
 (defn- get-subfields
-  "Returns the set of subfields within all of the provided temporal_facet params."
+  "Returns the subfields within all of the provided temporal_facet params."
   [temporal-facet-params]
-  ; (println "temporal-facet-params" temporal-facet-params)
   (let [field-regex (re-pattern "temporal_facet\\[\\d+\\]\\[(.*)\\]")]
     (keep #(second (re-matches field-regex %)) temporal-facet-params)))
 
@@ -45,14 +43,12 @@
         temporal-facet-params (keep (fn [[k v]]
                                       (when (re-matches field-reg-ex k) k))
                                     query-params)]
-    ; (println "Subfields are:" (get-subfields temporal-facet-params))
     (time-intervals->next-interval (map keyword (get-subfields temporal-facet-params)))))
 
 (defn temporal-facet
   "Creates a temporal facet for the provided field."
   [query-params]
   (let [interval-granularity (query-params->time-interval query-params)]
-    ; (println "Interval granularity is:" interval-granularity)
     {:date_histogram
      {:field :start-date-doc-values
       :interval interval-granularity}}))

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -23,10 +23,36 @@
   [datetime interval]
   (second (re-find #"^\d{4}-\d{2}-\d{2}T(\d{2}):\d{2}:\d{2}\+\d+$" datetime)))
 
+(defn- time-intervals->next-interval
+  "Returns the next interval based on the values in the map."
+  [time-intervals]
+  ; (println "My time intervals are" time-intervals)
+  (if-not (contains? (set time-intervals) :year)
+    :year
+    :month))
+
+(defn- get-subfields
+  "Returns the set of subfields within all of the provided temporal_facet params."
+  [temporal-facet-params]
+  ; (println "temporal-facet-params" temporal-facet-params)
+  (let [field-regex (re-pattern "temporal_facet\\[\\d+\\]\\[(.*)\\]")]
+    (keep #(second (re-matches field-regex %)) temporal-facet-params)))
+
+(defn query-params->time-interval
+  "Returns the time interval to request in temporal facets based on the query parameters."
+  [query-params]
+  (let [field-reg-ex (re-pattern "temporal_facet.*")
+        temporal-facet-params (keep (fn [[k v]]
+                                      (when (re-matches field-reg-ex k) k))
+                                    query-params)]
+    ; (println "Subfields are:" (get-subfields temporal-facet-params))
+    (time-intervals->next-interval (map keyword (get-subfields temporal-facet-params)))))
+
 (defn temporal-facet
   "Creates a temporal facet for the provided field."
-  [interval-granularity]
-  (let [interval-granularity :year]
+  [query-params]
+  (let [interval-granularity (query-params->time-interval query-params)]
+    ; (println "Interval granularity is:" interval-granularity)
     {:date_histogram
      {:field :start-date-doc-values
       :interval interval-granularity}}))

--- a/search-app/test/cmr/search/test/services/parameter_validation.clj
+++ b/search-app/test/cmr/search/test/services/parameter_validation.clj
@@ -359,3 +359,19 @@
       2010.2 2010.2
       0 0
       10000 10000)))
+
+(deftest valid-month-test
+  (testing "Valid months"
+    (doseq [month (map inc (range 12))]
+      (is (= true (pv/valid-month? month)))))
+  (testing "Invalid months"
+    (util/are3
+      [month]
+      (is (= false (pv/valid-month? month)))
+
+      "foo" "foo"
+      -5 -5
+      2010.2 2010.2
+      0 0
+      13 13
+      10000 10000)))

--- a/search-app/test/cmr/search/test/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/test/cmr/search/test/services/query_execution/facets/temporal_facets.clj
@@ -1,0 +1,44 @@
+(ns cmr.search.test.services.query-execution.facets.temporal-facets
+  "Unit tests for facets links helper namespace."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util]
+   [cmr.search.services.query-execution.facets.temporal-facets :as temporal-facets]))
+
+(deftest parse-date-test
+  (util/are3 [expected time-interval datetime-string]
+    (is (= expected (temporal-facets/parse-date datetime-string time-interval)))
+
+    "Year 2010"
+    "2010" :year "2010-12-30T10:15:35+000"
+
+    "Month 12"
+    "12" :month "2010-12-30T10:15:35+000"
+
+    "Day 30"
+    "30" :day "2010-12-30T10:15:35+000"
+
+    "Hour 10"
+    "10" :hour "2010-12-30T10:15:35+000"))
+
+(deftest query-params->time-interval-test
+  (util/are3 [expected query-params]
+    (is (= expected (temporal-facets/query-params->time-interval query-params)))
+
+    "No temporal facet parameters"
+    :year {"foo" "bar"}
+
+    "Single temporal-facet parameter with year"
+    :month {"temporal_facet[0][year]" "1537"}
+
+    "Single temporal-facet parameter with month"
+    :month {"temporal_facet[0][year]" "1537"
+            "temporal_facet[0][month]" "8"}
+
+    "Temporal facet in the value of a query parameter is ignored"
+    :year {"foo" "temporal_facet[0][year]=1537"}
+
+    "Multiple temporal-facet parameters"
+    :month {"temporal_facet[5][year]" 2010
+            "temporal_facet[5][month]" 10
+            "temporal_facet[2][year]" 2013}))

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
@@ -181,7 +181,7 @@
         gran2010-2 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                       coll (:concept-id coll)
                                       {:granule-ur "Granule2"
-                                       :beginning-date-time "2010-01-31T12:00:00Z"}))
+                                       :beginning-date-time "2010-05-31T12:00:00Z"}))
         gran2011-1 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                       coll (:concept-id coll)
                                       {:granule-ur "Granule3"

--- a/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
@@ -91,4 +91,7 @@
       ["parameter [not-year] is not a valid [temporal_facet] search term."]
 
       "Invalid year" {"temporal_facet[0][year]" -3}
-      ["Year [-3] within [temporal_facet] is not a valid year. Years must be between 1 and 9999."])))
+      ["Year [-3] within [temporal_facet] is not a valid year. Years must be between 1 and 9999."]
+
+      "Invalid month" {"temporal_facet[0][month]" 13}
+      ["Month [13] within [temporal_facet] is not a valid month. Months must be between 1 and 12."])))


### PR DESCRIPTION
The facets structure now includes months after selecting a year.

```
"facets" : {
  "title" : "Browse Granules",
  "type" : "group",
  "has_children" : true,
  "children" : [ {
    "title" : "Temporal",
    "type" : "group",
    "applied" : true,
    "has_children" : true,
    "children" : [ {
      "title" : "Year",
      "type" : "group",
      "applied" : true,
      "has_children" : true,
      "children" : [ {
        "title" : "2010",
        "type" : "filter",
        "applied" : true,
        "count" : 2,
        "links" : {
          "remove" : "http://localhost:3003/granules.json?include_facets=v2&collection_concept_id=C1-PROV1&page_size=0&pretty=true"
        },
        "has_children" : true,
        "children" : [ {
          "title" : "Month",
          "type" : "group",
          "applied" : false,
          "has_children" : true,
          "children" : [ {
            "title" : "05",
            "type" : "filter",
            "applied" : false,
            "count" : 1,
            "links" : {
              "apply" : "http://localhost:3003/granules.json?include_facets=v2&collection_concept_id=C1-PROV1&page_size=0&pretty=true&temporal_facet%5B0%5D%5Byear%5D=2010&temporal_facet%5B0%5D%5Bmonth%5D=05"
            },
            "has_children" : false
          }, {
            "title" : "01",
            "type" : "filter",
            "applied" : false,
            "count" : 1,
            "links" : {
              "apply" : "http://localhost:3003/granules.json?include_facets=v2&collection_concept_id=C1-PROV1&page_size=0&pretty=true&temporal_facet%5B0%5D%5Byear%5D=2010&temporal_facet%5B0%5D%5Bmonth%5D=01"
            },
            "has_children" : false
          } ]
        } ]
      } ]
    } ]
  } ]
}
```