### PR TITLE
Cmr 4752 reject all granule parameters

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1695,7 +1695,7 @@ __Sample response__
 ```
 
 ### <a name="granule-search-by-parameters"></a> Granule Search By Parameters
-Search performance for granule searches is significantly improved by including an identifier that limits the search to a certain collection or subset of collections. Examples of parameters which limit the scope of the search include collection_concept_id, short_name, entry_title, or provider.
+**Note:** The CMR does not permit queries across all granules in all collections in order to provide fast search responses. Granule queries must target a subset of the collections in the CMR using a condition like provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title.
 
 #### <a name="find-all-granules"></a> Find all granules for a collection.
 
@@ -1764,8 +1764,6 @@ For granule additional attributes search, the default is searching for the attri
 
 #### <a name="g-spatial"></a> Find granules by Spatial
 The parameters used for searching granules by spatial are the same as the spatial parameters used in collections searches. (See under "Find collections by Spatial" for more details.)
-
-**Note:** The CMR does not permit spatial queries across all granules in all collections in order to provide fast search responses. Spatial granule queries must target a subset of the collections in the CMR using a condition like provider, concept_id (referencing one collection), short_name, or entry_title.
 
 ##### <a name="g-polygon"></a> Polygon
 

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -9,14 +9,24 @@
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as svc-errors]
+   [cmr.common.util :as util]
    [cmr.search.api.core :as core-api]
    [cmr.search.services.parameters.legacy-parameters :as lp]
    [cmr.search.services.query-service :as query-svc]
    [cmr.search.services.result-format-helper :as rfh]
+   [cmr.search.validators.all-granule-validation :as all-gran-validation]
    [compojure.core :refer :all]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants and Utility Functions
+(defconfig allow-all-granule-params-flag
+  "Flag that indicates if we allow all granule queries."
+  {:default true :type Boolean}) 
+
+(defconfig allow-all-gran-header
+  "This is the header that allows operators to run all granule queries when 
+   allow-all-granule-params-flag is set to false."
+  {:default "Must be changed"})
 
 (def supported-provider-holdings-mime-types
   "The mime types supported by search."
@@ -70,6 +80,73 @@
       :too-many-requests
       "Excessive query rate. Please contact support@earthdata.nasa.gov.")))
 
+(defn- reject-all-granule-query?
+  "Returns true if the all granule query will be rejected."
+  [headers]
+  (and (= false (allow-all-granule-params-flag))
+       (or (not (some? (get headers "client-id")))
+           (not (= "true" (get headers (allow-all-gran-header)))))))
+
+(defn- handle-all-granule-params
+  "Throws error if all granule params needs to be rejected."
+  [headers]
+  (let [err-msg (str "The CMR does not currently allow querying across granules in all "
+                     "collections. To help optimize your search, you should limit your "
+                     "query using conditions that identify one or more collections, "
+                     "such as provider, provider_id, concept_id, collection_concept_id, "
+                     "short_name, version or entry_title. Visit the CMR Client Developer "
+                     "Forum at https://wiki.earthdata.nasa.gov/display/CMR/"
+                     "Granule+Queries+Now+Require+Collection+Identifiers for more "
+                     "information, and for any questions please contact "
+                     "support@earthdata.nasa.gov.")]  
+    (when (reject-all-granule-query? headers)
+      (svc-errors/throw-service-error :bad-request err-msg))))
+
+(defn- illegal-concept-id-in-granule-query?
+  "Check to see if any concept ids are not starting with G and C."
+  [concept-id-param]
+  (when (some? concept-id-param)
+    (let [concept-id-param-list (if (sequential? concept-id-param)
+                                  (remove #(= "" %) concept-id-param)
+                                  [concept-id-param])]
+      (some #(not (re-find #"^[GC]" %)) concept-id-param-list))))
+
+(defn function-for-remove-map-keys
+  "This function is used for remove-map-keys function.
+   The keys will be removed if their values are empty strings, or if it's sequential and
+   only contain empty strings.
+   Note:  When you pass a parameter with a = sign, but without a value,
+   it becomes an empty string in the params."
+  [v]
+  (or (= "" v)
+      (when (sequential? v)
+        (= [] (remove #(= "" %) v)))))
+
+(defn- all-granule-params?
+  "Returns true if it's a all granule query params.
+   Note: parameters with scroll-id don't need to be checked because it inherits the search
+   parameters from the original query, which would have been handled already." 
+  [scroll-id coll-constraints]
+  (and (not (some? scroll-id))
+       (empty? coll-constraints)))
+
+(defn- handle-granule-search-params
+  "Check the params when it is a granule search query."
+  [headers concept-type params scroll-id]
+  (when (= :granule concept-type)
+    ;; Check to see if any concept-id(s) are not starting with C or G. If so, bad request.
+    ;; otherwise, check to see if it's all-granule-params?, if so, handle it.
+    (let [params (lp/replace-parameter-aliases (util/map-keys->kebab-case params))
+          params (util/remove-map-keys function-for-remove-map-keys params)
+          constraints (select-keys params all-gran-validation/granule-limiting-search-fields)
+          concept-id-param (:concept-id constraints)
+          illegal-concept-id-msg (str "Granule query concept_id param [" concept-id-param
+                                      "] contains concept ids not starting with G or C.")]
+      (if (illegal-concept-id-in-granule-query? concept-id-param)
+        (svc-errors/throw-service-error :bad-request illegal-concept-id-msg) 
+        (when (all-granule-params? scroll-id constraints) 
+            (handle-all-granule-params headers))))))
+
 (defn- find-concepts-by-parameters
   "Invokes query service to parse the parameters query, find results, and
   return the response"
@@ -89,6 +166,7 @@
         search-params (if cached-search-params
                         cached-search-params
                         (lp/process-legacy-psa params))
+        _ (handle-granule-search-params headers concept-type search-params short-scroll-id)
         results (query-svc/find-concepts-by-parameters ctx concept-type search-params)]
     (if (:scroll-id results)
       (core-api/search-response ctx results search-params)

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -83,7 +83,7 @@
 (defn- reject-all-granule-query?
   "Returns true if the all granule query will be rejected."
   [headers]
-  (and (= false (allow-all-granule-params-flag))
+  (and (false? (allow-all-granule-params-flag))
        (or (not (some? (get headers "client-id")))
            (not (= "true" (get headers (allow-all-gran-header)))))))
 

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -111,8 +111,8 @@
                                   [concept-id-param])]
       (some #(not (re-find #"^[GC]" %)) concept-id-param-list))))
 
-(defn function-for-remove-map-keys
-  "This function is used for remove-map-keys function.
+(defn empty-string-values? 
+  "This function is used by remove-map-keys function.
    The keys will be removed if their values are empty strings, or if it's sequential and
    only contain empty strings.
    Note:  When you pass a parameter without = sign, it is considered a nil value and get  
@@ -138,7 +138,7 @@
     ;; Check to see if any concept-id(s) are not starting with C or G. If so, bad request.
     ;; otherwise, check to see if it's all-granule-params?, if so, handle it.
     (let [params (lp/replace-parameter-aliases (util/map-keys->kebab-case params))
-          params (util/remove-map-keys function-for-remove-map-keys params)
+          params (util/remove-map-keys empty-string-values? params)
           constraints (select-keys params all-gran-validation/granule-limiting-search-fields)
           concept-id-param (:concept-id constraints)
           illegal-concept-id-msg (str "Granule query concept_id param [" concept-id-param

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -115,8 +115,9 @@
   "This function is used for remove-map-keys function.
    The keys will be removed if their values are empty strings, or if it's sequential and
    only contain empty strings.
-   Note:  When you pass a parameter with a = sign, but without a value,
-   it becomes an empty string in the params."
+   Note:  When you pass a parameter without = sign, it is considered a nil value and get  
+   filtered out before getting to the params; with the = sign, no value, it becomes empty 
+   string."
   [v]
   (or (= "" v)
       (when (sequential? v)

--- a/search-app/src/cmr/search/validators/all_granule_validation.clj
+++ b/search-app/src/cmr/search/validators/all_granule_validation.clj
@@ -15,7 +15,7 @@
    :default 10000})
 
 (def granule-limiting-search-fields
-  #{:concept-id :provider :provider-id :short-name :entry-title :version :entry-id :collection-concept-id})
+  #{:concept-id :provider :provider-id :short-name :entry-title :version :collection-concept-id})
 
 (defn- granule-limiting-condition?
   "Returns true if the condition limits the query to granules within a set of collections."

--- a/system-int-test/test/cmr/system_int_test/search/all_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/all_granule_search_test.clj
@@ -1,0 +1,132 @@
+(ns cmr.system-int-test.search.all-granule-search-test
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common-app.test.side-api :as side]
+   [cmr.search.api.concepts-search :as concepts-search]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+;; Tests all granule search when allow-all-granule-params-flag is false
+;; Existing tests should cover the case when the flag is set to true. 
+(deftest allow-all-granule-params-flag-false-search-test 
+  (let [saved-flag-value (concepts-search/allow-all-granule-params-flag)
+        saved-header-value (concepts-search/allow-all-gran-header) 
+        _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! false))
+        _ (side/eval-form `(concepts-search/set-allow-all-gran-header! "allow-all-gran"))
+        header1 {"client-id" "testing", "allow-all-gran" true} 
+        header2 {"client-id" "testing", "allow-all-gran" false} 
+        header3 {"client-id" "testing"}
+        header4 {"allow-all-gran" true} 
+        header5 {"allow-all-gran" false}
+        header6 {}
+        params1 {:provider "PROV1"}
+        params2 {:provider_id "PROV1"}
+        params3 {:concept_id "G1234-PROV1"}
+        params3-alias {:echo_granule_id "G1234-PROV1"}
+        params3-collection {:concept_id "C1234-PROV1"}
+        params3-service {:concept_id "S1234-PROV1"}
+        params3-variable {:concept_id "V1234-PROV1"}
+        params3-empty-array {:concept_id ["" ""]}
+        params3-array-with-service {:concept_id ["" "S1234-PROV1"]}
+        params3-empty {:concept_id ""}
+        params4 {:collection_concept_id "C1234-PROV1"}
+        params4-alias {:echo_collection_id "C1234-PROV1"}
+        params5 {:short_name "short name"}
+        params5-alias {:shortName "short name"}
+        params6 {:version "1.0"}
+        params7 {:entry_title "testing"}
+        params7-alias {:dataset_id "testing"}
+        params8 {:bounding-box "-10,-5,10,5"}
+        params9 {"temporal[]" "2010-12-12T12:00:00Z,"}
+        params10 {"page_num" 2 "page_size" 5}
+        ;; With allow-all-granule-params-flag being set to false, all granule query is allowed
+        ;; only when client-id is present and allow-all-gran header is set to true. 
+        result1 (search/find-refs :granule {} {:headers header1})
+        ;; Without the proper headers and collection constriants, these should be rejected
+        result2 (search/find-refs :granule {} {:headers header2})
+        result3 (search/find-refs :granule {} {:headers header3})
+        result4 (search/find-refs :granule {} {:headers header4})
+        result5 (search/find-refs :granule {} {:headers header5})
+        result6 (search/find-refs :granule {} {:headers header6})
+        ;; Search with collection constraints should be allowed.
+        result7 (search/find-refs :granule params1)
+        result8 (search/find-refs :granule params2)
+        result9 (search/find-refs :granule params3)
+        result9-alias (search/find-refs :granule params3-alias)
+        result9-collection (search/find-refs :granule params3-collection)
+        ;; except for when service/variable concept ids are passed in.
+        ;; we only support granule and collection concept ids for the granule search.
+        result9-service (search/find-refs :granule params3-service)
+        result9-variable (search/find-refs :granule params3-variable)
+        result9-empty-array (search/find-refs :granule params3-empty-array)
+        result9-array-with-service (search/find-refs :granule params3-array-with-service)
+        result9-empty (search/find-refs :granule params3-empty)
+        result10 (search/find-refs :granule params4)
+        result10-alias (search/find-refs :granule params4-alias)
+        result11 (search/find-refs :granule params5)
+        result11-alias (search/find-refs :granule params5-alias)
+        result12 (search/find-refs :granule params6)
+        result13 (search/find-refs :granule params7)
+        result13-alias (search/find-refs :granule params7-alias)
+        ;; Search without collection constraints, but with other spatial, temporal page_num, page_size are rejected.
+        result14 (search/find-refs :granule params8)
+        result15 (search/find-refs :granule params9)
+        result16 (search/find-refs :granule params10)
+        err-msg "The CMR does not currently allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title. Visit the CMR Client Developer Forum at https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers for more information, and for any questions please contact support@earthdata.nasa.gov." 
+        err-msg-illegal-service-id "Granule query concept_id param [S1234-PROV1] contains concept ids not starting with G or C." 
+        err-msg-illegal-variable-id "Granule query concept_id param [V1234-PROV1] contains concept ids not starting with G or C." 
+        err-msg-illegal-service-id-in-array "Granule query concept_id param [[\"\" \"S1234-PROV1\"]] contains concept ids not starting with G or C." 
+        _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! ~saved-flag-value))
+        _ (side/eval-form `(concepts-search/set-allow-all-gran-header! ~saved-header-value))]
+    (is (= nil 
+           (:errors result1)))
+    (is (= [err-msg]
+           (:errors result2)))
+    (is (= [err-msg]
+           (:errors result3)))
+    (is (= [err-msg]
+           (:errors result4)))
+    (is (= [err-msg]
+           (:errors result5)))
+    (is (= [err-msg]
+           (:errors result6)))
+    (is (= nil
+           (:errors result7)))
+    (is (= nil
+           (:errors result8)))
+    (is (= nil
+           (:errors result9)))
+    (is (= nil
+           (:errors result9-alias)))
+    (is (= nil
+           (:errors result9-collection)))
+    (is (= [err-msg-illegal-service-id] 
+           (:errors result9-service)))
+    (is (= [err-msg-illegal-variable-id] 
+           (:errors result9-variable)))
+    (is (= [err-msg]
+           (:errors result9-empty-array)))
+    (is (= [err-msg-illegal-service-id-in-array]
+           (:errors result9-array-with-service)))
+    (is (= [err-msg]
+           (:errors result9-empty))) 
+    (is (= nil
+           (:errors result10)))
+    (is (= nil
+           (:errors result10-alias)))
+    (is (= nil
+           (:errors result11)))
+    (is (= nil
+           (:errors result11-alias)))
+    (is (= nil
+           (:errors result12)))
+    (is (= nil
+           (:errors result13)))
+    (is (= nil
+           (:errors result13-alias)))
+    (is (= [err-msg]
+           (:errors result14)))
+    (is (= [err-msg]
+           (:errors result15)))
+    (is (= [err-msg]
+           (:errors result16)))))
+

--- a/system-int-test/test/cmr/system_int_test/search/all_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/all_granule_search_test.clj
@@ -28,6 +28,7 @@
         params3-empty-array {:concept_id ["" ""]}
         params3-array-with-service {:concept_id ["" "S1234-PROV1"]}
         params3-empty {:concept_id ""}
+        params3-number {:concept_id 1}
         params4 {:collection_concept_id "C1234-PROV1"}
         params4-alias {:echo_collection_id "C1234-PROV1"}
         params5 {:short_name "short name"}
@@ -60,6 +61,7 @@
         result9-empty-array (search/find-refs :granule params3-empty-array)
         result9-array-with-service (search/find-refs :granule params3-array-with-service)
         result9-empty (search/find-refs :granule params3-empty)
+        result9-number (search/find-refs :granule params3-number)
         result10 (search/find-refs :granule params4)
         result10-alias (search/find-refs :granule params4-alias)
         result11 (search/find-refs :granule params5)
@@ -72,9 +74,10 @@
         result15 (search/find-refs :granule params9)
         result16 (search/find-refs :granule params10)
         err-msg "The CMR does not currently allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title. Visit the CMR Client Developer Forum at https://wiki.earthdata.nasa.gov/display/CMR/Granule+Queries+Now+Require+Collection+Identifiers for more information, and for any questions please contact support@earthdata.nasa.gov." 
-        err-msg-illegal-service-id "Granule query concept_id param [S1234-PROV1] contains concept ids not starting with G or C." 
-        err-msg-illegal-variable-id "Granule query concept_id param [V1234-PROV1] contains concept ids not starting with G or C." 
-        err-msg-illegal-service-id-in-array "Granule query concept_id param [[\"\" \"S1234-PROV1\"]] contains concept ids not starting with G or C." 
+        err-msg-illegal-service-id "Invalid concept_id [S1234-PROV1]. For granule queries concept_id must be either a granule or collection concept ID." 
+        err-msg-illegal-variable-id "Invalid concept_id [V1234-PROV1]. For granule queries concept_id must be either a granule or collection concept ID." 
+        err-msg-illegal-service-id-in-array "Invalid concept_id [[\"\" \"S1234-PROV1\"]]. For granule queries concept_id must be either a granule or collection concept ID." 
+        err-msg-illegal-number-id "Invalid concept_id [1]. For granule queries concept_id must be either a granule or collection concept ID." 
         _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! ~saved-flag-value))
         _ (side/eval-form `(concepts-search/set-allow-all-gran-header! ~saved-header-value))]
     (is (= nil 
@@ -108,7 +111,9 @@
     (is (= [err-msg-illegal-service-id-in-array]
            (:errors result9-array-with-service)))
     (is (= [err-msg]
-           (:errors result9-empty))) 
+           (:errors result9-empty)))
+    (is (= [err-msg-illegal-number-id]
+           (:errors result9-number))) 
     (is (= nil
            (:errors result10)))
     (is (= nil


### PR DESCRIPTION
For the most part, this has been reviewed and approved by Chris. Started a new branch for the following reasons:
1. Reorganized the code into smaller modules.
2. Added a validation step to reject queries with concept_id not being a granule or collection concept id.
This is an existing bug that will result in a true all granule query.
3. Added code and tests to handle the situations when parameter is passed in with a equal sign but missing a value, in both the single parameter case, and array of same parameter case.
4. Pulled the integration test out of the granule_spatial_test and created its own test.
5. Merge conflict.

Below is the original changes for the ticket:
1. Added defconfig allow-all-granule-params-flag, when set to true, all granule queries are allowed. The default value is set to true because many existing tests need it to pass. Need to write in the release note that we need to set the environment variable to false.
2. Added defconfig allow-all-gran-header, which sets the name for the header(it's done this way to hide the info from general public), when this header is set to true in the request and the client-id is present, operators are allowed to perform all granule queries, regardless of the value of allow-all-granule-params-flag. We need to set the environment variable for the header as well.
3. Added checking before the query is submitted to see if it's a all granule request, if so, based on the values of the first two steps, either allow it or reject it.
4. Added integration tests.
5. Updated the API doc.