### PR TITLE
CMR-4752: Added functionality to reject all granule queries.

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1695,7 +1695,7 @@ __Sample response__
 ```
 
 ### <a name="granule-search-by-parameters"></a> Granule Search By Parameters
-Search performance for granule searches is significantly improved by including an identifier that limits the search to a certain collection or subset of collections. Examples of parameters which limit the scope of the search include collection_concept_id, short_name, entry_title, or provider.
+Search performance for granule searches is significantly improved by including an identifier that limits the search to a certain collection or subset of collections. Examples of parameters which limit the scope of the search include concept_id, collection_concept_id, short_name, version, entry_title, entry_id, provider or provider_id.
 
 #### <a name="find-all-granules"></a> Find all granules for a collection.
 
@@ -1765,7 +1765,7 @@ For granule additional attributes search, the default is searching for the attri
 #### <a name="g-spatial"></a> Find granules by Spatial
 The parameters used for searching granules by spatial are the same as the spatial parameters used in collections searches. (See under "Find collections by Spatial" for more details.)
 
-**Note:** The CMR does not permit spatial queries across all granules in all collections in order to provide fast search responses. Spatial granule queries must target a subset of the collections in the CMR using a condition like provider, concept_id (referencing one collection), short_name, or entry_title.
+**Note:** The CMR does not permit spatial queries across all granules in all collections in order to provide fast search responses. Spatial granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version, entry_title or entry_id.
 
 ##### <a name="g-polygon"></a> Polygon
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1695,7 +1695,7 @@ __Sample response__
 ```
 
 ### <a name="granule-search-by-parameters"></a> Granule Search By Parameters
-Search performance for granule searches is significantly improved by including an identifier that limits the search to a certain collection or subset of collections. Examples of parameters which limit the scope of the search include concept_id, collection_concept_id, short_name, version, entry_title, entry_id, provider or provider_id.
+The CMR does not permit queries across all granules in all collections in order to provide fast search responses. Granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title.
 
 #### <a name="find-all-granules"></a> Find all granules for a collection.
 
@@ -1764,8 +1764,6 @@ For granule additional attributes search, the default is searching for the attri
 
 #### <a name="g-spatial"></a> Find granules by Spatial
 The parameters used for searching granules by spatial are the same as the spatial parameters used in collections searches. (See under "Find collections by Spatial" for more details.)
-
-**Note:** The CMR does not permit spatial queries across all granules in all collections in order to provide fast search responses. Spatial granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version, entry_title or entry_id.
 
 ##### <a name="g-polygon"></a> Polygon
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1695,7 +1695,7 @@ __Sample response__
 ```
 
 ### <a name="granule-search-by-parameters"></a> Granule Search By Parameters
-The CMR does not permit queries across all granules in all collections in order to provide fast search responses. Granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title.
+**Note:** The CMR does not permit queries across all granules in all collections in order to provide fast search responses. Granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title.
 
 #### <a name="find-all-granules"></a> Find all granules for a collection.
 

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -23,6 +23,10 @@
   "Flag that indicates if we allow all granule queries."
   {:default true :type Boolean}) 
 
+(defconfig allow-all-gran-header
+  "This is the header that allows the operator to run the all granule queries." 
+  {:default "Must be changed"})
+
 (def supported-provider-holdings-mime-types
   "The mime types supported by search."
   #{mt/any
@@ -63,23 +67,23 @@
                       all-gran-validation/granule-limiting-search-fields)]
     (and (= :granule concept-type)
          (not (some? scroll-id))
-         (not (seq (util/remove-nil-keys constraints))))))
+         (empty? (util/remove-nil-keys constraints)))))
 
 (defn- handle-all-granule-params
   "Throws error if all granule params needs to be rejected."
   [headers]
   (when (and (= false (allow-all-granule-params-flag))
              (or (not (some? (get headers "client-id")))
-                 (not (some? (get headers "allow-all-gran-query")))))
+                 (not (some? (get headers (allow-all-gran-header))))))
     (svc-errors/throw-service-error
       :bad-request
       (str "The CMR does not currently allow querying across granules in all collections. "
           "To help optimize your search, you should limit your query using conditions that "
           "identify one or more collections, such as provider, provider_id, concept_id, "
           "collection_concept_id, short_name, version, entry_title or entry_id. "
-          "For further support request, please contact support@earthdata.nasa.gov, "
-          "or go to Client Developer Forum link: "
-          "https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers"))))
+          "Visit the CMR Client Developer Forum at "
+          " https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers "
+          "for more information, and for any questions please contact support@earthdata.nasa.gov."))))
  
 (defn- find-concepts-by-parameters
   "Invokes query service to parse the parameters query, find results, and

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -64,7 +64,6 @@
    Only granule queries that don't have scroll-id and don't contain certain collection constraints
    are all granule params."
   [concept-type params scroll-id]
-  (println "params are: " params)
   (let [constraints (select-keys 
                       params 
                       all-gran-validation/granule-limiting-search-fields)]

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -5,17 +5,23 @@
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
    [cmr.common.cache :as cache]
+   [cmr.common.config :refer [defconfig]]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as svc-errors]
+   [cmr.common.util :as util]
    [cmr.search.api.core :as core-api]
    [cmr.search.services.parameters.legacy-parameters :as lp]
    [cmr.search.services.query-service :as query-svc]
    [cmr.search.services.result-format-helper :as rfh]
+   [cmr.search.validators.all-granule-validation :as all-gran-validation]
    [compojure.core :refer :all]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants and Utility Functions
+(defconfig allow-all-granule-params-flag
+  "Flag that indicates if we allow all granule queries."
+  {:default true :type Boolean}) 
 
 (def supported-provider-holdings-mime-types
   "The mime types supported by search."
@@ -47,6 +53,34 @@
         results (query-svc/find-concepts-by-json-query ctx concept-type params json-query)]
     (core-api/search-response ctx results)))
 
+(defn- all-granule-params?
+  "Check if the params is all granule params based on the concept-type,query params and scroll-id.
+   Only granule queries that don't have scroll-id and don't contain certain collection constraints
+   are all granule params."
+  [concept-type params scroll-id]
+  (let [constraints (select-keys 
+                      params 
+                      all-gran-validation/granule-limiting-search-fields)]
+    (and (= :granule concept-type)
+         (not (some? scroll-id))
+         (not (seq (util/remove-nil-keys constraints))))))
+
+(defn- handle-all-granule-params
+  "Throws error if all granule params needs to be rejected."
+  [headers]
+  (when (and (= false (allow-all-granule-params-flag))
+             (or (not (some? (get headers "client-id")))
+                 (not (some? (get headers "allow-all-gran-query")))))
+    (svc-errors/throw-service-error
+      :bad-request
+      (str "The CMR does not currently allow querying across granules in all collections. "
+          "To help optimize your search, you should limit your query using conditions that "
+          "identify one or more collections, such as provider, provider_id, concept_id, "
+          "collection_concept_id, short_name, version, entry_title or entry_id. "
+          "For further support request, please contact support@earthdata.nasa.gov, "
+          "or go to Client Developer Forum link: "
+          "https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers"))))
+ 
 (defn- find-concepts-by-parameters
   "Invokes query service to parse the parameters query, find results, and
   return the response"
@@ -65,6 +99,8 @@
         search-params (if cached-search-params
                         cached-search-params
                         (lp/process-legacy-psa params))
+        _ (when (all-granule-params? concept-type params short-scroll-id)
+            (handle-all-granule-params headers)) 
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)    
       (core-api/search-response ctx results search-params)

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -81,7 +81,7 @@
       (str "The CMR does not currently allow querying across granules in all collections. "
           "To help optimize your search, you should limit your query using conditions that "
           "identify one or more collections, such as provider, provider_id, concept_id, "
-          "collection_concept_id, short_name, version, entry_title or entry_id. "
+          "collection_concept_id, short_name, version or entry_title. "
           "Visit the CMR Client Developer Forum at "
           " https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers "
           "for more information, and for any questions please contact support@earthdata.nasa.gov."))))

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -1,7 +1,6 @@
 (ns cmr.search.api.concepts-search
   "Defines the API for search-by-concept in the CMR."
   (:require
-   [camel-snake-kebab.core :as csk]
    [clojure.string :as string]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
@@ -25,7 +24,8 @@
   {:default true :type Boolean}) 
 
 (defconfig allow-all-gran-header
-  "This is the header that allows the operator to run the all granule queries." 
+  "This is the header that allows operators to run all granule queries when 
+   allow-all-granule-params-flag is set to false." 
   {:default "Must be changed"})
 
 (def supported-provider-holdings-mime-types

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -1,6 +1,7 @@
 (ns cmr.search.api.concepts-search
   "Defines the API for search-by-concept in the CMR."
   (:require
+   [camel-snake-kebab.core :as csk]
    [clojure.string :as string]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
@@ -63,7 +64,7 @@
    are all granule params."
   [concept-type params scroll-id]
   (let [constraints (select-keys 
-                      params 
+                      (util/map-keys->kebab-case params) 
                       all-gran-validation/granule-limiting-search-fields)]
     (and (= :granule concept-type)
          (not (some? scroll-id))
@@ -74,7 +75,7 @@
   [headers]
   (when (and (= false (allow-all-granule-params-flag))
              (or (not (some? (get headers "client-id")))
-                 (not (some? (get headers (allow-all-gran-header))))))
+                 (not (= "true" (get headers (allow-all-gran-header))))))
     (svc-errors/throw-service-error
       :bad-request
       (str "The CMR does not currently allow querying across granules in all collections. "

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -1,7 +1,6 @@
 (ns cmr.search.api.concepts-search
   "Defines the API for search-by-concept in the CMR."
   (:require
-   [clojure.set :as set]
    [clojure.string :as string]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]

--- a/search-app/src/cmr/search/validators/all_granule_validation.clj
+++ b/search-app/src/cmr/search/validators/all_granule_validation.clj
@@ -15,7 +15,7 @@
    :default 10000})
 
 (def granule-limiting-search-fields
-  #{:concept-id :provider :provider-id :short-name :entry-title :version :entry-id :collection-concept-id})
+  #{:concept-id :provider :provider-id :short-name :entry-title :version :collection-concept-id})
 
 (defn- granule-limiting-condition?
   "Returns true if the condition limits the query to granules within a set of collections."

--- a/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
@@ -66,11 +66,16 @@
         header6 {}
         params1 {:provider "PROV1"}
         params2 {:provider_id "PROV1"}
-        params3 {:concept_id "C1234-PROV1"}
+        params3 {:concept_id "G1234-PROV1"}
+        params3-alias {:echo_granule_id "G1234-PROV1"}
+        params3-collection {:concept_id "C1234-PROV1"}
         params4 {:collection_concept_id "C1234-PROV1"}
+        params4-alias {:echo_collection_id "C1234-PROV1"}
         params5 {:short_name "short name"}
+        params5-alias {:ShortName "short name"}
         params6 {:version "1.0"}
         params7 {:entry_title "testing"}
+        params7-alias {:dataset_id "testing"}
         params8 {:bounding-box "-10,-5,10,5"}
         params9 {"temporal[]" "2010-12-12T12:00:00Z,"}
         params10 {"page_num" 2 "page_size" 5}
@@ -87,10 +92,15 @@
         result7 (search/find-refs :granule params1)
         result8 (search/find-refs :granule params2)
         result9 (search/find-refs :granule params3)
+        result9-alias (search/find-refs :granule params3-alias)
+        result9-collection (search/find-refs :granule params3-collection)
         result10 (search/find-refs :granule params4)
+        result10-alias (search/find-refs :granule params4-alias)
         result11 (search/find-refs :granule params5)
+        result11-alias (search/find-refs :granule params5-alias)
         result12 (search/find-refs :granule params6)
         result13 (search/find-refs :granule params7)
+        result13-alias (search/find-refs :granule params7-alias)
         ;; Search without collection constraints, but with other spatial, temporal page_num, page_size are rejected.
         result14 (search/find-refs :granule params8)
         result15 (search/find-refs :granule params9)
@@ -117,13 +127,23 @@
     (is (= nil
            (:errors result9)))
     (is (= nil
+           (:errors result9-alias)))
+    (is (= nil
+           (:errors result9-collection)))
+    (is (= nil
            (:errors result10)))
     (is (= nil
+           (:errors result10-alias)))
+    (is (= nil
            (:errors result11)))
+    (is (= nil
+           (:errors result11-alias)))
     (is (= nil
            (:errors result12)))
     (is (= nil
            (:errors result13)))
+    (is (= nil
+           (:errors result13-alias)))
     (is (= [err-msg]
            (:errors result14)))
     (is (= [err-msg]

--- a/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
@@ -52,7 +52,7 @@
   (codec/url-encode (umm-s/set-coordinate-system :geodetic (apply polygon ords))))
 
 ;; Tests all granule search when allow-all-granule-params-flag is false
-;; Existing tests should test the cover the case when the flag is set to true. 
+;; Existing tests should cover the case when the flag is set to true. 
 (deftest allow-all-granule-params-flag-false-search-test 
   (let [saved-flag-value (concepts-search/allow-all-granule-params-flag)
         saved-header-value (concepts-search/allow-all-gran-header) 

--- a/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
@@ -64,18 +64,38 @@
         header4 {"allow-all-gran" true} 
         header5 {"allow-all-gran" false}
         header6 {}
-        params {:short-name "testing"} 
+        params1 {:provider "PROV1"}
+        params2 {:provider_id "PROV1"}
+        params3 {:concept_id "C1234-PROV1"}
+        params4 {:collection_concept_id "C1234-PROV1"}
+        params5 {:short_name "short name"}
+        params6 {:version "1.0"}
+        params7 {:entry_title "testing"}
+        params8 {:bounding-box "-10,-5,10,5"}
+        params9 {"temporal[]" "2010-12-12T12:00:00Z,"}
+        params10 {"page_num" 2 "page_size" 5}
         ;; With allow-all-granule-params-flag being set to false, all granule query is allowed
         ;; only when client-id is present and allow-all-gran header is set to true. 
         result1 (search/find-refs :granule {} {:headers header1})
+        ;; Without the proper headers and collection constriants, these should be rejected
         result2 (search/find-refs :granule {} {:headers header2})
         result3 (search/find-refs :granule {} {:headers header3})
         result4 (search/find-refs :granule {} {:headers header4})
         result5 (search/find-refs :granule {} {:headers header5})
         result6 (search/find-refs :granule {} {:headers header6})
-        ;; search with collection constraint should be allowed.
-        result7 (search/find-refs :granule params)
-        err-msg "The CMR does not currently allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version, entry_title or entry_id. Visit the CMR Client Developer Forum at  https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers for more information, and for any questions please contact support@earthdata.nasa.gov."
+        ;; Search with collection constraints should be allowed.
+        result7 (search/find-refs :granule params1)
+        result8 (search/find-refs :granule params2)
+        result9 (search/find-refs :granule params3)
+        result10 (search/find-refs :granule params4)
+        result11 (search/find-refs :granule params5)
+        result12 (search/find-refs :granule params6)
+        result13 (search/find-refs :granule params7)
+        ;; Search without collection constraints, but with other spatial, temporal page_num, page_size are rejected.
+        result14 (search/find-refs :granule params8)
+        result15 (search/find-refs :granule params9)
+        result16 (search/find-refs :granule params10)
+        err-msg "The CMR does not currently allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title. Visit the CMR Client Developer Forum at  https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers for more information, and for any questions please contact support@earthdata.nasa.gov."
         _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! ~saved-flag-value))
         _ (side/eval-form `(concepts-search/set-allow-all-gran-header! ~saved-header-value))]
     (is (= nil 
@@ -89,9 +109,27 @@
     (is (= [err-msg]
            (:errors result5)))
     (is (= [err-msg]
-           (:errors result5)))
-    (is (= nil 
-           (:errors result7)))))
+           (:errors result6)))
+    (is (= nil
+           (:errors result7)))
+    (is (= nil
+           (:errors result8)))
+    (is (= nil
+           (:errors result9)))
+    (is (= nil
+           (:errors result10)))
+    (is (= nil
+           (:errors result11)))
+    (is (= nil
+           (:errors result12)))
+    (is (= nil
+           (:errors result13)))
+    (is (= [err-msg]
+           (:errors result14)))
+    (is (= [err-msg]
+           (:errors result15)))
+    (is (= [err-msg]
+           (:errors result16)))))
 
 ;; Tests search failure conditions
 (deftest spatial-search-validation-test


### PR DESCRIPTION
1. Added defconfig allow-all-granule-params-flag, when set to true, all granule queries are allowed. The default value is set to true because many existing tests need it to pass. Need to write in the release note that we need to set the environment variable to false. 
2. Added defconfig allow-all-gran-header, which sets the name for the header(it's done this way to hide the info from general public), when this header is set to true in the request and the client-id is present, operators are allowed to perform all granule queries, regardless of the value of allow-all-granule-params-flag. 
3. Added checking before the query is submitted to see if it's a all granule request, if so, based on the values of the first two steps, either allow it or reject it.
4. Added integration tests.