### PR TITLE
CMR-4620 Add validation for RelatedURL/description when it doesn't exist.

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/collection_misc_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_misc_validation_test.clj
@@ -137,7 +137,9 @@
     (is (some? (re-find #"object has missing required properties \(\[\"DataCenters\"\]\)"  (:warnings ingest-response))))
     (is (some? (re-find #"object has missing required properties \(\[\"DataCenters\"\]\)" (:warnings validation-response))))
     (is (some? (re-find #"\[:RelatedUrls 0 :URL\] \[htp://www.x.com\] is not a valid URL" (:warnings ingest-response))))
-    (is (some? (re-find #"\[:RelatedUrls 0 :URL\] \[htp://www.x.com\] is not a valid URL" (:warnings validation-response)))))))
+    (is (some? (re-find #"\[:RelatedUrls 0 :URL\] \[htp://www.x.com\] is not a valid URL" (:warnings validation-response))))
+    (is (some? (re-find #"\[:RelatedUrls 0\] RelatedUrl does not have a description." (:warnings ingest-response))))
+    (is (some? (re-find #"\[:RelatedUrls 0\] RelatedUrl does not have a description." (:warnings validation-response)))))))
 
 (comment
   (ingest/delete-provider "PROV1")

--- a/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
@@ -82,7 +82,7 @@
                (not= URL su/not-provided-url)
                (not (seq Description)))
       {field-path
-       [(vu/escape-error-string (format "[%s] RelatedURL does not have a description." URL))]})))
+       [(vu/escape-error-string "RelatedUrl does not have a description.")]})))
 
 (def urls-validation
   {:URL url-validation})

--- a/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/related_url.clj
@@ -74,11 +74,22 @@
        ;; Do the escape after the format here, so it doesn't get formatted out
        [(vu/escape-error-string (format "[%s] is not a valid URL" value))]})))
 
+(defn description-validation
+  "Validation that checks if description exists, when the URL is specified"
+  [field-path value]
+  (let [{:keys [URL Description]} value]
+    (when (and (some? URL)
+               (not= URL su/not-provided-url)
+               (not (seq Description)))
+      {field-path
+       [(vu/escape-error-string (format "[%s] RelatedURL does not have a description." URL))]})))
+
 (def urls-validation
   {:URL url-validation})
 
 (def related-url-validations
   [{:URL url-validation}
+   description-validation
    related-url-type-validation
    get-service-validation
    get-data-validation])

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
@@ -37,11 +37,11 @@
      (coll/map->UMM-C
       {:RelatedUrls [{:URL "http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip"
                       :URLContentType "DistributionURL"
+                      :Description "Description"
                       :Type "GET DATA"
                       :Subtype "ECHO"}
                      {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                       :URLContentType "PublicationURL"
-                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "USER'S GUIDE"}
                      {:URL "https://www.foo.com"
@@ -86,7 +86,7 @@
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}
       {:path [:RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
-      {:path [:RelatedUrls 0]
+      {:path [:RelatedUrls 1]
        :errors ["RelatedUrl does not have a description."]}
       {:path [:RelatedUrls 5]
        :errors ["Only URLContentType: DistributionURL Type: GET SERVICE can contain GetService, RelatedUrl contains URLContentType: PublicationURL Type: VIEW RELATED INFORMATION"]}
@@ -167,6 +167,7 @@
          [{:ContactInformation
            {:RelatedUrls [{:URL "http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                            :URLContentType "DataContactURL"
@@ -174,7 +175,6 @@
                            :Type "HOME PAGE"}
                           {:URL "https://www.foo.com"
                            :URLContentType "Bad URLContentType"
-                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "https://www.bar.com"
                            :URLContentType "DataContactURL"
@@ -187,14 +187,13 @@
                            :Subtype "Bad Subtype"}]}}]}]})
      [{:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
-      {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 0]
-       :errors ["RelatedUrl does not have a description."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 4]
        :errors ["URLContentType: DataContactURL, Type: HOME PAGE, Subtype: Bad Subtype is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 2]
-       :errors ["URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
+       :errors ["RelatedUrl does not have a description."
+                "URLContentType: Bad URLContentType, Type: HOME PAGE, Subtype: null is not a vaild URLContentType/Type/Subtype combination."
                 "URLContentType must be DataContactURL for ContactPersons or ContactGroups RelatedUrls"]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 1 :URL]
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}]))

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/related_url.clj
@@ -18,14 +18,17 @@
      (coll/map->UMM-C
                      {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                      :URLContentType "DistributionURL"
+                                     :Description "Description"
                                      :Type "GET DATA"
                                      :Subtype "ECHO"}
                                     {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                      :URLContentType "PublicationURL"
+                                     :Description "Description"
                                      :Type "VIEW RELATED INFORMATION"
                                      :Subtype "USER'S GUIDE"}
                                     {:URL "http://www.google.com"
                                      :URLContentType "VisualizationURL"
+                                     :Description "Description"
                                      :Type "GET RELATED VISUALIZATION"
                                      :Subtype "MAP"}]})))
 
@@ -38,22 +41,27 @@
                       :Subtype "ECHO"}
                      {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                       :URLContentType "PublicationURL"
+                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "USER'S GUIDE"}
                      {:URL "https://www.foo.com"
                       :URLContentType "Bad URLContentType"
+                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "USER'S GUIDE"}
                      {:URL "https://www.bar.com"
                       :URLContentType "PublicationURL"
+                      :Description "Description"
                       :Type "Bad Type"
                       :Subtype "USER'S GUIDE"}
                      {:URL "https://www.foobar.com"
                       :URLContentType "PublicationURL"
+                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "Bad Subtype"}
                      {:URL "https://www.baz.com"
                       :URLContentType "PublicationURL"
+                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "USER'S GUIDE"
                       :GetService {:MimeType "application/html"
@@ -62,6 +70,7 @@
                                    :Protocol "Not provided"}}
                      {:URL "https://www.baz.com"
                       :URLContentType "PublicationURL"
+                      :Description "Description"
                       :Type "VIEW RELATED INFORMATION"
                       :Subtype "USER'S GUIDE"
                       :GetData {:Size 10.0
@@ -77,6 +86,8 @@
        :errors ["[http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods] is not a valid URL"]}
       {:path [:RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:RelatedUrls 5]
        :errors ["Only URLContentType: DistributionURL Type: GET SERVICE can contain GetService, RelatedUrl contains URLContentType: PublicationURL Type: VIEW RELATED INFORMATION"]}
       {:path [:RelatedUrls 6]
@@ -90,9 +101,11 @@
                       [{:ContactInformation
                         {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                         :URLContentType "DataCenterURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}
                                        {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                         :URLContentType "DataCenterURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}]}}]})))
   (testing "Multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -104,19 +117,25 @@
                          :Type "HOME PAGE"}
                         {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                          :URLContentType "DataCenterURL"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.foo.com"
                          :URLContentType "Bad URLContentType"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.bar.com"
                          :URLContentType "DataCenterURL"
+                         :Description "Description"
                          :Type "Bad Type"}
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataCenterURL"
+                         :Description "Description"
                          :Type "HOME PAGE"
                          :Subtype "Bad Subtype"}]}}]})
      [{:path [:DataCenters 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:DataCenters 0 :ContactInformation :RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataCenterURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactInformation :RelatedUrls 4]
@@ -134,9 +153,11 @@
                         [{:ContactInformation
                           {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                           :URLContentType "DataContactURL"
+                                          :Description "Description"
                                           :Type "HOME PAGE"}
                                          {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                           :URLContentType "DataContactURL"
+                                          :Description "Description"
                                           :Type "HOME PAGE"}]}}]}]})))
   (testing "Contact Persons multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -149,19 +170,25 @@
                            :Type "HOME PAGE"}
                           {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "https://www.foo.com"
                            :URLContentType "Bad URLContentType"
+                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "https://www.bar.com"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "Bad Type"}
                           {:URL "https://www.foobar.com"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "HOME PAGE"
                            :Subtype "Bad Subtype"}]}}]}]})
      [{:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactPersons 0 :ContactInformation :RelatedUrls 4]
@@ -179,9 +206,11 @@
                         [{:ContactInformation
                           {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                           :URLContentType "DataContactURL"
+                                          :Description "Description"
                                           :Type "HOME PAGE"}
                                          {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                           :URLContentType "DataContactURL"
+                                          :Description "Description"
                                           :Type "HOME PAGE"}]}}]}]})))
   (testing "Contact Groups multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -194,19 +223,25 @@
                            :Type "HOME PAGE"}
                           {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "https://www.foo.com"
                            :URLContentType "Bad URLContentType"
+                           :Description "Description"
                            :Type "HOME PAGE"}
                           {:URL "https://www.bar.com"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "Bad Type"}
                           {:URL "https://www.foobar.com"
                            :URLContentType "DataContactURL"
+                           :Description "Description"
                            :Type "HOME PAGE"
                            :Subtype "Bad Subtype"}]}}]}]})
      [{:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:DataCenters 0 :ContactGroups 0 :ContactInformation :RelatedUrls 4]
@@ -225,9 +260,11 @@
                       [{:ContactInformation
                         {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                         :URLContentType "DataContactURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}
                                        {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                         :URLContentType "DataContactURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}]}}]})))
   (testing "Multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -239,19 +276,25 @@
                          :Type "HOME PAGE"}
                         {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.foo.com"
                          :URLContentType "Bad URLContentType"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.bar.com"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "Bad Type"}
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "HOME PAGE"
                          :Subtype "Bad Subtype"}]}}]})
      [{:path [:ContactPersons 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactPersons 0 :ContactInformation :RelatedUrls 4]
@@ -271,9 +314,11 @@
                       [{:ContactInformation
                         {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                         :URLContentType "DataContactURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}
                                        {:URL "http://gce-lter.marsci.uga.edu/lter/asp/db/send_eml.asp?detail=full&missing=NaN&delimiter=\t&accession=FNG-GCEM-0401"
                                         :URLContentType "DataContactURL"
+                                        :Description "Description"
                                         :Type "HOME PAGE"}]}}]})))
   (testing "Multiple invalid related urls"
     (h/assert-warnings-multiple-invalid
@@ -285,19 +330,25 @@
                          :Type "HOME PAGE"}
                         {:URL "http://ingrid.ldgo.columbia.edu/SOURCES/.IGOSS/.fsu/|u|u+|u|v/dods"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.foo.com"
                          :URLContentType "Bad URLContentType"
+                         :Description "Description"
                          :Type "HOME PAGE"}
                         {:URL "https://www.bar.com"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "Bad Type"}
                         {:URL "https://www.foobar.com"
                          :URLContentType "DataContactURL"
+                         :Description "Description"
                          :Type "HOME PAGE"
                          :Subtype "Bad Subtype"}]}}]})
      [{:path [:ContactGroups 0 :ContactInformation :RelatedUrls 0 :URL]
        :errors ["[http:\\\\fresc.usgs.gov\\products\\dataset\\moorhen_telemetry.zip] is not a valid URL"]}
+      {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 0]
+       :errors ["RelatedUrl does not have a description."]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 3]
        :errors ["URLContentType: DataContactURL, Type: Bad Type, Subtype: null is not a vaild URLContentType/Type/Subtype combination."]}
       {:path [:ContactGroups 0 :ContactInformation :RelatedUrls 4]
@@ -319,6 +370,7 @@
           (h/assert-valid (coll/map->UMM-C
                            {:RelatedUrls [{:URL "http://fresc.usgs.gov/products/dataset/moorhen_telemetry.zip"
                                            :URLContentType URLContentType
+                                           :Description "Description"
                                            :Type Type
                                            :Subtype Subtype}]})))))))
 
@@ -364,7 +416,8 @@
    (h/assert-warnings-valid
     (coll/map->UMM-C {:RelatedUrls [(merge
                                      url-type
-                                     {:URL "https://www.foo.com"})]})))))
+                                     {:URL "https://www.foo.com"
+                                      :Description "Description"})]})))))
 
 (deftest echo10-valid-url-types
  (testing "ECHO10 hard-coded conversion table contains valid combinations"
@@ -372,4 +425,5 @@
    (h/assert-warnings-valid
     (coll/map->UMM-C {:RelatedUrls [(merge
                                      url-type
-                                     {:URL "https://www.foo.com"})]})))))
+                                     {:URL "https://www.foo.com"
+                                      :Description "Description"})]})))))


### PR DESCRIPTION
This PR adds validation for RelatedUrls, when the URL is present but there is no description, there should be a warning returned.