### PR TITLE
CMR-4685 and CMR-4687

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/parameters/converters/nested_field.clj
@@ -13,7 +13,7 @@
 
 (def temporal-facet-subfields
   "The subfields of the granule temporal facet nested field."
-  [:year :month])
+  [:year :month :day])
 
 (defn get-subfield-names
   "Returns all of the subfields for the provided nested field. All nested field queries also support

--- a/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/granule_v2_facets.clj
@@ -70,12 +70,13 @@
 (defn add-group-nodes-to-facets
   "Adds group nodes (Year, Month, Day) as applicable to the provided facets."
   [facets remaining-levels]
-  (let [applied? (some? (some true? (map :applied facets)))
+  (let [has-children (not= remaining-levels ["Day"])
+        applied? (some? (some true? (map :applied facets)))
         children-facets (for [facet (reverse facets)]
                           (if (seq (:children facet))
                             (assoc facet :children [(add-group-nodes-to-facets
                                                      (:children facet) (rest remaining-levels))])
-                            facet))]
+                            (assoc facet :has_children has-children)))]
     (v2h/generate-group-node (first remaining-levels) applied? children-facets)))
 
 (defmethod v2-facets/create-v2-facets-by-concept-type :granule
@@ -91,7 +92,8 @@
                           (filter (fn [[k v]] (re-matches field-reg-ex k)))
                           seq
                           some?)
-            updated-subfacets (add-group-nodes-to-facets (:children subfacets) group-nodes-in-order)]
+            updated-subfacets (add-group-nodes-to-facets (:children subfacets)
+                                                         group-nodes-in-order)]
         [(merge v2h/sorted-facet-map
                 (v2h/generate-group-node "Temporal" applied?
                                          [updated-subfacets]))]))))

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -28,7 +28,9 @@
   [time-intervals]
   (if-not (contains? (set time-intervals) :year)
     :year
-    :month))
+    (if-not (contains? (set time-intervals) :month)
+      :month
+      :day)))
 
 (defn- get-subfields
   "Returns the subfields within all of the provided temporal_facet params."

--- a/search-app/test/cmr/search/test/services/parameter_validation.clj
+++ b/search-app/test/cmr/search/test/services/parameter_validation.clj
@@ -375,3 +375,19 @@
       0 0
       13 13
       10000 10000)))
+
+(deftest valid-day-test
+  (testing "Valid days"
+    (doseq [day (map inc (range 31))]
+      (is (= true (pv/valid-day? day)))))
+  (testing "Invalid days"
+    (util/are3
+      [day]
+      (is (= false (pv/valid-day? day)))
+
+      "foo" "foo"
+      -5 -5
+      2010.2 2010.2
+      0 0
+      32 32
+      10000 10000)))

--- a/search-app/test/cmr/search/test/services/parameter_validation.clj
+++ b/search-app/test/cmr/search/test/services/parameter_validation.clj
@@ -348,11 +348,11 @@
 (deftest valid-year-test
   (testing "Valid years"
     (doseq [year (map inc (range 9999))]
-      (is (= true (pv/valid-year? year)))))
+      (is (= true (pv/valid-value-for-date-field? year :year)))))
   (testing "Invalid years"
     (util/are3
       [year]
-      (is (= false (pv/valid-year? year)))
+      (is (= false (pv/valid-value-for-date-field? year :year)))
 
       "foo" "foo"
       -5 -5
@@ -363,11 +363,11 @@
 (deftest valid-month-test
   (testing "Valid months"
     (doseq [month (map inc (range 12))]
-      (is (= true (pv/valid-month? month)))))
+      (is (= true (pv/valid-value-for-date-field? month :month)))))
   (testing "Invalid months"
     (util/are3
       [month]
-      (is (= false (pv/valid-month? month)))
+      (is (= false (pv/valid-value-for-date-field? month :month)))
 
       "foo" "foo"
       -5 -5
@@ -379,11 +379,11 @@
 (deftest valid-day-test
   (testing "Valid days"
     (doseq [day (map inc (range 31))]
-      (is (= true (pv/valid-day? day)))))
+      (is (= true (pv/valid-value-for-date-field? day :day)))))
   (testing "Invalid days"
     (util/are3
       [day]
-      (is (= false (pv/valid-day? day)))
+      (is (= false (pv/valid-value-for-date-field? day :day)))
 
       "foo" "foo"
       -5 -5

--- a/search-app/test/cmr/search/test/services/query_execution/facets/hierarchical_v2_facets.clj
+++ b/search-app/test/cmr/search/test/services/query_execution/facets/hierarchical_v2_facets.clj
@@ -212,4 +212,10 @@
       "Temporal facets year and month selected"
       :temporal-facet {"temporal_facet[0][year]" "1537"
                        "temporal_facet[0][month]" "8"}
-      [:year :month])))
+      [:year :month :day]
+
+      "Temporal facets year, month, and day selected"
+      :temporal-facet {"temporal_facet[0][year]" "1537"
+                       "temporal_facet[0][month]" "8"
+                       "temporal_facet[0][day]" "15"}
+      [:year :month :day])))

--- a/search-app/test/cmr/search/test/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/test/cmr/search/test/services/query_execution/facets/temporal_facets.clj
@@ -32,13 +32,18 @@
     :month {"temporal_facet[0][year]" "1537"}
 
     "Single temporal-facet parameter with month"
-    :month {"temporal_facet[0][year]" "1537"
-            "temporal_facet[0][month]" "8"}
+    :day {"temporal_facet[0][year]" "1537"
+          "temporal_facet[0][month]" "8"}
+
+    "Single temporal-facet parameter with day"
+    :day {"temporal_facet[0][year]" "1537"
+          "temporal_facet[0][month]" "8"
+          "temporal_facet[0][day]" "15"}
 
     "Temporal facet in the value of a query parameter is ignored"
     :year {"foo" "temporal_facet[0][year]=1537"}
 
     "Multiple temporal-facet parameters"
-    :month {"temporal_facet[5][year]" 2010
-            "temporal_facet[5][month]" 10
-            "temporal_facet[2][year]" 2013}))
+    :day {"temporal_facet[5][year]" 2010
+          "temporal_facet[5][month]" 10
+          "temporal_facet[2][year]" 2013}))

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
@@ -176,12 +176,17 @@
         gran2010-1 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                       coll (:concept-id coll)
                                       {:granule-ur "Granule1"
-                                       :beginning-date-time "2010-01-01T12:00:00Z"
+                                       :beginning-date-time "2010-01-02T12:00:00Z"
                                        :ending-date-time "2010-01-11T12:00:00Z"}))
         gran2010-2 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                       coll (:concept-id coll)
                                       {:granule-ur "Granule2"
                                        :beginning-date-time "2010-05-31T12:00:00Z"}))
+        gran2010-3 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
+                                      coll (:concept-id coll)
+                                      {:granule-ur "Granule2010-3"
+                                       :beginning-date-time "2010-01-21T12:00:00Z"
+                                       :ending-date-time "2020-01-11T12:00:00Z"}))
         gran2011-1 (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                       coll (:concept-id coll)
                                       {:granule-ur "Granule3"
@@ -195,7 +200,7 @@
         gran2012-boundary (d/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                              coll (:concept-id coll)
                                              {:granule-ur "Granule5"
-                                              :beginning-date-time "2012-12-25T12:00:00Z"
+                                              :beginning-date-time "2012-12-21T12:00:00Z"
                                               :ending-date-time "2013-03-01T12:00:00Z"}))]
     (index/wait-until-indexed)
     (let [root-node (search-and-return-v2-facets {:collection-concept-id "C1-PROV1"
@@ -219,7 +224,7 @@
           [title cnt]
           (is (= cnt (get-count-by-title year-facets title)))
           "1999" "1999" 1
-          "2010" "2010" 2
+          "2010" "2010" 3
           "2011" "2011" 1
           "2012" "2012" 1))
       (testing "All of the years include a link to apply that year to the search."
@@ -236,7 +241,7 @@
               month-node (-> updated-facets :children first :children first :children first
                              :children first)
               month-facets (:children month-node)]
-          (assert-granules-match [gran2010-1 gran2010-2] granules-response)
+          (assert-granules-match [gran2010-1 gran2010-2 gran2010-3] granules-response)
           (is (= :remove (get-link-type "2010" updated-year-facets)))
           (testing "Selecting a year returns month facets for that year"
             (is (= "Month" (:title month-node)))
@@ -250,11 +255,39 @@
                     granules-response (get-in parsed-body [:feed :entry])
                     updated-year-facets (-> updated-facets :children first :children first
                                             :children)
-                    updated-month-facets (-> updated-facets :children first :children first
-                                             :children first :children first :children)]
-                (assert-granules-match [gran2010-1] granules-response)
+                    updated-month-facets (-> updated-year-facets first :children first :children)
+                    updated-day-facets (-> updated-month-facets first :children first :children)]
+                (assert-granules-match [gran2010-1 gran2010-3] granules-response)
                 (is (= :remove (get-link-type "2010" updated-year-facets)))
                 (is (= :remove (get-link-type "01" updated-month-facets)))
+                (testing "Days are displayed below month facets when selecting a month."
+                  (is (= ["21" "02"] (map :title updated-day-facets)))
+                  (testing "Select a day returns only granules for that year, month, and day."
+                    (let [response (traverse-link "21" updated-day-facets)
+                          parsed-body (json/parse-string (:body response) true)
+                          updated-facets (get-in parsed-body [:feed :facets])
+                          granules-response (get-in parsed-body [:feed :entry])
+                          updated-year-facets (-> updated-facets :children first :children first
+                                                  :children)
+                          updated-month-facets (-> updated-year-facets first :children first :children)
+                          updated-day-facets (-> updated-month-facets first :children first :children)]
+                      (assert-granules-match [gran2010-3] granules-response)
+                      (is (= :remove (get-link-type "2010" updated-year-facets)))
+                      (is (= :remove (get-link-type "01" updated-month-facets)))
+                      (is (= :remove (get-link-type "21" updated-day-facets)))
+                      (testing (str "Navigating to a remove year link removes the search filter "
+                                    "for year, month, and day.")
+                        (let [;; Note that the test above traversed to 2010,
+                              ;; so the 2010 link is now a remove link
+                              response (traverse-link "2010" updated-year-facets)
+                              parsed-body (json/parse-string (:body response) true)
+                              updated-facets (get-in parsed-body [:feed :facets])
+                              granules-response (get-in parsed-body [:feed :entry])
+                              updated-year-facets (-> updated-facets :children first :children first :children)]
+                          (assert-granules-match [gran1999-1 gran2010-1 gran2010-2 gran2010-3 gran2011-1
+                                                  gran2012-boundary]
+                                                 granules-response)
+                          (is (= :apply (get-link-type "2010" updated-year-facets))))))))
                 (testing "Navigating to a remove month link removes the search filter for that month."
                   (let [response (traverse-link "01" updated-month-facets)
                         parsed-body (json/parse-string (:body response) true)
@@ -263,18 +296,6 @@
                         updated-year-facets (-> updated-facets :children first :children first :children)
                         updated-month-facets (-> updated-facets :children first :children first
                                                  :children first :children first :children)]
-                    (assert-granules-match [gran2010-1 gran2010-2] granules-response)
+                    (assert-granules-match [gran2010-1 gran2010-2 gran2010-3] granules-response)
                     (is (= :apply (get-link-type "01" updated-month-facets)))
-                    (is (= :apply (get-link-type "05" updated-month-facets)))))
-                (testing (str "Navigating to a remove year link removes the search filter for both "
-                              "year and month.")
-                  (let [;; Note that the test above traversed to 2010,
-                        ;; so the 2010 link is now a remove link
-                        response (traverse-link "2010" updated-year-facets)
-                        parsed-body (json/parse-string (:body response) true)
-                        updated-facets (get-in parsed-body [:feed :facets])
-                        granules-response (get-in parsed-body [:feed :entry])
-                        updated-year-facets (-> updated-facets :children first :children first :children)]
-                    (assert-granules-match [gran1999-1 gran2010-1 gran2010-2 gran2011-1 gran2012-boundary]
-                                           granules-response)
-                    (is (= :apply (get-link-type "2010" updated-year-facets)))))))))))))
+                    (is (= :apply (get-link-type "05" updated-month-facets)))))))))))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
@@ -94,4 +94,7 @@
       ["Year [-3] within [temporal_facet] is not a valid year. Years must be between 1 and 9999."]
 
       "Invalid month" {"temporal_facet[0][month]" 13}
-      ["Month [13] within [temporal_facet] is not a valid month. Months must be between 1 and 12."])))
+      ["Month [13] within [temporal_facet] is not a valid month. Months must be between 1 and 12."]
+
+      "Invalid day" {"temporal_facet[0][day]" 32}
+      ["Day [32] within [temporal_facet] is not a valid day. Days must be between 1 and 31."])))


### PR DESCRIPTION
CMR-4685: Add has_children field to granule facets
CMR-4687: Add days to granule facets

These are the last two tickets to finish off the granule faceting capability by temporal. This adds support for days below months and makes sure the has_children field is always correctly set.