### PR TITLE
CMR-4651: OnlineResourceType and UseConstraintsType changes.

### DIFF
--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -100,7 +100,10 @@
                    (if (mt/umm-json? (:format concept))
                      (let [umm-version (mt/version-of (:format concept))
                            accept-version (config/ingest-accept-umm-version (:concept-type concept))]
-                       (if (>= 0 (compare umm-version accept-version))
+                       ;; when the umm-version goes to v1.10 and accept-version is v1.9, we need
+                       ;; to compare the numbers after the dot.  
+                       (if (>= 0 (compare (Integer. (last (str/split umm-version #"\.")))
+                                          (Integer. (last (str/split accept-version #"\.")))))
                          (umm-spec/validate-metadata (:concept-type concept)
                                                      (:format concept)
                                                      (:metadata concept))

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -114,8 +114,8 @@
                    (if (mt/umm-json? (:format concept))
                      (let [umm-version (mt/version-of (:format concept))
                            accept-version (config/ingest-accept-umm-version (:concept-type concept))]
-                       ;; when the umm-version goes to v1.10 and accept-version is v1.9, we need
-                       ;; to compare the numbers after the dot.  
+                       ;; when the umm-version goes to 1.10 and accept-version is 1.9, we need
+                       ;; to compare the versions with padded zeros.  
                        (if (>= 0 (compare-versions-with-padded-zeros umm-version accept-version))
                          (umm-spec/validate-metadata (:concept-type concept)
                                                      (:format concept)

--- a/ingest-app/test/cmr/ingest/test/validation/umm_version_comparison.clj
+++ b/ingest-app/test/cmr/ingest/test/validation/umm_version_comparison.clj
@@ -1,0 +1,13 @@
+(ns cmr.ingest.test.validation.umm-version-comparison
+  (:require
+   [clojure.test :refer :all]
+   [cmr.ingest.validation.validation :as validation]))
+
+(deftest compare-versions-with-padded-zeros
+  (is (> 0 (#'validation/compare-versions-with-padded-zeros "1.8" "1.9")))
+  (is (< 0 (#'validation/compare-versions-with-padded-zeros "1.10" "1.9")))
+  (is (< 0 (#'validation/compare-versions-with-padded-zeros "2.1" "1.10")))
+  (is (< 0 (#'validation/compare-versions-with-padded-zeros "2.1" "1.9")))
+  (is (< 0 (#'validation/compare-versions-with-padded-zeros "1.10.1" "1.9.2"))))
+
+    

--- a/system-int-test/test/cmr/system_int_test/ingest/ingest_lifecycle_integration_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/ingest_lifecycle_integration_test.clj
@@ -6,6 +6,8 @@
     [clj-time.core :as t]
     [clj-time.format :as f]
     [clojure.test :refer :all]
+    [cmr.common-app.config :as common-config]
+    [cmr.common-app.test.side-api :as side]
     [cmr.common.mime-types :as mt]
     [cmr.common.util :refer [are2]]
     [cmr.system-int-test.data2.core :as d]
@@ -147,6 +149,9 @@
 (deftest mmt-ingest-round-trip
   (testing "ingest and search UMM JSON metadata"
     ;; test for each UMM JSON version
+  (let [accepted-version (common-config/collection-umm-version)
+        _ (side/eval-form `(common-config/set-collection-umm-version! 
+                          ver/current-collection-version))]
     (doseq [v (ver/versions :collection)]
       (let [coll      expected-conversion/example-collection-record
             mime-type (str "application/vnd.nasa.cmr.umm+json;version=" v)
@@ -256,7 +261,8 @@
               [] {:browsable false}
 
               "bounding box"
-              [result] {:bounding_box "-180,-90,180,90"})))))
+              [result] {:bounding_box "-180,-90,180,90"})))
+    (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version)))))
 
 ;; Tests that over the lifecycle of a collection and granule the right data will be found.
 ;; Test Outline

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -92,8 +92,10 @@
 ;; This tests that searching for and retrieving metadata after refreshing the search cache works.
 ;; Other metadata tests all run before refreshing the cache so they cover that case.
 (deftest collection-metadata-cache-test
-  (dev-sys-util/eval-in-dev-sys `(common-config/set-collection-umm-version! "1.10"))
-  (let [c1-echo (d/ingest "PROV1" (dc/collection {:entry-title "c1-echo"})
+  (let [accepted-version (common-config/collection-umm-version)
+        _ (side/eval-form `(common-config/set-collection-umm-version!
+                          umm-version/current-collection-version))
+        c1-echo (d/ingest "PROV1" (dc/collection {:entry-title "c1-echo"})
                           {:format :echo10})
         c2-echo (d/ingest "PROV2" (dc/collection {:entry-title "c2-echo"})
                           {:format :echo10})
@@ -108,7 +110,7 @@
                                                          :long-name "c8-dif10"})
                            {:format :dif10})
         c10-umm-json (d/ingest "PROV1"
-                               exp-conv/curr-ingest-ver-example-collection-record
+                               exp-conv/example-collection-record
                                {:format :umm-json
                                 :accept-format :json})
         ;; An item ingested with and XML preprocessing line to ensure this is tested
@@ -202,12 +204,14 @@
               "ECHO10" :echo10
               "DIF" :dif
               "DIF10" :dif10
-              "ISO" :iso19115))))))
-  (dev-sys-util/eval-in-dev-sys `(common-config/set-collection-umm-version! "1.9")))
+              "ISO" :iso19115)))))
+  (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))
 
 (deftest collection-umm-json-metadata-cache-test
-  (dev-sys-util/eval-in-dev-sys `(common-config/set-collection-umm-version! "1.10"))
-  (let [c1-r1-echo (d/ingest "PROV1" (du/umm-spec-collection {:entry-title "c1-echo"})
+  (let [accepted-version (common-config/collection-umm-version)
+        _ (side/eval-form `(common-config/set-collection-umm-version!
+                          umm-version/current-collection-version))
+        c1-r1-echo (d/ingest "PROV1" (du/umm-spec-collection {:entry-title "c1-echo"})
                              {:format :echo10})
         c1-r2-echo (d/ingest "PROV1" (du/umm-spec-collection {:entry-title "c1-echo"
                                                               :description "updated"})
@@ -215,7 +219,7 @@
         c2-echo (d/ingest "PROV2" (du/umm-spec-collection {:entry-title "c2-echo"})
                           {:format :echo10})
         c10-umm-json (d/ingest "PROV1"
-                               exp-conv/curr-ingest-ver-example-collection-record
+                               exp-conv/example-collection-record
                                {:format :umm-json
                                 :accept-format :json})
         latest-umm-format {:format :umm-json :version umm-version/current-collection-version}]
@@ -247,12 +251,15 @@
        {:all-revisions true})
       (assert-cache-state {c1-r2-echo [:echo10 latest-umm-format]
                            c2-echo [:echo10 latest-umm-format]
-                           c10-umm-json [latest-umm-format]})))
-  (dev-sys-util/eval-in-dev-sys `(common-config/set-collection-umm-version! "1.9")))
+                           c10-umm-json [latest-umm-format]}))
+  (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))
 
 ;; Tests that we can ingest and find items in different formats
 (deftest multi-format-search-test
-  (let [c1-echo (d/ingest "PROV1" (dc/collection {:short-name "S1"
+  (let [accepted-version (common-config/collection-umm-version)
+        _ (side/eval-form `(common-config/set-collection-umm-version!
+                          umm-version/current-collection-version))
+       c1-echo (d/ingest "PROV1" (dc/collection {:short-name "S1"
                                                   :version-id "V1"
                                                   ;; Whitespace here but not stripped out for expected
                                                   ;; results. It will be present in metadata.
@@ -293,7 +300,7 @@
                            {:format :dif10})
 
         c10-umm-json (d/ingest "PROV1"
-                               exp-conv/curr-ingest-ver-example-collection-record
+                               exp-conv/example-collection-record
                                {:format :umm-json
                                 :accept-format :json})
 
@@ -386,7 +393,6 @@
          :dif10 all-colls
          (search/find-metadata :collection :dif10 {} {:url-extension "dif10"}))))
 
-
     (testing "Retrieving results as XML References"
       (let [refs (search/find-refs :collection {:short-name "S1"})
             location (:location (first (:refs refs)))]
@@ -412,7 +418,8 @@
       (testing "ECHO10"
         (d/assert-echo-compatible-metadata-results-match
          :echo10 all-colls
-         (search/find-metadata :collection :echo10 {:echo-compatible true}))))))
+         (search/find-metadata :collection :echo10 {:echo-compatible true}))))
+   (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))
 
 ; Tests that we can ingest and find difs with spatial and that granules in the dif can also be
 ; ingested and found
@@ -737,7 +744,10 @@
 
 (deftest organizations-in-json-correctly-ordered
   (testing "the organizations field in JSON response is correctly ordered by archive-center, distribution center, then the rest"
-    (let [distribution-org (dc/org :distribution-center "distribution-org")
+    (let [accepted-version (common-config/collection-umm-version)
+          _ (side/eval-form `(common-config/set-collection-umm-version!
+                          umm-version/current-collection-version))
+          distribution-org (dc/org :distribution-center "distribution-org")
           distribution-org-1 (dc/org :distribution-center "distribution-org-1")
           archive-org (dc/org :archive-center "archive-org")
           originating-org (dc/org :originating-center "originating-org")
@@ -776,7 +786,7 @@
                 {:format :iso19115})
 
       (d/ingest "PROV1"
-                (assoc exp-conv/curr-ingest-ver-example-collection-record :ShortName "S-UMM-JSON")
+                (assoc exp-conv/example-collection-record :ShortName "S-UMM-JSON")
                 {:format :umm-json
                  :accept-format :json})
       (index/wait-until-indexed)
@@ -805,4 +815,5 @@
         "S-ISO19115" ["archive-org"]
 
         "UMM-JSON has an archive center and processing center"
-        "S-UMM-JSON" ["TNRIS" "NSIDC" "LPDAAC" "Processing Center"]))))
+        "S-UMM-JSON" ["TNRIS" "NSIDC" "LPDAAC" "Processing Center"])
+     (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version)))))

--- a/umm-spec-lib/resources/example_data/iso19115/artificial_test_data.xml
+++ b/umm-spec-lib/resources/example_data/iso19115/artificial_test_data.xml
@@ -876,6 +876,38 @@ Cite as: Forgy Coleman, C. and US DOC; NOAA; NESDIS; National Oceanographic Data
             </gmd:resourceConstraints>
             <gmd:resourceConstraints>
                 <gmd:MD_LegalConstraints>
+                   <gmd:useLimitation>
+                      <gco:CharacterString>This product must not be used for the purposes of determining water quality.</gco:CharacterString>
+                   </gmd:useLimitation>
+                   <gmd:useConstraints>
+                     <gmd:MD_RestrictionCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+                   </gmd:useConstraints>
+                   <gmd:otherConstraints>
+                      <gco:CharacterString>licenseURL: https://www.nasa.examplelicenseurl.gov</gco:CharacterString>
+                   </gmd:otherConstraints>
+                   <gmd:otherConstraints>
+                      <gco:CharacterString>LICENSETEXT: Sample license text so that the review has an idea of what to put here: Apache License Version 2.0, January 2004  http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 1. Definitions. License shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document. ...</gco:CharacterString>
+                   </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                   <gmd:useLimitation>
+                      <gco:CharacterString>This product must not be used for the purposes of determining water quality2.</gco:CharacterString>
+                   </gmd:useLimitation>
+                   <gmd:useConstraints>
+                     <gmd:MD_RestrictionCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+                   </gmd:useConstraints>
+                   <gmd:otherConstraints>
+                      <gco:CharacterString>LicenseUrl: https://www.nasa.examplelicenseurl.gov2</gco:CharacterString>
+                   </gmd:otherConstraints>
+                   <gmd:otherConstraints>
+                      <gco:CharacterString>LicenseText: Sample license text so that the review has an idea of what to put here: Apache License Version 2.0, January 2004  http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 1. Definitions. License shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document2. ...</gco:CharacterString>
+                   </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
                     <gmd:accessConstraints>
                         <gmd:MD_RestrictionCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
                     </gmd:accessConstraints>

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-c-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-c-json-schema.json
@@ -1,6 +1,45 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
+    "UseConstraintsDescriptionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This sub-element either contains a license summary or free-text description that details the permitted use or limitation of this collection.",
+      "properties": {
+        "Description": {
+          "description": "This sub-element either contains a license summary or free-text description that details the permitted use or limitation of this collection.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        }
+      }
+    },
+    "UseConstraintsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element defines how the data may or may not be used after access is granted to assure the protection of privacy or intellectual property. This includes license text, license URL, or any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the data set. Data providers may request acknowledgement of the data from users and claim no responsibility for quality and completeness of data.",
+      "properties": {
+        "Description": { 
+          "$ref": "#/definitions/UseConstraintsDescriptionType"
+        },
+        "LicenseUrl": {
+          "description": "This element holds the URL and associated information to access the License on the web. If this element is used the LicenseText element cannot be used.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/OnlineResourceType"
+        },
+        "LicenseText": {
+          "description": "This element holds the actual license text. If this element is used the LicenseUrl element cannot be used.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000
+        }
+      },
+      "anyOf": [
+          {"required": ["Description"]},
+          {"required": ["LicenseUrl"]},
+          {"required": ["LicenseText"]}
+      ],
+      "not": {"required": ["LicenseUrl", "LicenseText"]}
+    },
     "DirectoryNameType": {
       "type": "object",
       "additionalProperties": false,
@@ -423,7 +462,7 @@
     },
     "UseConstraints": {
       "description": "Designed to protect privacy and/or intellectual property by allowing the author to specify how the collection may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness. Note: Use Constraints describe how the item may be used once access has been granted; and is distinct from Access Constraints, which refers to any constraints in accessing the item.",
-      "$ref": "umm-cmn-json-schema.json#/definitions/UseConstraintsType"
+      "$ref": "#/definitions/UseConstraintsType"
     },
     "AccessConstraints": {
       "description": "Allows the author to constrain access to the collection. This includes any special restrictions, legal prerequisites, limitations and/or warnings on obtaining collection data. Some words that may be used in this element's value include: Public, In-house, Limited, None. The value field is used for special ACL rules (Access Control Lists (http://en.wikipedia.org/wiki/Access_control_list)). For example it can be used to hide metadata when it isn't ready for public consumption.",

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
@@ -1486,12 +1486,6 @@
       "minLength": 1,
       "maxLength": 12000
     },
-    "UseConstraintsType": {
-      "description": "Free-text information about how the data may or may not be used after access is granted to assure the protection of privacy or intellectual property. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the data set. Data providers may request acknowledgement of the data from users and claim no responsibility for quality and completeness of data.",
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 20000
-    },
     "MetadataAssociateTypeEnum": {
       "description": "The set of supported values for MetadataAssociationType.Type.",
       "type": "string",

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-cmn-json-schema.json
@@ -423,9 +423,13 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 1024
+        },
+        "MimeType": {
+          "description": "The mime type of the online resource.",
+          "$ref": "#/definitions/URLMimeTypeEnum"
         }
       },
-      "required": ["Linkage", "Name", "Description"]
+      "required": ["Linkage"]
     },
     "FileSizeType": {
       "description": "Represents a data file size.",

--- a/umm-spec-lib/src/cmr/umm_spec/dif_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/dif_util.clj
@@ -8,12 +8,6 @@
    [cmr.umm-spec.url :as url]
    [cmr.umm-spec.util :as util]))
 
-(def dif-online-resource-name
- "Reference Online Resource")
-
-(def dif-online-resource-description
- "Reference Online Resource")
-
 ;; For now, we assume DIF9 and DIF10 contain the same IDN_Nodes structures
 ;; after confirming with the system engineer people - even though some of DIF10 files
 ;; contain different structures.
@@ -307,10 +301,7 @@
   (values-at doc "DIF/ISO_Topic_Category"))
 
 (defn parse-publication-reference-online-resouce
- "Parse the Online Resource from the XML publication reference. Name and description are hardcoded."
+ "Parse the Online Resource from the XML publication reference."
  [pub-ref sanitize?]
- {:Linkage (util/with-default-url
-            (url/format-url (value-of pub-ref "Online_Resource") sanitize?)
-            sanitize?)
-  :Name dif-online-resource-name
-  :Description dif-online-resource-description})
+ (when-let [linkage (value-of pub-ref "Online_Resource")]
+   {:Linkage (url/format-url linkage sanitize?)}))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/related_url_migration.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/related_url_migration.clj
@@ -86,6 +86,17 @@
       (assoc :Relation relation)
       (dissoc :URLContentType :Type :Subtype :GetData :GetService))))
 
+(defn migrate-online-resource-down
+  "Migrate online-resource from version 1.10 to 1.9. 
+   Need to remove MimeType, add default for Name and Description if they don't exist."
+  [element]
+  (if-let [ol-resource (:OnlineResource element)]
+    (-> element
+        (assoc :OnlineResource {:Linkage (:Linkage ol-resource)
+                                :Name (util/with-default (:Name ol-resource) true)
+                                :Description (util/with-default (:Description ol-resource) true)}))
+    element))
+
 (defn migrate-related-url-to-online-resource
   "Migrate the RelatedUrl in the element to Online Resource.
   Applies to RelatedUrls in UMM spec v1.8 and lower."

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
@@ -218,7 +218,9 @@
       util/remove-empty-maps
       (update-in [:SpatialExtent :VerticalSpatialDomains] spatial-conversion/drop-invalid-vertical-spatial-domains)
       char-data-type-normalization/migrate-up
-      doi/migrate-missing-reason-up))
+      doi/migrate-missing-reason-up
+      (assoc :UseConstraints (when-let [description (:UseConstraints c)]
+                               {:Description description}))))
 
 (defmethod interface/migrate-umm-version [:collection "1.10" "1.9"]
   [context c & _]
@@ -226,4 +228,6 @@
       coll-progress-migration/migrate-down
       (util/update-in-all [:RelatedUrls :GetData] dissoc :MimeType)
       (util/update-in-all [:RelatedUrls :GetService] dissoc :Format)
-      doi/migrate-missing-reason-down))
+      doi/migrate-missing-reason-down
+      (assoc :UseConstraints (when-let [description (get-in c [:UseConstraints :Description])]
+                               description))))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
@@ -235,6 +235,8 @@
       (util/update-in-all [:RelatedUrls :GetData] dissoc :MimeType)
       (util/update-in-all [:RelatedUrls :GetService] dissoc :Format)
       doi/migrate-missing-reason-down
+      (update-in-each [:PublicationReferences] related-url/migrate-online-resource-down)
+      (update-in-each [:CollectionCitations] related-url/migrate-online-resource-down) 
       (assoc :UseConstraints (when-let [description (get-in c [:UseConstraints :Description])]
                                ;; Description in 1.10 is object/record.
                                ;; It needs to be converted to string when becoming UseConstraints in 1.9.i

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
@@ -220,12 +220,13 @@
       (update-in [:SpatialExtent :VerticalSpatialDomains] spatial-conversion/drop-invalid-vertical-spatial-domains)
       char-data-type-normalization/migrate-up
       doi/migrate-missing-reason-up
-      (assoc :UseConstraints (when-let [description (:UseConstraints c)]
-                               ;; UseConstraints is string in 1.9, object in 1.10. 
-                               ;; This string becomes Description in 1.10, which is also an object.
-                               (umm-coll-models/map->UseConstraintsType 
-                                 {:Description (umm-coll-models/map->UseConstraintsDescriptionType 
-                                                {:Description description})})))))
+      ;; Can't do (assoc :UseConstraints (when-let [description (:UseConstraints c)]... because when :UseConstraints
+      ;; is nil, it will be turned into (:Description nil :LIcenseUrl nil :LicenseText nil) which will fail validation.
+      (as-> coll (if-let [description (:UseConstraints c)]
+                   (assoc coll :UseConstraints 
+                               {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                               {:Description description})})
+                   coll))))
 
 (defmethod interface/migrate-umm-version [:collection "1.10" "1.9"]
   [context c & _]

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_collection_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_collection_models.clj
@@ -235,6 +235,16 @@
   ])
 (record-pretty-printer/enable-record-pretty-printing PaleoTemporalCoverageType)
 
+;; This sub-element either contains a license summary or free-text description that details the
+;; permitted use or limitation of this collection.
+(defrecord UseConstraintsDescriptionType
+  [
+   ;; This sub-element either contains a license summary or free-text description that details the
+   ;; permitted use or limitation of this collection.
+   Description
+  ])
+(record-pretty-printer/enable-record-pretty-printing UseConstraintsDescriptionType)
+
 ;; This element defines a mapping to the GCMD KMS hierarchical location list. It replaces
 ;; SpatialKeywords. Each tier must have data in the tier above it.
 (defrecord LocationKeywordType
@@ -413,6 +423,25 @@
    LongName
   ])
 (record-pretty-printer/enable-record-pretty-printing DirectoryNameType)
+
+;; This element defines how the data may or may not be used after access is granted to assure the
+;; protection of privacy or intellectual property. This includes license text, license URL, or any
+;; special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the
+;; data set. Data providers may request acknowledgement of the data from users and claim no
+;; responsibility for quality and completeness of data.
+(defrecord UseConstraintsType
+  [
+   Description
+
+   ;; This element holds the URL and associated information to access the License on the web. If
+   ;; this element is used the LicenseText element cannot be used.
+   LicenseUrl
+
+   ;; This element holds the actual license text. If this element is used the LicenseUrl element
+   ;; cannot be used.
+   LicenseText
+  ])
+(record-pretty-printer/enable-record-pretty-printing UseConstraintsType)
 
 (defrecord VerticalCoordinateSystemType
   [

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_common_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_common_models.clj
@@ -674,6 +674,9 @@
    ;; The function of the online resource. In ISO where this class originated the valid values are:
    ;; download, information, offlineAccess, order, and search.
    Function
+
+   ;; The mime type of the online resource.
+   MimeType
   ])
 (record-pretty-printer/enable-record-pretty-printing OnlineResourceType)
 

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -327,5 +327,7 @@
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:TemporalExtents] update :EndsAtPresentFlag #(if % % false)) ; true or false, not nil
       (assoc :UseConstraints (when-let [description (get-in umm-coll [:UseConstraints :Description])]
-                               {:Description description}))
+                               (umm-c/map->UseConstraintsType
+                                 ;; description from umm-coll is already an object.
+                                 {:Description description})))
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -284,13 +284,10 @@
 (defn- expected-collection-citations
   "Adds OnlineResource Name and Description to CollectionCitations"
   [collection-citations]
-  (for [collection-citation collection-citations
-        :let [linkage (get-in collection-citation [:OnlineResource :Linkage])]]
-    (-> collection-citation
-        (assoc-in [:OnlineResource :Name] "Dataset Citation")
-        (assoc-in [:OnlineResource :Description] "Dataset Citation")
-        (assoc-in [:OnlineResource :Linkage] (or linkage su/not-provided-url))
-        (update :OnlineResource dissoc :Function :ApplicationProfile :Protocol))))
+  (for [collection-citation collection-citations]
+    (if (:OnlineResource collection-citation)
+      (update collection-citation :OnlineResource #(select-keys % [:Linkage]))
+      collection-citation)))
 
 (def coll-progress-enum-list
   "Part of the enum list for CollectionProgress in v1.10. that could be converted from dif10"

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -326,4 +326,6 @@
       (update-in [:CollectionCitations] expected-collection-citations)
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:TemporalExtents] update :EndsAtPresentFlag #(if % % false)) ; true or false, not nil
+      (assoc :UseConstraints (when-let [description (get-in umm-coll [:UseConstraints :Description])]
+                               {:Description description}))
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -299,5 +299,6 @@
         (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
         (update-in [:CollectionCitations] expected-collection-citations (:Version umm-coll))
         (assoc :UseConstraints (when-let [description (get-in umm-coll [:UseConstraints :Description])]
-                                 {:Description description}))
+                                 (umm-c/map->UseConstraintsType
+                                   {:Description description})))
         js/parse-umm-c)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -254,18 +254,13 @@
   "Adds OnlineResource Name and Description to CollectionCitations"
   [collection-citations version]
   (if (empty? collection-citations)
-    [{:Version version
-      :OnlineResource {:Linkage su/not-provided-url
-                       :Name "Data Set Citation"
-                       :Description "Data Set Citation"}}]
-    (for [collection-citation collection-citations
-          :let [linkage (get-in collection-citation [:OnlineResource :Linkage])]]
-      (-> collection-citation
-          (assoc-in [:OnlineResource :Name] "Data Set Citation")
-          (assoc-in [:OnlineResource :Description] "Data Set Citation")
-          (assoc-in [:OnlineResource :Linkage] (or linkage su/not-provided-url))
-          (update :OnlineResource dissoc :Function :ApplicationProfile :Protocol)
-          (assoc :Version version)))))
+    [{:Version version}]
+    (for [collection-citation collection-citations]
+      (if (:OnlineResource collection-citation)
+        (assoc (update collection-citation :OnlineResource #(select-keys % [:Linkage]))
+          :Version version)
+        (assoc collection-citation 
+          :Version version)))))
 
 (defn umm-expected-conversion-dif9
   [umm-coll]

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif9_expected_conversion.clj
@@ -298,4 +298,6 @@
         (update :DataLanguage conversion-util/dif-expected-data-language)
         (assoc :CollectionProgress (conversion-util/expected-coll-progress umm-coll))
         (update-in [:CollectionCitations] expected-collection-citations (:Version umm-coll))
+        (assoc :UseConstraints (when-let [description (get-in umm-coll [:UseConstraints :Description])]
+                                 {:Description description}))
         js/parse-umm-c)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
@@ -91,9 +91,11 @@
                                                   :MaximumValue 10.0}}]
     :AccessConstraints {:Description "Restriction Comment: Access constraints"
                         :Value "0"}
-    :UseConstraints {:Description (umm-coll-models/map->UseConstraintsDescriptionType
-                                    {:Description "example-collection-record Description"})
-                     :LicenseUrl {:Linkage "http://example-collection-record.com"}}
+    :UseConstraints (umm-coll-models/map->UseConstraintsType 
+                      {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                      {:Description "example-collection-record Description"})
+                       :LicenseUrl (cmn/map->OnlineResourceType
+                                     {:Linkage "http://example-collection-record.com"})})
     :Distributions [{:Sizes [{:Size 15.0 :Unit "KB"}]
                      :DistributionMedia "8 track"
                      :DistributionFormat "Animated GIF"

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion.clj
@@ -10,6 +10,7 @@
    [cmr.common-app.config :as common-config]
    [cmr.umm-spec.json-schema :as js]
    [cmr.umm-spec.migration.version.core :as core]
+   [cmr.umm-spec.models.umm-collection-models :as umm-coll-models]
    [cmr.umm-spec.models.umm-common-models :as cmn]
    [cmr.umm-spec.models.umm-service-models]
    [cmr.umm-spec.test.dif10-expected-conversion :as dif10]
@@ -90,7 +91,9 @@
                                                   :MaximumValue 10.0}}]
     :AccessConstraints {:Description "Restriction Comment: Access constraints"
                         :Value "0"}
-    :UseConstraints "Restriction Flag: Use constraints"
+    :UseConstraints {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                    {:Description "example-collection-record Description"})
+                     :LicenseUrl {:Linkage "http://example-collection-record.com"}}
     :Distributions [{:Sizes [{:Size 15.0 :Unit "KB"}]
                      :DistributionMedia "8 track"
                      :DistributionFormat "Animated GIF"

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
@@ -109,23 +109,11 @@
   (when (seq addresses)
     [(first addresses)]))
 
-(defn sanitize-online-resource
-  "Sanitize the OnlineResource URL (Linkage)"
-  [online-resource]
-  (if (:Linkage online-resource)
-    (update online-resource :Linkage #(url/format-url % true))
-    online-resource))
-
 (defn dif-online-resource
-  "Sanitize the URL, set Name and Description, and dissoc unmapped fields"
+  "Sanitize the URL and dissoc unmapped fields"
   [online-resource]
   (cmn/map->OnlineResourceType
-   (-> online-resource
-       sanitize-online-resource
-       (update :Linkage #(su/with-default-url % true))
-       (select-keys [:Linkage])
-       (assoc :Name dif-util/dif-online-resource-name)
-       (assoc :Description dif-util/dif-online-resource-description))))
+   (select-keys (update online-resource :Linkage #(url/format-url % true)) [:Linkage])))
 
 (defn- check-nil-pub-ref
  "If the online resource name and description are the only fields in the publication
@@ -230,5 +218,7 @@
   (-> pub-ref
       (update-in [:DOI] expected-dif-doi)
       (update :ISBN su/format-isbn)
-      (update :OnlineResource dif-online-resource)
+      (as-> pr (if (:OnlineResource pr)
+                 (update pr :OnlineResource dif-online-resource)
+                 pr))
       check-nil-pub-ref))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -51,7 +51,7 @@
  (when online-resource
   (-> online-resource
       (update :Linkage #(url/format-url % true))
-      (update :MimeType #(when % nil))
+      (assoc :MimeType nil)
       (update :Description #(when % (str  %  " PublicationReference:"))))))
 
 (defn- expected-doi-in-publication-reference
@@ -352,6 +352,13 @@
                               cc))))) 
     [{}]))
 
+(defn- expected-use-constraints
+  "Returns the expected UseConstraints."
+  [use-constraints]
+  (if (:LicenseUrl use-constraints)
+    (update use-constraints :LicenseUrl #(select-keys % [:Linkage]))
+    use-constraints))
+
 (defn umm-expected-conversion-iso19115
   [umm-coll]
   (-> umm-coll
@@ -391,4 +398,5 @@
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
       (update :DOI iso-shared/expected-doi)
+      (update :UseConstraints expected-use-constraints)  
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -352,13 +352,6 @@
                               cc))))) 
     [{}]))
 
-(defn- expected-use-constraints
-  "Returns the expected UseConstraints."
-  [use-constraints]
-  (if (:LicenseUrl use-constraints)
-    (update use-constraints :LicenseUrl #(select-keys % [:Linkage]))
-    use-constraints))
-
 (defn umm-expected-conversion-iso19115
   [umm-coll]
   (-> umm-coll
@@ -398,5 +391,5 @@
       (update :TilingIdentificationSystems spatial-conversion/expected-tiling-id-systems-name)
       (update-in-each [:Platforms] char-data-type-normalization/normalize-platform-characteristics-data-type)
       (update :DOI iso-shared/expected-doi)
-      (update :UseConstraints expected-use-constraints)  
+      (update :UseConstraints iso-shared/expected-use-constraints)  
       js/parse-umm-c))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso19115_expected_conversion.clj
@@ -51,8 +51,8 @@
  (when online-resource
   (-> online-resource
       (update :Linkage #(url/format-url % true))
-      (update :Name #(su/with-default % true))
-      (update :Description #(str (su/with-default % true) " PublicationReference:")))))
+      (update :MimeType #(when % nil))
+      (update :Description #(when % (str  %  " PublicationReference:"))))))
 
 (defn- expected-doi-in-publication-reference
   "Returns the expected DOI field in a publication reference."
@@ -344,7 +344,12 @@
   [collection-citations]
   (if collection-citations
     (conj [] (cmn/map->ResourceCitationType
-               (iso-shared/trim-collection-citation (first collection-citations))))
+               (-> collection-citations
+                   first
+                   iso-shared/trim-collection-citation
+                   (as-> cc (if (:OnlineResource cc)
+                              (update cc :OnlineResource #(assoc % :MimeType nil))
+                              cc))))) 
     [{}]))
 
 (defn umm-expected-conversion-iso19115

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
@@ -13,6 +13,13 @@
    [cmr.umm-spec.models.umm-collection-models]
    [cmr.umm-spec.models.umm-common-models]))
 
+(defn expected-use-constraints
+  "Returns the expected UseConstraints."
+  [use-constraints]
+  (if-let [linkage (get-in use-constraints [:LicenseUrl :Linkage])]
+    (assoc use-constraints :LicenseUrl (cmn/map->OnlineResourceType {:Linkage linkage}))
+    use-constraints))
+
 (defn- create-contact-person
   "Creates a contact person given the info of a creator, editor and publisher"
   [person]

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -307,6 +307,13 @@
                               cc)))))
     (conj [] (cmn/map->ResourceCitationType {:Title su/not-provided}))))
 
+(defn- expected-use-constraints
+  "Returns the expected UseConstraints."
+  [use-constraints]
+  (if-let [linkage (get-in use-constraints [:LicenseUrl :Linkage])]
+    (assoc use-constraints :LicenseUrl (cmn/map->OnlineResourceType {:Linkage linkage}))
+    use-constraints))
+
 (defn umm-expected-conversion-iso-smap
   "Change the UMM to what is expected when translating from ISO SMAP so that it can
    be compared to the actual translation."
@@ -330,7 +337,7 @@
                                  (iso-shared/trim-collection-citation (first (:CollectionCitations umm-coll))))
                                "Technical Contact"))
       (update :CollectionCitations expected-collection-citations)
-      (assoc :UseConstraints nil)
+      (update :UseConstraints expected-use-constraints) 
       (assoc :AccessConstraints nil)
       (assoc :SpatialKeywords nil)
       (assoc :TemporalKeywords nil)

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -307,13 +307,6 @@
                               cc)))))
     (conj [] (cmn/map->ResourceCitationType {:Title su/not-provided}))))
 
-(defn- expected-use-constraints
-  "Returns the expected UseConstraints."
-  [use-constraints]
-  (if-let [linkage (get-in use-constraints [:LicenseUrl :Linkage])]
-    (assoc use-constraints :LicenseUrl (cmn/map->OnlineResourceType {:Linkage linkage}))
-    use-constraints))
-
 (defn umm-expected-conversion-iso-smap
   "Change the UMM to what is expected when translating from ISO SMAP so that it can
    be compared to the actual translation."
@@ -337,7 +330,7 @@
                                  (iso-shared/trim-collection-citation (first (:CollectionCitations umm-coll))))
                                "Technical Contact"))
       (update :CollectionCitations expected-collection-citations)
-      (update :UseConstraints expected-use-constraints) 
+      (update :UseConstraints iso-shared/expected-use-constraints) 
       (assoc :AccessConstraints nil)
       (assoc :SpatialKeywords nil)
       (assoc :TemporalKeywords nil)

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_smap_expected_conversion.clj
@@ -298,8 +298,13 @@
   [collection-citations]
   (if collection-citations
     (conj [] (cmn/map->ResourceCitationType
-               (iso-shared/trim-collection-citation
-                 (update (first collection-citations) :Title #(if % % su/not-provided)))))
+               (-> collection-citations
+                   first
+                   (update :Title #(if % % su/not-provided))
+                   iso-shared/trim-collection-citation
+                   (as-> cc (if (:OnlineResource cc)
+                              (update cc :OnlineResource #(assoc % :MimeType nil))
+                              cc)))))
     (conj [] (cmn/map->ResourceCitationType {:Title su/not-provided}))))
 
 (defn umm-expected-conversion-iso-smap

--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_generators.clj
@@ -37,7 +37,7 @@
   with keys properties, required, and additionalProperties. This is used to handle a normal object
   with properties or an object which uses oneOf to specify between lists of properties."
   [schema type-name schema-type]
-  (rejected-unexpected-fields #{:properties :required :additionalProperties} schema-type)
+  (rejected-unexpected-fields #{:properties :required :additionalProperties :not} schema-type)
   (let [constructor-fn (if type-name
                          (record-gen/schema-type-constructor schema type-name)
                          identity)
@@ -108,7 +108,7 @@
 
 (defmethod schema-type->generator "object"
   [schema type-name schema-type]
-  (rejected-unexpected-fields #{:properties :additionalProperties :required :oneOf :anyOf} schema-type)
+  (rejected-unexpected-fields #{:properties :additionalProperties :required :oneOf :anyOf :not} schema-type)
   (if-let [one-of (:oneOf schema-type)]
     (object-one-of->generator schema type-name schema-type)
     ;; else

--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_record_sanitizer.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_record_sanitizer.clj
@@ -199,10 +199,22 @@
       (update-in-each [:CollectionCitations] sanitize-online-resource)
       (update-in-each [:CollectionCitations] sanitize-umm-online-resource-function)))
 
+(defn- sanitize-umm-use-constraints
+  "Sanitize UseConstraints data.
+   Even though the schema will fail the validation
+   when both LicenseUrl and LicenseText are present,
+   somehow it still gets generated."
+  [record]
+  (if (and (get-in record [:UseConstraints :LicenseUrl])
+           (get-in record [:UseConstraints :LicenseText]))
+    (assoc-in record [:UseConstraints :LicenseText] nil)
+    record)) 
+     
 (defn sanitized-umm-c-record
   "Returns the sanitized version of the given umm-c record."
   [record]
   (-> record
+      sanitize-umm-use-constraints
       ;; DataLanguage should be from a list of enumerations which are not defined in UMM JSON schema
       ;; so here we just replace the generated value to eng to make it through the validation.
       (set-if-exist :DataLanguage "eng")

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
@@ -321,7 +321,8 @@
     (generate-projects (:Projects c))
     [:Quality (:Quality c)]
     [:Access_Constraints (-> c :AccessConstraints :Description)]
-    [:Use_Constraints (:UseConstraints c)]
+    (when-let [description (get-in c [:UseConstraints :Description])]
+      [:Use_Constraints (:Description description)]) 
     (dif-util/generate-dataset-language :Dataset_Language (:DataLanguage c))
     (center/generate-organizations c)
     (for [dist (:Distributions c)]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
@@ -242,7 +242,8 @@
            [:Persistent_Identifier
             [:Type "DOI"]
             [:Identifier doi]])
-         [:Online_Resource (get-in collection-citation [:OnlineResource :Linkage])]]))))
+         (when-let [online-resource (:OnlineResource collection-citation)]
+           [:Online_Resource (:Linkage online-resource)])]))))
 
 (defn umm-c-to-dif10-xml
   "Returns DIF10 XML from a UMM-C collection record."

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
@@ -66,7 +66,8 @@
        [:Data_Presentation_Form (:DataPresentationForm collection-citation)]
        [:Other_Citation_Details (:OtherCitationDetails collection-citation)]
        [:Dataset_DOI (get-in c [:DOI :DOI])]
-       [:Online_Resource (get-in collection-citation [:OnlineResource :Linkage])]])))
+       (when-let [online-resource (:OnlineResource collection-citation)]
+         [:Online_Resource (:Linkage online-resource)])])))
 
 (defn umm-c-to-dif9-xml
   "Returns DIF9 XML structure from UMM collection record c."

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif9.clj
@@ -159,7 +159,8 @@
        [:Long_Name LongName]])
     [:Quality (:Quality c)]
     [:Access_Constraints (-> c :AccessConstraints :Description)]
-    [:Use_Constraints (:UseConstraints c)]
+    (when-let [description (get-in c [:UseConstraints :Description])]
+      [:Use_Constraints (:Description description)])
     (dif-util/generate-dataset-language :Data_Set_Language (:DataLanguage c))
     (center/generate-data-centers c)
     (for [distribution (:Distributions c)]

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -191,8 +191,10 @@
                 [:gmd:URL (:Linkage online-resource)]]
                [:gmd:protocol (char-string (:Protocol online-resource))]
                [:gmd:applicationProfile (char-string (:ApplicationProfile online-resource))]
-               [:gmd:name (char-string (:Name online-resource))]
-               [:gmd:description (char-string (str (:Description online-resource) " PublicationReference:"))]
+             (when-let [name (:Name online-resource)]
+               [:gmd:name (char-string name)])
+             (when-let [description (:Description online-resource)]
+               [:gmd:description (char-string (str description " PublicationReference:"))])
                [:gmd:function
                 [:gmd:CI_OnLineFunctionCode
                  {:codeList (str (:iso iso/code-lists) "#CI_OnLineFunctionCode")

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -232,15 +232,30 @@
   [c]
   (let [description (get-in c [:AccessConstraints :Description])
         value (get-in c [:AccessConstraints :Value])
-        use-constraints (:UseConstraints c)]
+        use-constraints (:UseConstraints c)
+        uc-description (:Description (:Description use-constraints))
+        license-url (:LicenseUrl use-constraints)
+        license-text (:LicenseText use-constraints)]
     [:gmd:resourceConstraints
      (when (or description value use-constraints)
        [:gmd:MD_LegalConstraints
-        (when use-constraints
-          [:gmd:useLimitation (char-string (:UseConstraints c))])
+        (when uc-description
+          [:gmd:useLimitation 
+            [:gco:CharacterString uc-description]]) 
         (when description
           [:gmd:useLimitation
             [:gco:CharacterString (str "Restriction Comment: " description)]])
+        (when (or license-url license-text)
+          [:gmd:useConstraints
+            [:gmd:MD_RestrictionCode 
+              {:codeList "https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode"
+               :codeListValue "otherRestrictions"} "otherRestrictions"]])
+        (when license-url
+          [:gmd:otherConstraints 
+            [:gco:CharacterString (str "LicenseUrl:" (:Linkage license-url))]])
+        (when license-text
+          [:gmd:otherConstraints 
+            [:gco:CharacterString (str "LicenseText:" license-text)]])
         (when value
           [:gmd:otherConstraints
             [:gco:CharacterString (str "Restriction Flag:" value)]])])]))

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_shared/collection_citation.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso_shared/collection_citation.clj
@@ -84,10 +84,12 @@
               [:gco:CharacterString (:Protocol online-resource)]]
              [:gmd:applicationProfile
               [:gco:CharacterString (:ApplicationProfile online-resource)]]
+           (when-let [name (:Name online-resource)]
              [:gmd:name
-              [:gco:CharacterString (:Name online-resource)]]
+              [:gco:CharacterString name]])
+           (when-let [description (:Description online-resource)]
              [:gmd:description
-              [:gco:CharacterString (:Description online-resource)]]
+              [:gco:CharacterString description]])
              [:gmd:function
               [:gmd:CI_OnLineFunctionCode {:codeList (str (:ngdc iso/code-lists) "#CI_RoleCode")
                                            :codeListValue (:Function online-resource)}(:Function online-resource)]]]]]]

--- a/umm-spec-lib/src/cmr/umm_spec/util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/util.clj
@@ -19,7 +19,7 @@
   300)
 
 (def USECONSTRAINTS_MAX
-  20000)
+  4000)
 
 (def QUALITY_MAX
   12000)

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -10,6 +10,7 @@
    [cmr.umm-spec.date-util :as date]
    [cmr.umm-spec.dif-util :as dif-util]
    [cmr.umm-spec.json-schema :as js]
+   [cmr.umm-spec.models.umm-collection-models :as umm-coll-models]
    [cmr.umm-spec.url :as url]
    [cmr.umm-spec.util :as su :refer [without-default-value-of]]
    [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
@@ -231,7 +232,12 @@
    :DirectoryNames (dif-util/parse-idn-node doc)
    :Quality (su/truncate (value-of doc "/DIF/Quality") su/QUALITY_MAX sanitize?)
    :AccessConstraints (dif-util/parse-access-constraints doc sanitize?)
-   :UseConstraints (su/truncate (value-of doc "/DIF/Use_Constraints") su/USECONSTRAINTS_MAX sanitize?)
+   :UseConstraints (when-let [description (su/truncate
+                                            (value-of doc "/DIF/Use_Constraints")
+                                            su/USECONSTRAINTS_MAX
+                                            sanitize?)]
+                     {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                     {:Description description})}) 
    :Platforms (for [platform (select doc "/DIF/Platform")]
                 {:ShortName (value-of platform "Short_Name")
                  :LongName (value-of platform "Long_Name")

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -193,9 +193,8 @@
         :IssueIdentification (value-of data-set-citation "Issue_Identification")
         :DataPresentationForm (value-of data-set-citation "Data_Presentation_Form")
         :OtherCitationDetails (value-of data-set-citation "Other_Citation_Details")
-        :OnlineResource {:Linkage (or (value-of data-set-citation "Online_Resource") su/not-provided-url)
-                         :Name "Dataset Citation"
-                         :Description "Dataset Citation"}}))))
+        :OnlineResource (when-let [linkage (value-of data-set-citation "Online_Resource")]
+                          {:Linkage linkage})}))))
 
 (defn parse-dif10-xml
   "Returns collection map from DIF10 collection XML document."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -236,8 +236,9 @@
                                             (value-of doc "/DIF/Use_Constraints")
                                             su/USECONSTRAINTS_MAX
                                             sanitize?)]
-                     {:Description (umm-coll-models/map->UseConstraintsDescriptionType
-                                     {:Description description})}) 
+                     (umm-coll-models/map->UseConstraintsType 
+                       {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                       {:Description description})}))
    :Platforms (for [platform (select doc "/DIF/Platform")]
                 {:ShortName (value-of platform "Short_Name")
                  :LongName (value-of platform "Long_Name")

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
@@ -116,9 +116,8 @@
        :IssueIdentification (value-of data-set-citation "Issue_Identification")
        :DataPresentationForm (value-of data-set-citation "Data_Presentation_Form")
        :OtherCitationDetails (value-of data-set-citation "Other_Citation_Details")
-       :OnlineResource {:Linkage (or (value-of data-set-citation "Online_Resource") su/not-provided-url)
-                        :Name "Data Set Citation"
-                        :Description "Data Set Citation"}})))
+       :OnlineResource (when-let [linkage (value-of data-set-citation "Online_Resource")] 
+                         {:Linkage linkage})})))
 
 (defn- parse-dif9-xml
   "Returns collection map from DIF9 collection XML document."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
@@ -165,8 +165,9 @@
                                               (value-of doc "/DIF/Use_Constraints")
                                               su/USECONSTRAINTS_MAX
                                               sanitize?)]
-                       {:Description (umm-coll-models/map->UseConstraintsDescriptionType
-                                       {:Description description})})
+                       (umm-coll-models/map->UseConstraintsType
+                         {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                         {:Description description})}))
      :Platforms (parse-platforms doc sanitize?)
      :TemporalExtents (parse-temporal-extents doc sanitize?)
      :PaleoTemporalCoverages (pt/parse-paleo-temporal doc)

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif9.clj
@@ -10,6 +10,7 @@
     [cmr.umm-spec.date-util :as date]
     [cmr.umm-spec.dif-util :as dif-util]
     [cmr.umm-spec.json-schema :as js]
+    [cmr.umm-spec.models.umm-collection-models :as umm-coll-models]
     [cmr.umm-spec.models.umm-common-models :as cmn]
     [cmr.umm-spec.url :as url]
     [cmr.umm-spec.util :as su]
@@ -160,7 +161,12 @@
                              :DetailedLocation (value-of lk "Detailed_Location")}))
      :Quality (su/truncate (value-of doc "/DIF/Quality") su/QUALITY_MAX sanitize?)
      :AccessConstraints (dif-util/parse-access-constraints doc sanitize?)
-     :UseConstraints (su/truncate (value-of doc "/DIF/Use_Constraints") su/USECONSTRAINTS_MAX sanitize?)
+     :UseConstraints (when-let [description (su/truncate
+                                              (value-of doc "/DIF/Use_Constraints")
+                                              su/USECONSTRAINTS_MAX
+                                              sanitize?)]
+                       {:Description (umm-coll-models/map->UseConstraintsDescriptionType
+                                       {:Description description})})
      :Platforms (parse-platforms doc sanitize?)
      :TemporalExtents (parse-temporal-extents doc sanitize?)
      :PaleoTemporalCoverages (pt/parse-paleo-temporal doc)

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -21,6 +21,7 @@
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.use-constraints :as use-constraints]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.additional-attribute :as aa]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.data-contact :as data-contact]
    [cmr.umm-spec.xml-to-umm-mappings.iso19115-2.distributions-related-url :as dru]
@@ -253,12 +254,7 @@
       :Quality (su/truncate (char-string-value doc quality-xpath) su/QUALITY_MAX sanitize?)
       :DataDates (iso-util/parse-data-dates doc data-dates-xpath)
       :AccessConstraints (parse-access-constraints doc sanitize?)
-      :UseConstraints
-      (su/truncate
-       (regex-value doc (str constraints-xpath "/gmd:useLimitation/gco:CharacterString")
-                    #"(?s)^(?!Restriction Comment:).+")
-       su/USECONSTRAINTS_MAX
-       sanitize?)
+      :UseConstraints (use-constraints/parse-use-constraints doc constraints-xpath sanitize?)
       :LocationKeywords (kws/parse-location-keywords md-data-id-el)
       :TemporalKeywords (kws/descriptive-keywords md-data-id-el "temporal")
       :DataLanguage (char-string-value md-data-id-el "gmd:language")

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -186,12 +186,13 @@
                                             "[gmd:role/gmd:CI_RoleCode/@codeListValue='resourceProvider']")))]
   (when-let [online-resource
              (first (select party "gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource"))]
-    {:Linkage (url/format-url (value-of online-resource "gmd:linkage/gmd:URL") sanitize?)
-     :Protocol (char-string-value online-resource "gmd:protocol")
-     :ApplicationProfile (char-string-value online-resource "gmd:applicationProfile")
-     :Name (su/with-default (char-string-value online-resource ":gmd:name") sanitize?)
-     :Description (su/with-default (char-string-value online-resource "gmd:description") sanitize?)
-     :Function (value-of online-resource "gmd:function/gmd:CI_OnLineFunctionCode")})))
+    (when-let [linkage (value-of online-resource "gmd:linkage/gmd:URL")]
+      {:Linkage (url/format-url linkage sanitize?)
+       :Protocol (char-string-value online-resource "gmd:protocol")
+       :ApplicationProfile (char-string-value online-resource "gmd:applicationProfile")
+       :Name (char-string-value online-resource ":gmd:name")
+       :Description (char-string-value online-resource "gmd:description")
+       :Function (value-of online-resource "gmd:function/gmd:CI_OnLineFunctionCode")}))))
 
 (defn- parse-doi-for-publication-reference
   "Returns the DOI field within a publication reference."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/collection_citation.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/collection_citation.clj
@@ -154,12 +154,13 @@
               description (value-of online-resource-party description-xpath)
               function (value-of online-resource-party function-xpath)]]
     (util/remove-nil-keys
-      {:Linkage linkage
-       :Protocol protocol
-       :ApplicationProfile app-profile
-       :Name name
-       :Description description
-       :Function function})))
+      (when linkage
+        {:Linkage linkage
+         :Protocol protocol
+         :ApplicationProfile app-profile
+         :Name name
+         :Description description
+         :Function function}))))
 
 (defn parse-collection-citation
   "Parse the Collection Citation from XML resource citation"

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/use_constraints.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/use_constraints.clj
@@ -1,0 +1,74 @@
+(ns cmr.umm-spec.xml-to-umm-mappings.iso-shared.use-constraints
+  "Functions for parsing UMM use constraints records out of ISO XML documents."
+  (:require
+   [clojure.string :as str]
+   [cmr.common.util :as util]
+   [cmr.common.xml.parse :refer :all]
+   [cmr.common.xml.simple-xpath :refer :all]
+   [cmr.umm-spec.date-util :as date]
+   [cmr.umm-spec.iso19115-2-util :refer :all]
+   [cmr.umm-spec.models.umm-collection-models :as umm-coll-models]
+   [cmr.umm-spec.models.umm-common-models :as umm-cmn-models]
+   [cmr.umm-spec.url :as url]
+   [cmr.umm-spec.util :as su]))
+
+(defn- get-license-value
+  "Get the first LicenseUrl or LicenseText info from a list of other-constraints.
+   get the char-string-value from each other-constraint, Parse the label part out,
+   remove all the spaces from the label, if the lower-case of the label is the same as
+   the license-label, then this other-constraint is the license-constraint."
+  [other-constraints-list license-label]
+  (when-let [value (some #(when-let [value (value-of % "gco:CharacterString")]
+                            (when-let [label (str/replace (first (str/split value #":")) #" " "")]
+                              (when (= license-label (str/lower-case label))
+                                value)))
+                         other-constraints-list)]
+    (let [label-pattern (re-pattern (str (first (str/split value #":")) ":")) 
+          license-value (second (str/split value label-pattern))]
+      license-value)))
+
+(defn- get-description-value
+  "Get description value from the list of gmd:useLimitation values.
+   Pick the first that doesn't start with Restriction Comment:."
+  [description-list sanitize?]
+  (when-let [value (some #(when-let [value (value-of % "gco:CharacterString")]
+                            (when-not (.contains value "Restriction Comment:")
+                              value))
+                         description-list)]
+    (su/truncate value su/USECONSTRAINTS_MAX sanitize?))) 
+
+(defn- get-use-constraints
+  "Get the use constraints."
+  [constraints-list sanitize?]
+  (for [constraints constraints-list
+         :let [description-list (select constraints "gmd:useLimitation")
+               description (get-description-value description-list sanitize?)
+               other-constraints-list (select constraints "gmd:otherConstraints")
+               linkage (get-license-value other-constraints-list "licenseurl")   
+               license-text (when-not linkage
+                              (get-license-value other-constraints-list "licensetext"))]]
+      (util/remove-nil-keys
+        {:Description (when description
+                        (umm-coll-models/map->UseConstraintsDescriptionType
+                          {:Description description}))
+         :LicenseUrl (when linkage
+                       (umm-cmn-models/map->OnlineResourceType
+                         {:Linkage linkage}))
+         :LicenseText (when-not linkage
+                        license-text)})))
+
+(defn parse-use-constraints
+  "Parse the use constraints from XML resource constraint.
+   constraints-xpath is: 
+   /gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints.
+   We want to return the first set of use-constraints that contains the license info. If there is no license info, 
+   return the first use-constraints that contains Description."
+  [doc constraints-xpath sanitize?]
+  (let [constraints-list (seq (select doc constraints-xpath))
+        use-constraints-list (get-use-constraints constraints-list sanitize?)
+        first-non-empty (some #(when (seq %) %) use-constraints-list)
+        first-with-license (some #(when (or (:LicenseUrl %) (:LicenseText %)) %) 
+                                use-constraints-list)]
+    (if first-with-license
+      first-with-license
+      first-non-empty)))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/use_constraints.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/use_constraints.clj
@@ -47,15 +47,16 @@
                linkage (get-license-value other-constraints-list "licenseurl")   
                license-text (when-not linkage
                               (get-license-value other-constraints-list "licensetext"))]]
-      (util/remove-nil-keys
-        {:Description (when description
-                        (umm-coll-models/map->UseConstraintsDescriptionType
-                          {:Description description}))
-         :LicenseUrl (when linkage
-                       (umm-cmn-models/map->OnlineResourceType
-                         {:Linkage linkage}))
-         :LicenseText (when-not linkage
-                        license-text)})))
+      (umm-coll-models/map->UseConstraintsType
+        (util/remove-nil-keys
+          {:Description (when description
+                          (umm-coll-models/map->UseConstraintsDescriptionType
+                            {:Description description}))
+           :LicenseUrl (when linkage
+                         (umm-cmn-models/map->OnlineResourceType
+                           {:Linkage linkage}))
+           :LicenseText (when-not linkage
+                          license-text)}))))
 
 (defn parse-use-constraints
   "Parse the use constraints from XML resource constraint.

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -15,6 +15,7 @@
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.iso-topic-categories :as iso-topic-categories]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform :as platform]
    [cmr.umm-spec.xml-to-umm-mappings.iso-shared.project-element :as project]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.use-constraints :as use-constraints]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.data-contact :as data-contact]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.distributions-related-url :as dru]
    [cmr.umm-spec.xml-to-umm-mappings.iso-smap.spatial :as spatial]
@@ -33,6 +34,9 @@
 (def md-identification-base-xpath
   (str "/gmd:DS_Series/gmd:seriesMetadata/gmi:MI_Metadata"
        "/gmd:identificationInfo/gmd:MD_DataIdentification"))
+
+(def constraints-xpath
+  (str md-identification-base-xpath "/gmd:resourceConstraints/gmd:MD_LegalConstraints"))
 
 (def citation-base-xpath
   (str md-identification-base-xpath
@@ -136,6 +140,7 @@
                              sanitize?)
        :Quality (u/truncate (char-string-value doc quality-xpath) u/QUALITY_MAX sanitize?)
        :DataDates (iso-util/parse-data-dates doc data-dates-xpath)
+       :UseConstraints (use-constraints/parse-use-constraints doc constraints-xpath sanitize?)
        :DataLanguage (value-of short-name-el "gmd:language/gco:CharacterString")
        :Platforms (platform/parse-platforms doc base-xpath sanitize?)
        :TemporalExtents (or (seq (parse-temporal-extents data-id-el))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
@@ -1543,7 +1543,9 @@
                                  {:DOI nil})
                  :DOI))))
    (testing "UseConstraints migration from 1.9.0 to 1.10.0"
-    (is (= {:Description "description"}
+    (is (= (umm-c/map->UseConstraintsType 
+             {:Description (umm-c/map->UseConstraintsDescriptionType
+                             {:Description "description"})})
          (:UseConstraints
            (vm/migrate-umm {} :collection "1.9" "1.10"
                           {:UseConstraints "description"}))))
@@ -1596,12 +1598,16 @@
      (is (= "description"
          (:UseConstraints
            (vm/migrate-umm {} :collection "1.10" "1.9"
-                          {:UseConstraints {:Description "description"
-                                            :LicenseText "license text"}}))))
+                          {:UseConstraints (umm-c/map->UseConstraintsType
+                                             {:Description (umm-c/map->UseConstraintsDescriptionType
+                                                             {:Description "description"})
+                                              :LicenseText "license text"})}))))
      (is (nil?
          (:UseConstraints
            (vm/migrate-umm {} :collection "1.10" "1.9"
-                          {:UseConstraints {:LicenseUrl {:Linkage "https://www.nasa.examplelicenseurl.gov"}}}))))))
+                          {:UseConstraints (umm-c/map->UseConstraintsType
+                                             {:LicenseUrl (umm-cmn/map->OnlineResourceType 
+                                                            {:Linkage "https://www.nasa.examplelicenseurl.gov"})})}))))))
 
 (deftest migrate-1-9-tiling-identification-systems-to-1-10
   (let [tiling-id-systems {:TilingIdentificationSystems

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
@@ -1543,12 +1543,11 @@
                                  {:DOI nil})
                  :DOI))))
    (testing "UseConstraints migration from 1.9.0 to 1.10.0"
-    (is (= (umm-c/map->UseConstraintsType 
-             {:Description (umm-c/map->UseConstraintsDescriptionType
-                             {:Description "description"})})
-         (:UseConstraints
-           (vm/migrate-umm {} :collection "1.9" "1.10"
-                          {:UseConstraints "description"}))))
+    (is (= {:Description (umm-c/map->UseConstraintsDescriptionType
+                           {:Description "description"})}
+           (:UseConstraints
+             (vm/migrate-umm {} :collection "1.9" "1.10"
+                             {:UseConstraints "description"}))))
     (is (nil?
          (:UseConstraints
            (vm/migrate-umm {} :collection "1.9" "1.10"

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
@@ -1593,20 +1593,40 @@
                                        :Explanation "This is an explanation."}})
                 :DOI))))
 
+  (testing "CollectionCitation's OnlineResource migration from version 1.10 to 1.9"
+    (let [result (vm/migrate-umm {} :collection "1.10" "1.9"
+                   {:CollectionCitations [{:SeriesName ">np", :Creator "^", :ReleasePlace ";CUhWxe", :Title "u8,#XJA4U=",
+                                           :Publisher nil, :ReleaseDate nil, :IssueIdentification nil,
+                                           :Editor nil, :DataPresentationForm nil, :Version nil, :OtherCitationDetails nil
+                                           :OnlineResource {:Linkage "www.google.com"
+                                                            :Name "URL Title"
+                                                            :Description "URL Description"
+                                                            :MimeType "application/json"}}]
+                    :PublicationReferences [{:OnlineResource {:Linkage "www.google.com"}}]})]
+       (is (= {:Linkage "www.google.com" 
+               :Name "URL Title"
+               :Description "URL Description"}
+              (:OnlineResource (first (:CollectionCitations result)))))
+
+       (is (= {:Linkage "www.google.com" 
+               :Name "Not provided" 
+               :Description "Not provided"}
+              (:OnlineResource (first (:PublicationReferences result)))))))  
+
   (testing "UseConstraints migration from version 1.10 to 1.9"
-     (is (= "description"
-         (:UseConstraints
-           (vm/migrate-umm {} :collection "1.10" "1.9"
-                          {:UseConstraints (umm-c/map->UseConstraintsType
-                                             {:Description (umm-c/map->UseConstraintsDescriptionType
-                                                             {:Description "description"})
-                                              :LicenseText "license text"})}))))
-     (is (nil?
-         (:UseConstraints
-           (vm/migrate-umm {} :collection "1.10" "1.9"
-                          {:UseConstraints (umm-c/map->UseConstraintsType
-                                             {:LicenseUrl (umm-cmn/map->OnlineResourceType 
-                                                            {:Linkage "https://www.nasa.examplelicenseurl.gov"})})}))))))
+    (is (= "description"
+        (:UseConstraints
+          (vm/migrate-umm {} :collection "1.10" "1.9"
+                         {:UseConstraints (umm-c/map->UseConstraintsType
+                                            {:Description (umm-c/map->UseConstraintsDescriptionType
+                                                            {:Description "description"})
+                                             :LicenseText "license text"})}))))
+    (is (nil?
+        (:UseConstraints
+          (vm/migrate-umm {} :collection "1.10" "1.9"
+                         {:UseConstraints (umm-c/map->UseConstraintsType
+                                            {:LicenseUrl (umm-cmn/map->OnlineResourceType 
+                                                           {:Linkage "https://www.nasa.examplelicenseurl.gov"})})}))))))
 
 (deftest migrate-1-9-tiling-identification-systems-to-1-10
   (let [tiling-id-systems {:TilingIdentificationSystems

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
@@ -1536,12 +1536,21 @@
                :Type "Atmosphere Layer"}
               {:Value "There is no limit if you believe -Bob Ross",
                :Type "Maximum Altitude"}]
-           (get-in result [:SpatialExtent :VerticalSpatialDomains]))))
+           (get-in result [:SpatialExtent :VerticalSpatialDomains])))))
    (testing "DOI MissingReason and Explanation"
      (is (= {:MissingReason "Not Applicable"}
             (get (vm/migrate-umm {} :collection "1.9" "1.10"
                                  {:DOI nil})
-                 :DOI))))))
+                 :DOI))))
+   (testing "UseConstraints migration from 1.9.0 to 1.10.0"
+    (is (= {:Description "description"}
+         (:UseConstraints
+           (vm/migrate-umm {} :collection "1.9" "1.10"
+                          {:UseConstraints "description"}))))
+    (is (nil?
+         (:UseConstraints
+           (vm/migrate-umm {} :collection "1.9" "1.10"
+                          {}))))))
 
 (deftest migrate-1_10-down-to-1_9
   (testing "CollectionProgress migration from version 1.10 to 1.9"
@@ -1581,7 +1590,18 @@
            (get (vm/migrate-umm {} :collection "1.10" "1.9"
                                 {:DOI {:MissingReason "Not Applicable"
                                        :Explanation "This is an explanation."}})
-                :DOI)))))
+                :DOI))))
+
+  (testing "UseConstraints migration from version 1.10 to 1.9"
+     (is (= "description"
+         (:UseConstraints
+           (vm/migrate-umm {} :collection "1.10" "1.9"
+                          {:UseConstraints {:Description "description"
+                                            :LicenseText "license text"}}))))
+     (is (nil?
+         (:UseConstraints
+           (vm/migrate-umm {} :collection "1.10" "1.9"
+                          {:UseConstraints {:LicenseUrl {:Linkage "https://www.nasa.examplelicenseurl.gov"}}}))))))
 
 (deftest migrate-1-9-tiling-identification-systems-to-1-10
   (let [tiling-id-systems {:TilingIdentificationSystems


### PR DESCRIPTION
There are two parts of schema changes involved
Part 1: OnlineResourceType change: a. Added MimeType, b. Removed required Description and Name. There is no translation of MimeType. So no new data is needed. 
Part2: UseConstraintsType Change, which will make use of the new OnlineResouceType:  It is changed from a string to an object containing objects. Existing dif/dif10 data covers it. Echo10 has no change. Added new ISO19115 data file. 
Note: 
1. the schema change recommended for this in the ticket doesn't work. I had to use an alternative way to accomplish the same:
a. oneOf [ {Description LicenseUrl} {Description LicenseText}] doesn't seem to work with the same "Description" in both. when validating, it doesn't know which schema to use.
b. oneOf [ {required "Description"} {required "LicenseUrl"}] doesn't work the way it looks. It doesn't allow
both "Description" and "LicenseUrl" to appear together.  This doesn't work even when you have the simplest structure without the nested oneOf. 

2. We don't have a mechanism to really test the schema currently.  In generate-and-parse, we just validate the umm AFTER it's converted from the xml file, which will never have all "Description" "LicenseUrl" and "LicenseText".  I hard-coded one there(removed now) to see if my schema will allow the different combinations and reject the case when both LicenseUrl and LicenseText are present. So I know the schema works as expected and that's how I found out the oneOf doesn't work.

3. I'm not familiar with how the umm are generated based on the schema. One strange thing is that even though I've tested that LicenseUrl and LicenseText can not appear together to pass the validation. But when the collection is generated, it could still contain both(with nil values).  Had to sanitize it. 

4. Found a bug in ingest validation that that is supposed to limit the ingest version - have to fix it to resolve other test failures because it depends on this to work. 