### PR TITLE
CMR-4746: Fix services to use transaction ID instead of revision ID when creating and deleting services.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -51,6 +51,12 @@
          (:transaction-id concept)
          (map :transaction-id (:variable-associations concept))))
 
+(defmethod get-elastic-version :service
+ [concept]
+ (apply max
+        (:transaction-id concept)
+        (map :transaction-id (:service-associations concept))))
+
 (defmethod get-elastic-version :default
   [concept]
   (:revision-id concept))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -275,6 +275,11 @@
   (let [variable-associations (meta-db/get-associations-for-variable context concept)]
     (get-elastic-version-with-associations context concept nil variable-associations nil)))
 
+(defmethod get-elastic-version :service
+  [context concept]
+  (let [service-associations (meta-db/get-associations-for-variable context concept)]
+    (get-elastic-version-with-associations context concept nil service-associations nil)))
+
 (defmulti get-tag-associations
   "Returns the tag associations of the concept"
   (fn [context concept]

--- a/message-queue-lib/src/cmr/message_queue/services/queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/services/queue.clj
@@ -42,8 +42,7 @@
   Requests to publish a message are wrapped in a timeout to handle error cases with the Rabbit MQ
   server. Otherwise failures to publish will be retried indefinitely."
   [queue-broker exchange-name msg]
-  (debug "Publishing message" msg
-         "[broker =" queue-broker "exchange =" exchange-name "]")
+  (debug (format "Publishing message: %s exchange: [%s]" msg exchange-name))
   (let [start-time (System/currentTimeMillis)]
     (try
       (timeout/thunk-timeout #(try-to-publish queue-broker exchange-name msg)

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -9,7 +9,7 @@
    [clojure.set :as set]
    [cmr.common.dev.record-pretty-printer :as record-pretty-printer]
    [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.log :as log :refer (debug trace info warn error)]
    [cmr.common.util :as util]
    [cmr.message-queue.config :as iconfig]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
@@ -116,11 +116,11 @@
         tagged-msg (assoc msg :id msg-id)]
     ;; Set the initial state of the message to :initial
     (update-message-queue-history broker queue-name :enqueue tagged-msg :initial)
-    (debug "Updated message queue history")
+    (trace "Updated message queue history")
     ;; Mark the enqueue as failed if we are timing things out or it fails
     (if (or @timeout?-atom (not (queue-protocol/publish-to-queue queue-broker queue-name tagged-msg)))
       (do
-        (debug "Published; preparing to update history ...")
+        (trace "Published; preparing to update history ...")
         (update-message-queue-history broker queue-name :enqueue tagged-msg :failure)
         false)
       true)))

--- a/search-app/src/cmr/search/data/elastic_results_to_query_results.clj
+++ b/search-app/src/cmr/search/data/elastic_results_to_query_results.clj
@@ -10,3 +10,7 @@
 (defmethod elastic-results/get-revision-id-from-elastic-result :variable
   [concept-type elastic-result]
   (first (get-in elastic-result [:fields :revision-id])))
+
+(defmethod elastic-results/get-revision-id-from-elastic-result :service
+  [concept-type elastic-result]
+  (first (get-in elastic-result [:fields :revision-id])))

--- a/transmit-lib/src/cmr/transmit/metadata_db.clj
+++ b/transmit-lib/src/cmr/transmit/metadata_db.clj
@@ -203,6 +203,13 @@
                 :latest true}]
     (find-concepts context params :variable-association)))
 
+(defn get-associations-for-service
+  "Get service associations (including tombstones) for a given service."
+  [context concept]
+  (let [params {:service-concept-id (:concept-id concept)
+                :latest true}]
+    (find-concepts context params :service-association)))
+
 (defn-timed find-collections
   "Searches metadata db for concepts matching the given parameters."
   [context params]


### PR DESCRIPTION
Since services have associations we need to use the transaction ID when specifying the version for the Elasticsearch document that gets created. We do the same for collections, variables, and tags.

We had existing tests which failed when switching to transaction ID in one place, and then succeeded when switching to use transaction IDs everywhere.