### PR TITLE
CMR-4650: Change JSON schema for DOI to support two different definitions

### DIFF
--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
@@ -509,22 +509,42 @@
       }
     },
     "DoiType": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used. While this element is not required, NASA metadata providers are strongly encouraged to include DOI and DOI Authority for their collections.",
-      "properties": {
-        "Authority": {
-          "description": "Authority is the registry that registers the DOI. For ESDIS records the value of http://dx.doi.org should be used.",
-          "$ref": "#/definitions/AuthorityType"
+      "oneOf": [{
+        "type": "object",
+        "additionalProperties": false,
+        "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used. While this element is not required, NASA metadata providers are strongly encouraged to include DOI and DOI Authority for their collections. For those that want to specify that a DOI is not applicable for their record use the second option.",
+        "properties": {
+          "Authority": {
+            "description": "The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used.",
+            "$ref": "#/definitions/AuthorityType"
+          },
+          "DOI": {
+            "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection.  Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
         },
-        "DOI": {
-          "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used. While this element is not required, NASA metadata providers are strongly encouraged to include DOI and DOI Authority for their collections.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1024
-        }
-      },
-      "required": ["DOI"]
+        "required": ["DOI"]
+      }, {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "This element stores the fact that the DOI (Digital Object Identifier) is not applicable.",
+        "properties": {
+          "MissingReason": {
+            "description": "This element stores the fact that a DOI (Digital Object Identifier) is not applicable for this record.",
+            "type": "string",
+            "enum": ["Not Applicable"]
+          },
+          "Explanation": {
+            "description": "This element describes the reason the DOI is not applicable.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "required": ["MissingReason"]
+      }]
     },
     "AccessConstraintsType": {
       "type": "object",

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -307,6 +307,13 @@
        " value: "
        val))
 
+(defn- top-level-one-of-definition
+  "Returns true if the definition is a oneOf definition with multiple potential object definitions."
+  [type-definition]
+  (and (:oneOf type-definition)
+       (seq (filter #(= "object" (:type %))
+                    (:oneOf type-definition)))))
+
 (defn coerce
   "Returns x coerced according to a JSON schema type type definition."
   ([schema x]
@@ -314,7 +321,10 @@
   ([schema type-definition x]
    (let [type-name (or (-> type-definition :$ref :type-name)
                        (:root schema))
-         [schema type-definition] (resolve-$refs [schema type-definition])]
+         [schema type-definition] (resolve-$refs [schema type-definition])
+         type-definition (if (top-level-one-of-definition type-definition)
+                           (assoc type-definition :type "oneOf")
+                           type-definition)]
      (case (:type type-definition)
 
        "string"  (case (:format type-definition)
@@ -336,6 +346,9 @@
                    (= "true" x)
                    (boolean x))
 
+       ;; Note that this would not support creating records for any fields within a oneOf that
+       ;; could also potentially be records. Those would just stay as maps instead of records.
+       "oneOf" ((record-ctor schema type-name) x)
 
        ;; The most important job of this function:
        "object"  (let [ctor (record-ctor schema type-name)

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -51,6 +51,8 @@
         ;; This is needed for a nested properties def in an allOf
         (:properties type-def) "object"
 
+        (:oneOf type-def) "oneOf"
+
         ;; This will trigger an error
         :else
         (throw (Exception. (str "Unable to resolve ref on " (pr-str type-def)))))))
@@ -104,6 +106,10 @@
 (defmethod resolve-ref "array"
   [schema-name type-def]
   (update-in type-def [:items] (partial resolve-ref schema-name)))
+
+(defmethod resolve-ref "oneOf"
+  [schema-name type-def]
+  (resolve-one-of schema-name type-def))
 
 ;;; No resolution
 

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_common_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_common_models.clj
@@ -277,27 +277,24 @@
   ])
 (record-pretty-printer/enable-record-pretty-printing ResourceCitationType)
 
-;; This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The
-;; values should start with the directory indicator which in ESDIS' case is 10. If the DOI was
-;; registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not
-;; stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for
-;; creating the DOI is described in the Authority element. For ESDIS records the value of
-;; https://doi.org/ should be used. While this element is not required, NASA metadata providers are
-;; strongly encouraged to include DOI and DOI Authority for their collections.
 (defrecord DoiType
   [
-   ;; Authority is the registry that registers the DOI. For ESDIS records the value of
-   ;; http://dx.doi.org should be used.
+   ;; The DOI organization that is responsible for creating the DOI is described in the Authority
+   ;; element. For ESDIS records the value of https://doi.org/ should be used.
    Authority
 
    ;; This element stores the DOI (Digital Object Identifier) that identifies the collection. Note:
    ;; The values should start with the directory indicator which in ESDIS' case is 10. If the DOI
    ;; was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is
-   ;; not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible
-   ;; for creating the DOI is described in the Authority element. For ESDIS records the value of
-   ;; https://doi.org/ should be used. While this element is not required, NASA metadata providers
-   ;; are strongly encouraged to include DOI and DOI Authority for their collections.
+   ;; not stored here; it should be stored as a RelatedURL.
    DOI
+
+   ;; This element stores the fact that a DOI (Digital Object Identifier) is not applicable for this
+   ;; record.
+   MissingReason
+
+   ;; This element describes the reason the DOI is not applicable.
+   Explanation
   ])
 (record-pretty-printer/enable-record-pretty-printing DoiType)
 

--- a/umm-spec-lib/src/cmr/umm_spec/record_generator.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/record_generator.clj
@@ -111,7 +111,7 @@
   "Converts a JSON Schema definition into a record description if it's appropriate to have a record
   for it. Returns nil otherwise."
   [type-name type-def]
-  (when (= "object" (:type type-def))
+  (when (or (= "object" (:type type-def)) (:oneOf type-def))
     (let [merged-properties (apply merge (:properties type-def)
                                    (map :properties (:oneOf type-def)))]
       {:record-name (name type-name)
@@ -197,5 +197,3 @@
   (generated-file-warning js/umm-c-schema-file)
 
   )
-
-

--- a/umm-spec-lib/src/cmr/umm_spec/record_generator.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/record_generator.clj
@@ -30,7 +30,6 @@
         find-var
         var-get)))
 
-
 (def ^:private MAX_LINE_SIZE
   "Defines the maximum line size for Clojure files."
   100)

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -259,6 +259,13 @@
       [(cmn/map->ResourceCitationType
         {:OtherCitationDetails other-citation-details})])))
 
+(defn- expected-doi
+  "Updates the expected DOI for ECHO10."
+  [doi]
+  (let [updated-doi (util/remove-nil-keys (dissoc doi :MissingReason :Explanation))]
+    (when (seq updated-doi)
+      updated-doi)))
+
 (defn umm-expected-conversion-echo10
   [umm-coll]
   (-> umm-coll
@@ -300,4 +307,5 @@
       (assoc :MetadataDates (expected-metadata-dates umm-coll))
       (update :ScienceKeywords expected-science-keywords)
       (update :AccessConstraints conversion-util/expected-access-constraints)
-      (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))))
+      (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
+      (update :DOI expected-doi)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -264,7 +264,7 @@
   [doi]
   (let [updated-doi (util/remove-nil-keys (dissoc doi :MissingReason :Explanation))]
     (when (seq updated-doi)
-      updated-doi)))
+      (cmn/map->DoiType updated-doi))))
 
 (defn umm-expected-conversion-echo10
   [umm-coll]

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
@@ -138,17 +138,6 @@
     pub-ref)
    pub-ref)))
 
-(defn dif-publication-reference
-  "Returns the expected value of a parsed DIF 9 or DIF10 publication reference"
-  [pub-ref]
-  (-> pub-ref
-      (update-in [:DOI] (fn [doi]
-                          (util/remove-nil-keys
-                           (dissoc doi :Authority :MissingReason :Explanation))))
-      (update :ISBN su/format-isbn)
-      (update :OnlineResource dif-online-resource)
-      check-nil-pub-ref))
-
 (defn expected-dif-url-type
  "Perform a roundtrip of the URLContentType, Type, and Subtype to get the values back.
  Returns {:URLContentType 'X' :Type 'Y' :Subtype 'Z'}"
@@ -230,4 +219,15 @@
 (defn expected-dif-doi
   "DIF9 and DIF10 do not have several DOI fields so remove them."
   [doi]
-  (dissoc doi :Authority :MissingReason :Explanation))
+  (let [updated-doi (util/remove-nil-keys (dissoc doi :Authority :MissingReason :Explanation))]
+    (when (seq updated-doi)
+      updated-doi)))
+
+(defn dif-publication-reference
+  "Returns the expected value of a parsed DIF 9 or DIF10 publication reference"
+  [pub-ref]
+  (-> pub-ref
+      (update-in [:DOI] expected-dif-doi)
+      (update :ISBN su/format-isbn)
+      (update :OnlineResource dif-online-resource)
+      check-nil-pub-ref))

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
@@ -219,9 +219,10 @@
 (defn expected-dif-doi
   "DIF9 and DIF10 do not have several DOI fields so remove them."
   [doi]
-  (let [updated-doi (util/remove-nil-keys (dissoc doi :Authority :MissingReason :Explanation))]
+  (let [updated-doi (util/remove-nil-keys
+                     (dissoc doi :Authority :MissingReason :Explanation))]
     (when (seq updated-doi)
-      updated-doi)))
+      (cmn/map->DoiType updated-doi))))
 
 (defn dif-publication-reference
   "Returns the expected value of a parsed DIF 9 or DIF10 publication reference"

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
@@ -15,7 +15,7 @@
   [cmr.umm-spec.util :as su]))
 
 (def coll-progress-enum-list
-  "The enum list for CollectionProgress in v1.10. that could be converted from 
+  "The enum list for CollectionProgress in v1.10. that could be converted from
    all formats except for DIF10"
   (set ["PLANNED" "ACTIVE" "COMPLETE" "NOT PROVIDED" "NOT APPLICABLE"]))
 
@@ -139,10 +139,12 @@
    pub-ref)))
 
 (defn dif-publication-reference
-  "Returns the expected value of a parsed DIF 9 publication reference"
+  "Returns the expected value of a parsed DIF 9 or DIF10 publication reference"
   [pub-ref]
   (-> pub-ref
-      (update-in [:DOI] (fn [doi] (when doi (assoc doi :Authority nil))))
+      (update-in [:DOI] (fn [doi]
+                          (util/remove-nil-keys
+                           (dissoc doi :Authority :MissingReason :Explanation))))
       (update :ISBN su/format-isbn)
       (update :OnlineResource dif-online-resource)
       check-nil-pub-ref))
@@ -226,8 +228,6 @@
       (dif-util/dif-language->umm-language dif-language))))
 
 (defn expected-dif-doi
-  "dif9 and dif10 don't have :Authority field, so assign nil to it"
+  "DIF9 and DIF10 do not have several DOI fields so remove them."
   [doi]
-  (if (get-in doi [:Authority])
-    (assoc doi :Authority nil)
-    doi))
+  (dissoc doi :Authority :MissingReason :Explanation))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -59,7 +59,7 @@
   [doi]
   (let [updated-doi (util/remove-nil-keys (dissoc doi :Authority :Explanation :MissingReason))]
     (when (seq updated-doi)
-      updated-doi)))
+      (cmn/map->DoiType updated-doi))))
 
 (defn- iso-19115-2-publication-reference
   "Returns the expected value of a parsed ISO-19115-2 publication references"

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -54,6 +54,13 @@
       (update :Name #(su/with-default % true))
       (update :Description #(str (su/with-default % true) " PublicationReference:")))))
 
+(defn- expected-doi-in-publication-reference
+  "Returns the expected DOI field in a publication reference."
+  [doi]
+  (let [updated-doi (util/remove-nil-keys (dissoc doi :Authority :Explanation :MissingReason))]
+    (when (seq updated-doi)
+      updated-doi)))
+
 (defn- iso-19115-2-publication-reference
   "Returns the expected value of a parsed ISO-19115-2 publication references"
   [pub-refs]
@@ -61,7 +68,7 @@
              :when (and (:Title pub-ref) (:PublicationDate pub-ref))]
          (-> pub-ref
              (assoc :ReportNumber nil :Volume nil :PublicationPlace nil)
-             (update-in [:DOI] (fn [doi] (dissoc doi :Authority :Explanation :MissingReason)))
+             (update-in [:DOI] expected-doi-in-publication-reference)
              (update-in [:PublicationDate] conversion-util/date-time->date)
              (update :ISBN su/format-isbn)
              (update :OnlineResource expected-online-resource)))))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -61,7 +61,7 @@
              :when (and (:Title pub-ref) (:PublicationDate pub-ref))]
          (-> pub-ref
              (assoc :ReportNumber nil :Volume nil :PublicationPlace nil)
-             (update-in [:DOI] (fn [doi] (when doi (assoc doi :Authority nil))))
+             (update-in [:DOI] (fn [doi] (dissoc doi :Authority :Explanation :MissingReason)))
              (update-in [:PublicationDate] conversion-util/date-time->date)
              (update :ISBN su/format-isbn)
              (update :OnlineResource expected-online-resource)))))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -362,4 +362,5 @@
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
+      (update :DOI iso-shared/expected-doi)
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
@@ -98,4 +98,4 @@
   [doi]
   (let [updated-doi (util/remove-nil-keys (dissoc doi :MissingReason :Explanation))]
     (when (seq updated-doi)
-      updated-doi)))
+      (cmn/map->DoiType updated-doi))))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
@@ -92,3 +92,10 @@
        (map iso-topic-categories/xml->umm-iso-topic-category-map)
        (remove nil?)
        seq))
+
+(defn expected-doi
+  "Returns the expected DOI."
+  [doi]
+  (let [updated-doi (util/remove-nil-keys (dissoc doi :MissingReason :Explanation))]
+    (when (seq updated-doi)
+      updated-doi)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -327,4 +327,5 @@
       (assoc :MetadataDates nil)
       (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
-      (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)))
+      (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
+      (update :DOI iso-shared/expected-doi)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
@@ -89,15 +89,15 @@
     (if (= uniq-keys #{:required})
       ;; Using oneOfs with each only specifying :required
       (let [field-sets (mapv (comp set (partial mapv keyword)) (mapv :required one-of))
-              all-required-fields (reduce into field-sets)
-              all-fields (set (keys (:properties schema-type)))
-              one-of-types (for [field-set field-sets
-                                 :let [excluded-fields (set/difference all-required-fields field-set)]]
-                             (-> schema-type
-                                 (update-in [:properties] #(apply dissoc % excluded-fields))
-                                 (update-in [:required] concat field-set)
-                                 (dissoc :oneOf)))]
-          (gen/one-of (mapv #(object-like-schema-type->generator schema type-name %) one-of-types)))
+            all-required-fields (reduce into field-sets)
+            all-fields (set (keys (:properties schema-type)))
+            one-of-types (for [field-set field-sets
+                               :let [excluded-fields (set/difference all-required-fields field-set)]]
+                           (-> schema-type
+                               (update-in [:properties] #(apply dissoc % excluded-fields))
+                               (update-in [:required] concat field-set)
+                               (dissoc :oneOf)))]
+        (gen/one-of (mapv #(object-like-schema-type->generator schema type-name %) one-of-types)))
       ;; Using oneOf with each specifying the full object mapping
       (do
         ;; These fields aren't supported in schema-type if oneOf is used with other fields

--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
@@ -15,6 +15,7 @@
   (fn [schema type-name schema-type]
     (cond
       (:type schema-type) (:type schema-type)
+      (:oneOf schema-type) "oneOf"
       (:$ref schema-type) :$ref)))
 
 (defmethod schema-type->generator :default
@@ -121,6 +122,10 @@
       (object-like-schema-type->generator
         schema type-name
         (select-keys schema-type [:properties :required :additionalProperties])))))
+
+(defmethod schema-type->generator "oneOf"
+  [schema type-name schema-type]
+  (object-one-of->generator schema type-name schema-type))
 
 (def array-min-items 0)
 (def array-max-items 5)

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_smap.clj
@@ -2,11 +2,11 @@
   "Defines mappings from UMM records into ISO SMAP XML."
   (:require
     [clojure.string :as string]
+    [cmr.common.util :as util]
     [cmr.common.xml.gen :refer :all]
     [cmr.umm-spec.date-util :as du]
     [cmr.umm-spec.iso-keywords :as kws]
     [cmr.umm-spec.iso19115-2-util :as iso]
-    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.spatial :as iso19115-spatial-conversion]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.collection-citation :as collection-citation]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.collection-progress :as collection-progress]
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.distributions-related-url :as sdru]
@@ -16,6 +16,7 @@
     [cmr.umm-spec.umm-to-xml-mappings.iso-shared.project-element :as project]
     [cmr.umm-spec.umm-to-xml-mappings.iso-smap.collection-citation :as smap-collection-citation]
     [cmr.umm-spec.umm-to-xml-mappings.iso-smap.data-contact :as data-contact]
+    [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.spatial :as iso19115-spatial-conversion]
     [cmr.umm-spec.umm-to-xml-mappings.iso19115-2.tiling-system :as tiling]
     [cmr.umm-spec.util :as su :refer [with-default char-string]]))
 
@@ -72,6 +73,28 @@
   (let [project-keywords (map iso/generate-title projects)]
     (kws/generate-iso-smap-descriptive-keywords "project" project-keywords)))
 
+(defn- generate-doi
+  "Returns the DOI field."
+  [c]
+  (let [doi (util/remove-nil-keys (dissoc (:DOI c) :MissingReason :Explanation))]
+    (when (seq doi)
+      [:gmd:identifier
+       [:gmd:MD_Identifier
+         (when-let [authority (:Authority doi)]
+           [:gmd:authority
+            [:gmd:CI_Citation
+             [:gmd:title [:gco:CharacterString ""]]
+             [:gmd:date ""]
+             [:gmd:citedResponsibleParty
+              [:gmd:CI_ResponsibleParty
+               [:gmd:organisationName [:gco:CharacterString authority]]
+               [:gmd:role
+                [:gmd:CI_RoleCode {:codeList "http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
+                                   :codeListValue ""} "authority"]]]]]])
+         [:gmd:code [:gco:CharacterString (:DOI doi)]]
+         [:gmd:codeSpace [:gco:CharacterString "gov.nasa.esdis.umm.doi"]]
+         [:gmd:description [:gco:CharacterString "DOI"]]]])))
+
 (defn umm-c-to-iso-smap-xml
   "Returns ISO SMAP XML from UMM-C record c."
   [c]
@@ -104,23 +127,7 @@
              [:gmd:MD_Identifier
               [:gmd:code (char-string (:Version c))]
               [:gmd:description [:gco:CharacterString "The ECS Version ID"]]]]
-            (when-let [doi (:DOI c)]
-              [:gmd:identifier
-               [:gmd:MD_Identifier
-                 (when-let [authority (:Authority doi)]
-                   [:gmd:authority
-                    [:gmd:CI_Citation
-                     [:gmd:title [:gco:CharacterString ""]]
-                     [:gmd:date ""]
-                     [:gmd:citedResponsibleParty
-                      [:gmd:CI_ResponsibleParty
-                       [:gmd:organisationName [:gco:CharacterString authority]]
-                       [:gmd:role
-                        [:gmd:CI_RoleCode {:codeList "http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
-                                           :codeListValue ""} "authority"]]]]]])
-                 [:gmd:code [:gco:CharacterString (:DOI doi)]]
-                 [:gmd:codeSpace [:gco:CharacterString "gov.nasa.esdis.umm.doi"]]
-                 [:gmd:description [:gco:CharacterString "DOI"]]]])
+            (generate-doi c)
             (when-let [collection-data-type (:CollectionDataType c)]
              [:gmd:identifier
               [:gmd:MD_Identifier
@@ -155,41 +162,41 @@
               [:gmd:keyword
                (char-string (kws/smap-keyword-str instrument))])]]
           [:gmd:language (char-string (or (:DataLanguage c) "eng"))]
-        (iso-topic-categories/generate-iso-topic-categories c)
-        (when (first (:TilingIdentificationSystems c))
-         [:gmd:extent
-          [:gmd:EX_Extent {:id "TilingIdentificationSystem"}
-           [:gmd:description
-            [:gco:CharacterString "Tiling Identitfication System"]]
-              (tiling/tiling-system-elements c)]])
-         [:gmd:extent
-          [:gmd:EX_Extent
-           (generate-spatial-extent (:SpatialExtent c))
-           (iso19115-spatial-conversion/generate-vertical-domain c)
-           (for [temporal (:TemporalExtents c)
-                 rdt (:RangeDateTimes temporal)]
-             [:gmd:temporalElement
-              [:gmd:EX_TemporalExtent
-               [:gmd:extent
-                [:gml:TimePeriod {:gml:id (su/generate-id)}
-                 [:gml:beginPosition (:BeginningDateTime rdt)]
-                 (let [ends-at-present (:EndsAtPresentFlag temporal)]
-                   [:gml:endPosition (if ends-at-present
-                                       {:indeterminatePosition "now"}
-                                       {})
-                    (when-not ends-at-present
-                      (or (:EndingDateTime rdt) ""))])]]]])
-           (for [temporal (:TemporalExtents c)
-                 date (:SingleDateTimes temporal)]
-             [:gmd:temporalElement
-              [:gmd:EX_TemporalExtent
-               [:gmd:extent
-                [:gml:TimeInstant {:gml:id (su/generate-id)}
-                 [:gml:timePosition date]]]]])]]
+          (iso-topic-categories/generate-iso-topic-categories c)
+          (when (first (:TilingIdentificationSystems c))
+            [:gmd:extent
+              [:gmd:EX_Extent {:id "TilingIdentificationSystem"}
+                [:gmd:description
+                  [:gco:CharacterString "Tiling Identitfication System"]]
+                (tiling/tiling-system-elements c)]])
+          [:gmd:extent
+           [:gmd:EX_Extent
+            (generate-spatial-extent (:SpatialExtent c))
+            (iso19115-spatial-conversion/generate-vertical-domain c)
+            (for [temporal (:TemporalExtents c)
+                  rdt (:RangeDateTimes temporal)]
+              [:gmd:temporalElement
+               [:gmd:EX_TemporalExtent
+                [:gmd:extent
+                 [:gml:TimePeriod {:gml:id (su/generate-id)}
+                  [:gml:beginPosition (:BeginningDateTime rdt)]
+                  (let [ends-at-present (:EndsAtPresentFlag temporal)]
+                    [:gml:endPosition (if ends-at-present
+                                        {:indeterminatePosition "now"}
+                                        {})
+                     (when-not ends-at-present
+                       (or (:EndingDateTime rdt) ""))])]]]])
+            (for [temporal (:TemporalExtents c)
+                  date (:SingleDateTimes temporal)]
+              [:gmd:temporalElement
+               [:gmd:EX_TemporalExtent
+                [:gmd:extent
+                 [:gml:TimeInstant {:gml:id (su/generate-id)}
+                  [:gml:timePosition date]]]]])]]
 
-        (when processing-level
-         [:gmd:processingLevel
-          (proc-level/generate-iso-processing-level processing-level)])]]
+          (when processing-level
+           [:gmd:processingLevel
+            (proc-level/generate-iso-processing-level processing-level)])]]
         [:gmd:identificationInfo
          [:gmd:MD_DataIdentification
           [:gmd:citation

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -157,9 +157,13 @@
 (defn- parse-doi
   "There could be multiple DOIs under Collection, just take the first one for now."
   [doc]
-  (let [doi (first (select doc "Collection/DOI"))]
-    {:DOI (value-of doi "DOI")
-     :Authority (value-of doi "Authority")}))
+  (let [doi (first (select doc "Collection/DOI"))
+        doi-value (value-of doi "DOI")
+        authority (value-of doi "Authority")]
+    (when (or doi-value authority)
+      (util/remove-nil-keys
+       {:DOI doi-value
+        :Authority authority}))))
 
 (defn- parse-echo10-xml
   "Returns UMM-C collection structure from ECHO10 collection XML document."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -17,6 +17,7 @@
    [cmr.umm-spec.util :as su :refer [char-string]]
    [cmr.umm-spec.xml-to-umm-mappings.get-umm-element :as get-umm-element]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.collection-citation :as collection-citation]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.doi :as doi]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
@@ -192,27 +193,39 @@
      :Description (su/with-default (char-string-value online-resource "gmd:description") sanitize?)
      :Function (value-of online-resource "gmd:function/gmd:CI_OnLineFunctionCode")})))
 
-(defn- parse-doi
-  "There could be multiple CI_Citations. Each CI_Citation could contain multiple gmd:identifiers.
-   Each gmd:identifier could contain at most ONE DOI. The doi-list below will contain something like:
-   [[nil]
-    [nil {:DOI \"doi1\" :Authority \"auth1\"} {:DOI \"doi2\" :Authority \"auth2\"}]
-    [{:DOI \"doi3\" :Authority \"auth3\"]]
-   We will pick the first DOI for now."
-  [doc]
-  (let [orgname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
-                          "gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString")
-        indname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
-                          "gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString")
-        doi-list (for [ci-ct (select doc citation-base-xpath)]
-                   (for [gmd-id (select ci-ct "gmd:identifier")]
-                     (when (and (= (value-of gmd-id "gmd:MD_Identifier/gmd:description/gco:CharacterString") "DOI")
-                                (= (value-of gmd-id "gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString")
-                                   "gov.nasa.esdis.umm.doi"))
-                       {:DOI (value-of gmd-id "gmd:MD_Identifier/gmd:code/gco:CharacterString")
-                        :Authority (or (value-of gmd-id orgname-path)
-                                       (value-of gmd-id orgname-path))})))]
-    (first (first (remove empty? (map #(remove nil? %) doi-list))))))
+(defn- parse-doi-for-publication-reference
+  "Returns the DOI field within a publication reference."
+  [pub-ref]
+  (when-let [doi-value (char-string-value pub-ref "gmd:identifier/gmd:MD_Identifier/gmd:code")]
+    {:DOI doi-value}))
+
+(defn- parse-publication-references
+  "Returns the publication references."
+  [doc md-data-id-el sanitize?]
+  (for [publication (select md-data-id-el publication-xpath)
+        :let [role-xpath "gmd:citedResponsibleParty/gmd:CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='%s']"
+              online-resource (parse-online-resource publication sanitize?)
+              select-party (fn [name xpath]
+                             (char-string-value publication
+                                                (str (format role-xpath name) xpath)))]
+         :when (or (nil? (:Description online-resource))
+                   (not (string/includes? (:Description online-resource) "PublicationURL")))]
+    {:Author (select-party "author" "/gmd:organisationName")
+     :PublicationDate (date/sanitize-and-parse-date
+                       (str (date-at publication
+                                     (str "gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='publication']/"
+                                          "gmd:date/gco:Date")))
+                       sanitize?)
+     :Title (char-string-value publication "gmd:title")
+     :Series (char-string-value publication "gmd:series/gmd:CI_Series/gmd:name")
+     :Edition (char-string-value publication "gmd:edition")
+     :Issue (char-string-value publication "gmd:series/gmd:CI_Series/gmd:issueIdentification")
+     :Pages (char-string-value publication "gmd:series/gmd:CI_Series/gmd:page")
+     :Publisher (select-party "publisher" "/gmd:organisationName")
+     :ISBN (su/format-isbn (char-string-value publication "gmd:ISBN"))
+     :DOI (parse-doi-for-publication-reference publication)
+     :OnlineResource (parse-online-resource publication sanitize?)
+     :OtherReferenceDetails (char-string-value publication "gmd:otherCitationDetails")}))
 
 (defn- parse-iso19115-xml
   "Returns UMM-C collection structure from ISO19115-2 collection XML document."
@@ -226,7 +239,7 @@
      (data-contact/parse-contacts doc sanitize?) ; DataCenters, ContactPersons, ContactGroups
      {:ShortName (char-string-value id-el "gmd:code")
       :EntryTitle (char-string-value citation-el "gmd:title")
-      :DOI (parse-doi doc)
+      :DOI (doi/parse-doi doc citation-base-xpath)
       :Version (char-string-value citation-el "gmd:edition")
       :VersionDescription version-description
       :Abstract abstract
@@ -266,30 +279,7 @@
       :Platforms (platform/parse-platforms doc "" sanitize?)
       :Projects (project/parse-projects doc projects-xpath sanitize?)
 
-      :PublicationReferences (for [publication (select md-data-id-el publication-xpath)
-                                   :let [role-xpath "gmd:citedResponsibleParty/gmd:CI_ResponsibleParty[gmd:role/gmd:CI_RoleCode/@codeListValue='%s']"
-                                         online-resource (parse-online-resource publication sanitize?)
-                                         select-party (fn [name xpath]
-                                                        (char-string-value publication
-                                                                           (str (format role-xpath name) xpath)))]
-                                    :when (or (nil? (:Description online-resource))
-                                              (not (string/includes? (:Description online-resource) "PublicationURL")))]
-                               {:Author (select-party "author" "/gmd:organisationName")
-                                :PublicationDate (date/sanitize-and-parse-date
-                                                  (str (date-at publication
-                                                                (str "gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='publication']/"
-                                                                     "gmd:date/gco:Date")))
-                                                  sanitize?)
-                                :Title (char-string-value publication "gmd:title")
-                                :Series (char-string-value publication "gmd:series/gmd:CI_Series/gmd:name")
-                                :Edition (char-string-value publication "gmd:edition")
-                                :Issue (char-string-value publication "gmd:series/gmd:CI_Series/gmd:issueIdentification")
-                                :Pages (char-string-value publication "gmd:series/gmd:CI_Series/gmd:page")
-                                :Publisher (select-party "publisher" "/gmd:organisationName")
-                                :ISBN (su/format-isbn (char-string-value publication "gmd:ISBN"))
-                                :DOI {:DOI (char-string-value publication "gmd:identifier/gmd:MD_Identifier/gmd:code")}
-                                :OnlineResource (parse-online-resource publication sanitize?)
-                                :OtherReferenceDetails (char-string-value publication "gmd:otherCitationDetails")})
+      :PublicationReferences (parse-publication-references doc md-data-id-el sanitize?)
       :MetadataAssociations (ma/xml-elem->metadata-associations doc)
       :AncillaryKeywords (descriptive-keywords-type-not-equal
                           md-data-id-el

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/doi.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/doi.clj
@@ -1,0 +1,40 @@
+(ns cmr.umm-spec.xml-to-umm-mappings.iso-shared.doi
+  "Functions for parsing UMM DOI records out of ISO 19115 and ISO SMAP XML documents."
+  (:require
+   [cmr.common.util :as util]
+   [cmr.common.xml.simple-xpath :refer [select]]
+   [cmr.common.xml.parse :refer [value-of]]))
+
+(def doi-namespace
+  "DOI namespace."
+  "gov.nasa.esdis.umm.doi")
+
+(defn- is-doi-field?
+  "Returns true if the given gmd-id is for a DOI field."
+  [gmd-id]
+  (and (= (value-of gmd-id "gmd:MD_Identifier/gmd:description/gco:CharacterString") "DOI")
+       (= (value-of gmd-id "gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString") doi-namespace)))
+
+(defn parse-doi
+  "There could be multiple CI_Citations. Each CI_Citation could contain multiple gmd:identifiers.
+   Each gmd:identifier could contain at most ONE DOI. The doi-list below will contain something like:
+   [[nil]
+    [nil {:DOI \"doi1\" :Authority \"auth1\"} {:DOI \"doi2\" :Authority \"auth2\"}]
+    [{:DOI \"doi3\" :Authority \"auth3\"]]
+   We will pick the first DOI for now."
+  [doc citation-base-xpath]
+  (let [orgname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
+                          "gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString")
+        indname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
+                          "gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString")
+        doi-list (for [ci-ct (select doc citation-base-xpath)
+                       gmd-id (select ci-ct "gmd:identifier")
+                       :when (is-doi-field? gmd-id)
+                       :let [doi-value (value-of
+                                        gmd-id "gmd:MD_Identifier/gmd:code/gco:CharacterString")]
+                       :when doi-value]
+                   (util/remove-nil-keys
+                    {:DOI doi-value
+                     :Authority (or (value-of gmd-id orgname-path)
+                                    (value-of gmd-id orgname-path))}))]
+    (first doi-list)))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -11,6 +11,7 @@
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.xml-to-umm-mappings.get-umm-element :as get-umm-element]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.collection-citation :as collection-citation]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.doi :as doi]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
@@ -112,28 +113,6 @@
      :SingleDateTimes (values-at temporal "gml:TimeInstant/gml:timePosition")
      :EndsAtPresentFlag (some? (seq (select temporal "gml:TimePeriod/gml:endPosition[@indeterminatePosition='now']")))}))
 
-(defn- parse-doi
-  "There could be multiple CI_Citations. Each CI_Citation could contain multiple gmd:identifiers.
-   Each gmd:identifier could contain at most ONE DOI. The doi-list below will contain something like:
-   [[nil]
-    [nil {:DOI \"doi1\" :Authority \"auth1\"} {:DOI \"doi2\" :Authority \"auth2\"}]
-    [{:DOI \"doi3\" :Authority \"auth3\"]]
-   We will pick the first DOI for now."
-  [doc]
-  (let [orgname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
-                          "gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString")
-        indname-path (str "gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:citedResponsibleParty/"
-                          "gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString")
-        doi-list (for [ci-ct (select doc citation-base-xpath)]
-                   (for [gmd-id (select ci-ct "gmd:identifier")]
-                     (when (and (= (value-of gmd-id "gmd:MD_Identifier/gmd:description/gco:CharacterString") "DOI")
-                                (= (value-of gmd-id "gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString")
-                                   "gov.nasa.esdis.umm.doi"))
-                       {:DOI (value-of gmd-id "gmd:MD_Identifier/gmd:code/gco:CharacterString")
-                        :Authority (or (value-of gmd-id orgname-path)
-                                       (value-of gmd-id orgname-path))})))]
-    (first (first (remove empty? (map #(remove nil? %) doi-list))))))
-
 (defn iso-smap-xml-to-umm-c
   "Returns UMM-C collection record from ISO-SMAP collection XML document. The :sanitize? option
   tells the parsing code to set the default values for fields when parsing the metadata into umm."
@@ -146,7 +125,7 @@
       {:ShortName (value-of data-id-el short-name-xpath)
        :EntryTitle (value-of doc entry-title-xpath)
        :ISOTopicCategories (iso-topic-categories/parse-iso-topic-categories doc base-xpath)
-       :DOI (parse-doi doc)
+       :DOI (doi/parse-doi doc citation-base-xpath)
        :Version (value-of data-id-el version-xpath)
        :Abstract (u/truncate (value-of short-name-el "gmd:abstract/gco:CharacterString") u/ABSTRACT_MAX sanitize?)
        :Purpose (u/truncate (value-of short-name-el "gmd:purpose/gco:CharacterString") u/PURPOSE_MAX sanitize?)

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -198,11 +198,11 @@
     [umm-record (gen/no-shrink umm-gen/umm-c-generator)
      metadata-format (gen/elements tested-collection-formats)]
     (let [umm-record (js/parse-umm-c
-                        (assoc umm-record
-                               :DataDates [{:Date (t/date-time 2012)
-                                            :Type "CREATE"}
-                                           {:Date (t/date-time 2013)
-                                            :Type "UPDATE"}]))
+                      (assoc umm-record
+                             :DataDates [{:Date (t/date-time 2012)
+                                          :Type "CREATE"}
+                                         {:Date (t/date-time 2013)
+                                          :Type "UPDATE"}]))
           expected (expected-conversion/convert umm-record metadata-format)
           actual (xml-round-trip :collection metadata-format umm-record)
           ;; Change fields to sets for comparison


### PR DESCRIPTION
![oneofus](https://user-images.githubusercontent.com/4248343/37284313-735a847c-25d1-11e8-8e07-cd766b454b77.jpeg)

This change allows the UMM for the DOI field to be either DOI and Authority or MissingReason and Explanation. We needed to add support for field level oneOf definitions in JSON schema in order to make this work.