### PR TITLE
CMR-4785: Prelinimary refactoring for Metadata-DB API cleanup

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/concepts.clj
@@ -10,6 +10,7 @@
     [db providers params]
     "Finds concepts by the given parameters")
 
+  ;; XXX maybe we can combine this definition with just the regular find-latest-concepts ...
   (find-concepts-in-batches
     [db provider params batch-size]
     [db provider params batch-size start-index]

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -154,8 +154,7 @@
     (map map-fn concepts)))
 
 (defrecord MemoryDB
-  [
-   ;; A sequence of concepts stored in metadata db
+  [;; A sequence of concepts stored in metadata db
    concepts-atom
 
    ;; The next id to use for generating a concept id.
@@ -165,295 +164,364 @@
    next-transaction-id-atom
 
    ;; A map of provider ids to providers that exist
-   providers-atom]
+   providers-atom])
 
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  lifecycle/Lifecycle
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; CMR Component Implementation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-  (start [this system]
-         this)
+(defn start
+  [this system]
+  this)
 
-  (stop [this system]
-        this)
+(defn stop
+  [this system]
+  this)
 
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  concepts/ConceptSearch
+(def component-lifecycle-behaviour
+  {:start start
+   :stop stop})
 
-  (find-concepts
-   [db providers params]
-   (let [found-concepts (mapcat #(concepts/search-with-params
-                                  @concepts-atom
-                                  (assoc params :provider-id (:provider-id %)))
-                                providers)]
-     (concepts->find-result found-concepts params)))
+(extend MemoryDB
+        lifecycle/Lifecycle
+        component-lifecycle-behaviour)
 
-  (find-latest-concepts
-   [db provider params]
-   (let [latest-concepts (latest-revisions @concepts-atom)
-         found-concepts (concepts/search-with-params
-                         latest-concepts
-                         (assoc params :provider-id (:provider-id provider)))]
-     (concepts->find-result found-concepts params)))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Metadata DB ConceptSearch Implementation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-  concepts/ConceptsStore
+(defn find-concepts
+  [db providers params]
+  (let [found-concepts (mapcat #(concepts/search-with-params
+                                @(:concepts-atom db)
+                                (assoc params :provider-id (:provider-id %)))
+                              providers)]
+    (concepts->find-result found-concepts params)))
 
-  (generate-concept-id
-   [this concept]
-   (let [{:keys [concept-type provider-id]} concept
-         num (swap! next-id-atom inc)]
-     (cc/build-concept-id {:concept-type concept-type
-                           :sequence-number num
-                           :provider-id provider-id})))
+(defn find-latest-concepts
+  [db provider params]
+  (let [latest-concepts (latest-revisions @(:concepts-atom db))
+        found-concepts (concepts/search-with-params
+                        latest-concepts
+                        (assoc params :provider-id (:provider-id provider)))]
+    (concepts->find-result found-concepts params)))
 
-  (get-concept-id
-   [this concept-type provider native-id]
-   (let [provider-id (:provider-id provider)
-         concept-type (if (keyword? concept-type) concept-type (keyword concept-type))]
-     (->> @concepts-atom
-          (filter (fn [c]
+(def concept-search-behaviour
+  {:find-concepts find-concepts
+   :find-latest-concepts find-latest-concepts})
+
+(extend MemoryDB
+        concepts/ConceptSearch
+        concept-search-behaviour)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Metadata DB ConceptsStore Implementation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn generate-concept-id
+  [db concept]
+  (let [{:keys [concept-type provider-id]} concept
+       num (swap! (:next-id-atom db) inc)]
+   (cc/build-concept-id {:concept-type concept-type
+                         :sequence-number num
+                         :provider-id provider-id})))
+
+(defn get-concept-id
+  [db concept-type provider native-id]
+  (let [provider-id (:provider-id provider)
+       concept-type (if (keyword? concept-type) concept-type (keyword concept-type))]
+   (->> @(:concepts-atom db)
+        (filter (fn [c]
+                  (and (= concept-type (:concept-type c))
+                       (= provider-id (:provider-id c))
+                       (= native-id (:native-id c)))))
+        first
+        :concept-id)))
+
+(defn get-granule-concept-ids
+  [db provider native-id]
+  (let [provider-id (:provider-id provider)
+        matched-gran (->> @(:concepts-atom db)
+                          (filter (fn [c]
+                                   (and (= :granule (:concept-type c))
+                                        (= provider-id (:provider-id c))
+                                        (= native-id (:native-id c)))))
+                          (sort-by :revisoin-id)
+                          last)
+        {:keys [concept-id deleted]} matched-gran
+        parent-collection-id (get-in matched-gran [:extra-fields :parent-collection-id])]
+    [concept-id parent-collection-id deleted]))
+
+(defn- -get-concept
+  [db concept-type provider concept-id]
+  (let [revisions (filter
+                   (fn [c]
                     (and (= concept-type (:concept-type c))
-                         (= provider-id (:provider-id c))
-                         (= native-id (:native-id c)))))
-          first
-          :concept-id)))
+                         (= (:provider-id provider) (:provider-id c))
+                         (= concept-id (:concept-id c))))
+                   @(:concepts-atom db))]
+    (->> revisions
+         (sort-by :revision-id)
+         last)))
 
-  (get-granule-concept-ids
-   [this provider native-id]
-   (let [provider-id (:provider-id provider)
-         matched-gran (->> @concepts-atom
-                           (filter (fn [c]
-                                     (and (= :granule (:concept-type c))
-                                          (= provider-id (:provider-id c))
-                                          (= native-id (:native-id c)))))
-                           (sort-by :revisoin-id)
-                           last)
-         {:keys [concept-id deleted]} matched-gran
-         parent-collection-id (get-in matched-gran [:extra-fields :parent-collection-id])]
-     [concept-id parent-collection-id deleted]))
-
-  (get-concept
-   [db concept-type provider concept-id]
-   (let [revisions (filter
-                    (fn [c]
-                      (and (= concept-type (:concept-type c))
-                           (= (:provider-id provider) (:provider-id c))
-                           (= concept-id (:concept-id c))))
-                    @concepts-atom)]
-     (->> revisions
-          (sort-by :revision-id)
-          last)))
-
-  (get-concept
-   [db concept-type provider concept-id revision-id]
-   (if-not revision-id
-     (concepts/get-concept db concept-type provider concept-id)
-     (first (filter
-             (fn [c]
-               (and (= concept-type (:concept-type c))
-                    (= (:provider-id provider) (:provider-id c))
-                    (= concept-id (:concept-id c))
-                    (= revision-id (:revision-id c))))
-             @concepts-atom))))
-
-  (get-concepts
-   [this concept-type provider concept-id-revision-id-tuples]
-   (filter identity
-           (map (fn [[concept-id revision-id]]
-                  (concepts/get-concept this concept-type provider concept-id revision-id))
-                concept-id-revision-id-tuples)))
-
-  (get-latest-concepts
-   [db concept-type provider concept-ids]
-   (let [concept-id-set (set concept-ids)
-         concept-map (reduce (fn [concept-map {:keys [concept-id revision-id] :as concept}]
-                               (if (contains? concept-id-set concept-id)
-                                 (cond
-
-                                   (nil? (get concept-map concept-id))
-                                   (assoc concept-map concept-id concept)
-
-                                   (> revision-id (:revision-id (get concept-map concept-id)))
-                                   (assoc concept-map concept-id concept)
-
-                                   :else
-                                   concept-map)
-                                 concept-map))
-                             {}
-                             @concepts-atom)]
-     (keep (partial get concept-map) concept-ids)))
-
-  (get-transactions-for-concept
-   [db provider con-id]
-   (keep (fn [{:keys [concept-id revision-id transaction-id]}]
-           (when (= con-id concept-id)
-             {:revision-id revision-id :transaction-id transaction-id}))
-         @concepts-atom))
-
-  (save-concept
-   [this provider concept]
-   {:pre [(:revision-id concept)]}
-
-   (if-let [error (validate-concept-id-native-id-not-changing this provider concept)]
-     ;; There was a concept id, native id mismatch with earlier concepts
-     error
-     ;; Concept id native id pair was valid
-     (let [{:keys [concept-type provider-id concept-id revision-id]} concept
-           concept (update-in concept
-                              [:revision-date]
-                              #(or % (f/unparse (f/formatters :date-time) (tk/now))))
-           ;; Set the created-at time to the current timekeeper time for concepts which have
-           ;; the created-at field and do not already have a :created-at time set.
-           concept (if (some #{concept-type} [:collection :granule :service :variable])
-                     (update-in concept
-                                [:created-at]
-                                #(or % (f/unparse (f/formatters :date-time) (tk/now))))
-                     concept)
-           concept (assoc concept :transaction-id (swap! next-transaction-id-atom inc))
-           concept (if (= concept-type :granule)
-                     (-> concept
-                         (dissoc :user-id)
-                         ;; This is not stored in the real db.
-                         (update-in [:extra-fields] dissoc :parent-entry-title))
-                     concept)]
-       (if (or (nil? revision-id)
-               (concepts/get-concept this concept-type provider concept-id revision-id))
-         {:error :revision-id-conflict}
-         (do
-           (swap! concepts-atom (fn [concepts]
-                                  (after-save this (conj concepts concept)
-                                              concept)))
-           nil)))))
-
-  (force-delete
-   [db concept-type provider concept-id revision-id]
-   (swap! concepts-atom
-          #(filter
+(defn- -get-concept-with-revision
+  [db concept-type provider concept-id revision-id]
+  (if-not revision-id
+    (concepts/get-concept db concept-type provider concept-id)
+    (first (filter
             (fn [c]
-              (not (and (= concept-type (:concept-type c))
-                        (= (:provider-id provider) (:provider-id c))
-                        (= concept-id (:concept-id c))
-                        (= revision-id (:revision-id c)))))
-            %)))
+             (and (= concept-type (:concept-type c))
+                  (= (:provider-id provider) (:provider-id c))
+                  (= concept-id (:concept-id c))
+                  (= revision-id (:revision-id c))))
+            @(:concepts-atom db)))))
 
-  (force-delete-concepts
-   [db provider concept-type concept-id-revision-id-tuples]
-   (doseq [[concept-id revision-id] concept-id-revision-id-tuples]
-     (concepts/force-delete db concept-type provider concept-id revision-id)))
+(defn get-concept
+  ([db concept-type provider concept-id]
+    (-get-concept db concept-type provider concept-id))
+  ([db concept-type provider concept-id revision-id]
+    (-get-concept-with-revision
+     db concept-type provider concept-id revision-id)))
 
-  (get-concept-type-counts-by-collection
-   [db concept-type provider]
-   (->> @concepts-atom
-        (filter #(= (:provider-id provider) (:provider-id %)))
+(defn get-concepts
+  [db concept-type provider concept-id-revision-id-tuples]
+  (filter
+   identity
+   (map (fn [[concept-id revision-id]]
+          (concepts/get-concept db concept-type provider concept-id revision-id))
+        concept-id-revision-id-tuples)))
+
+(defn get-latest-concepts
+[db concept-type provider concept-ids]
+  (let [concept-id-set (set concept-ids)
+        concept-map (reduce (fn [concept-map {:keys [concept-id revision-id] :as concept}]
+                             (if (contains? concept-id-set concept-id)
+                               (cond
+
+                                 (nil? (get concept-map concept-id))
+                                 (assoc concept-map concept-id concept)
+
+                                 (> revision-id (:revision-id (get concept-map concept-id)))
+                                 (assoc concept-map concept-id concept)
+
+                                 :else
+                                 concept-map)
+                               concept-map))
+                            {}
+                            @(:concepts-atom db))]
+   (keep (partial get concept-map) concept-ids)))
+
+(defn get-transactions-for-concept
+  [db provider con-id]
+  (keep (fn [{:keys [concept-id revision-id transaction-id]}]
+         (when (= con-id concept-id)
+           {:revision-id revision-id :transaction-id transaction-id}))
+       @(:concepts-atom db)))
+
+(defn save-concept
+  [db provider concept]
+  {:pre [(:revision-id concept)]}
+
+  (if-let [error (validate-concept-id-native-id-not-changing db provider concept)]
+   ;; There was a concept id, native id mismatch with earlier concepts
+   error
+   ;; Concept id native id pair was valid
+   (let [{:keys [concept-type provider-id concept-id revision-id]} concept
+         concept (update-in concept
+                            [:revision-date]
+                            #(or % (f/unparse (f/formatters :date-time) (tk/now))))
+         ;; Set the created-at time to the current timekeeper time for concepts which have
+         ;; the created-at field and do not already have a :created-at time set.
+         concept (if (some #{concept-type} [:collection :granule :service :variable])
+                   (update-in concept
+                              [:created-at]
+                              #(or % (f/unparse (f/formatters :date-time) (tk/now))))
+                   concept)
+         concept (assoc concept :transaction-id (swap! (:next-transaction-id-atom db) inc))
+         concept (if (= concept-type :granule)
+                   (-> concept
+                       (dissoc :user-id)
+                       ;; This is not stored in the real db.
+                       (update-in [:extra-fields] dissoc :parent-entry-title))
+                   concept)]
+     (if (or (nil? revision-id)
+             (concepts/get-concept db concept-type provider concept-id revision-id))
+       {:error :revision-id-conflict}
+       (do
+         (swap! (:concepts-atom db) (fn [concepts]
+                                     (after-save db (conj concepts concept)
+                                                 concept)))
+         nil)))))
+
+(defn force-delete
+  [db concept-type provider concept-id revision-id]
+  (swap! (:concepts-atom db)
+         #(filter
+           (fn [c]
+            (not (and (= concept-type (:concept-type c))
+                      (= (:provider-id provider) (:provider-id c))
+                      (= concept-id (:concept-id c))
+                      (= revision-id (:revision-id c)))))
+           %)))
+
+(defn force-delete-concepts
+  [db provider concept-type concept-id-revision-id-tuples]
+  (doseq [[concept-id revision-id] concept-id-revision-id-tuples]
+    (concepts/force-delete db concept-type provider concept-id revision-id)))
+
+(defn get-concept-type-counts-by-collection
+  [db concept-type provider]
+  (->> @(:concepts-atom db)
+      (filter #(= (:provider-id provider) (:provider-id %)))
+      (filter #(= concept-type (:concept-type %)))
+      (group-by (comp :parent-collection-id :extra-fields))
+      (map #(update-in % [1] count))
+      (into {})))
+
+(defn reset
+  [db]
+  (reset! (:concepts-atom db) [])
+  (reset! (:next-id-atom db) (dec cmr.metadata-db.data.oracle.concepts/INITIAL_CONCEPT_NUM))
+  (reset! (:next-transaction-id-atom db) 1))
+
+(defn get-expired-concepts
+  [db provider concept-type]
+  (->> @(:concepts-atom db)
+       (filter #(= (:provider-id provider) (:provider-id %)))
+       (filter #(= concept-type (:concept-type %)))
+       latest-revisions
+       (filter expired?)
+       (remove :deleted)))
+
+(defn get-tombstoned-concept-revisions
+  [db provider concept-type tombstone-cut-off-date limit]
+  (->> @(:concepts-atom db)
+       (filter #(= concept-type (:concept-type %)))
+       (filter #(= (:provider-id provider) (:provider-id %)))
+       (filter :deleted)
+       (filter #(t/before? (p/parse-datetime (:revision-date %)) tombstone-cut-off-date))
+       (map #(vector (:concept-id %) (:revision-id %)))
+       (take limit)))
+
+(defn get-old-concept-revisions
+  [db provider concept-type max-versions limit]
+  (letfn [(drop-highest
+          [concepts]
+          (->> concepts
+               (sort-by :revision-id)
+               (drop-last max-versions)))]
+   (->> @(:concepts-atom db)
         (filter #(= concept-type (:concept-type %)))
-        (group-by (comp :parent-collection-id :extra-fields))
-        (map #(update-in % [1] count))
-        (into {})))
-
-  (reset
-   [db]
-   (reset! concepts-atom [])
-   (reset! next-id-atom (dec cmr.metadata-db.data.oracle.concepts/INITIAL_CONCEPT_NUM))
-   (reset! next-transaction-id-atom 1))
-
-  (get-expired-concepts
-   [db provider concept-type]
-   (->> @concepts-atom
         (filter #(= (:provider-id provider) (:provider-id %)))
-        (filter #(= concept-type (:concept-type %)))
-        latest-revisions
-        (filter expired?)
-        (remove :deleted)))
+        (group-by :concept-id)
+        vals
+        (filter #(> (count %) max-versions))
+        (mapcat drop-highest)
+        (map concept->tuple))))
 
-  (get-tombstoned-concept-revisions
-   [db provider concept-type tombstone-cut-off-date limit]
-   (->> @concepts-atom
-        (filter #(= concept-type (:concept-type %)))
-        (filter #(= (:provider-id provider) (:provider-id %)))
-        (filter :deleted)
-        (filter #(t/before? (p/parse-datetime (:revision-date %)) tombstone-cut-off-date))
-        (map #(vector (:concept-id %) (:revision-id %)))
-        (take limit)))
+(def concept-store-behaviour
+  {:generate-concept-id generate-concept-id
+   :get-concept-id get-concept-id
+   :get-granule-concept-ids get-granule-concept-ids
+   :get-concept get-concept
+   :get-concepts get-concepts
+   :get-latest-concepts get-latest-concepts
+   :get-transactions-for-concept get-transactions-for-concept
+   :save-concept save-concept
+   :force-delete force-delete
+   :force-delete-concepts force-delete-concepts
+   :get-concept-type-counts-by-collection get-concept-type-counts-by-collection
+   :reset reset
+   :get-expired-concepts get-expired-concepts
+   :get-tombstoned-concept-revisions get-tombstoned-concept-revisions
+   :get-old-concept-revisions get-old-concept-revisions})
 
-  (get-old-concept-revisions
-   [db provider concept-type max-versions limit]
-   (letfn [(drop-highest
-            [concepts]
-            (->> concepts
-                 (sort-by :revision-id)
-                 (drop-last max-versions)))]
-     (->> @concepts-atom
-          (filter #(= concept-type (:concept-type %)))
-          (filter #(= (:provider-id provider) (:provider-id %)))
-          (group-by :concept-id)
-          vals
-          (filter #(> (count %) max-versions))
-          (mapcat drop-highest)
-          (map concept->tuple))))
+(extend MemoryDB
+        concepts/ConceptsStore
+        concept-store-behaviour)
 
-  providers/ProvidersStore
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Metadata DB ProvidersStore Implementation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-  (save-provider
-   [db {:keys [provider-id] :as provider}]
-   (swap! providers-atom assoc provider-id provider))
+(defn save-provider
+  [db {:keys [provider-id] :as provider}]
+  (swap! (:providers-atom db) assoc provider-id provider))
 
-  (get-providers
-   [db]
-   (vals @providers-atom))
+(defn get-providers
+  [db]
+  (vals @(:providers-atom db)))
 
-  (get-provider
-   [db provider-id]
-   (@providers-atom provider-id))
+(defn get-provider
+  [db provider-id]
+  (@(:providers-atom db) provider-id))
 
-  (update-provider
-   [db {:keys [provider-id] :as provider}]
-   (swap! providers-atom assoc provider-id provider))
+(defn update-provider
+  [db {:keys [provider-id] :as provider}]
+  (swap! (:providers-atom db) assoc provider-id provider))
 
-  (delete-provider
-   [db provider]
-   ;; Cascade to delete the concepts
-   (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts db [provider] nil)]
-     (concepts/force-delete db concept-type provider concept-id revision-id))
+(defn delete-provider
+  [db provider]
+  ;; Cascade to delete the concepts
+  (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts db [provider] nil)]
+   (concepts/force-delete db concept-type provider concept-id revision-id))
 
-   ;; Cascade to delete the variable associations and service associations,
-   ;; this is a hacky way of doing things
-   (doseq [assoc-type [:variable-association :service-association]]
-     (doseq [association (concepts/find-concepts db
-                                                 [{:provider-id "CMR"}]
-                                                 {:concept-type assoc-type})]
-       (let [{:keys [concept-id revision-id extra-fields]} association
-             {:keys [associated-concept-id variable-concept-id service-concept-id]} extra-fields
-             referenced-providers (map (fn [cid]
-                                         (some-> cid
-                                                 cc/parse-concept-id
-                                                 :provider-id))
-                                       [associated-concept-id variable-concept-id service-concept-id])]
-         ;; If the association references the deleted provider through
-         ;; either collection or variable/service, delete the association
-         (when (some #{(:provider-id provider)} referenced-providers)
-           (concepts/force-delete
-             db assoc-type {:provider-id "CMR"} concept-id revision-id)))))
+  ;; Cascade to delete the variable associations and service associations,
+  ;; this is a hacky way of doing things
+  (doseq [assoc-type [:variable-association :service-association]]
+   (doseq [association (concepts/find-concepts db
+                                               [{:provider-id "CMR"}]
+                                               {:concept-type assoc-type})]
+     (let [{:keys [concept-id revision-id extra-fields]} association
+           {:keys [associated-concept-id variable-concept-id service-concept-id]} extra-fields
+           referenced-providers (map (fn [cid]
+                                       (some-> cid
+                                               cc/parse-concept-id
+                                               :provider-id))
+                                     [associated-concept-id variable-concept-id service-concept-id])]
+       ;; If the association references the deleted provider through
+       ;; either collection or variable/service, delete the association
+       (when (some #{(:provider-id provider)} referenced-providers)
+         (concepts/force-delete
+           db assoc-type {:provider-id "CMR"} concept-id revision-id)))))
 
-   ;; to find items that reference the provider that should be deleted (e.g. ACLs)
-   (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts
-                                                          db
-                                                          [pv/cmr-provider]
-                                                          {:target-provider-id (:provider-id provider)})]
-     (concepts/force-delete db concept-type pv/cmr-provider concept-id revision-id))
-   ;; finally delete the provider
-   (swap! providers-atom dissoc (:provider-id provider)))
+  ;; to find items that reference the provider that should be deleted (e.g. ACLs)
+  (doseq [{:keys [concept-type concept-id revision-id]} (concepts/find-concepts
+                                                        db
+                                                        [pv/cmr-provider]
+                                                        {:target-provider-id (:provider-id provider)})]
+   (concepts/force-delete db concept-type pv/cmr-provider concept-id revision-id))
+  ;; finally delete the provider
+  (swap! (:providers-atom db) dissoc (:provider-id provider)))
 
-  (reset-providers
-   [db]
-   (reset! providers-atom {})))
+(defn reset-providers
+  [db]
+  (reset! (:providers-atom db) {}))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def provider-store-behaviour
+  {:save-provider save-provider
+   :get-providers get-providers
+   :get-provider get-provider
+   :update-provider update-provider
+   :delete-provider delete-provider
+   :reset-providers reset-providers})
 
+(extend MemoryDB
+        providers/ProvidersStore
+        provider-store-behaviour)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; MemoryDB Constructor
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn create-db
   "Creates and returns an in-memory database."
   ([]
    (create-db []))
   ([concepts]
+   ;; XXX as part of being self-documenting, let's use map->MemoryDB here
+   ;;     so we can look at the keys and know to what each corresponds in
+   ;      the record ...
    ;; sort by revision-id reversed so latest will be first
    (->MemoryDB (atom (reverse (sort-by :revision-id concepts)))
                (atom (dec cmr.metadata-db.data.oracle.concepts/INITIAL_CONCEPT_NUM))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/collection_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/collection_table.clj
@@ -1,6 +1,7 @@
 (ns cmr.metadata-db.data.oracle.collection-table
   "Contains helper functions to create collection table."
-  (require [clojure.java.jdbc :as j]))
+  (:require
+   [clojure.java.jdbc :as j]))
 
 (defmulti collection-column-sql
   "Returns the sql to define provider collection columns"

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concept_tables.clj
@@ -1,14 +1,15 @@
 (ns cmr.metadata-db.data.oracle.concept-tables
-  (require [cmr.common.services.errors :as errors]
-           [cmr.common.log :refer (debug info warn error)]
-           [cmr.common.util :as cutil]
-           [clojure.string :as string]
-           [clojure.pprint :refer (pprint pp)]
-           [clojure.java.jdbc :as j]
-           [inflections.core :as inf]
-           [cmr.metadata-db.services.provider-validation :as pv]
-           [cmr.metadata-db.data.oracle.collection-table :as ct]
-           [cmr.metadata-db.data.oracle.granule-table :as gt]))
+  (:require
+   [clojure.java.jdbc :as j]
+   [clojure.pprint :refer (pprint pp)]
+   [clojure.string :as string]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.util :as cutil]
+   [cmr.metadata-db.data.oracle.collection-table :as ct]
+   [cmr.metadata-db.data.oracle.granule-table :as gt]
+   [cmr.metadata-db.services.provider-validation :as pv]
+   [inflections.core :as inf]))
 
 (def all-provider-concept-types
   "All the concept types that have tables for each (non-small) provider"

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -340,7 +340,7 @@
                                                           (from table)
                                                           (where `(and (= :concept-id ~concept-id)
                                                                        (= :revision-id ~revision-id))))))))
-     (concepts/get-concept db concept-type provider concept-id))))
+     (get-concept db concept-type provider concept-id))))
 
 (defn get-concepts
   [db concept-type provider concept-id-revision-id-tuples]
@@ -369,7 +369,7 @@
 
 (defn get-latest-concepts
   [db concept-type provider concept-ids]
-  (concepts/get-concepts
+  (get-concepts
    db concept-type provider
    (get-latest-concept-id-revision-id-tuples db concept-type provider concept-ids)))
 

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
@@ -1,6 +1,7 @@
 (ns cmr.metadata-db.data.oracle.granule-table
   "Contains helper functions to create granule table."
-  (require [clojure.java.jdbc :as j]))
+  (:require
+   [clojure.java.jdbc :as j]))
 
 (defmulti granule-column-sql
   "Returns the sql to define provider granule columns"

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -1,14 +1,17 @@
 (ns cmr.metadata-db.data.oracle.providers
   "Functions for saving, retrieving, deleting providers."
-  (:require [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.util :as cutil]
-            [clojure.pprint :refer (pprint pp)]
-            [clojure.java.jdbc :as j]
-            [cmr.metadata-db.data.providers :as p]
-            [cmr.metadata-db.data.oracle.sql-helper :as sh]
-            [cmr.metadata-db.data.oracle.concept-tables :as ct]
-            [cmr.oracle.sql-utils :as su :refer [insert values select from where with order-by desc delete as]])
-  (:import cmr.oracle.connection.OracleStore))
+  (:require
+   [clojure.java.jdbc :as j]
+   [clojure.pprint :refer [pprint pp]]
+   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.util :as cutil]
+   [cmr.metadata-db.data.oracle.concept-tables :as ct]
+   [cmr.metadata-db.data.oracle.sql-helper :as sh]
+   [cmr.metadata-db.data.providers :as p]
+   [cmr.oracle.sql-utils :as su :refer
+    [insert values select from where with order-by desc delete as]])
+  (:import
+   (cmr.oracle.connection OracleStore)))
 
 (defn dbresult->provider
   "Converts a map result from the database to a provider map"

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -100,7 +100,7 @@
 
 (defn reset-providers
   [db]
-  (doseq [provider (p/get-providers db)]
+  (doseq [provider (get-providers db)]
     (delete-provider db provider)))
 
 (def behaviour

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/providers.clj
@@ -62,60 +62,71 @@
     (j/delete! db (ct/get-table-name provider :service) ["provider_id = ?" provider-id])
     (j/delete! db :providers ["provider_id = ?" provider-id])))
 
-(extend-protocol p/ProvidersStore
-  OracleStore
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-  (save-provider
-    [db provider]
-    (let [{:keys [provider-id short-name cmr-only small]} provider]
-      (j/insert! db
-                 :providers
-                 ["provider_id" "short_name" "cmr_only" "small"]
-                 [provider-id short-name (if cmr-only 1 0) (if small 1 0)])
-      (when (not small)
-        (ct/create-provider-concept-tables db provider))))
-
-  (get-providers
-    [db]
-    (map dbresult->provider
-         (j/query db ["SELECT * FROM providers"])))
-
-  (get-provider
-    [db provider-id]
-    (first (map dbresult->provider
-                (j/query db
-                         ["SELECT provider_id, short_name, cmr_only, small FROM providers where provider_id = ?"
-                          provider-id]))))
-
-  (update-provider
-    [db {:keys [provider-id short-name cmr-only]}]
-    (j/update! db
+(defn save-provider
+  [db provider]
+  (let [{:keys [provider-id short-name cmr-only small]} provider]
+    (j/insert! db
                :providers
-               {:short_name short-name
-                :cmr_only (if cmr-only 1 0)}
-               ["provider_id = ?" provider-id]))
+               ["provider_id" "short_name" "cmr_only" "small"]
+               [provider-id short-name (if cmr-only 1 0) (if small 1 0)])
+    (when (not small)
+      (ct/create-provider-concept-tables db provider))))
 
-  (delete-provider
-    [db provider]
-    (purge-provider-data db provider))
+(defn get-providers
+  [db]
+  (map dbresult->provider
+       (j/query db ["SELECT * FROM providers"])))
 
-  (reset-providers
-    [db]
-    (doseq [provider (p/get-providers db)]
-      (p/delete-provider db provider))))
+(defn get-provider
+  [db provider-id]
+  (first (map dbresult->provider
+              (j/query db
+                       ["SELECT provider_id, short_name, cmr_only, small FROM providers where provider_id = ?"
+                       provider-id]))))
 
+(defn update-provider
+  [db {:keys [provider-id short-name cmr-only]}]
+  (j/update! db
+             :providers
+             {:short_name short-name
+              :cmr_only (if cmr-only 1 0)}
+             ["provider_id = ?" provider-id]))
+
+(defn delete-provider
+  [db provider]
+  (purge-provider-data db provider))
+
+(defn reset-providers
+  [db]
+  (doseq [provider (p/get-providers db)]
+    (delete-provider db provider)))
+
+(def behaviour
+  {:save-provider save-provider
+   :get-providers get-providers
+   :get-provider get-provider
+   :update-provider update-provider
+   :delete-provider delete-provider
+   :reset-providers reset-providers})
+
+(extend OracleStore
+        p/ProvidersStore
+        behaviour)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (comment
 
   (def db (get-in user/system [:apps :metadata-db :db]))
 
-  (p/get-providers db)
-  (p/reset-providers db)
-  (p/delete-provider db "PROV1")
-  (p/delete-provider db "FOO")
+  (get-providers db)
+  (reset-providers db)
+  (delete-provider db "PROV1")
+  (delete-provider db "FOO")
 
   (->> (j/query db ["SELECT count(1) FROM providers where provider_id = ?" provider-id])
        first vals first (== 0))
-
 
   (j/delete! db :providers ["provider_id = ?" "FOO"]))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -149,7 +149,7 @@
 
 (defn find-concepts-in-batches
   ([db provider params batch-size]
-   (c/find-concepts-in-batches db provider params batch-size 0))
+   (find-concepts-in-batches db provider params batch-size 0))
   ([db provider params batch-size requested-start-index]
    (let [{:keys [concept-type]} params
          provider-id (:provider-id provider)

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/sql_helper.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/sql_helper.clj
@@ -1,12 +1,12 @@
 (ns cmr.metadata-db.data.oracle.sql-helper
   "Contains helper functions that are shared by providers and concepts."
   (:require
-    [clj-time.format :as time-format]
-    [clojure.java.jdbc :as j]
-    [clojure.string :as str]
-    [cmr.common.services.errors :as errors]
-    [cmr.metadata-db.data.oracle.concept-tables :as ct]
-    [cmr.oracle.sql-utils :as su :refer [insert values select from where with order-by desc delete as]])
+   [clj-time.format :as time-format]
+   [clojure.java.jdbc :as j]
+   [clojure.string :as str]
+   [cmr.common.services.errors :as errors]
+   [cmr.metadata-db.data.oracle.concept-tables :as ct]
+   [cmr.oracle.sql-utils :as su :refer [insert values select from where with order-by desc delete as]])
   (:import cmr.oracle.connection.OracleStore))
 
 (defn find-params->sql-clause

--- a/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
@@ -1,12 +1,13 @@
 (ns cmr.metadata-db.services.provider-service
-  (:require [cmr.metadata-db.data.providers :as providers]
-            [cmr.metadata-db.services.util :as mdb-util]
-            [cmr.common.services.errors :as errors]
-            [cmr.metadata-db.services.messages :as msg]
-            [cmr.metadata-db.services.provider-validation :as pv]
-            [cmr.common.services.messages :as cmsg]
-            [cmr.common.util :as util]
-            [cmr.common.log :refer (debug info warn error)]))
+  (:require
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.services.messages :as cmsg]
+   [cmr.common.util :as util]
+   [cmr.metadata-db.data.providers :as providers]
+   [cmr.metadata-db.services.messages :as msg]
+   [cmr.metadata-db.services.provider-validation :as pv]
+   [cmr.metadata-db.services.util :as mdb-util]))
 
 (defn create-provider
   "Save a provider and setup concept tables in the database."


### PR DESCRIPTION
There will be several branches/PRs for this work, so this is the first in a series of what might be 3 or 4 PRs.

Tasks completed so far:
* Evaluate current implementation of metadata-cmr API
* Document proposed changes to the API and update development tasks here
* Implement non-breaking changes, test in workload, and merge
  * Convert all extend-* to just extend
  * Separate methods out from records into independent functions
  * Update implicit contextual references to record fields to explicit record field lookups
  * Do this for in-memory DB:
     * cmr.metadata-db.data.memory-db)
  * Do this for Oracle:
     * cmr.metadata-db.data.oracle.concepts
     * cmr.metadata-db.data.oracle.providers
     * cmr.metadata-db.data.oracle.search

A little more explanation about the motivation here:

There are several ways in which implementations for protocols can be done in Clojure ... the way the CMR has done them so far is quite common: bury all your methods in a record and use `extend-type`. This can be nice for isolated code, since it neatly encapsulates everything. However, if you want to share functions between implementations or do other forms of refactoring, you're out of luck.

This PR switches the metadata-db over to splitting out methods into stand-alone functions, gathering them together in a behaviour data structure, and then using `extend` directly instead of the `extend-*` wrapping macros like we have been.

Once this PR lands, we will be in a position to easily refactor the rest of the code in `metadata-db/data`.