### PR TITLE
CMR-4656: Allow client to search services sorted by their LongNames.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -15,7 +15,7 @@
   [context concept parsed-concept]
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields]} concept
-        {:keys [service-name]} extra-fields
+        {:keys [service-name long-name]} extra-fields
         schema-keys [:LongName
                      :Name
                      :Version
@@ -37,6 +37,8 @@
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)
+       :long-name long-name 
+       :long-name.lowercase (string/lower-case long-name)
        :provider-id provider-id
        :provider-id.lowercase (string/lower-case provider-id)
        :native-id native-id
@@ -49,6 +51,8 @@
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)
+       :long-name long-name 
+       :long-name.lowercase (string/lower-case long-name)
        :provider-id provider-id
        :provider-id.lowercase (string/lower-case provider-id)
        :native-id native-id

--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -15,7 +15,8 @@
   [context concept parsed-concept]
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields]} concept
-        {:keys [service-name long-name]} extra-fields
+        {:keys [service-name]} extra-fields
+        long-name (:LongName parsed-concept)
         schema-keys [:LongName
                      :Name
                      :Version

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -665,6 +665,8 @@
    :provider-id.lowercase (m/doc-values m/string-field-mapping)
    :service-name (-> m/string-field-mapping m/stored m/doc-values)
    :service-name.lowercase (m/doc-values m/string-field-mapping)
+   :long-name (-> m/string-field-mapping m/stored m/doc-values)
+   :long-name.lowercase (m/doc-values m/string-field-mapping)
    :keyword m/text-field-mapping
    :deleted (-> m/bool-field-mapping m/stored m/doc-values)
    :user-id (-> m/string-field-mapping m/stored m/doc-values)

--- a/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
@@ -8,8 +8,7 @@
   "Returns service concept with fields necessary for ingest into metadata db
   under :extra-fields."
   [context concept service]
-  (assoc concept :extra-fields {:service-name (:Name service) 
-                                :long-name (:LongName service)}))
+  (assoc concept :extra-fields {:service-name (:Name service)})) 
 
 (defn-timed save-service
   "Store a service concept in mdb and indexer. Return name, long-name, concept-id, and

--- a/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
@@ -8,7 +8,8 @@
   "Returns service concept with fields necessary for ingest into metadata db
   under :extra-fields."
   [context concept service]
-  (assoc concept :extra-fields {:service-name (:Name service)}))
+  (assoc concept :extra-fields {:service-name (:Name service) 
+                                :long-name (:LongName service)}))
 
 (defn-timed save-service
   "Store a service concept in mdb and indexer. Return name, long-name, concept-id, and

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3677,6 +3677,7 @@ One or more sort keys can be specified using the sort_key[] parameter. The order
 
 ###### Valid Service Sort Keys
   * `name`
+  * `long_name`
   * `provider`
   * `revision_date`
 

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -305,6 +305,7 @@
   [_]
   {:service-name :service-name.lowercase
    :name :service-name.lowercase
+   :long-name :long-name.lowercase
    :provider :provider-id.lowercase})
 
 (defmethod q2e/concept-type->sort-key-map :granule

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -261,6 +261,7 @@
 (defmethod cpv/valid-sort-keys :service
   [_]
   #{:name
+    :long-name
     :revision-date
     :provider})
 

--- a/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
@@ -576,15 +576,19 @@
 (deftest service-search-sort
   (let [service1 (services/ingest-service-with-attrs {:native-id "svc1"
                                                       :Name "service"
+                                                      :LongName "LongName1"
                                                       :provider-id "PROV2"})
         service2 (services/ingest-service-with-attrs {:native-id "svc2"
                                                       :Name "Service 2"
+                                                      :LongName "LongName2"
                                                       :provider-id "PROV1"})
         service3 (services/ingest-service-with-attrs {:native-id "svc3"
                                                       :Name "a service"
+                                                      :LongName "LongName3"
                                                       :provider-id "PROV1"})
         service4 (services/ingest-service-with-attrs {:native-id "svc4"
                                                       :Name "service"
+                                                      :LongName "LongName4"
                                                       :provider-id "PROV1"})]
     (index/wait-until-indexed)
 
@@ -619,6 +623,14 @@
 
       "Sort by revision-date descending order"
       "-revision_date"
+      [service4 service3 service2 service1]
+
+      "Sort by long-name"
+      "long_name"
+      [service1 service2 service3 service4]
+
+      "Sort by long-name descending order"
+      "-long_name"
       [service4 service3 service2 service1]
 
       "Sort by name ascending then provider id ascending explicitly"

--- a/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
@@ -576,7 +576,7 @@
 (deftest service-search-sort
   (let [service1 (services/ingest-service-with-attrs {:native-id "svc1"
                                                       :Name "service"
-                                                      :LongName "LongName1"
+                                                      :LongName "LongName4"
                                                       :provider-id "PROV2"})
         service2 (services/ingest-service-with-attrs {:native-id "svc2"
                                                       :Name "Service 2"
@@ -584,11 +584,11 @@
                                                       :provider-id "PROV1"})
         service3 (services/ingest-service-with-attrs {:native-id "svc3"
                                                       :Name "a service"
-                                                      :LongName "LongName3"
+                                                      :LongName "LongName1"
                                                       :provider-id "PROV1"})
         service4 (services/ingest-service-with-attrs {:native-id "svc4"
                                                       :Name "service"
-                                                      :LongName "LongName4"
+                                                      :LongName "LongName3"
                                                       :provider-id "PROV1"})]
     (index/wait-until-indexed)
 
@@ -627,11 +627,11 @@
 
       "Sort by long-name"
       "long_name"
-      [service1 service2 service3 service4]
+      [service3 service2 service4 service1]
 
       "Sort by long-name descending order"
       "-long_name"
-      [service4 service3 service2 service1]
+      [service1 service4 service2 service3]
 
       "Sort by name ascending then provider id ascending explicitly"
       ["name" "provider"]


### PR DESCRIPTION
1. Looks like the code change works for the sorting purpose. Not sure if I should add the service association index for the LongName for collections, just to be consistent with other sorting parameters.

2. The baseline code failed on the two tests: 
FAIL in (render-edsc-link) (collection_renderer.clj:48)
FAIL in (retrieve-collection-by-cmr-concept-id) (collection_concept_retrieval_test.clj:167)
