### PR TITLE
CMR-4768: Fixed gem install issue for collection-renderer-lib.

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -73,7 +73,8 @@
                             ~cmr-metadata-preview-repo
                             ~metadata-preview-commit]
             "clean-gems" ["shell" "rm" "-rf" ~gem-install-path]
-            "install!" ["do" ["clean-gems" "install-gems" "install" "clean"]]
+            "install" ["do" "clean-gems," "install-gems," "install," "clean"]
+            "install!" "install"
             "internal-install!" ["with-profile" "+internal-repos" "do"
                                   ["clean-gems" "install-gems" "install" "clean"]]
             ;; Alias to test2junit for consistency with lein-test-out


### PR DESCRIPTION
This turned out to be so much simpler than I thought once I started reading the content of the project.clj. Basically whatever you call from the CMR root, the same command will propagate to all the subdirectories, so `lein install!` at CMR root will trigger `lein clean` `lein install` and `lein clean` in all the subdirectories... 
* Fixed `lein install!` in project.clj under collection-renderer-lib by changing the syntax of the tasks.
* Added "install" alias in project.clj under collection-render-lib so that when `lein install!` is run under CMR root, gems can be installed for collection-render-lib.  The default install task for collection-renderer-lib subdirectory does not install the gems - this is actually true for the old branch too, it only creates empty gems directory if it doesn't exist. So the issue is not caused by the recent changes. 
* I'm keeping the "install!" alias in the project.clj under collection-renderer-lib just in case people still want to use it that way. Otherwise, it could be removed.