### PR TITLE
CMR-4657: Support all-revisions for services in search

### DIFF
--- a/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
+++ b/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
@@ -1,19 +1,21 @@
 (ns cmr.collection-renderer.test.services.collection-renderer
-  (require [clojure.test :refer :all]
-           [cmr.common.test.test-check-ext :as ext :refer [defspec]]
-           [clojure.test.check.generators :as gen]
-           [com.gfredericks.test.chuck.clojure-test :refer [for-all]]
-           [clojure.string :as str]
-           [cmr.common.lifecycle :as l]
-           [cmr.collection-renderer.services.collection-renderer :as cr]
-           [cmr.umm-spec.test.expected-conversion :as expected-conversion]
-           [cmr.umm-spec.test.umm-generators :as umm-gen]))
+  (require
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [cmr.collection-renderer.services.collection-renderer :as cr]
+   [cmr.common.lifecycle :as l]
+   [cmr.common.test.test-check-ext :as ext :refer [defspec]]
+   [cmr.umm-spec.test.expected-conversion :as expected-conversion]
+   [cmr.umm-spec.test.umm-generators :as umm-gen]
+   [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
 
 (defn create-renderer-context
   "Returns a context to use with testing collection"
   []
   {:system (l/start {cr/system-key (cr/create-collection-renderer)
-                     :public-conf {:relative-root-url "/search" :edsc-url "https://search.earthdata.nasa.gov"}}
+                     :public-conf {:relative-root-url "/search"
+                                   :edsc-url "https://search.earthdata.nasa.gov"}}
                     nil)})
 
 (def renderer-context
@@ -21,28 +23,29 @@
   (memoize create-renderer-context))
 
 (deftest render-default-collection
-  (let [coll expected-conversion/example-collection-record
-        ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
-    (is html "Expected some HTML to be returned")
-    (is (.contains html (:EntryTitle coll)))))
+  (testing "Get returned HTML"
+    (let [coll expected-conversion/example-collection-record
+          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
+      (is (string/includes? html (:EntryTitle coll))))))
 
 ;; This checks that we can render any UMM collection without getting an exception.
 ;; A small number of tries is done to avoid making tests take a long time.
 (defspec render-any-umm-collection 10
-  (for-all [umm-record (gen/no-shrink umm-gen/umm-c-generator)]
-    (let [^String html (cr/render-collection (renderer-context) umm-record "C1234-PROV1")]
-      (and html (.contains html (:EntryTitle umm-record))))))
+  (testing "Render without exception"
+    (for-all [umm-record (gen/no-shrink umm-gen/umm-c-generator)]
+      (let [^String html (cr/render-collection (renderer-context) umm-record "C1234-PROV1")]
+        (and html (string/includes? html (:EntryTitle umm-record)))))))
 
-;; Verify that the title of the html is the entry title
 (deftest render-title-as-entry-title
-  (let [coll expected-conversion/example-collection-record
-        ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
-    (is html "Expected a title containing the entry title")
-    (is (.contains html (str "<title>" (:EntryTitle coll) "</title>")))))
+  (testing "Verify that the title of the html is the entry title"
+    (let [coll expected-conversion/example-collection-record
+          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
+      (is (string/includes? html (str "<title>" (:EntryTitle coll) "</title>"))))))
 
-;; Verify that the correct EDSC url is rendered
 (deftest render-edsc-link
-  (let [coll expected-conversion/example-collection-record
-        ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
-    (is html "Expected the correct edsc url to be rendered")
-    (is (.contains html (str "https://search.earthdata.nasa.gov/search/granules?p=C1234-PROV1")))))
+  (testing "Verify that the correct EDSC url is rendered"
+    (let [coll expected-conversion/example-collection-record
+          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
+      (is (string/includes?
+           html
+           "https://search.earthdata.nasa.gov/search/granules?p=C1234-PROV1")))))

--- a/indexer-app/int-test/cmr/indexer/test/services/index_fields/services.clj
+++ b/indexer-app/int-test/cmr/indexer/test/services/index_fields/services.clj
@@ -102,3 +102,17 @@
   (delete-service "S1234-PROV1" 2 {:all-revisions-index? true})
   (assert-delete-svc "S1234-PROV1")
   (assert-not-match-in-svc "S1234-PROV1,2" [:keyword] "keyword"))
+
+(deftest save-service-all-revisions-false-test
+  (save-service (es-doc-svc-rev-1) "S1234-PROV1" 1 {:all-revisions-index? false})
+  (assert-match-in-svc "S1234-PROV1" [:keyword] "kw")
+  (assert-match-in-svc "S1234-PROV1" [:keyword] "kw3")
+  (assert-not-match-in-svc "S1234-PROV1" [:keyword] "keyword")
+  (save-service (es-doc-svc-rev-2) "S1234-PROV1" 2 {:all-revisions-index? false})
+  (assert-match-in-svc "S1234-PROV1" [:keyword] "keyword")
+  (assert-match-in-svc "S1234-PROV1" [:keyword] "keyword3")
+  (assert-not-match-in-svc "S1234-PROV1" [:keyword] "kw")
+  (delete-service "S1234-PROV1" 2 {:all-revisions-index? false})
+  (assert-delete-svc "S1234-PROV1")
+  (assert-not-match-in-svc "S1234-PROV1" [:keyword] "keyword")
+  (assert-not-match-in-svc "S1234-PROV1" [:keyword] "kw"))

--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -17,7 +17,6 @@
                 revision-date format extra-fields]} concept
         {:keys [service-name]} extra-fields
         long-name (:LongName parsed-concept)
-        concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))
         schema-keys [:LongName
                      :Name
                      :Version
@@ -32,11 +31,8 @@
         keyword-values (keyword-util/concept-keys->keyword-text
                         parsed-concept schema-keys)]
     (if deleted
-      ;; This is only called by re-indexing (bulk indexing)
-      ;; Regular deleted services would have gone through the index-service/delete-concept path.
       {:concept-id concept-id
        :revision-id revision-id
-       :concept-seq-id concept-seq-id
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)
@@ -49,7 +45,6 @@
        :revision-date revision-date}
       {:concept-id concept-id
        :revision-id revision-id
-       :concept-seq-id concept-seq-id
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)

--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -17,6 +17,7 @@
                 revision-date format extra-fields]} concept
         {:keys [service-name]} extra-fields
         long-name (:LongName parsed-concept)
+        concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))
         schema-keys [:LongName
                      :Name
                      :Version
@@ -35,11 +36,10 @@
       ;; Regular deleted services would have gone through the index-service/delete-concept path.
       {:concept-id concept-id
        :revision-id revision-id
+       :concept-seq-id concept-seq-id
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)
-       :long-name long-name 
-       :long-name.lowercase (string/lower-case long-name)
        :provider-id provider-id
        :provider-id.lowercase (string/lower-case provider-id)
        :native-id native-id
@@ -49,10 +49,11 @@
        :revision-date revision-date}
       {:concept-id concept-id
        :revision-id revision-id
+       :concept-seq-id concept-seq-id
        :deleted deleted
        :service-name service-name
        :service-name.lowercase (string/lower-case service-name)
-       :long-name long-name 
+       :long-name long-name
        :long-name.lowercase (string/lower-case long-name)
        :provider-id provider-id
        :provider-id.lowercase (string/lower-case provider-id)

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -665,7 +665,6 @@
   {:_id  {:path "concept-id"}}
   {:concept-id (-> m/string-field-mapping m/stored m/doc-values)
    :revision-id (-> m/int-field-mapping m/stored m/doc-values)
-   :concept-seq-id (m/doc-values m/int-field-mapping)
    :native-id (-> m/string-field-mapping m/stored m/doc-values)
    :native-id.lowercase (m/doc-values m/string-field-mapping)
    :provider-id (-> m/string-field-mapping m/stored m/doc-values)

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -665,6 +665,7 @@
   {:_id  {:path "concept-id"}}
   {:concept-id (-> m/string-field-mapping m/stored m/doc-values)
    :revision-id (-> m/int-field-mapping m/stored m/doc-values)
+   :concept-seq-id (m/doc-values m/int-field-mapping)
    :native-id (-> m/string-field-mapping m/stored m/doc-values)
    :native-id.lowercase (m/doc-values m/string-field-mapping)
    :provider-id (-> m/string-field-mapping m/stored m/doc-values)

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -160,6 +160,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Searching for Services](#searching-for-services)
         * [Service Search Parameters](#service-search-params)
         * [Service Search Response](#service-search-response)
+    * [Retrieving All Revisions of a Service](#retrieving-all-revisions-of-a-service)
     * [Sorting Service Results](#sorting-service-results)
     * [Service Access Control](#service-access-control)
     * [Service association](#service-association)
@@ -3667,6 +3668,42 @@ Content-Type: application/vnd.nasa.cmr.umm_results+json;version=1.1; charset=utf
     }
   ]
 }
+```
+
+##### <a name="retrieving-all-revisions-of-a-service"></a> Retrieving All Revisions of a Service
+
+In addition to retrieving the latest revision for a service parameter search, it is possible to return all revisions, including tombstone (deletion marker) revisions, by passing in `all_revisions=true` with the URL parameters. The reference, JSON and UMM JSON response formats are supported for all revision searches. References to tombstone revisions do not include the `location` tag and include an additional tag, `deleted`, which always has content of "true".
+
+    curl "%CMR-ENDPOINT%/services?concept_id=S1200000010-PROV1&all_revisions=true&pretty=true"
+
+__Sample response__
+
+```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <results>
+        <hits>3</hits>
+        <took>3</took>
+        <references>
+            <reference>
+                <name>Service1</name>
+                <id>S1200000010-PROV1</id>
+                <location>http://localhost:3003/concepts/S1200000010-PROV1/3</location>
+                <revision-id>3</revision-id>
+            </reference>
+            <reference>
+                <name>Service1</name>
+                <id>S1200000010-PROV1</id>
+                <deleted>true</deleted>
+                <revision-id>2</revision-id>
+            </reference>
+            <reference>
+                <name>Service1</name>
+                <id>S1200000010-PROV1</id>
+                <location>http://localhost:3003/concepts/S1200000010-PROV1/1</location>
+                <revision-id>1</revision-id>
+            </reference>
+        </references>
+    </results>
 ```
 
 ##### <a name="sorting-service-results"></a> Sorting Service Results

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -157,7 +157,9 @@
 
 (defmethod common-esi/concept-type->index-info :service
   [context _ query]
-  {:index-name "1_services"
+  {:index-name (if (:all-revisions? query)
+                 "1_all_service_revisions"
+                 "1_services")
    :type-name "service"})
 
 (defn context->conn

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -362,6 +362,11 @@
   [{(q2e/query-field->elastic-field :name :variable) {:order "asc"}}
    {(q2e/query-field->elastic-field :provider :variable) {:order "asc"}}])
 
+(def service-all-revision-sub-sort-fields
+  "Defines the sub sort fields for an all revisions service search."
+  [{(q2e/query-field->elastic-field :concept-id :service) {:order "asc"}}
+   {(q2e/query-field->elastic-field :revision-id :service) {:order "desc"}}])
+
 (def service-latest-sub-sort-fields
   "This defines the sub sort fields for a latest revision service search."
   [{(q2e/query-field->elastic-field :name :service) {:order "asc"}}
@@ -403,7 +408,7 @@
         specified-sort (q2e/sort-keys->elastic-sort concept-type sort-keys)
         default-sort (q2e/sort-keys->elastic-sort concept-type (q/default-sort-keys concept-type))
         sub-sort-fields (if (:all-revisions? query)
-                          (all-revision-sub-sort-fields :service)
+                          service-all-revision-sub-sort-fields
                           service-latest-sub-sort-fields)]
     (concat (or specified-sort default-sort) sub-sort-fields)))
 

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -362,14 +362,14 @@
   [{(q2e/query-field->elastic-field :name :variable) {:order "asc"}}
    {(q2e/query-field->elastic-field :provider :variable) {:order "asc"}}])
 
+(def service-latest-sub-sort-fields
+  "This defines the sub sort fields for a latest revision service search."
+  [{(q2e/query-field->elastic-field :name :service) {:order "asc"}}
+   {(q2e/query-field->elastic-field :provider :service) {:order "asc"}}])
+
 (defmethod q2e/concept-type->sub-sort-fields :granule
   [_]
   [{(q2e/query-field->elastic-field :concept-seq-id :granule) {:order "asc"}}])
-
-(defmethod q2e/concept-type->sub-sort-fields :service
-  [_]
-  [{(q2e/query-field->elastic-field :name :service) {:order "asc"}}
-   {(q2e/query-field->elastic-field :provider :service) {:order "asc"}}])
 
 ;; Collections will default to the keyword sort if they have no sort specified and search by keywords
 (defmethod q2e/query->sort-params :collection
@@ -395,6 +395,16 @@
         sub-sort-fields (if (:all-revisions? query)
                           (all-revision-sub-sort-fields :variable)
                           variable-latest-sub-sort-fields)]
+    (concat (or specified-sort default-sort) sub-sort-fields)))
+
+(defmethod q2e/query->sort-params :service
+  [query]
+  (let [{:keys [concept-type sort-keys]} query
+        specified-sort (q2e/sort-keys->elastic-sort concept-type sort-keys)
+        default-sort (q2e/sort-keys->elastic-sort concept-type (q/default-sort-keys concept-type))
+        sub-sort-fields (if (:all-revisions? query)
+                          (all-revision-sub-sort-fields :service)
+                          service-latest-sub-sort-fields)]
     (concat (or specified-sort default-sort) sub-sort-fields)))
 
 (extend-protocol c2s/ComplexQueryToSimple

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -408,6 +408,13 @@
     [(dissoc params :all-revisions)
      (merge query-attribs {:all-revisions? (= "true" (:all-revisions params))})]))
 
+(defmethod common-params/parse-query-level-params :service
+  [concept-type params]
+  (let [[params query-attribs] (common-params/default-parse-query-level-params
+                                 :service params)]
+    [(dissoc params :all-revisions)
+     (merge query-attribs {:all-revisions? (= "true" (:all-revisions params))})]))
+
 (defn timeline-parameters->query
   "Converts parameters from a granule timeline request into a query."
   [context params]

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -79,7 +79,7 @@
   [_]
   (cpv/merge-params-config
     cpv/basic-params-config
-    {:single-value #{:keyword}
+    {:single-value #{:keyword :all-revisions}
      :multiple-value #{:name :provider :native-id :concept-id}
      :always-case-sensitive #{}
      :disallow-pattern #{}}))
@@ -206,6 +206,10 @@
   #{:echo-compatible :include-facets})
 
 (defmethod cpv/valid-query-level-params :variable
+  [_]
+  #{:all-revisions})
+
+(defmethod cpv/valid-query-level-params :service
   [_]
   #{:all-revisions})
 
@@ -732,7 +736,8 @@
    :tag cpv/common-validations
    :variable (concat cpv/common-validations
                      [boolean-value-validation])
-   :service cpv/common-validations})
+   :service (concat cpv/common-validations
+                    [boolean-value-validation])})
 
 (def standard-query-parameter-validations
   "A list of functions that can validate the query parameters passed in with an AQL or JSON search.

--- a/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
@@ -1,0 +1,123 @@
+(ns cmr.system-int-test.search.service.service-revisions-search-test
+  "Integration test for service all revisions search"
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :refer [are3]]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-json :as du]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.association-util :as au]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as metadata-db]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.service-util :as service]
+   [cmr.umm-spec.versioning :as umm-version]))
+
+(use-fixtures :each
+              (join-fixtures
+               [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
+                service/grant-all-service-fixture]))
+
+(deftest search-service-all-revisions
+  (let [token (e/login (s/context) "user1")
+        svc1-concept (service/make-service-concept {:native-id "SVC1"
+                                                   :Name "Service1"
+                                                   :provider-id "PROV1"})
+        svc2-concept (service/make-service-concept {:native-id "SVC2"
+                                                   :Name "Service2"
+                                                   :provider-id "PROV1"})
+        svc2-2-concept (service/make-service-concept {:native-id "SVC2"
+                                                      :Name "Service2-2"
+                                                      :provider-id "PROV1"})
+        svc3-concept (service/make-service-concept {:native-id "SVC3"
+                                                   :Name "Service1"
+                                                   :provider-id "PROV2"})
+        svc1-1 (service/ingest-service svc1-concept)
+        svc1-2-tombstone (merge (ingest/delete-concept
+                                 ; svc1-concept)
+                                 svc1-concept (service/token-opts token))
+                                svc1-concept
+                                {:deleted true
+                                 :user-id "user1"})
+        svc1-3 (service/ingest-service svc1-concept)
+        svc2-1 (service/ingest-service svc2-concept)
+        svc2-2 (service/ingest-service svc2-2-concept)
+        svc2-3-tombstone (merge (ingest/delete-concept
+                                 svc2-2-concept (service/token-opts token))
+                                svc2-2-concept
+                                {:deleted true
+                                 :user-id "user1"})
+        svc3 (service/ingest-service svc3-concept)]
+    (index/wait-until-indexed)
+    (testing "search services for all revisions"
+      (are3 [services params]
+        (do
+          ;; find references with all revisions
+          (service/assert-service-references-match
+           services (service/search params))
+          ;; search in JSON with all-revisions
+          (service/assert-service-search services (service/search params))
+          ;; search in UMM JSON with all-revisions
+          (du/assert-service-umm-jsons-match
+           umm-version/current-service-version services
+           (search/find-concepts-umm-json :service params))
+          )
+
+        "provider-id all-revisions=false"
+        [svc1-3]
+        {:provider-id "PROV1" :all-revisions false}
+
+        "provider-id all-revisions unspecified"
+        [svc1-3]
+        {:provider-id "PROV1"}
+
+        "provider-id all-revisions=true"
+        [svc1-1 svc1-2-tombstone svc1-3 svc2-1 svc2-2 svc2-3-tombstone]
+        {:provider-id "PROV1" :all-revisions true}
+
+        "native-id all-revisions=false"
+        [svc1-3]
+        {:native-id "svc1" :all-revisions false}
+
+        "native-id all-revisions unspecified"
+        [svc1-3]
+        {:native-id "svc1"}
+
+        "native-id all-revisions=true"
+        [svc1-1 svc1-2-tombstone svc1-3]
+        {:native-id "svc1" :all-revisions true}
+
+        ;; this test is across providers
+        "name all-revisions false"
+        [svc1-3 svc3]
+        {:name "Service1" :all-revisions false}
+
+        ;; this test is across providers
+        "name all-revisions unspecified"
+        [svc1-3 svc3]
+        {:name "Service1"}
+
+        "name all-revisions true"
+        [svc1-1 svc1-2-tombstone svc1-3 svc3]
+        {:name "Service1" :all-revisions true}
+
+        "name is updated on revision -- not found without all-revisions true"
+        []
+        {:name "Service2"}
+
+        "name is updated on revision -- found with all-revisions true"
+        [svc2-1]
+        {:name "Service2" :all-revisions true}
+
+        "all-revisions true"
+        [svc1-1 svc1-2-tombstone svc1-3 svc2-1 svc2-2 svc2-3-tombstone svc3]
+        {:all-revisions true}))))
+
+(deftest search-all-revisions-error-cases
+  (testing "service search with all_revisions bad value"
+    (let [{:keys [status errors]} (search/find-refs :service {:all-revisions "foo"})]
+      (is (= [400 ["Parameter all_revisions must take value of true, false, or unset, but was [foo]"]]
+             [status errors])))))

--- a/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
@@ -4,14 +4,10 @@
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
-   [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.umm-json :as du]
-   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as s]
-   [cmr.system-int-test.utils.association-util :as au]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
-   [cmr.system-int-test.utils.metadata-db-util :as metadata-db]
    [cmr.system-int-test.utils.search-util :as search]
    [cmr.system-int-test.utils.service-util :as service]
    [cmr.umm-spec.versioning :as umm-version]))
@@ -37,7 +33,6 @@
                                                    :provider-id "PROV2"})
         svc1-1 (service/ingest-service svc1-concept)
         svc1-2-tombstone (merge (ingest/delete-concept
-                                 ; svc1-concept)
                                  svc1-concept (service/token-opts token))
                                 svc1-concept
                                 {:deleted true

--- a/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_revisions_search_test.clj
@@ -20,17 +20,17 @@
 (deftest search-service-all-revisions
   (let [token (e/login (s/context) "user1")
         svc1-concept (service/make-service-concept {:native-id "SVC1"
-                                                   :Name "Service1"
-                                                   :provider-id "PROV1"})
+                                                    :Name "Service1"
+                                                    :provider-id "PROV1"})
         svc2-concept (service/make-service-concept {:native-id "SVC2"
-                                                   :Name "Service2"
-                                                   :provider-id "PROV1"})
+                                                    :Name "Service2"
+                                                    :provider-id "PROV1"})
         svc2-2-concept (service/make-service-concept {:native-id "SVC2"
                                                       :Name "Service2-2"
                                                       :provider-id "PROV1"})
         svc3-concept (service/make-service-concept {:native-id "SVC3"
-                                                   :Name "Service1"
-                                                   :provider-id "PROV2"})
+                                                    :Name "Service1"
+                                                    :provider-id "PROV2"})
         svc1-1 (service/ingest-service svc1-concept)
         svc1-2-tombstone (merge (ingest/delete-concept
                                  svc1-concept (service/token-opts token))
@@ -58,8 +58,7 @@
           ;; search in UMM JSON with all-revisions
           (du/assert-service-umm-jsons-match
            umm-version/current-service-version services
-           (search/find-concepts-umm-json :service params))
-          )
+           (search/find-concepts-umm-json :service params)))
 
         "provider-id all-revisions=false"
         [svc1-3]


### PR DESCRIPTION
![image](https://i.imgur.com/l828o8L.gif)

This is the third and final PR for this ticket. Summary so far: 

1) Preparation and cleanup (see PR #455)
2) Indexing (see PR #457)
3) Search (this PR)

This PR worked on the following:

 * [x] More work on indexer app
    * [x] In cmr.indexer.data.index-set, update #'service-mapping :service to include  concept-seq-id
 * [x] In cmr.search.data.elastic-search-index, update common-esi/concept-type->index-info :service to check :all-revisions
 * [x] In cmr.search.data.query-to-elastic:
    * [x] add a defmethod for q2e/query->sort-params :service
    * [x] remove q2e/concept-type->sub-sort-fields :service
    * [x] add a def for service-latest-sub-sort-fields
 * [x] In cmr.search.services.parameters.conversion, add defmethod for common-params/parse-query-level-params :variable
 * [x] In cmr.search.services.parameters.parameter-validation:
    * [x] add :all-revisions to cpv/params-config :service
    * [x] add defmethod for cpv/valid-query-level-params :service
    * [x] add boolean-value-validation to :service in parameter-validations def
 * [x] Add/update sys-int tests
 * [x] Update search docs

I'll push an update when the docs have been updated; it's ready for review now, though.