### PR TITLE
CMR-4841: Log the first 255 characters of the response body.

### DIFF
--- a/transmit-lib/src/cmr/transmit/metadata_db.clj
+++ b/transmit-lib/src/cmr/transmit/metadata_db.clj
@@ -334,11 +334,11 @@
         ;; For CMR-4841 - log the first 255 characters of the response body if
         ;; the parsing of the html throws exception. 
         response-body (:body response)
-        response-body-logged (subs response-body 0 (min 255 (.length response-body)))
+        response-body-logged (subs response-body 0 (min 255 (count response-body)))
         body (try
                (json/decode response-body)
                (catch Exception e 
-                 (info "Exception occurred while parsing the response body: " response-body-logged)
+                 (warn "Exception occurred while parsing the response body: " response-body-logged)
                  (throw e)))
         {:strs [concept-id revision-id]} body]
     (case status

--- a/transmit-lib/src/cmr/transmit/metadata_db.clj
+++ b/transmit-lib/src/cmr/transmit/metadata_db.clj
@@ -331,7 +331,15 @@
                                 :throw-exceptions false
                                 :headers (ch/context->http-headers context)}))
         status (int (:status response))
-        body (json/decode (:body response))
+        ;; For CMR-4841 - log the first 255 characters of the response body if
+        ;; the parsing of the html throws exception. 
+        response-body (:body response)
+        first-255-body (subs response-body 0 (min 255 (.length response-body)))
+        body (try
+               (json/decode response-body)
+               (catch Exception e 
+                 (info "Exception occurred while parsing the response body: " first-255-body)
+                 (throw e)))
         {:strs [concept-id revision-id]} body]
     (case status
       422

--- a/transmit-lib/src/cmr/transmit/metadata_db.clj
+++ b/transmit-lib/src/cmr/transmit/metadata_db.clj
@@ -334,11 +334,11 @@
         ;; For CMR-4841 - log the first 255 characters of the response body if
         ;; the parsing of the html throws exception. 
         response-body (:body response)
-        first-255-body (subs response-body 0 (min 255 (.length response-body)))
+        response-body-logged (subs response-body 0 (min 255 (.length response-body)))
         body (try
                (json/decode response-body)
                (catch Exception e 
-                 (info "Exception occurred while parsing the response body: " first-255-body)
+                 (info "Exception occurred while parsing the response body: " response-body-logged)
                  (throw e)))
         {:strs [concept-id revision-id]} body]
     (case status


### PR DESCRIPTION
The error happens when the parsing of the html response body fails. We should catch the exception and log the first 255 characters of the body when it occurs. 
Note: This fix only involves logging, so there won't be testing for it.  Have tried to manually introduce an error and ran a demo to verify the code worked.