### PR TITLE
CMR-4879 As an operator, I should not be able to delete a CMR provider if it contains one or more collections

### DIFF
--- a/ingest-app/src/cmr/ingest/api/provider.clj
+++ b/ingest-app/src/cmr/ingest/api/provider.clj
@@ -50,6 +50,7 @@
                              headers :headers}
       (acl/verify-ingest-management-permission request-context :update)
       (common-enabled/validate-write-enabled request-context "ingest")
+      (ps/verify-empty-provider request-context provider-id)
       (result->response-map
         (ps/delete-provider request-context provider-id)))
 

--- a/ingest-app/src/cmr/ingest/services/provider_service.clj
+++ b/ingest-app/src/cmr/ingest/services/provider_service.clj
@@ -8,6 +8,7 @@
    [cmr.transmit.metadata-db :as mdb]))
 
 (defn verify-empty-provider
+  "Throws error if provider still has collections."
   [context provider]
   (let [collections (mdb/find-collections context {:provider-id provider
                                                    :latest true})

--- a/ingest-app/src/cmr/ingest/services/provider_service.clj
+++ b/ingest-app/src/cmr/ingest/services/provider_service.clj
@@ -2,8 +2,20 @@
   "Functions for CRUD operations on providers. All functions return
   the underlying Metadata DB API clj-http response which can be used
   as a Ring response."
-  (:require [cmr.transmit.metadata-db :as mdb]
-            [cmr.ingest.data.ingest-events :as ingest-events]))
+  (:require
+   [cmr.common.services.errors :as errors]
+   [cmr.ingest.data.ingest-events :as ingest-events]
+   [cmr.transmit.metadata-db :as mdb]))
+
+(defn verify-empty-provider
+  [context provider]
+  (let [collections (mdb/find-collections context {:provider-id provider
+                                                   :latest true})
+        non-deleted-colls (remove #(= true (:deleted %)) collections)]
+    (when-not (empty? non-deleted-colls)
+      (errors/throw-service-error
+       :unauthorized
+       "You cannot perform this action on a provider that has collections."))))
 
 (defn- successful?
   "Returns true if the mdb response was successful."

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
@@ -192,6 +192,18 @@
                                  (:items
                                   (access-control/search-for-acls (transmit-config/echo-system-token) {:provider "PROV1"}))))))
 
+      ;; delete provider PROV1, fails because collections exist
+      (let [{:keys [status errors]} (ingest/delete-ingest-provider "PROV1")]
+        (is (= 401 status))
+        (is (= ["You cannot perform this action on a provider that has collections."]
+               errors)))
+
+      (ingest/delete-concept (d/umm-c-collection->concept coll1 :echo10) {:accept-format :json
+                                                                          :raw? true})
+      (ingest/delete-concept (d/umm-c-collection->concept coll2 :echo10) {:accept-format :json
+                                                                          :raw? true})
+      (index/wait-until-indexed)
+      
       ;; delete provider PROV1
       (let [{:keys [status content-length]} (ingest/delete-ingest-provider "PROV1")]
         (is (= 204 status))


### PR DESCRIPTION
This PR adds check for provider delete preventing non empty providers from being deleted