### PR TITLE
CMR-4753 Unable to update GES_DISC ACL due to unknown concept id

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
@@ -420,21 +420,12 @@
                                    :collection_identifier {:entry_titles ["notreal"]}}}
 
           "An error is returned if specifying a collection identifier with collection concept-ids that do not exist."
-          ["[INVALID ID] is not a valid collection concept-id."
-           "collection with concept-id [INVALID ID] does not exist in provider [PROV1]"]
+          ["[INVALID ID] is not a valid collection concept-id."]
           {:group_permissions [{:user_type "guest" :permissions ["read"]}]
            :catalog_item_identity {:name "A Catalog Item ACL"
                                    :provider_id "PROV1"
                                    :collection_applicable true
                                    :collection_identifier {:concept_ids ["INVALID ID"]}}}
-
-          "An error is returned if specifying a collection identifier with collection concept-ids that do not exist."
-          ["collection with concept-id [C999999999-PROV1] does not exist in provider [PROV1]"]
-          {:group_permissions [{:user_type "guest" :permissions ["read"]}]
-           :catalog_item_identity {:name "A Catalog Item ACL"
-                                   :provider_id "PROV1"
-                                   :collection_applicable true
-                                   :collection_identifier {:concept_ids ["C999999999-PROV1"]}}}
 
           "At least one of a range (min and/or max) or include_undefined value must be specified (collection_identifier)"
           ["either include_undefined_value or the combination of min_value and max_value must be specified"]

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -11,7 +11,7 @@
     [cmr.common-app.services.search.group-query-conditions :as gc]
     [cmr.common-app.services.search.query-execution :as qe]
     [cmr.common-app.services.search.query-model :as qm]
-    [cmr.common.log :refer [info debug]]
+    [cmr.common.log :refer [info debug warn]]
     [cmr.common.mime-types :as mt]
     [cmr.common.services.errors :as errors]
     [cmr.common.util :refer [defn-timed] :as util]
@@ -141,7 +141,7 @@
                                     (assoc :concept-ids synced-concept-ids)
                                     util/remove-nil-keys)]
       (when (seq dropped-concept-ids)
-        (info (format "Dropping non existent collection concept-ids from collection identifier: %s"
+        (warn (format "Dropping non existent collection concept-ids from collection identifier: %s"
                       (vec dropped-concept-ids))))
       (assoc-in acl [:catalog-item-identity :collection-identifier] collection-identifier))
     acl))

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -141,7 +141,7 @@
                                     (assoc :concept-ids synced-concept-ids)
                                     util/remove-nil-keys)]
       (when (seq dropped-concept-ids)
-        (info (format "Concept-ids %s do not exist, dropping them from collection identifier"
+        (info (format "Concept-ids %s do not exist, dropping them from collection identifier."
                       (vec dropped-concept-ids))))
       (assoc-in acl [:catalog-item-identity :collection-identifier] collection-identifier))
     acl))

--- a/access-control-app/src/cmr/access_control/services/acl_util.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_util.clj
@@ -141,7 +141,7 @@
                                     (assoc :concept-ids synced-concept-ids)
                                     util/remove-nil-keys)]
       (when (seq dropped-concept-ids)
-        (info (format "Concept-ids %s do not exist, dropping them from collection identifier."
+        (info (format "Dropping non existent collection concept-ids from collection identifier: %s"
                       (vec dropped-concept-ids))))
       (assoc-in acl [:catalog-item-identity :collection-identifier] collection-identifier))
     acl))

--- a/access-control-app/src/cmr/access_control/services/acl_validation.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_validation.clj
@@ -101,10 +101,7 @@
     [(v/every (fn [key-path concept-id]
                 (let [regex #"C\d+-\S+"]
                   (when-not (re-matches regex concept-id)
-                    {key-path [(format "[%s] is not a valid collection concept-id." concept-id)]}))))
-     (v/every (fn [key-path concept-id]
-                (when-not (seq (mdb1/find-concepts context {:provider-id provider-id :concept-id concept-id} :collection))
-                  {key-path [(format "collection with concept-id [%s] does not exist in provider [%s]" concept-id provider-id)]})))]))
+                    {key-path [(format "[%s] is not a valid collection concept-id." concept-id)]}))))]))
 
 (defn- access-value-validation
   "Validates the access_value part of a collection or granule identifier."


### PR DESCRIPTION
This PR is to address an ACL in UAT that has collections that do not exist anymore in metadata-db by have somehow been left in the ACL(the delete didn't cascade).  I haven't been able to find when the collections were deleted in splunk, my guess is that they were deleted a long ago and the tombstones are just now decaying off after 356 days. The ACL in question was last successfully modified on 2017-11-29 17:44:13.082 

The event queue logic that handles cascading collection deletions to ACLs looks solid. So it is unclear how the ACL got to this state.

I think the simplest solution is to just remove the validation.  The entry-title/concept-id sync works when updating/creating an ACL prevents any collection that doesn't exist in the provider from being added to the ACL.  We do lose the feedback to the user telling them that the concept-id they tried to add didn't exist, but I'm not sure what the use case is for this.  Perhaps a compromise could be to add in a warning message to the ACL response instead of failing validation entirely.  This could be handled in another ticket.

If we want to keep the validation. A migration to fix ACLs will be needed, or the user will need to remove the collection concept-ids from the ACL collection identifier when updating the ACL.  This is difficult to do in MMT where the ACL has many collections in the collection identifier.