### PR TITLE
CMR-4808 adds umm s version 1.1

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -129,13 +129,12 @@
    :LongName :LongName
    :Name :Name
    :Version :Version
-   ;; Nested single-value data
-   :RelatedURL #(related-url->keywords (:RelatedURL %))
    ;; Simple multi-valued data
    :AncillaryKeywords :AncillaryKeywords
    :ContactGroups #(mapcat contact-group->keywords (:ContactGroups %))
    :ContactPersons #(mapcat contact-person->keywords (:ContactPersons %))
    :Platforms #(mapcat platform->keywords (:Platforms %))
+   :RelatedURLs #(mapcat related-url->keywords (:RelatedURLs %))
    :ServiceKeywords #(mapcat service-keyword->keywords (:ServiceKeywords %))
    :ServiceOrganizations #(mapcat service-organization->keywords (:ServiceOrganizations %))})
 

--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -24,7 +24,7 @@
                      :ContactGroups
                      :ContactPersons
                      :Platforms
-                     :RelatedURL
+                     :RelatedURLs
                      :ScienceKeywords
                      :ServiceKeywords
                      :ServiceOrganizations]

--- a/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
@@ -14,12 +14,11 @@
    :Type "OPeNDAP"
    :Version "1.9"
    :Description "AIRS Level-3 retrieval product created using AIRS IR, AMSU without HSB."
-   :RelatedURL {
-     :URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"
-     :Description "OPeNDAP Service"
-     :Type "GET SERVICE"
-     :Subtype "ACCESS WEB SERVICE"
-     :URLContentType "CollectionURL"}
+   :RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"
+                  :Description "OPeNDAP Service"
+                  :Type "GET SERVICE"
+                  :Subtype "ACCESS WEB SERVICE"
+                  :URLContentType "CollectionURL"}]
    :ContactPersons [
      {:Roles ["AUTHOR"]
       :ContactInformation {
@@ -128,7 +127,7 @@
   (is (= ["Airbus A340-600" "A340-600" "Senso-matic Wonder Eye 4B" "SMWE4B"]
          ((:Platforms keyword-util/fields->fn-mapper) sample-umm-service-concept)))
   (is (= ["OPeNDAP Service" "ACCESS WEB SERVICE" "GET SERVICE" "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" "CollectionURL"]
-         ((:RelatedURL keyword-util/fields->fn-mapper) sample-umm-service-concept)))
+         ((:RelatedURLs keyword-util/fields->fn-mapper) sample-umm-service-concept)))
   (is (= ["EARTH SCIENCE SERVICES" nil "GEOGRAPHIC INFORMATION SYSTEMS" "DATA ANALYSIS AND VISUALIZATION" nil nil nil "ATMOSPHERE" "RADAR" "SURFACE WINDS" "ATMOSPHERIC WINDS" "SPECTRAL/ENGINEERING" "MICROWAVE" "MICROWAVE IMAGERY" "SCIENCE CAT 3" nil "SCIENCE TERM 3" "SCIENCE TOPIC 3" nil nil nil]
          ((:ScienceKeywords keyword-util/fields->fn-mapper) sample-umm-service-concept)))
   (is (= ["DATA ANALYSIS AND VISUALIZATION" nil nil "VISUALIZATION/IMAGE PROCESSING" "DATA ANALYSIS AND VISUALIZATION" nil nil nil nil nil nil "STATISTICAL APPLICATIONS"]
@@ -144,7 +143,7 @@
   (is (= ["ACCESS WEB SERVICE" "CollectionURL" "GET SERVICE" "OPeNDAP Service" "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"]
          (sort
           (keyword-util/concept-key->keywords
-           sample-umm-service-concept :RelatedURL))))
+           sample-umm-service-concept :RelatedURLs))))
   (is (= ["ATMOSPHERE" "ATMOSPHERIC WINDS" "DATA ANALYSIS AND VISUALIZATION" "EARTH SCIENCE SERVICES" "GEOGRAPHIC INFORMATION SYSTEMS" "MICROWAVE" "MICROWAVE IMAGERY" "RADAR" "SCIENCE CAT 3" "SCIENCE TERM 3" "SCIENCE TOPIC 3" "SPECTRAL/ENGINEERING" "SURFACE WINDS"]
          (sort
           (keyword-util/concept-key->keywords
@@ -156,7 +155,7 @@
               "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/aqua_airs_level3/airx3std.006/ "
               "level3 nasa opendap opendap service service web")
         (keyword-util/concept-key->keyword-text
-         sample-umm-service-concept :RelatedURL)))
+         sample-umm-service-concept :RelatedURLs)))
   (is (= (str "3 analysis and atmosphere atmospheric atmospheric winds cat "
               "data data analysis and visualization earth earth science "
               "services engineering geographic geographic information systems "
@@ -182,7 +181,7 @@
                      :ContactGroups
                      :ContactPersons
                      :Platforms
-                     :RelatedURL
+                     :RelatedURLs
                      :ScienceKeywords
                      :ServiceKeywords
                      :ServiceOrganizations]]
@@ -222,7 +221,7 @@
                      :ContactGroups
                      :ContactPersons
                      :Platforms
-                     :RelatedURL
+                     :RelatedURLs
                      :ScienceKeywords
                      :ServiceKeywords
                      :ServiceOrganizations]]

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -24,7 +24,7 @@
 (defconfig service-umm-version
   "Defines the latest service umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"
-  {:default "1.0"})
+  {:default "1.1"})
 
 (defn ingest-accept-umm-version
   "Returns the latest umm version accepted by ingest for the given concept-type."

--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_service.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_service.clj
@@ -16,11 +16,10 @@
    :Type "OPeNDAP"
    :Version "1.9"
    :Description "AIRS Level-3 retrieval product created using AIRS IR, AMSU without HSB."
-   :RelatedURL {
-     :URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"
-     :Description "OPeNDAP Service"
-     :Type "GET SERVICE"
-     :URLContentType "CollectionURL"}
+   :RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"
+                  :Description "OPeNDAP Service"
+                  :Type "GET SERVICE"
+                  :URLContentType "CollectionURL"}]
    :ServiceKeywords [
       {:ServiceCategory "DATA ANALYSIS AND VISUALIZATION"
        :ServiceTopic "VISUALIZATION/IMAGE PROCESSING"}]

--- a/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_search_test.clj
@@ -279,10 +279,10 @@
                                         :Subtype "USER'S GUIDE"})
         svc1 (services/ingest-service-with-attrs {:native-id "svc-1"
                                                   :Name "Service 1"
-                                                  :RelatedURL url1})
+                                                  :RelatedURLs [url1]})
         svc2 (services/ingest-service-with-attrs {:native-id "svc-2"
                                                   :Name "Service 2"
-                                                  :RelatedURL url2})
+                                                  :RelatedURLs [url2]})
         svc3 (services/ingest-service-with-attrs {:native-id "svc-3"
                                                   :Name "Service 3"})]
     (index/wait-until-indexed)
@@ -663,8 +663,8 @@
         {:accept (mime-types/with-version mime-types/umm-json umm-version/current-service-version)}
 
         "explicit UMM JSON version through suffix"
-        "1.0"
-        {:url-extension "umm_json_v1_0"})))
+        "1.1"
+        {:url-extension "umm_json_v1_1"})))
 
   (testing "Searching with non-existent UMM JSON version"
     (are3 [options]

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-cmn-json-schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "RelatedUrlType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents Internet sites that contain information related to the data, as well as related Internet sites such as project home pages, related data archives/servers, metadata extensions, online software packages, web mapping services, and calibration/validation data.",
+      "properties": {
+        "Description": {
+          "description": "Description of the web page at this URL.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "URLContentType": {
+            "description": "A keyword describing the distinct content type of the online resource to this resource. (e.g., 'DATACENTER URL', 'DATA CONTACT URL', 'DISTRIBUTION URL').",
+            "$ref": "#/definitions/RelatedURLContentTypeEnum"
+        },
+        "Type": {
+            "description": "A keyword describing the type of the online resource to this resource. This helps the GUI to know what to do with this resource. (e.g., 'GET DATA', 'GET SERVICE', 'GET VISUALIZATION').",
+            "$ref": "#/definitions/RelatedUrlTypeEnum"
+        },
+        "Subtype": {
+            "description": "A keyword describing the subtype of the online resource to this resource. This further helps the GUI to know what to do with this resource. (e.g., 'MEDIA', 'BROWSE', 'OPENDAP', 'OPENSEARCH', 'WEB COVERAGE SERVICES', 'WEB FEATURE SERVICES', 'WEB MAPPING SERVICES', 'SSW', 'ESI').",
+            "$ref": "#/definitions/RelatedURLSubTypeEnum"
+        },
+        "URL": {
+          "description": "The URL for the relevant web page (e.g., the URL of the responsible organization's home page, the URL of the collection landing page, the URL of the download site for the collection).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "GetData": {
+               "description": "The data distribution information for the relevant web page (e.g., browse, media).",
+               "$ref": "#/definitions/GetDataType"
+        },
+        "GetService": {
+            "description": "The service distribution for the relevant web page (e.g., OPeNDAP, OpenSearch, WCS, WFS, WMS).",
+            "$ref": "#/definitions/GetServiceType"
+        }
+      },
+      "required": ["URL", "URLContentType", "Type"]
+    },
+    "GetDataType": {
+        "description": "Represents the information needed for a DistributionURL where data is retrieved.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Format": {
+                "description": "The format of the data.",
+                "$ref": "#/definitions/GetDataTypeFormatEnum"
+            },
+            "Size": {
+                "description": "The size of the data.",
+               "type": "number"
+            },
+            "Unit": {
+                "description": "Unit of information, together with Size determines total size in bytes of the data.",
+                "type": "string",
+                "enum": ["KB", "MB", "GB", "TB", "PB"]
+            },
+            "Fees": {
+                "description": "The fee for ordering the collection data.  The fee is entered as a number, in US Dollars.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "Checksum": {
+                "description": "The checksum, usually a SHA1 or md5 checksum for the data file.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 50
+            }
+        },
+        "required": ["Format", "Size", "Unit"]
+    },
+    "GetServiceType": {
+        "description": "Represents a Service through a URL where the service will act on data and return the result to the caller.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "MimeType": {
+                "description": "The mime type of the service.",
+                "$ref": "#/definitions/URLMimeTypeEnum"
+            },
+            "Protocol": {
+                "description": "The protocol of the service.",
+                "type": "string",
+                "enum": ["HTTP", "HTTPS", "FTP", "FTPS", "Not provided"]
+            },
+            "FullName": {
+                "description": "The full name of the service.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "DataID": {
+                "description": "The data identifier of the data provided by the service. Typically, this is a file name.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "DataType": {
+                "description": "The data type of the data provided by the service.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "URI": {
+                "description": "The URI of the data provided by the service.",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1024
+                },
+                "minItems": 1
+            }
+        }
+    },
+   "ScienceKeywordType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Enables specification of Earth science keywords related to the collection.  The Earth Science keywords are chosen from a controlled keyword hierarchy maintained in the Keyword Management System (KMS).",
+      "properties": {
+        "Category": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "Topic": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "Term": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel1": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel2": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel3": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "DetailedVariable": {
+          "$ref": "#/definitions/KeywordStringType"
+        }
+      },
+      "required": ["Category", "Topic", "Term"]
+    },
+    "UuidType": {
+      "description": "A Level 3 UUID, see wiki link http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29",
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89abAB][0-9a-f]{3}-[0-9a-f]{12}"
+    },
+    "KeywordStringType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,79}"
+    },
+    "RelatedURLContentTypeEnum": {
+      "type": "string",
+      "enum": ["CollectionURL", "PublicationURL", "DataCenterURL", "DistributionURL", "DataContactURL", "VisualizationURL"]
+    },
+    "RelatedUrlTypeEnum": {
+      "type": "string",
+      "enum": ["GET DATA", "GET SERVICE", "GET RELATED VISUALIZATION", "DATA SET LANDING PAGE", "DOI",
+               "EXTENDED METADATA", "PROFESSIONAL HOME PAGE", "PROJECT HOME PAGE", "VIEW RELATED INFORMATION",
+               "HOME PAGE"]
+    },
+    "RelatedURLSubTypeEnum": {
+      "type": "string",
+      "enum": ["DATACAST URL", "EARTHDATA SEARCH", "ECHO", "EDG", "EOSDIS DATA POOL", "GDS", "GIOVANNI", "KML",
+               "LAADS", "LANCE", "LAS", "MIRADOR", "MODAPS", "NOAA CLASS", "ON-LINE ARCHIVE", "REVERB",
+               "ACCESS MAP VIEWER", "ACCESS MOBILE APP", "ACCESS WEB SERVICE", "DIF", "MAP SERVICE", "NOMADS",
+               "OPENDAP DATA", "OPENDAP DATA (DODS)", "OPENDAP DIRECTORY (DODS)", "OpenSearch", "SERF", "SOFTWARE PACKAGE",
+               "SSW", "SUBSETTER", "THREDDS CATALOG", "THREDDS DATA", "THREDDS DIRECTORY", "TOOL", "WEB COVERAGE SERVICE (WCS)",
+               "WEB FEATURE SERVICE (WFS)", "WEB MAP FOR TIME SERIES", "WEB MAP SERVICE (WMS)", "WORKFLOW (SERVICE CHAIN)",
+               "GIBS", "MAP", "ALGORITHM THEORETICAL BASIS DOCUMENT", "CALIBRATION DATA DOCUMENTATION", "DATA QUALITY",
+               "CASE STUDY", "DATA USAGE", "DELIVERABLES CHECKLIST", "GENERAL DOCUMENTATION", "HOW-TO", "PI DOCUMENTATION",
+               "PROCESSING HISTORY", "PRODUCTION VERSION HISTORY", "PRODUCT QUALITY ASSESSMENT", "PRODUCT USAGE",
+               "PRODUCT HISTORY", "PUBLICATIONS", "RADIOMETRIC AND GEOMETRIC CALIBRATION METHODS", "READ-ME",
+               "RECIPE", "REQUIREMENTS AND DESIGN", "SCIENCE DATA PRODUCT SOFTWARE DOCUMENTATION",
+               "SCIENCE DATA PRODUCT VALIDATION", "USER FEEDBACK", "USER'S GUIDE"]
+    },
+    "URLMimeTypeEnum": {
+      "type": "string",
+      "enum": ["application/json", "application/xml", "application/x-netcdf", "application/gml+xml",
+               "application/vnd.google-earth.kml+xml", "image/gif", "image/tiff", "image/bmp", "text/csv",
+               "text/xml", "application/pdf", "application/x-hdf", "application/xhdf5",
+               "application/octet-stream", "application/vnd.google-earth.kmz", "image/jpeg", "image/png",
+               "image/vnd.collada+xml", "text/html", "text/plain", "Not provided"]
+    },
+    "GetDataTypeFormatEnum": {
+      "type": "string",
+      "enum": ["ascii", "binary", "GRIB", "BUFR", "HDF4", "HDF5", "HDF-EOS4", "HDF-EOS5", "jpeg", "png", "tiff", "geotiff", "kml", "Not provided"]
+    }
+  }
+}

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
@@ -496,7 +496,7 @@
       "properties": {
         "CoverageSpatialExtentTypeType": {
           "description": "Type of the spatial extent for the coverage available from the service..",
-          "$ref": "#/definitions/CoverageSpatialTypeEnum"
+          "$ref": "#/definitions/CoverageSpatialExtentTypeEnum"
         },
         "Uuid": {
           "description": "Uuid of the spatial extent.",
@@ -537,7 +537,7 @@
       "properties": {
         "CoverageTemporalExtentTypeType": {
           "description": "The type of the temporal extent for the coverage available from the service.",
-          "$ref": "#/definitions/CoverageTemporalTypeEnum"
+          "$ref": "#/definitions/CoverageTemporalExtentTypeEnum"
         },
         "CoverageTimePoints": {
           "description": "Points in time representing the temporal extent of the layer or coverage.",
@@ -576,12 +576,12 @@
         }
       }
     },
-    "CoverageSpatialTypeEnum": {
+    "CoverageSpatialExtentTypeEnum": {
       "description": "This element is used to identify the coverage spatial type, either: point, linestring, bounding box or polygon.",
       "type": "string",
       "enum": ["SPATIAL_POINT", "SPATIAL_LINE_STRING", "BOUNDING_BOX", "SPATIAL_POLYGON"]
     },
-    "CoverageTemporalTypeEnum": {
+    "CoverageTemporalExtentTypeEnum": {
       "description": "This element is used to identify the coverage temporal type, either: time stamp, time series, or time average.",
       "type": "string",
       "enum": ["TIME_STAMP", "TIME_SERIES", "TIME_AVERAGE"]

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
@@ -771,7 +771,7 @@
       "Type",
       "Version",
       "Description",
-      "RelatedURL",
+      "RelatedURLs",
       "ServiceKeywords",
       "ServiceOrganizations"
     ]

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-json-schema.json
@@ -1,0 +1,778 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ServiceOptionsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object describes service options, data transformations and output formats.",
+      "properties": {
+        "SubsetTypes": {
+          "description": "This element is used to identify the list of supported subsetting requests.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubsetTypeEnum"
+          },
+          "minItems": 0
+        },
+        "SupportedProjections": {
+          "description": "This element is used to identify the list of supported projections types.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProjectionTypeEnum"
+          },
+          "minItems": 0
+        },
+        "InterpolationTypes": {
+          "description": "This element is used to identify the list of supported interpolation types.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InterpolationTypeEnum"
+          },
+          "minItems": 0
+        },
+        "SupportedFormats": {
+          "description": "This project element describes the list of names of the formats supported by the service.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FormatTypeEnum"
+          },
+          "minItems": 0
+        }
+      }
+    },
+    "SubsetTypeEnum": {
+      "description": "This element is used to identify the subset type of the variable.",
+      "type": "string",
+      "enum": ["Spatial", "Temporal", "Variable"]
+    },
+    "ProjectionTypeEnum": {
+      "description": "This element is used to identify the projection type of the variable.",
+      "type": "string",
+      "enum": ["Geographic", "Sinusoidal", "Mercator", "Transverse Mercator", "Universal Transverse Mercator",  "UTM Northern Hemisphere", "UTM Southern Hemisphere", "State Plane Coordinates", "Albers Equal-Area Conic",  "Lambert Conic Conformal", "Lambert Azimuthal Equal Area", "Cylindrical Equal Area", "Polar Stereographic", "EASE-Grid", "EASE-Grid 2.0", "WGS 84 / UPS North (N,E)", "WGS84 - World Geodetic System 1984", "NSIDC EASE-Grid North", "NSIDC EASE-Grid Global", "NSIDC Sea Ice Polar Stereographic North", "WGS 84 / NSIDC Sea Ice Polar Stereographic North", "WGS 84 / North Pole LAEA Bering Sea", "WGS 84 / North Pole LAEA Alaska", "WGS 84 / North Pole LAEA Canada", "WGS 84 / North Pole LAEA Atlantic", "WGS 84 / North Pole LAEA Europe", "WGS 84 / North Pole LAEA Russia", "WGS 84 / NSIDC EASE-Grid North", "WGS 84 / NSIDC EASE-Grid Global", "WGS 84 / UTM zone 24N", "WGS 84 / Pseudo-Mercator -- Spherical Mercator, Google Maps, OpenStreetMap, Bing, ArcGIS, ESRI", "Google Maps Global Mercator -- Spherical Mercator", "WGS 84 / Antarctic Polar Stereographic", "NSIDC EASE-Grid South", "NSIDC Sea Ice Polar Stereographic South", "WGS 84 / NSIDC EASE-Grid South", "WGS 84 / NSIDC Sea Ice Polar Stereographic South", "WGS 84 / UPS South (N,E)"]
+    },
+    "InterpolationTypeEnum": {
+      "description": "This element is used to identify the interpolation type of the variable.",
+      "type": "string",
+      "enum": ["Bilinear Interpolation", "Bicubic Interpolation", "Distance-weighted average resampling", "Nearest Neighbor"]
+    },
+    "FormatTypeEnum": {
+     "description": "This element contains a list of file formats supported by the service.",
+     "type": "string",
+     "enum": ["HDF4", "HDF5", "HDF-EOS4", "HDF-EOS5", "netCDF-3", "netCDF-4", "Binary", "ASCII", "PNG", "JPEG", "GeoTIFF", "image/png", "image/tiff", "image/gif", "image/png; mode=24bit", "image/jpeg", "image/vnd.wap.wbmp"]
+    },
+    "ServiceKeywordType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Enables specification of Earth science service keywords related to the service.  The Earth Science Service keywords are chosen from a controlled keyword hierarchy maintained in the Keyword Management System (KMS).",
+      "properties": {
+        "ServiceCategory": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "ServiceTopic": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "ServiceTerm": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "ServiceSpecificTerm": {
+          "$ref": "#/definitions/KeywordStringType"
+        }
+      },
+      "required": ["ServiceCategory", "ServiceTopic"]
+    },
+    "KeywordStringType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,79}"
+    },
+    "ServiceOrganizationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines a service organization which is either an organization or institution responsible for distributing, archiving, or processing the data via a service, etc.",
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the service organization.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceOrganizationRoleEnum"
+          },
+          "minItems": 1
+        },
+        "ShortName": {
+          "description": "This is the short name of the service organization.",
+           "$ref": "#/definitions/ServiceOrganizationShortNameType"
+        },
+        "LongName": {
+          "description": "This is the long name of the service organization.",
+           "$ref": "#/definitions/LongNameType"
+        },
+        "ContactGroups": {
+          "description": "This is the contact groups of the service organization.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContactGroupType"
+          }
+        },
+        "ContactPersons": {
+          "description": "This is the contact persons of the service organization.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContactPersonType"
+          }
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the service organization.",
+          "$ref": "#/definitions/ContactInformationType"
+        }
+      },
+      "required": ["Roles", "ShortName"]
+    },
+    "ContactGroupType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the service contact.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceContactRoleEnum"
+          },
+          "minItems": 1
+        },
+        "Uuid": {
+          "description": "Uuid of the service contact.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/UuidType"
+        },
+        "NonServiceOrganizationAffiliation": {
+          "description": "This is the contact person or group that is not affiliated with the service organizations.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the service contact.",
+          "$ref": "#/definitions/ContactInformationType"
+        },
+        "GroupName": {
+          "description": "This is the contact group name.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "required": ["Roles", "GroupName"]
+    },
+    "ContactPersonType": {
+      "type": "object",
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the service contact.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceOrganizationRoleEnum"
+          },
+          "minItems": 1
+        },
+        "Uuid": {
+          "description": "Uuid of the data contact.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/UuidType"
+        },
+        "NonServiceOrganizationAffiliation": {
+          "description": "This is the contact person or group that is not affiliated with the service organization.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the service contact.",
+          "$ref": "#/definitions/ContactInformationType"
+        },
+        "FirstName": {
+          "description": "First name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "MiddleName": {
+          "description": "Middle name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "LastName": {
+          "description": "Last name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "required": ["Roles", "LastName"]
+    },
+    "ContactInformationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines the contact information of a service organization or service contact.",
+      "properties": {
+        "RelatedUrls": {
+          "description": "A URL associated with the contact, e.g., the home page for the service provider which is responsible for the service.",
+          "type": "array",
+          "items": {
+            "$ref": "umm-cmn-json-schema.json#/definitions/RelatedUrlType"
+          },
+          "minItems": 0
+        },
+        "ServiceHours": {
+          "description": "Time period when the contact answers questions or provides services.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInstruction": {
+          "description": "Supplemental instructions on how or when to contact the responsible party.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "ContactMechanisms": {
+          "description": "Mechanisms of contacting.",
+          "type": "array",
+          "items": {
+             "$ref": "#/definitions/ContactMechanismType"
+          }
+        },
+         "Addresses": {
+          "description": "Contact addresses.",
+          "type": "array",
+          "items": {
+             "$ref": "#/definitions/AddressType"
+          }
+        }
+      }
+    },
+    "ContactMechanismType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Method for contacting the service contact. A contact can be available via phone, email, Facebook, or Twitter.",
+      "properties": {
+        "Type": {
+          "description": "This is the method type for contacting the responsible party - phone, email, Facebook, or Twitter.",
+          "$ref": "#/definitions/ContactMechanismTypeEnum"
+        },
+        "Value": {
+          "description": "This is the contact phone number, email address, Facebook address, or Twitter handle associated with the contact method.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        }
+      },
+      "required": ["Type", "Value"]
+    },
+    "ServiceOrganizationShortNameType": {
+      "description": "The unique name of the service organization.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 85,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,84}"
+    },
+    "ServiceOrganizationRoleEnum": {
+      "description": "Defines the possible values of a service provider role.",
+      "type": "string",
+      "enum": ["SERVICE PROVIDER", "DEVELOPER", "PUBLISHER", "AUTHOR", "ORIGINATOR"]
+    },
+    "LongNameType": {
+      "description": "The expanded or long name related to the short name.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "ServiceTypeEnum": {
+      "description": "This element is used to identify the type of the service.",
+      "type": "string",
+      "enum": ["OPeNDAP", "THREDDS", "WEB SERVICES", "WCS", "WMS", "SOFTWARE PACKAGE", "TOOL", "WEB PORTAL", "International Web Portal", "MODEL", "NOT PROVIDED"]
+    },
+    "ServiceQualityType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object describes service quality, composed of the quality flag, the quality flagging system, traceability and lineage.",
+      "properties": {
+        "QualityFlag": {
+          "description": "The quality flag for the service.",
+          "$ref": "#/definitions/QualityFlagEnum"
+        },
+        "Traceability": {
+          "description": "The quality traceability of the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "Lineage": {
+          "description": "The quality lineage of the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        }
+      },
+      "required": ["QualityFlag"]
+    },
+    "QualityFlagEnum": {
+      "description": "Defines the possible quality flags.",
+      "type": "string",
+      "enum": ["Available", "Unavailable", "Reviewed", "Not Reviewed", "Other"]
+    },
+    "AccessConstraintsType": {
+      "description": "Information about any constraints for accessing the service, software, or tool.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4000
+    },
+    "UseConstraintsType": {
+      "description": "Information on how the item (service, software, or tool) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20000
+    },
+    "AncillaryKeywordsType": {
+      "description": "Words or phrases to further describe the service, software, or tool.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "PlatformType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element describes the platform information.",
+      "properties": {
+        "ShortName": {
+          "description": "The short name of the platform associated with the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "LongName": {
+          "description": "The long name of the platform associated with the service.",
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 1024
+        },
+        "Instruments": {
+          "description": "Associates the instrument/sensor that is supported by the service, software, or tool.",
+          "type": "array",
+          "items": {
+              "$ref": "#/definitions/InstrumentType"
+          },
+        "minItems": 0
+        }
+      }
+    },
+    "InstrumentType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element describes instrument information.",
+      "properties": {
+        "ShortName": {
+          "description": "The short name of the instrument associated with the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "LongName": {
+          "description": "The long name of the instrument associated with the service.",
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 1024
+        }
+      }
+    },
+    "ServiceContactRoleEnum": {
+      "description": "Defines the possible values of a service provider role.",
+      "type": "string",
+      "enum": ["SERVICE PROVIDER CONTACT", "TECHNICAL CONTACT", "SCIENCE CONTACT", "INVESTIGATOR", "SOFTWARE AUTHOR", "TOOL AUTHOR", "USER SERVICES", "SCIENCE SOFTWARE DEVELOPMENT", "SERVICE PROVIDER"]
+    },
+    "ContactMechanismTypeEnum": {
+      "description": "Defines the possible contact mechanism types.",
+      "type": "string",
+      "enum": ["Direct Line", "Email", "Facebook", "Fax", "Mobile", "Modem", "Primary", "TDD/TTY Phone", "Telephone", "Twitter", "U.S. toll free", "Other"]
+    },
+    "AddressType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This entity contains the physical address details for the contact.",
+      "properties": {
+        "StreetAddresses": {
+          "description": "An address line for the street address, used for mailing or physical addresses of organizations or individuals who serve as contacts for the service.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "minItems": 0
+        },
+        "City": {
+          "description": "The city portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "StateProvince": {
+          "description": "The state or province portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "Country": {
+          "description": "The country of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "PostalCode": {
+          "description": "The zip or other postal code portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20
+        }
+      }
+    },
+    "CoordinatesType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The coordinates consist of a latitude and longitude.",
+      "properties": {
+        "Latitude": {
+          "description": "The latitude of the point.",
+          "type": "number"
+        },
+        "Longitude": {
+          "description": "The longitude of the point.",
+          "type": "number"
+        }
+      },
+      "required": ["Latitude", "Longitude"]
+    },
+    "LineStringType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The line string consists of two points: a start point and an end ppint.",
+      "properties": {
+        "StartPoint": {
+          "description": "The start point of the line string.",
+          "$ref": "#/definitions/CoordinatesType"
+        },
+        "EndPoint": {
+          "description": "The end point of the line string.",
+          "$ref": "#/definitions/CoordinatesType"
+        }
+      },
+      "required": ["StartPoint", "EndPoint"]
+    },
+    "BBoxType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The bounding box consists of min x, min y, max y and max y ordinates.",
+      "properties": {
+        "MinX": {
+          "description": "The minimum x ordinate of the bounding box.",
+          "type": "number"
+        },
+        "MinY": {
+          "description": "The minimum y ordinate of the bounding box.",
+          "type": "number"
+        },
+        "MaxX": {
+          "description": "The maximum x ordinate of the bounding box.",
+          "type": "number"
+        },
+        "MaxY": {
+          "description": "The maximum y ordinate of the bounding box.",
+          "type": "number"
+        }
+      },
+      "required": ["MinX", "MinY", "MaxX", "MaxY"]
+    },
+    "CoverageSpatialExtentType": {
+      "type": "object",
+      "properties": {
+        "CoverageSpatialExtentTypeType": {
+          "description": "Type of the spatial extent for the coverage available from the service..",
+          "$ref": "#/definitions/CoverageSpatialTypeEnum"
+        },
+        "Uuid": {
+          "description": "Uuid of the spatial extent.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/UuidType"
+        },
+        "SpatialPoints": {
+          "description": "The spatial extent of the layer or coverage described by a point.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CoordinatesType"
+          },
+          "minItems": 1
+        },
+        "SpatialLineStrings": {
+          "description": "The spatial extent of the layer or coverage described by a line string.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LineStringType"
+          },
+          "minItems": 1
+        },
+        "SpatialBoundingBox": {
+          "description": "The spatial extent of the layer or coverage described by a bounding box.",
+          "$ref": "#/definitions/BBoxType"
+        },
+        "SpatialPolygons": {
+          "description": "The spatial extent of the layer or coverage described by a polygon.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CoordinatesType"
+          },
+          "minItems": 3
+        }
+      }
+    },
+    "CoverageTemporalExtentType": {
+      "type": "object",
+      "properties": {
+        "CoverageTemporalExtentTypeType": {
+          "description": "The type of the temporal extent for the coverage available from the service.",
+          "$ref": "#/definitions/CoverageTemporalTypeEnum"
+        },
+        "CoverageTimePoints": {
+          "description": "Points in time representing the temporal extent of the layer or coverage.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimePointsType"
+          },
+          "minItems": 1
+        },
+        "Uuid": {
+          "description": "Uuid of the temporal extent.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/UuidType"
+        }
+      }
+    },
+    "TimePointsType": {
+      "type": "object",
+      "properties": {
+        "TimeFormat": {
+          "description": "Time format representing time point of the temporal extent.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "TimeValue": {
+          "description": "Time value of the time point of temporal extent.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Description": {
+          "description": "Description of the time value of the temporal extent.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    },
+    "CoverageSpatialTypeEnum": {
+      "description": "This element is used to identify the coverage spatial type, either: point, linestring, bounding box or polygon.",
+      "type": "string",
+      "enum": ["SPATIAL_POINT", "SPATIAL_LINE_STRING", "BOUNDING_BOX", "SPATIAL_POLYGON"]
+    },
+    "CoverageTemporalTypeEnum": {
+      "description": "This element is used to identify the coverage temporal type, either: time stamp, time series, or time average.",
+      "type": "string",
+      "enum": ["TIME_STAMP", "TIME_SERIES", "TIME_AVERAGE"]
+    },
+    "CoverageType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element describes coverage information.",
+      "properties": {
+        "Name": {
+          "description": "The name of the coverage available from the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "CoverageSpatialExtent": {
+          "description": "The spatial extent of the coverage available from the service. These are coordinate pairs which describe either the point, line string, or polygon representing the spatial extent. The bounding box is described by the west, south, east and north ordinates",
+          "$ref": "#/definitions/CoverageSpatialExtentType"
+        },
+        "SpatialResolution": {
+          "description": "The spatial resolution of the coverage available from the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "SpatialResolutionUnit": {
+          "description": "The unit of the spatial resolution of the coverage available from the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "CoverageTemporalExtent": {
+          "description": "The temporal extent of the coverage available from the service.",
+          "$ref": "#/definitions/CoverageTemporalExtentType"
+        },
+        "TemporalResolution": {
+          "description": "The temporal resolution of the coverage available from the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "TemporalResolutionUnit": {
+          "description": "The unit of the temporal resolution of the coverage available from the service.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "RelativePath": {
+          "description": "Path relative to the root universal resource locator for the coverage.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    }
+  },
+    "title": "UMM-S",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "Name": {
+        "description": "The name of the service, software, or tool.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 85
+      },
+      "LongName": {
+        "description": "The long name of the service, software, or tool.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 120
+      },
+      "Type": {
+        "description": "The type of the service, software, or tool.",
+        "$ref": "#/definitions/ServiceTypeEnum"
+      },
+      "Version": {
+        "description": "The edition or version of the service, software, or tool.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 20
+      },
+      "Description": {
+        "description": "A brief description of the service.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1024
+      },
+      "RelatedURLs": {
+        "description": "This element contains important information about the universal resource locator (URL) for the service.",
+        "type": "array",
+        "items": {
+            "$ref": "umm-cmn-json-schema.json#/definitions/RelatedUrlType"
+        },
+        "minItems": 1
+      },
+      "OnlineAccessURLPatternMatch": {
+        "description": "A field needed for pattern matching in OPeNDAP services",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1024
+      },
+      "OnlineAccessURLPatternSubstitution": {
+        "description": "A field needed for pattern substitution in OPeNDAP services",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1024
+      },
+      "ScienceKeywords": {
+        "description": "Allows for the specification of Earth Science keywords that are representative of the service, software, or tool being described. The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS).",
+        "type": "array",
+        "items": {
+            "$ref": "umm-cmn-json-schema.json#/definitions/ScienceKeywordType"
+        },
+      "minItems": 0
+      },
+      "ServiceKeywords": {
+        "description": "Allows for the specification of Earth Science Service keywords that are representative of the service, software, or tool being described. The controlled vocabulary for Service Keywords is maintained in the Keyword Management System (KMS).",
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/ServiceKeywordType"
+        },
+      "minItems": 1
+      },
+      "ServiceOrganizations": {
+        "description": "The service provider, or organization, or institution responsible for developing, archiving, and/or distributing the service, software, or tool.",
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/ServiceOrganizationType"
+        },
+      "minItems": 1
+      },
+      "ContactGroups": {
+        "description": "This is the contact groups of the service.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ContactGroupType"
+        }
+      },
+      "ContactPersons": {
+        "description": "This is the contact persons of the service.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ContactPersonType"
+        }
+      },
+      "Platforms": {
+        "description": "Associates the satellite/platform that is supported by the service, software, or tool.",
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/PlatformType"
+        },
+      "minItems": 0
+      },
+      "ServiceQuality": {
+        "description": "Information about the quality of the service, software, or tool, or any quality assurance procedures followed in development.",
+        "$ref": "#/definitions/ServiceQualityType"
+      },
+      "AccessConstraints": {
+        "description": "Information about any constraints for accessing the service, software, or tool.",
+         "$ref": "#/definitions/AccessConstraintsType"
+      },
+      "UseConstraints": {
+        "description": "Information on how the item (service, software, or tool) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness.",
+        "$ref": "#/definitions/UseConstraintsType"
+      },
+      "AncillaryKeywords": {
+        "description": "Words or phrases to further describe the service, software, or tool.",
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/AncillaryKeywordsType"
+        },
+        "minItems": 0
+      },
+      "ServiceOptions": {
+        "description": "This element contains important information about the Unique Resource Locator for the service.",
+        "$ref": "#/definitions/ServiceOptionsType"
+      },
+      "Coverage": {
+        "description": "This element contains important information about the coverage for the service.",
+        "$ref": "#/definitions/CoverageType"
+      }
+    },
+    "required": [
+      "Name",
+      "LongName",
+      "Type",
+      "Version",
+      "Description",
+      "RelatedURL",
+      "ServiceKeywords",
+      "ServiceOrganizations"
+    ]
+  }

--- a/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/service/umm/v1.1/umm-s-search-results-json-schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-s-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["service"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "type": "string",
+          "minLength": 4,
+          "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "user-id": {
+          "description": "The id of the user who created this item revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "deleted": {
+          "description": "Indicates if the item represents a tombstone",
+          "type": "boolean"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date"]
+    },
+    "ConceptRevisionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Concept id and revision id.",
+      "properties": {
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "type": "string",
+          "minLength": 4,
+          "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        }
+      },
+      "required": ["concept-id"]
+    }
+  },
+  "title": "UMM Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
@@ -18,6 +18,7 @@
    [cmr.umm-spec.migration.version.collection]
    [cmr.umm-spec.migration.version.interface :as interface]
    [cmr.umm-spec.migration.version.variable]
+   [cmr.umm-spec.migration.version.service]
    [cmr.umm-spec.spatial-conversion :as spatial-conversion]
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.versioning :refer [versions current-version]]
@@ -60,10 +61,10 @@
 
 (defn migrate-umm
   [context concept-type source-version dest-version data]
-  (log/info "concept-type" concept-type)
-  (log/info "source-version" source-version)
-  (log/info "dest-version" dest-version)
-  (log/info "data" data)
+  (log/error "concept-type" concept-type)
+  (log/error "source-version" source-version)
+  (log/error "dest-version" dest-version)
+  (log/error "data" data)
   (if (= source-version dest-version)
     data
     ;; Migrating across versions is just reducing over the discrete steps between each version.

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
@@ -5,6 +5,7 @@
    [clojure.string :as string]
    [cmr.common-app.services.kms-fetcher :as kf]
    [cmr.common.mime-types :as mt]
+   [cmr.common.log :as log]
    [cmr.common.util :as util :refer [update-in-each]]
    [cmr.umm-spec.dif-util :as dif-util]
    [cmr.umm-spec.location-keywords :as lk]
@@ -59,6 +60,10 @@
 
 (defn migrate-umm
   [context concept-type source-version dest-version data]
+  (log/info "concept-type" concept-type)
+  (log/info "source-version" source-version)
+  (log/info "dest-version" dest-version)
+  (log/info "data" data)
   (if (= source-version dest-version)
     data
     ;; Migrating across versions is just reducing over the discrete steps between each version.

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
@@ -61,10 +61,6 @@
 
 (defn migrate-umm
   [context concept-type source-version dest-version data]
-  (log/error "concept-type" concept-type)
-  (log/error "source-version" source-version)
-  (log/error "dest-version" dest-version)
-  (log/error "data" data)
   (if (= source-version dest-version)
     data
     ;; Migrating across versions is just reducing over the discrete steps between each version.

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/interface.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/interface.clj
@@ -19,7 +19,6 @@
 
 (defmethod migrate-umm-version :default
   [context concept & _]
-  (log/error "DBG:1234" concept)
   ;; Do nothing by default. This lets us skip over "holes" in the version
   ;; sequence, where the UMM version may be updated but a particular concept
   ;; type's schema may not be affected.

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/interface.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/interface.clj
@@ -1,6 +1,8 @@
 (ns cmr.umm-spec.migration.version.interface
   "Contains the interface definition for migrating between versions of UMM
-  schemas.")
+  schemas."
+  (:require
+   [cmr.common.log :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Interface for Migrating Between Versions
@@ -17,6 +19,7 @@
 
 (defmethod migrate-umm-version :default
   [context concept & _]
+  (log/error "DBG:1234" concept)
   ;; Do nothing by default. This lets us skip over "holes" in the version
   ;; sequence, where the UMM version may be updated but a particular concept
   ;; type's schema may not be affected.

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -33,7 +33,6 @@
 
 (defmethod interface/migrate-umm-version [:service "1.0" "1.1"]
   [context s & _]
-  (log/error "DBG: MIGRATING SERVICE UP 1.0 to 1.1" s)
   (-> s
       (assoc :AccessConstraints (first (:AccessConstraints s)))
       (update :AccessConstraints #(util/trunc % 1024))
@@ -46,7 +45,6 @@
 
 (defmethod interface/migrate-umm-version [:service "1.1" "1.0"]
   [context s & _]
-  (log/error "DBG: MIGRATING SERVICE DOWN 1.1 to 1.0" s)
   (-> s
       (assoc :AccessConstraints [(:AccessConstraints s)])
       (assoc :RelatedURL (first (:RelatedURLs s)))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -2,6 +2,7 @@
   "Contains functions for migrating between versions of the UMM Service schema."
   (:require
    [cmr.common.util :as util]
+   [cmr.common.log :as log]
    [cmr.umm-spec.migration.version.interface :as interface]))
 
 (defn- migrate-related-url-subtype-down
@@ -32,6 +33,7 @@
 
 (defmethod interface/migrate-umm-version [:service "1.0" "1.1"]
   [context s & _]
+  (log/error "DBG: MIGRATING SERVICE UP 1.0 to 1.1" s)
   (-> s
       (assoc :AccessConstraints (first (:AccessConstraints s)))
       (update :AccessConstraints #(util/trunc % 1024))
@@ -44,6 +46,7 @@
 
 (defmethod interface/migrate-umm-version [:service "1.1" "1.0"]
   [context s & _]
+  (log/error "DBG: MIGRATING SERVICE DOWN 1.1 to 1.0" s)
   (-> s
       (assoc :AccessConstraints [(:AccessConstraints s)])
       (assoc :RelatedURL (first (:RelatedURLs s)))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -16,15 +16,15 @@
   [coverage-type]
   (-> coverage-type
       (assoc :Type (get-in coverage-type [:CoverageSpatialExtentType :CoverageSpatialExtentTypeType]))
-      (update :CoverageTemporalExtentType dissoc :CoverageTemporalExtentTypeType)
-      (update :CoverageSpatialExtentType dissoc :CoverageSpatialExtentTypeType)))
+      (update :CoverageTemporalExtent dissoc :CoverageTemporalExtentType)
+      (update :CoverageSpatialExtent dissoc :CoverageSpatialExtentType)))
 
 (defn- migrate-coverage-type-up
   "Migrate CoverageType changes up from 1.0 to 1.1"
   [coverage-type]
   (-> coverage-type
-      (update :CoverageSpatialExtentType
-              assoc :CoverageSpatialExtentTypeType (get coverage-type :Type))
+      (update :CoverageSpatialExtent
+              assoc :CoverageSpatialExtentType (get coverage-type :Type))
       (dissoc :Type)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -1,0 +1,53 @@
+(ns cmr.umm-spec.migration.version.service
+  "Contains functions for migrating between versions of the UMM Service schema."
+  (:require
+   [cmr.common.util :as util]
+   [cmr.umm-spec.migration.version.interface :as interface]))
+
+(defn- migrate-related-url-subtype-down
+  "Migrate value TOOL to nil"
+  [related-url]
+  (if (= "TOOL" (get related-url :SubType))
+    (assoc related-url :SubType nil)
+    related-url))
+
+(defn- migrate-coverage-type-down
+  "Migrate CoverageType changes down from 1.1 to 1.0"
+  [coverage-type]
+  (-> coverage-type
+      (assoc :Type (get-in coverage-type [:CoverageSpatialExtentType :CoverageSpatialExtentTypeType]))
+      (update :CoverageTemporalExtentType dissoc :CoverageTemporalExtentTypeType)
+      (update :CoverageSpatialExtentType dissoc :CoverageSpatialExtentTypeType)))
+
+(defn- migrate-coverage-type-up
+  "Migrate CoverageType changes up from 1.0 to 1.1"
+  [coverage-type]
+  (-> coverage-type
+      (update :CoverageSpatialExtentType
+              assoc :CoverageSpatialExtentTypeType (get coverage-type :Type))
+      (dissoc :Type)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;; Service Migration Implementations
+
+(defmethod interface/migrate-umm-version [:service "1.0" "1.1"]
+  [context v & _]
+  (-> v
+      (assoc :AccessConstraints (first (:AccessConstraints v)))
+      (update :AccessConstraints #(util/trunc % 1024))
+      (update :UseConstraints #(util/trunc % 1024))
+      (update-in [:ServiceQuality :Lineage] #(util/trunc % 100))
+      (assoc :RelatedURLs [(:RelatedURL v)])
+      (update :CoverageType migrate-coverage-type-up)
+      (dissoc :RelatedURL)
+      util/remove-empty-maps))
+
+(defmethod interface/migrate-umm-version [:service "1.1" "1.0"]
+  [context v & _]
+  (-> v
+      (assoc :AccessConstraints [(:AccessConstraints v)])
+      (assoc :RelatedURL (first (:RelatedURLs v)))
+      (update :RelatedURL migrate-related-url-subtype-down)
+      (update :CoverageType migrate-coverage-type-down)
+      (dissoc :RelatedURLs)
+      util/remove-empty-maps))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -15,16 +15,16 @@
   "Migrate CoverageType changes down from 1.1 to 1.0"
   [coverage-type]
   (-> coverage-type
-      (assoc :Type (get-in coverage-type [:CoverageSpatialExtent :CoverageSpatialExtentType]))
-      (update :CoverageTemporalExtent dissoc :CoverageTemporalExtentType)
-      (update :CoverageSpatialExtent dissoc :CoverageSpatialExtentType)))
+      (assoc :Type (get-in coverage-type [:CoverageSpatialExtent :CoverageSpatialExtentTypeType]))
+      (update :CoverageTemporalExtent dissoc :CoverageTemporalExtentTypeType)
+      (update :CoverageSpatialExtent dissoc :CoverageSpatialExtentTypeType)))
 
 (defn- migrate-coverage-type-up
   "Migrate CoverageType changes up from 1.0 to 1.1"
   [coverage-type]
   (-> coverage-type
       (update :CoverageSpatialExtent
-              assoc :CoverageSpatialExtentType (get coverage-type :Type))
+              assoc :CoverageSpatialExtentTypeType (get coverage-type :Type))
       (dissoc :Type)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -31,22 +31,22 @@
  ;;; Service Migration Implementations
 
 (defmethod interface/migrate-umm-version [:service "1.0" "1.1"]
-  [context v & _]
-  (-> v
-      (assoc :AccessConstraints (first (:AccessConstraints v)))
+  [context s & _]
+  (-> s
+      (assoc :AccessConstraints (first (:AccessConstraints s)))
       (update :AccessConstraints #(util/trunc % 1024))
       (update :UseConstraints #(util/trunc % 1024))
       (update-in [:ServiceQuality :Lineage] #(util/trunc % 100))
-      (assoc :RelatedURLs [(:RelatedURL v)])
+      (assoc :RelatedURLs [(:RelatedURL s)])
       (update :Coverage migrate-coverage-type-up)
       (dissoc :RelatedURL)
       util/remove-empty-maps))
 
 (defmethod interface/migrate-umm-version [:service "1.1" "1.0"]
-  [context v & _]
-  (-> v
-      (assoc :AccessConstraints [(:AccessConstraints v)])
-      (assoc :RelatedURL (first (:RelatedURLs v)))
+  [context s & _]
+  (-> s
+      (assoc :AccessConstraints [(:AccessConstraints s)])
+      (assoc :RelatedURL (first (:RelatedURLs s)))
       (update :RelatedURL migrate-related-url-subtype-down)
       (update :Coverage migrate-coverage-type-down)
       (dissoc :RelatedURLs)

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/service.clj
@@ -15,7 +15,7 @@
   "Migrate CoverageType changes down from 1.1 to 1.0"
   [coverage-type]
   (-> coverage-type
-      (assoc :Type (get-in coverage-type [:CoverageSpatialExtentType :CoverageSpatialExtentTypeType]))
+      (assoc :Type (get-in coverage-type [:CoverageSpatialExtent :CoverageSpatialExtentType]))
       (update :CoverageTemporalExtent dissoc :CoverageTemporalExtentType)
       (update :CoverageSpatialExtent dissoc :CoverageSpatialExtentType)))
 
@@ -38,7 +38,7 @@
       (update :UseConstraints #(util/trunc % 1024))
       (update-in [:ServiceQuality :Lineage] #(util/trunc % 100))
       (assoc :RelatedURLs [(:RelatedURL v)])
-      (update :CoverageType migrate-coverage-type-up)
+      (update :Coverage migrate-coverage-type-up)
       (dissoc :RelatedURL)
       util/remove-empty-maps))
 
@@ -48,6 +48,6 @@
       (assoc :AccessConstraints [(:AccessConstraints v)])
       (assoc :RelatedURL (first (:RelatedURLs v)))
       (update :RelatedURL migrate-related-url-subtype-down)
-      (update :CoverageType migrate-coverage-type-down)
+      (update :Coverage migrate-coverage-type-down)
       (dissoc :RelatedURLs)
       util/remove-empty-maps))

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_service_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_service_models.clj
@@ -5,10 +5,6 @@
 
 (defrecord UMM-S
   [
-   ;; This element contains important information about the universal resource locator (URL) for the
-   ;; service.
-   RelatedURL
-
    ;; This element contains important information about the coverage for the service.
    Coverage
 
@@ -52,6 +48,10 @@
 
    ;; The name of the service, software, or tool.
    Name
+
+   ;; This element contains important information about the universal resource locator (URL) for the
+   ;; service.
+   RelatedURLs
 
    ;; A brief description of the service.
    Description

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_service_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_service_models.clj
@@ -168,9 +168,6 @@
    ;; This is the long name of the service organization.
    LongName
 
-   ;; Uuid of the service organization.
-   Uuid
-
    ;; This is the contact groups of the service organization.
    ContactGroups
 
@@ -200,17 +197,13 @@
 ;; This element describes coverage information.
 (defrecord CoverageType
   [
-   ;; The temporal resolution of the coverage available from the service.
-   TemporalResolution
+   ;; The name of the coverage available from the service.
+   Name
 
-   ;; Path relative to the root universal resource locator for the coverage.
-   RelativePath
-
-   ;; The unit of the temporal resolution of the coverage available from the service.
-   TemporalResolutionUnit
-
-   ;; The temporal extent of the coverage available from the service.
-   CoverageTemporalExtent
+   ;; The spatial extent of the coverage available from the service. These are coordinate pairs
+   ;; which describe either the point, line string, or polygon representing the spatial extent. The
+   ;; bounding box is described by the west, south, east and north ordinates
+   CoverageSpatialExtent
 
    ;; The spatial resolution of the coverage available from the service.
    SpatialResolution
@@ -218,16 +211,17 @@
    ;; The unit of the spatial resolution of the coverage available from the service.
    SpatialResolutionUnit
 
-   ;; The spatial extent of the coverage available from the service. These are coordinate pairs
-   ;; which describe either the point, line string, or polygon representing the spatial extent. The
-   ;; bounding box is described by the west, south, east and north ordinates
-   CoverageSpatialExtent
+   ;; The temporal extent of the coverage available from the service.
+   CoverageTemporalExtent
 
-   ;; The name of the coverage available from the service.
-   Name
+   ;; The temporal resolution of the coverage available from the service.
+   TemporalResolution
 
-   ;; The type of the coverage available from the service.
-   Type
+   ;; The unit of the temporal resolution of the coverage available from the service.
+   TemporalResolutionUnit
+
+   ;; Path relative to the root universal resource locator for the coverage.
+   RelativePath
   ])
 (record-pretty-printer/enable-record-pretty-printing CoverageType)
 
@@ -247,6 +241,9 @@
 
 (defrecord CoverageTemporalExtentType
   [
+   ;; The type of the temporal extent for the coverage available from the service.
+   CoverageTemporalExtentTypeType
+
    ;; Points in time representing the temporal extent of the layer or coverage.
    CoverageTimePoints
 
@@ -261,10 +258,10 @@
    ;; The minimum x ordinate of the bounding box.
    MinX
 
-   ;; The minimum x ordinate of the bounding box.
+   ;; The minimum y ordinate of the bounding box.
    MinY
 
-   ;; The maximum y ordinate of the bounding box.
+   ;; The maximum x ordinate of the bounding box.
    MaxX
 
    ;; The maximum y ordinate of the bounding box.
@@ -342,8 +339,8 @@
 
 (defrecord CoverageSpatialExtentType
   [
-   ;; Type of the spatial extent.
-   Type
+   ;; Type of the spatial extent for the coverage available from the service..
+   CoverageSpatialExtentTypeType
 
    ;; Uuid of the spatial extent.
    Uuid

--- a/umm-spec-lib/src/cmr/umm_spec/versioning.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/versioning.clj
@@ -11,7 +11,7 @@
   The sequence must be updated when new schema versions are added for the concept type."
   {:collection ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6" "1.7" "1.8" "1.9" "1.10"]
    :variable ["1.0" "1.1"]
-   :service ["1.0"]})
+   :service ["1.0" "1.1"]})
 
 (def current-collection-version
   "The current version of the collection UMM schema."

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
@@ -1,0 +1,62 @@
+(ns cmr.umm-spec.test.migration.version.service
+  (:require
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.test.test-check-ext :as ext :refer [defspec]]
+   [cmr.umm-spec.migration.version.core :as vm]
+   [cmr.umm-spec.test.location-keywords-helper :as lkt]
+   [cmr.umm-spec.test.umm-generators :as umm-gen]
+   [cmr.umm-spec.umm-spec-core :as core]
+   [cmr.umm-spec.util :as u]
+   [cmr.umm-spec.versioning :as v]
+   [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
+
+(def service-concept-1-0
+  {:CoverageType {:Type "SPATIAL_POINT"}
+   :AccessConstraints ["TEST"]
+   :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                :Type "GET SERVICE"
+                :URLContentType "CollectionURL"}})
+(def service-concept-1-1
+  {:RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                  :Type "GET SERVICE"
+                  :URLContentType "CollectionURL"}]
+   :AccessConstraints "TEST"
+   :CoverageType {:CoverageSpatialExtentType {:CoverageSpatialExtentTypeType
+                                              "SPATIAL_POINT"}}})
+
+(deftest test-version-steps
+  (with-bindings {#'cmr.umm-spec.versioning/versions {:service ["1.0" "1.1"]}}
+    (is (= [] (#'vm/version-steps :service "1.1" "1.1")))
+    (is (= [["1.0" "1.1"]] (#'vm/version-steps :service "1.0" "1.1")))
+    (is (= [["1.1" "1.0"]] (#'vm/version-steps :service "1.1" "1.0")))))
+
+(defspec all-migrations-produce-valid-umm-spec 100
+  (for-all [umm-record   (gen/no-shrink umm-gen/umm-var-generator)
+            dest-version (gen/elements (v/versions :service))]
+    (let [dest-media-type (str mt/umm-json "; version=" dest-version)
+          metadata (core/generate-metadata (lkt/setup-context-for-test)
+                                           umm-record dest-media-type)]
+      (empty? (core/validate-metadata :service dest-media-type metadata)))))
+
+(deftest migrate-1_0-up-to-1_1
+  (is (= service-concept-1-1
+         (vm/migrate-umm {} :service "1.0" "1.1"
+                            {:CoverageType {:Type "SPATIAL_POINT"}
+                             :AccessConstraints ["TEST"]
+                             :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                                          :Type "GET SERVICE"
+                                          :URLContentType "CollectionURL"}}))))
+
+(deftest migrate-1_1-down-to-1_0
+  (is (= service-concept-1-0
+         (vm/migrate-umm {} :service "1.1" "1.0"
+                         {:RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                                         :Type "GET SERVICE"
+                                         :URLContentType "CollectionURL"}]
+                          :AccessConstraints "TEST"
+                          :CoverageType {:CoverageSpatialExtentType {:CoverageSpatialExtentTypeType
+                                                                     "SPATIAL_POINT"}
+                                         :CoverageTemporalExtentType {:CoverageTemporalExtentTypeType
+                                                                      "TIME_STAMP"}}}))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
@@ -23,7 +23,7 @@
                   :Type "GET SERVICE"
                   :URLContentType "CollectionURL"}]
    :AccessConstraints "TEST"
-   :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentType
+   :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType
                                       "SPATIAL_POINT"}}})
 
 (deftest test-version-steps
@@ -56,7 +56,7 @@
                                          :Type "GET SERVICE"
                                          :URLContentType "CollectionURL"}]
                           :AccessConstraints "TEST"
-                          :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentType
+                          :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType
                                                              "SPATIAL_POINT"}
-                                     :CoverageTemporalExtent {:CoverageTemporalExtentType
+                                     :CoverageTemporalExtent {:CoverageTemporalExtentTypeType
                                                               "TIME_STAMP"}}}))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
@@ -13,18 +13,20 @@
    [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
 
 (def service-concept-1-0
-  {:Coverage {:Type "SPATIAL_POINT"}
-   :AccessConstraints ["TEST"]
-   :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+  {:RelatedURL {:URLContentType "CollectionURL"
+                :Description "OPeNDAP Service"
                 :Type "GET SERVICE"
-                :URLContentType "CollectionURL"}})
+                :URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"},
+   :Coverage {:Type "SPATIAL_POINT"}
+   :AccessConstraints ["TEST"]})
+
 (def service-concept-1-1
-  {:RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
-                  :Type "GET SERVICE"
-                  :URLContentType "CollectionURL"}]
+  {:Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType "SPATIAL_POINT"}}
    :AccessConstraints "TEST"
-   :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType
-                                      "SPATIAL_POINT"}}})
+   :RelatedURLs [{:URLContentType "CollectionURL"
+                  :Description "OPeNDAP Service"
+                  :Type "GET SERVICE"
+                  :URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/"}]})
 
 (deftest test-version-steps
   (with-bindings {#'cmr.umm-spec.versioning/versions {:service ["1.0" "1.1"]}}
@@ -43,20 +45,20 @@
 (deftest migrate-1_0-up-to-1_1
   (is (= service-concept-1-1
          (vm/migrate-umm {} :service "1.0" "1.1"
-                            {:Coverage {:Type "SPATIAL_POINT"}
-                             :AccessConstraints ["TEST"]
-                             :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
-                                          :Type "GET SERVICE"
-                                          :URLContentType "CollectionURL"}}))))
+           {:Coverage {:Type "SPATIAL_POINT"}
+            :AccessConstraints ["TEST"]
+            :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                         :Type "GET SERVICE"
+                         :URLContentType "CollectionURL"}}))))
 
 (deftest migrate-1_1-down-to-1_0
   (is (= service-concept-1-0
          (vm/migrate-umm {} :service "1.1" "1.0"
-                         {:RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
-                                         :Type "GET SERVICE"
-                                         :URLContentType "CollectionURL"}]
-                          :AccessConstraints "TEST"
-                          :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType
-                                                             "SPATIAL_POINT"}
-                                     :CoverageTemporalExtent {:CoverageTemporalExtentTypeType
-                                                              "TIME_STAMP"}}}))))
+           {:RelatedURLs [{:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
+                           :Type "GET SERVICE"
+                           :URLContentType "CollectionURL"}]
+            :AccessConstraints "TEST"
+            :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentTypeType
+                                               "SPATIAL_POINT"}
+                       :CoverageTemporalExtent {:CoverageTemporalExtentTypeType
+                                                "TIME_STAMP"}}}))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/service.clj
@@ -13,7 +13,7 @@
    [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
 
 (def service-concept-1-0
-  {:CoverageType {:Type "SPATIAL_POINT"}
+  {:Coverage {:Type "SPATIAL_POINT"}
    :AccessConstraints ["TEST"]
    :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
                 :Type "GET SERVICE"
@@ -23,8 +23,8 @@
                   :Type "GET SERVICE"
                   :URLContentType "CollectionURL"}]
    :AccessConstraints "TEST"
-   :CoverageType {:CoverageSpatialExtentType {:CoverageSpatialExtentTypeType
-                                              "SPATIAL_POINT"}}})
+   :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentType
+                                      "SPATIAL_POINT"}}})
 
 (deftest test-version-steps
   (with-bindings {#'cmr.umm-spec.versioning/versions {:service ["1.0" "1.1"]}}
@@ -43,7 +43,7 @@
 (deftest migrate-1_0-up-to-1_1
   (is (= service-concept-1-1
          (vm/migrate-umm {} :service "1.0" "1.1"
-                            {:CoverageType {:Type "SPATIAL_POINT"}
+                            {:Coverage {:Type "SPATIAL_POINT"}
                              :AccessConstraints ["TEST"]
                              :RelatedURL {:URL "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/" :Description "OPeNDAP Service"
                                           :Type "GET SERVICE"
@@ -56,7 +56,7 @@
                                          :Type "GET SERVICE"
                                          :URLContentType "CollectionURL"}]
                           :AccessConstraints "TEST"
-                          :CoverageType {:CoverageSpatialExtentType {:CoverageSpatialExtentTypeType
-                                                                     "SPATIAL_POINT"}
-                                         :CoverageTemporalExtentType {:CoverageTemporalExtentTypeType
-                                                                      "TIME_STAMP"}}}))))
+                          :Coverage {:CoverageSpatialExtent {:CoverageSpatialExtentType
+                                                             "SPATIAL_POINT"}
+                                     :CoverageTemporalExtent {:CoverageTemporalExtentType
+                                                              "TIME_STAMP"}}}))))


### PR DESCRIPTION
UMM-S Service/Access Constraints should not be repeatable as there is only one set of access constraints per collection record. Leave as plural and should be object and not array
UMM-S Service/Access Constraints: Increase Field length to 4,000 characters
UMM-S Service/Use Constraints: Increase Field Length to 20,000 characters
UMM-S Service/Use Constraints: Field Should be set as an object and not an array (not repeatable) in the schema
UMM-S Service/ServiceQuality/Lineage: Increase Field Length to 4,000 characters
MM-S Service/RelatedURL: Field Should Be Repeatable (make multiple) in schema
UMM-S Service/RelatedURL/GetService: Sub-Field Should Not Be Required
Add "TOOL" just after "THREDDS DIRECTORY" to the list of valid RelatedURLSubTypeEnum. Depending if we use the same validation as Collections then we will also need to change cmr.umm-spec.util and add TOOL there as well.
UMM-S Service/Coverage/Type removed
UMM-S Service/Coverage/CoverageSpatialExtent/CoverageSpatialExtentType added, with enum
UMM-S Service/Coverage/CoverageSpatialExtent/CoverageSpatialExtentType added, with enum