### PR TITLE
CMR-4824: Fixed the code that caused the search on created_at to fail.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -204,7 +204,7 @@
             :revision-date-doc-values revision-date
             :downloadable downloadable
             :browsable browsable
-            :created-at created-at
+            :created-at (or created-at revision-date)
             :start-date (index-util/date->elastic start-date)
             :start-date-doc-values (index-util/date->elastic start-date)
             :end-date (index-util/date->elastic end-date)

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
@@ -27,7 +27,7 @@
        ;; fully populated.
        "granule_ur VARCHAR(250),
         transaction_id INTEGER DEFAULT 0 NOT NULL,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL"))
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP"))
 
 (defmethod granule-column-sql true
   [provider]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
@@ -27,7 +27,7 @@
        ;; fully populated.
        "granule_ur VARCHAR(250),
         transaction_id INTEGER DEFAULT 0 NOT NULL,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP"))
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL"))
 
 (defmethod granule-column-sql true
   [provider]

--- a/metadata-db-app/src/migrations/066_add_default_to_created_at_in_granule_tables.clj
+++ b/metadata-db-app/src/migrations/066_add_default_to_created_at_in_granule_tables.clj
@@ -1,0 +1,30 @@
+(ns migrations.066-add-default-to-created-at-in-granule-tables
+  "Add default value SYSTIMESTAMP to created_at column in granule tables."
+  (:require
+   [clojure.java.jdbc :as j]
+   [config.mdb-migrate-helper :as h]
+   [config.migrate-config :as config]))
+
+(defn- add-default-to-created-at
+  []
+  (doseq [t (h/get-granule-tablenames)]
+    (h/sql 
+      (format "alter table %s modify created_at DEFAULT SYSTIMESTAMP" 
+              t))))
+
+(defn- drop-default-from-created-at
+  []
+  (doseq [t (h/get-granule-tablenames)]
+    (h/sql (format "alter table %s modify created_at DEFAULT NULL" t))))
+
+(defn up
+  "Migrates the database up to version 66."
+  []
+  (println "migrations.066-add-default-to-created-at-in-granule-tables up...")
+  (add-default-to-created-at))
+
+(defn down
+  "Migrates the database down from version 66."
+  []
+  (println "migrations.066-add-default-to-created-at-in-granule-tables down...")
+  (drop-default-from-created-at))

--- a/metadata-db-app/src/migrations/066_add_default_to_created_at_in_granule_tables.clj
+++ b/metadata-db-app/src/migrations/066_add_default_to_created_at_in_granule_tables.clj
@@ -1,9 +1,7 @@
 (ns migrations.066-add-default-to-created-at-in-granule-tables
   "Add default value SYSTIMESTAMP to created_at column in granule tables."
   (:require
-   [clojure.java.jdbc :as j]
-   [config.mdb-migrate-helper :as h]
-   [config.migrate-config :as config]))
+   [config.mdb-migrate-helper :as h]))
 
 (defn- add-default-to-created-at
   []


### PR DESCRIPTION
1. Added the migration to add the DEFAULT SYSTIMESTAMP to created_at column in granule tables. This will allow the newly ingested granules to have the created_at populated, more importantly it will be populated with the same SYSTIMESTAMP as revision_date, which is important.  Note: it allows null, so we don't have to worry about the existing rows with null values.
2. Modified the code to index on revision_date when created_at is null. This is to allow the existing granules with null created_at values to be searchable through created_at constraint.
3. Modified the granule_table.clj to remove the "not null" constraint so that the newly created tables will have the same constraint as the existing tables - Leo preferred not to change this. 
4. Testing - Not sure how to do it yet because the schema contains DEFAULT value, so we don't have the created_at equal null case...  Tried to pass in nil created-at, not allowed in the code. so can't test it.
