### PR TITLE
CMR-4902: Read granule size from ISO SMAP.

### DIFF
--- a/ingest-app/resources/CMR-4902/4902_smap_iso_collection.xml
+++ b/ingest-app/resources/CMR-4902/4902_smap_iso_collection.xml
@@ -1,0 +1,614 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:DS_Series xmlns:gco="http://www.isotc211.org/2005/gco"
+            xmlns:gmd="http://www.isotc211.org/2005/gmd"
+            xmlns:gmi="http://www.isotc211.org/2005/gmi"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:gmx="http://www.isotc211.org/2005/gmx"
+            xmlns:gsr="http://www.isotc211.org/2005/gsr"
+            xmlns:gss="http://www.isotc211.org/2005/gss"
+            xmlns:gts="http://www.isotc211.org/2005/gts"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi http://cdn.earthdata.nasa.gov/iso/schema/1.0/ISO19115-2_EOS.xsd">
+            <gmd:composedOf gco:nilReason="inapplicable"/>
+            <gmd:seriesMetadata>
+                <gmi:MI_Metadata>
+                    <!-- With reference to file name here, do we need to use MD_Identification/CI_Citation to reference the file. -->
+                    <gmd:fileIdentifier>
+                        <gco:CharacterString>L3_SM_P</gco:CharacterString>
+                        <!-- Assume that the file Identifier for series metadata would be the identifier that denotes that a file belongs to this series. -->
+                    </gmd:fileIdentifier>
+                    <gmd:language>
+                        <gco:CharacterString>eng</gco:CharacterString>
+                    </gmd:language>
+                    <gmd:characterSet>
+                        <gmd:MD_CharacterSetCode
+                            codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+                    </gmd:characterSet>
+                    <gmd:hierarchyLevel>
+                        <gmd:MD_ScopeCode
+                            codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="series">series</gmd:MD_ScopeCode>
+                    </gmd:hierarchyLevel>
+                    <gmd:contact>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:organisationName>
+                                <gco:CharacterString>NSIDC DAAC &gt; National Snow and Ice Data Center DAAC</gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:address>
+                                    <gmd:CI_Address>
+                                    <gmd:electronicMailAddress>
+                                    <gco:CharacterString>nsidc@nsidc.org</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                    </gmd:CI_Address>
+                                    </gmd:address>
+                                    <gmd:onlineResource>
+                                    <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                    <gmd:URL>http://nsidc.org/daac/</gmd:URL>
+                                    </gmd:linkage>
+                                    </gmd:CI_OnlineResource>
+                                    </gmd:onlineResource>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:contact>
+                    <gmd:dateStamp>
+                        <gco:Date>2014-04-15</gco:Date>
+                    </gmd:dateStamp>
+                    <gmd:metadataStandardName>
+                        <gco:CharacterString>ISO 19115-2 Geographic information - Metadata - Part 2: Extensions for imagery and gridded data</gco:CharacterString>
+                    </gmd:metadataStandardName>
+                    <gmd:metadataStandardVersion>
+                        <gco:CharacterString>ISO 19115-2:2009-02-15</gco:CharacterString>
+                    </gmd:metadataStandardVersion>
+                    <gmd:identificationInfo>
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <!-- If file name reference in MI_Metadata is sufficient, can use this CI_Citation to reference Product Specification Document. -->
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <!-- This field provides the product Long Name required by the ECS. -->
+                                    <gco:CharacterString>SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <!-- This field provides the date of a particular release or build. For the ECS, this is the RevisionDate, a required field. -->
+                                    <gco:Date>2016-09-09</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <!-- Specifies the SMAP Release ID -->
+                                    <gco:CharacterString>R14</gco:CharacterString>
+                                    </gmd:edition>
+                                    <gmd:identifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <!-- This field provides the product Short Name.  This is the ECS Short Name rather than the SMAP Short Name.  -->
+                                    <gco:CharacterString>SPL3SMP</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <!-- This field is intended to provide a namespace identifier for SMAP data product Short Names. Team should devise an identifier. -->
+                                    <gco:CharacterString>smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>The ECS Short Name</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:identifier>
+                                    <gmd:MD_Identifier>
+                                    <!-- This field provides the ECS Version ID. -->
+                                    <gmd:code>
+                                    <gco:CharacterString>004</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <!-- This field is intended to provide the namespace for ECS Version IDs for the SMAP mission.  Team should devise an identifier.-->
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>The ECS Version ID</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:identifier>
+                                    <gmd:MD_Identifier>
+                                    <!-- This field provides the Digital Object Identifier (DOI). -->
+                                    <gmd:code>
+                                    <gmx:Anchor
+                                    xlink:actuate="onRequest" xlink:href="http://dx.doi.org/10.5067/OBBHQ5W22HME">doi:10.5067/OBBHQ5W22HME</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <!-- This field is intended to provide a namespace identifier for DOIs.  What would be best specification?-->
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI)</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:citedResponsibleParty>
+                                    <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <gco:CharacterString>National Aeronautics and Space Administration (NASA)</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:role>
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="resourceProvider">resourceProvider</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                    </gmd:CI_ResponsibleParty>
+                                    </gmd:citedResponsibleParty>
+                                    <gmd:citedResponsibleParty>
+                                    <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <!-- This field provides the ProcessingCenter, a required field for the ECS. The ECS will need to check the roleCode to ensure they're viewing the correct field.-->
+                                    <gco:CharacterString>Jet Propulsion Laboratory</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:role>
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="originator">originator</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                    </gmd:CI_ResponsibleParty>
+                                    </gmd:citedResponsibleParty>
+                                    <gmd:presentationForm>
+                                    <gmd:CI_PresentationFormCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_PresentationFormCode" codeListValue="documentDigital">documentDigital</gmd:CI_PresentationFormCode>
+                                    </gmd:presentationForm>
+                                    <gmd:otherCitationDetails>
+                                    <gco:CharacterString>The Calibration and Validation Version 3 Release of the SMAP Level 3 Daily Global Composite Passive Soil Moisture Science Processing Software.</gco:CharacterString>
+                                    </gmd:otherCitationDetails>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <!-- This field contains the CollectionDescription required by the ECS. -->
+                                <gco:CharacterString>Daily global composite of up-to 30 half-orbit L2_SM_P soil moisture estimates based on radiometer brightness temperature measurements acquired by the SMAP radiometer during descending and ascending half-orbits at approximately 6 AM or 6 PM local solar time, respectively.</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:purpose>
+                                <gco:CharacterString>The SMAP L3_SM_P algorithm provides daily global composite of soil moistures based on radiometer data on a 36 km grid.</gco:CharacterString>
+                            </gmd:purpose>
+                            <gmd:credit>
+                                <!-- This field can name individuals or organizations for credit. For now, it specifies NASA. -->
+                                <gco:CharacterString>The software that generates the Level 3 Soil Moisture Passive product and the data system that automates its production were designed and implemented 
+                            at the Jet Propulsion Laboratory, California Institute of Technology in Pasadena, California.</gco:CharacterString>
+                            </gmd:credit>
+                            <gmd:status>
+                                <gmd:MD_ProgressCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing">onGoing</gmd:MD_ProgressCode>
+                            </gmd:status>
+                            <gmd:pointOfContact>
+                                <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <!-- This field provides the ArchiveCenter, a required entry for the ECS. -->
+                                    <gco:CharacterString>EDF_DEV01</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:role>
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                </gmd:CI_ResponsibleParty>
+                            </gmd:pointOfContact>
+                            <gmd:resourceMaintenance>
+                                <gmd:MD_MaintenanceInformation>
+                                    <gmd:maintenanceAndUpdateFrequency>
+                                    <gmd:MD_MaintenanceFrequencyCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+                                    </gmd:maintenanceAndUpdateFrequency>
+                                    <gmd:dateOfNextUpdate>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:dateOfNextUpdate>
+                                    <gmd:updateScope>
+                                    <gmd:MD_ScopeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="series">series</gmd:MD_ScopeCode>
+                                    </gmd:updateScope>
+                                </gmd:MD_MaintenanceInformation>
+                            </gmd:resourceMaintenance>
+                            <gmd:resourceFormat>
+                                <gmd:MD_Format>
+                                    <gmd:name>
+                                    <gco:CharacterString>HDF5</gco:CharacterString>
+                                    </gmd:name>
+                                    <gmd:version>
+                                    <gco:CharacterString>1.8.13</gco:CharacterString>
+                                    </gmd:version>
+                                </gmd:MD_Format>
+                            </gmd:resourceFormat>
+                            <gmd:descriptiveKeywords>
+                                <gmd:MD_Keywords>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; LAND SURFACE &gt; SOILS &gt; SOIL MOISTURE/WATER CONTENT</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; CLIMATE INDICATORS &gt; LAND SURFACE/AGRICULTURE INDICATORS &gt; SOIL MOISTURE</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; SPECTRAL/ENGINEERING &gt; MICROWAVE &gt; BRIGHTNESS TEMPERATURE</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; TERRESTRIAL HYDROSPHERE &gt; SNOW/ICE &gt; FREEZE/THAW</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; CRYOSPHERE &gt; SNOW/ICE &gt; FREEZE/THAW</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; VEGETATION &gt; PLANT CHARACTERISTICS &gt; VEGETATION WATER CONTENT</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; LAND SURFACE &gt; SURFACE RADIATIVE PROPERTIES &gt; ALBEDO</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; LAND SURFACE &gt; TOPOGRAPHY &gt; SURFACE ROUGHNESS</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; LAND SURFACE &gt; SURFACE RADIATIVE PROPERTIES &gt; ALBEDO</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>EARTH SCIENCE &gt; TERRESTRIAL HYDROSPHERE&gt; SNOW/ICE &gt; FREEZE/THAW</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:type>
+                                    <gmd:MD_KeywordTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                                    </gmd:type>
+                                    <gmd:thesaurusName>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>NASA/GCMD Earth Science Keywords</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date gco:nilReason="unknown"/>
+                                    </gmd:CI_Citation>
+                                    </gmd:thesaurusName>
+                                </gmd:MD_Keywords>
+                            </gmd:descriptiveKeywords>
+                            <gmd:descriptiveKeywords>
+                                <gmd:MD_Keywords>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Imaging Spectrometers/Radiometers &gt; SMAP L-BAND RADIOMETER &gt; SMAP L-Band Radiometer</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:type>
+                                    <gmd:MD_KeywordTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                                    </gmd:type>
+                                    <gmd:thesaurusName>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>NASA/GCMD Earth Science Keywords</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date gco:nilReason="unknown"/>
+                                    </gmd:CI_Citation>
+                                    </gmd:thesaurusName>
+                                </gmd:MD_Keywords>
+                            </gmd:descriptiveKeywords>
+                            <gmd:descriptiveKeywords>
+                                <gmd:MD_Keywords>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>Earth Observation Satellites &gt; NASA Decadal Survey &gt; SMAP &gt; Soil Moisture Active and Passive Observatory</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:type>
+                                    <gmd:MD_KeywordTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                                    </gmd:type>
+                                    <gmd:thesaurusName>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>NASA/GCMD Earth Science Keywords</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date gco:nilReason="unknown"/>
+                                    </gmd:CI_Citation>
+                                    </gmd:thesaurusName>
+                                </gmd:MD_Keywords>
+                            </gmd:descriptiveKeywords>
+                            <gmd:descriptiveKeywords>
+                                <gmd:MD_Keywords>
+                                    <gmd:keyword>
+                                    <gco:CharacterString>GEOGRAPHIC REGION &gt; GLOBAL</gco:CharacterString>
+                                    </gmd:keyword>
+                                    <gmd:type>
+                                    <gmd:MD_KeywordTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                                    </gmd:type>
+                                    <gmd:thesaurusName>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>NASA/GCMD Earth Science Keywords</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date gco:nilReason="unknown"/>
+                                    </gmd:CI_Citation>
+                                    </gmd:thesaurusName>
+                                </gmd:MD_Keywords>
+                            </gmd:descriptiveKeywords>
+                            <gmd:aggregationInfo>
+                                <gmd:MD_AggregateInformation>
+                                    <gmd:aggregateDataSetIdentifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:aggregateDataSetIdentifier>
+                                    <gmd:associationType>
+                                    <gmd:DS_AssociationTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DS_AssociationTypeCode" codeListValue="largerWorkCitation">largerWorkCitation</gmd:DS_AssociationTypeCode>
+                                    </gmd:associationType>
+                                    <gmd:initiativeType>
+                                    <gmd:DS_InitiativeTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DS_AssociationTypeCode" codeListValue="mission">mission</gmd:DS_InitiativeTypeCode>
+                                    </gmd:initiativeType>
+                                </gmd:MD_AggregateInformation>
+                            </gmd:aggregationInfo>
+                            <gmd:spatialRepresentationType>
+                                <gmd:MD_SpatialRepresentationTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="grid">grid</gmd:MD_SpatialRepresentationTypeCode>
+                            </gmd:spatialRepresentationType>
+                            <gmd:spatialResolution>
+                                <gmd:MD_Resolution>
+                                    <gmd:distance>
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmd:distance>
+                                </gmd:MD_Resolution>
+                            </gmd:spatialResolution>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                            <gmd:characterSet>
+                                <gmd:MD_CharacterSetCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+                            </gmd:characterSet>
+                            <gmd:topicCategory>
+                                <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+                            </gmd:topicCategory>
+                            <gmd:environmentDescription>
+                                <gco:CharacterString>Data product generated by the SMAP mission in HDF5 format with metadata that conforms to the ISO 19115 model.</gco:CharacterString>
+                            </gmd:environmentDescription>
+                            <gmd:extent>
+                                <gmd:EX_Extent>
+                                    <gmd:description>
+                                    <gco:CharacterString>Soil moisture is retrieved over land targets on the descending (AM) and ascending (PM) SMAP half-orbits when the SMAP spacecraft is travelling from North to South or from South to North, respectively, 
+                                while the SMAP instruments are operating in the nominal mode.  Retrievals are performed but flagged as questionable 
+                                over urban areas, mountainous areas with high elevation variability, and areas with high ( &gt; 5 kg/m**2) vegetation 
+                                water content; for retrievals using the high-resolution radar, cells in the nadir region are also flagged.
+                                Retrievals are inhibited for permanent snow/ice, frozen ground, and excessive static or transient open water in the cell,
+                                and for excessive RFI in the sensor data.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:geographicElement>
+                                    <!-- This defines the bounding box for all SMAP Level 3 Passive Soil Moisture data products. -->
+                                    <gmd:EX_GeographicBoundingBox>
+                                    <gmd:extentTypeCode>
+                                    <gco:Boolean>1</gco:Boolean>
+                                    </gmd:extentTypeCode>
+                                    <gmd:westBoundLongitude>
+                                    <gco:Decimal>-180.00</gco:Decimal>
+                                    </gmd:westBoundLongitude>
+                                    <gmd:eastBoundLongitude>
+                                    <gco:Decimal>180.00</gco:Decimal>
+                                    </gmd:eastBoundLongitude>
+                                    <gmd:southBoundLatitude>
+                                    <gco:Decimal>-85.0445</gco:Decimal>
+                                    </gmd:southBoundLatitude>
+                                    <gmd:northBoundLatitude>
+                                    <gco:Decimal>85.0445</gco:Decimal>
+                                    </gmd:northBoundLatitude>
+                                    </gmd:EX_GeographicBoundingBox>
+                                    </gmd:geographicElement>
+                                    <gmd:temporalElement>
+                                    <gmd:EX_TemporalExtent>
+                                    <!-- Mimics use in GHRSST. See no evidence of conformance to standard -->
+                                    <gmd:extent>
+                                    <gml:TimePeriod gml:id="swathTemporalExtent">
+                                    <!-- This defines the time period covered by all SMAP Level 3 Passive Soil Moisture data products. 
+                                            ECS indicates that they will automatically extend the final time based on receipt of data products. -->
+                                    <gml:beginPosition>2015-03-31T00:00:00.000Z</gml:beginPosition>
+                                    <gml:endPosition>2020-12-31T00:00:00.000Z</gml:endPosition>
+                                    </gml:TimePeriod>
+                                    </gmd:extent>
+                                    </gmd:EX_TemporalExtent>
+                                    </gmd:temporalElement>
+                                </gmd:EX_Extent>
+                            </gmd:extent>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                    <gmd:identificationInfo>
+                        <!-- This field is used to reference the Product Specification Document. If and when the model moves to ISO 19115-1, move this reference to additionalDocumentation.  -->
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>Product Specification Document for the SMAP Level 3 Passive Soil Moisture Product (L3_SM_P)</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2013-02-08</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>1.0</gco:CharacterString>
+                                    </gmd:edition>
+                                    <gmd:identifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L3_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <!-- This field is intended to provide a namespace identifier for SMAP data product Short Names. Team should devise an identifier. -->
+                                    <gco:CharacterString>smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>Short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 3 Passive Soil Moisture product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:presentationForm>
+                                    <gmd:CI_PresentationFormCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_PresentationFormCode" codeListValue="documentDigital">documentDigital</gmd:CI_PresentationFormCode>
+                                    </gmd:presentationForm>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <gco:CharacterString>The Product Specification Document that fully describes the content and format of this data product.</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                            <gmd:characterSet>
+                                <gmd:MD_CharacterSetCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+                            </gmd:characterSet>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                    <gmd:identificationInfo>
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>DataSetId</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T12:46:42.738Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <gco:CharacterString>DataSetId</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:aggregationInfo>
+                                <gmd:MD_AggregateInformation>
+                                    <gmd:aggregateDataSetIdentifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture V004</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:aggregateDataSetIdentifier>
+                                    <gmd:associationType/>
+                                </gmd:MD_AggregateInformation>
+                            </gmd:aggregationInfo>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                    <gmd:identificationInfo>
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>InsertTime</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2017-11-07T17:47:00.433Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <gco:CharacterString>InsertTime</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:purpose>
+                                <gco:CharacterString>InsertTime</gco:CharacterString>
+                            </gmd:purpose>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                    <gmd:identificationInfo>
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>UpdateTime</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T12:46:42.738Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <gco:CharacterString>UpdateTime</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:purpose>
+                                <gco:CharacterString>UpdateTime</gco:CharacterString>
+                            </gmd:purpose>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                    <gmd:identificationInfo>
+                        <gmd:MD_DataIdentification>
+                            <gmd:citation>
+                                <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>DIFID</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T12:46:42.738Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:identifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SPL3SMP_004</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                </gmd:CI_Citation>
+                            </gmd:citation>
+                            <gmd:abstract>
+                                <gco:CharacterString>DIFID</gco:CharacterString>
+                            </gmd:abstract>
+                            <gmd:purpose>
+                                <gco:CharacterString>DIFID</gco:CharacterString>
+                            </gmd:purpose>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                        </gmd:MD_DataIdentification>
+                    </gmd:identificationInfo>
+                </gmi:MI_Metadata>
+            </gmd:seriesMetadata>
+        </gmd:DS_Series>

--- a/ingest-app/resources/CMR-4902/4902_smap_iso_granule.xml
+++ b/ingest-app/resources/CMR-4902/4902_smap_iso_granule.xml
@@ -1,0 +1,3454 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:DS_Series xmlns="http://www.isotc211.org/2005/gmi"
+            xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+            xmlns:gco="http://www.isotc211.org/2005/gco"
+            xmlns:gmd="http://www.isotc211.org/2005/gmd"
+            xmlns:gmi="http://www.isotc211.org/2005/gmi"
+            xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:gmx="http://www.isotc211.org/2005/gmx"
+            xmlns:gsr="http://www.isotc211.org/2005/gsr"
+            xmlns:gss="http://www.isotc211.org/2005/gss"
+            xmlns:gts="http://www.isotc211.org/2005/gts"
+            xmlns:srv="http://www.isotc211.org/2005/srv"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi http://cdn.earthdata.nasa.gov/iso/schema/1.0/ISO19115-2_EOS.xsd">
+            <gmd:composedOf xlink:type="simple">
+                <gmd:DS_DataSet>
+                    <gmd:has xlink:type="simple">
+                        <gmi:MI_Metadata>
+                            <gmd:fileIdentifier>
+                                <gmx:FileName>SMAP_L3_SM_P_20170331_R14010_001.h5</gmx:FileName>
+                            </gmd:fileIdentifier>
+                            <gmd:language>
+                                <gco:CharacterString>eng</gco:CharacterString>
+                            </gmd:language>
+                            <gmd:characterSet>
+                                <gmd:MD_CharacterSetCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+                            </gmd:characterSet>
+                            <gmd:hierarchyLevel>
+                                <gmd:MD_ScopeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+                            </gmd:hierarchyLevel>
+                            <gmd:contact xlink:type="simple">
+                                <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <gco:CharacterString>NSIDC DAAC &amp;gt; National Snow and Ice Data Center DAAC</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:contactInfo xlink:type="simple">
+                                    <gmd:CI_Contact>
+                                    <gmd:address xlink:type="simple">
+                                    <gmd:CI_Address>
+                                    <gmd:electronicMailAddress>
+                                    <gco:CharacterString>nsidc@nsidc.org</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                    </gmd:CI_Address>
+                                    </gmd:address>
+                                    <gmd:onlineResource xlink:type="simple">
+                                    <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                    <gmd:URL>http://nsidc.org/daac/</gmd:URL>
+                                    </gmd:linkage>
+                                    </gmd:CI_OnlineResource>
+                                    </gmd:onlineResource>
+                                    </gmd:CI_Contact>
+                                    </gmd:contactInfo>
+                                    <gmd:role>
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                </gmd:CI_ResponsibleParty>
+                            </gmd:contact>
+                            <gmd:dateStamp>
+                                <gco:Date>2014-06-17</gco:Date>
+                            </gmd:dateStamp>
+                            <gmd:metadataStandardName>
+                                <gco:CharacterString>ISO 19115-2 Geographic information - Metadata - Part 2: Extensions for imagery and gridded data</gco:CharacterString>
+                            </gmd:metadataStandardName>
+                            <gmd:metadataStandardVersion>
+                                <gco:CharacterString>ISO 19115-2:2009-02-15</gco:CharacterString>
+                            </gmd:metadataStandardVersion>
+                            <gmd:spatialRepresentationInfo xlink:type="simple">
+                                <gmd:MD_Georeferenceable>
+                                    <gmd:numberOfDimensions>
+                                    <gco:Integer>2</gco:Integer>
+                                    </gmd:numberOfDimensions>
+                                    <gmd:axisDimensionProperties xlink:type="simple">
+                                    <gmd:MD_Dimension>
+                                    <gmd:dimensionName>
+
+                                    <gmd:MD_DimensionNameTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="column">column</gmd:MD_DimensionNameTypeCode>
+                                    </gmd:dimensionName>
+                                    <gmd:dimensionSize>
+                                    <gco:Integer>964</gco:Integer>
+                                    </gmd:dimensionSize>
+                                    <gmd:resolution>
+                                    <gco:Measure uom="km">36</gco:Measure>
+                                    </gmd:resolution>
+                                    </gmd:MD_Dimension>
+                                    </gmd:axisDimensionProperties>
+                                    <gmd:axisDimensionProperties xlink:type="simple">
+                                    <gmd:MD_Dimension>
+                                    <gmd:dimensionName>
+
+                                    <gmd:MD_DimensionNameTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="row">row</gmd:MD_DimensionNameTypeCode>
+                                    </gmd:dimensionName>
+                                    <gmd:dimensionSize>
+                                    <gco:Integer>406</gco:Integer>
+                                    </gmd:dimensionSize>
+                                    <gmd:resolution>
+                                    <gco:Measure uom="km">36</gco:Measure>
+                                    </gmd:resolution>
+                                    </gmd:MD_Dimension>
+                                    </gmd:axisDimensionProperties>
+                                    <gmd:cellGeometry>
+                                    <gmd:MD_CellGeometryCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CellGeometryCode" codeListValue="point">point</gmd:MD_CellGeometryCode>
+                                    </gmd:cellGeometry>
+                                    <gmd:transformationParameterAvailability>
+                                    <gco:Boolean>false</gco:Boolean>
+                                    </gmd:transformationParameterAvailability>
+                                    <gmd:controlPointAvailability>
+                                    <gco:Boolean>false</gco:Boolean>
+                                    </gmd:controlPointAvailability>
+                                    <gmd:orientationParameterAvailability>
+                                    <gco:Boolean>false</gco:Boolean>
+                                    </gmd:orientationParameterAvailability>
+                                    <gmd:georeferencedParameters xlink:type="simple">
+                                    <gco:Record xsi:type="gco:CharacterString_PropertyType">
+                                    <gco:CharacterString>SMAP Fixed Earth Grids, SMAP Science Document no:  033, May 11, 2009</gco:CharacterString>
+                                    </gco:Record>
+                                    </gmd:georeferencedParameters>
+                                </gmd:MD_Georeferenceable>
+                            </gmd:spatialRepresentationInfo>
+                            <gmd:identificationInfo xlink:type="simple">
+                                <gmd:MD_DataIdentification>
+                                    <gmd:citation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_20170331_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>2173699e-287e-4066-9abf-9ac5471d8ad9</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>Open Software Foundation</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Universally Unique Identifier (UUID)</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SPL3SMP</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>The ECS Short Name</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>004</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>The ECS Version ID</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    <gmd:citedResponsibleParty xlink:type="simple">
+                                    <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <gco:CharacterString>Jet Propulsion Laboratory</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:role>
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="originator">originator</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                    </gmd:CI_ResponsibleParty>
+                                    </gmd:citedResponsibleParty>
+                                    <gmd:series xlink:type="simple">
+                                    <gmd:CI_Series>
+                                    <gmd:name>
+                                    <gco:CharacterString>L3_SM_P</gco:CharacterString>
+                                    </gmd:name>
+                                    </gmd:CI_Series>
+                                    </gmd:series>
+                                    <gmd:otherCitationDetails>
+                                    <gco:CharacterString>The Calibration and Validation Version 2 Release of the SMAP Level 3 Daily Global Composite Passive Soil Moisture Science Processing Software.</gco:CharacterString>
+                                    </gmd:otherCitationDetails>
+                                    </gmd:CI_Citation>
+                                    </gmd:citation>
+                                    <gmd:abstract>
+                                    <gco:CharacterString>Daily global composite of up-to 15 half-orbit L2_SM_P soil moisture estimates based on radiometer brightness temperature measurements acquired by the SMAP radiometer during descending half-orbits at approximately 6 AM local solar time.</gco:CharacterString>
+                                    </gmd:abstract>
+                                    <gmd:purpose>
+                                    <gco:CharacterString>The SMAP L3_SM_P effort provides soil moistures based on radiometer data on a 36 km grid.</gco:CharacterString>
+                                    </gmd:purpose>
+                                    <gmd:credit>
+                                    <gco:CharacterString>The software that generates the Level 3 SM_P product and the data system that automates its production were designed and implemented at the Jet Propulsion Laboratory, California Institute of Technology in Pasadena, California.</gco:CharacterString>
+                                    </gmd:credit>
+                                    <gmd:status>
+                                    <gmd:MD_ProgressCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing">onGoing</gmd:MD_ProgressCode>
+                                    </gmd:status>
+                                    <gmd:resourceMaintenance xlink:type="simple">
+                                    <gmd:MD_MaintenanceInformation>
+                                    <gmd:maintenanceAndUpdateFrequency>
+
+                                    <gmd:MD_MaintenanceFrequencyCode
+                                    codeList="undefined" codeListValue="undefined">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+                                    </gmd:maintenanceAndUpdateFrequency>
+                                    <gmd:dateOfNextUpdate>
+                                    <gco:Date>2016-05-01</gco:Date>
+                                    </gmd:dateOfNextUpdate>
+                                    </gmd:MD_MaintenanceInformation>
+                                    </gmd:resourceMaintenance>
+                                    <gmd:resourceFormat xlink:type="simple">
+                                    <gmd:MD_Format>
+                                    <gmd:name>
+                                    <gco:CharacterString>HDF5</gco:CharacterString>
+                                    </gmd:name>
+                                    <gmd:version>
+                                    <gco:CharacterString>1.8.13</gco:CharacterString>
+                                    </gmd:version>
+                                    </gmd:MD_Format>
+                                    </gmd:resourceFormat>
+                                    <gmd:aggregationInfo xlink:type="simple">
+                                    <gmd:MD_AggregateInformation>
+                                    <gmd:aggregateDataSetName xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_20170331_R14010_001.qa</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+                                    <gmd:otherCitationDetails>
+                                    <gco:CharacterString>An ASCII product that contains statistical information on data product results.  These statistics enable data producers and users to assess the quality of the data in the data product granule.</gco:CharacterString>
+                                    </gmd:otherCitationDetails>
+                                    </gmd:CI_Citation>
+                                    </gmd:aggregateDataSetName>
+                                    <gmd:associationType>
+
+                                    <gmd:DS_AssociationTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DS_AssociationTypeCode" codeListValue="crossReference">crossReference</gmd:DS_AssociationTypeCode>
+                                    </gmd:associationType>
+                                    </gmd:MD_AggregateInformation>
+                                    </gmd:aggregationInfo>
+                                    <gmd:spatialRepresentationType>
+
+                                    <gmd:MD_SpatialRepresentationTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="grid">grid</gmd:MD_SpatialRepresentationTypeCode>
+                                    </gmd:spatialRepresentationType>
+                                    <gmd:language>
+                                    <gco:CharacterString>eng</gco:CharacterString>
+                                    </gmd:language>
+                                    <gmd:characterSet>
+                                    <gmd:MD_CharacterSetCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+                                    </gmd:characterSet>
+                                    <gmd:topicCategory>
+                                    <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+                                    </gmd:topicCategory>
+                                    <gmd:environmentDescription>
+                                    <gco:CharacterString>Data product generated by the SMAP mission in HDF5 format with metadata that conforms to the ISO 19115 model.</gco:CharacterString>
+                                    </gmd:environmentDescription>
+                                    <gmd:extent xlink:type="simple">
+                                    <gmd:EX_Extent>
+                                    <gmd:description>
+                                    <gco:CharacterString>Soil moisture is retrieved over land targets on the descending (AM) SMAP half-orbits when the SMAP spacecraft is travelling from North to South, while the SMAP instruments are operating in the nominal mode.  The L3_SM_P product represents soil moisture retrieved over the entre UTC day. Retrievals are performed but flagged as questionable over urban areas, mountainous areas with high elevation variability, and areas with high ( &amp;gt; 5 kg/m**2) vegetation water content; for retrievals using the high-resolution radar, cells in the nadir region are also flagged. Retrievals are inhibited for permanent snow/ice, frozen ground, and excessive static or transient open water in the cell, and for excessive RFI in the sensor data.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:geographicElement xlink:type="simple">
+                                    <gmd:EX_GeographicBoundingBox>
+                                    <gmd:extentTypeCode>
+                                    <gco:Boolean>true</gco:Boolean>
+                                    </gmd:extentTypeCode>
+                                    <gmd:westBoundLongitude>
+                                    <gco:Decimal>-180</gco:Decimal>
+                                    </gmd:westBoundLongitude>
+                                    <gmd:eastBoundLongitude>
+                                    <gco:Decimal>180</gco:Decimal>
+                                    </gmd:eastBoundLongitude>
+                                    <gmd:southBoundLatitude>
+                                    <gco:Decimal>-85.044502258300781</gco:Decimal>
+                                    </gmd:southBoundLatitude>
+                                    <gmd:northBoundLatitude>
+                                    <gco:Decimal>85.044502258300781</gco:Decimal>
+                                    </gmd:northBoundLatitude>
+                                    </gmd:EX_GeographicBoundingBox>
+                                    </gmd:geographicElement>
+                                    <gmd:temporalElement xlink:type="simple">
+                                    <gmd:EX_TemporalExtent>
+                                    <gmd:extent xlink:type="simple">
+                                    <gml:TimePeriod
+                                    frame="#ISO-8601" gml:id="JPL_ID_3">
+
+                                    <gml:beginPosition frame="#ISO-8601">2017-03-31T00:00:00.000Z</gml:beginPosition>
+
+                                    <gml:endPosition frame="#ISO-8601">2017-03-31T23:59:59.999Z</gml:endPosition>
+                                    </gml:TimePeriod>
+                                    </gmd:extent>
+                                    </gmd:EX_TemporalExtent>
+                                    </gmd:temporalElement>
+                                    </gmd:EX_Extent>
+                                    </gmd:extent>
+                                </gmd:MD_DataIdentification>
+                            </gmd:identificationInfo>
+                            <gmd:identificationInfo>
+                                <gmd:MD_DataIdentification>
+                                    <gmd:citation>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>SC:SPL3SMP.004:305562</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T13:43:53.579Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                    codeListValue="creation" xmlns="">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    </gmd:CI_Citation>
+                                    </gmd:citation>
+                                    <gmd:abstract>
+                                    <gco:CharacterString>GranuleUR</gco:CharacterString>
+                                    </gmd:abstract>
+                                    <gmd:purpose>
+                                    <gco:CharacterString>GranuleUR</gco:CharacterString>
+                                    </gmd:purpose>
+                                    <gmd:language>
+                                    <gco:CharacterString>eng</gco:CharacterString>
+                                    </gmd:language>
+                                </gmd:MD_DataIdentification>
+                            </gmd:identificationInfo>
+                            <gmd:identificationInfo>
+                                <gmd:MD_DataIdentification>
+                                    <gmd:citation>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>DataSetId</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T13:44:44.455Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                    codeListValue="revision" xmlns="">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    </gmd:CI_Citation>
+                                    </gmd:citation>
+                                    <gmd:abstract>
+                                    <gco:CharacterString>DataSetId</gco:CharacterString>
+                                    </gmd:abstract>
+                                    <gmd:aggregationInfo>
+                                    <gmd:MD_AggregateInformation>
+                                    <gmd:aggregateDataSetIdentifier>
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture V004</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:aggregateDataSetIdentifier>
+                                    <gmd:associationType/>
+                                    </gmd:MD_AggregateInformation>
+                                    </gmd:aggregationInfo>
+                                    <gmd:language>
+                                    <gco:CharacterString>eng</gco:CharacterString>
+                                    </gmd:language>
+                                </gmd:MD_DataIdentification>
+                            </gmd:identificationInfo>
+                            <gmd:identificationInfo>
+                                <gmd:MD_DataIdentification>
+                                    <gmd:citation>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>InsertTime</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T13:43:53.579Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                    codeListValue="creation" xmlns="">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    </gmd:CI_Citation>
+                                    </gmd:citation>
+                                    <gmd:abstract>
+                                    <gco:CharacterString>InsertTime</gco:CharacterString>
+                                    </gmd:abstract>
+                                    <gmd:purpose>
+                                    <gco:CharacterString>InsertTime</gco:CharacterString>
+                                    </gmd:purpose>
+                                    <gmd:language>
+                                    <gco:CharacterString>eng</gco:CharacterString>
+                                    </gmd:language>
+                                </gmd:MD_DataIdentification>
+                            </gmd:identificationInfo>
+                            <gmd:identificationInfo>
+                                <gmd:MD_DataIdentification>
+                                    <gmd:citation>
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>UpdateTime</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date>
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:DateTime>2018-05-15T13:44:44.455Z</gco:DateTime>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                    codeListValue="revision" xmlns="">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    </gmd:CI_Citation>
+                                    </gmd:citation>
+                                    <gmd:abstract>
+                                    <gco:CharacterString>UpdateTime</gco:CharacterString>
+                                    </gmd:abstract>
+                                    <gmd:purpose>
+                                    <gco:CharacterString>UpdateTime</gco:CharacterString>
+                                    </gmd:purpose>
+                                    <gmd:language>
+                                    <gco:CharacterString>eng</gco:CharacterString>
+                                    </gmd:language>
+                                </gmd:MD_DataIdentification>
+                            </gmd:identificationInfo>
+                            <gmd:distributionInfo>
+                                <gmd:MD_Distribution>
+                                    <gmd:distributor>
+                                    <gmd:MD_Distributor>
+                                    <gmd:distributorContact/>
+                                    <gmd:distributorTransferOptions>
+                                    <gmd:MD_DigitalTransferOptions>
+                                    <gmd:transferSize>
+                                    <gco:Real>22.2031965255737</gco:Real>
+                                    </gmd:transferSize>
+                                    <gmd:onLine>
+                                    <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                    <gmd:URL>https://f5eil01.edn.ecs.nasa.gov/datapool/DEV01//FS2/SMAP/SPL3SMP.004/2017.03.31/SMAP_L3_SM_P_20170331_R14010_001.h5</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:applicationProfile>
+                                    <gco:CharacterString>application/x-hdfeos</gco:CharacterString>
+                                    </gmd:applicationProfile>
+                                    </gmd:CI_OnlineResource>
+                                    </gmd:onLine>
+                                    </gmd:MD_DigitalTransferOptions>
+                                    </gmd:distributorTransferOptions>
+                                    <gmd:distributorTransferOptions>
+                                    <gmd:MD_DigitalTransferOptions>
+                                    <gmd:onLine>
+                                    <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                    <gmd:URL>https://f5eil01.edn.ecs.nasa.gov/datapool/DEV01//FS2/OTHR/QA.001/2018.05.15/SMAP_L3_SM_P_20170331_R14010_001.qa</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:applicationProfile>
+                                    <gco:CharacterString>text/plain</gco:CharacterString>
+                                    </gmd:applicationProfile>
+                                    <gmd:name>
+                                    <gco:CharacterString>Quality Assurance</gco:CharacterString>
+                                    </gmd:name>
+                                    </gmd:CI_OnlineResource>
+                                    </gmd:onLine>
+                                    </gmd:MD_DigitalTransferOptions>
+                                    </gmd:distributorTransferOptions>
+                                    <gmd:distributorTransferOptions>
+                                    <gmd:MD_DigitalTransferOptions>
+                                    <gmd:onLine>
+                                    <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                    <gmd:URL>https://f5eil01.edn.ecs.nasa.gov/datapool/DEV01//FS2/SMAP/SPL3SMP.004/2017.03.31/SMAP_L3_SM_P_20170331_R14010_001.h5.iso.xml</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:applicationProfile>
+                                    <gco:CharacterString>text/xml</gco:CharacterString>
+                                    </gmd:applicationProfile>
+                                    <gmd:name>
+                                    <gco:CharacterString>METADATA</gco:CharacterString>
+                                    </gmd:name>
+                                    </gmd:CI_OnlineResource>
+                                    </gmd:onLine>
+                                    </gmd:MD_DigitalTransferOptions>
+                                    </gmd:distributorTransferOptions>
+                                    </gmd:MD_Distributor>
+                                    </gmd:distributor>
+                                </gmd:MD_Distribution>
+                            </gmd:distributionInfo>
+                            <gmd:dataQualityInfo xlink:type="simple">
+                                <gmd:DQ_DataQuality>
+                                    <gmd:scope xlink:type="simple">
+                                    <gmd:DQ_Scope>
+                                    <gmd:level>
+                                    <gmd:MD_ScopeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="attribute">attribute</gmd:MD_ScopeCode>
+                                    </gmd:level>
+                                    <gmd:levelDescription>
+                                    <gmd:MD_ScopeDescription>
+                                    <gmd:dataset>
+                                    <gco:CharacterString>soil_moisture</gco:CharacterString>
+                                    </gmd:dataset>
+                                    </gmd:MD_ScopeDescription>
+                                    </gmd:levelDescription>
+                                    </gmd:DQ_Scope>
+                                    </gmd:scope>
+                                    <gmd:report xlink:type="simple">
+                                    <gmd:DQ_DomainConsistency>
+                                    <gmd:nameOfMeasure>
+                                    <gco:CharacterString>Percentage of EASE2 grid cells with Retrieved Soil Moistures outside the Acceptable Range.</gco:CharacterString>
+                                    </gmd:nameOfMeasure>
+                                    <gmd:measureDescription>
+                                    <gco:CharacterString>Percentage of EASE2 grid cells with soil moisture measures that fall outside of a predefined acceptable range.</gco:CharacterString>
+                                    </gmd:measureDescription>
+                                    <gmd:evaluationMethodType>
+
+                                    <gmd:DQ_EvaluationMethodTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DQ_EvaluationMethodTypeCode" codeListValue="directInternal">directInternal</gmd:DQ_EvaluationMethodTypeCode>
+                                    </gmd:evaluationMethodType>
+                                    <gmd:result xlink:type="simple">
+                                    <gmd:DQ_QuantitativeResult>
+                                    <gmd:valueUnit xlink:type="simple">
+
+                                    <gml:UnitDefinition gml:id="JPL_ID_1">
+
+                                    <gml:identifier codeSpace="http://jpl.nasa.gov/undefined">*undefined*</gml:identifier>
+
+                                    <gml:quantityType xlink:type="simple">percent</gml:quantityType>
+                                    </gml:UnitDefinition>
+                                    </gmd:valueUnit>
+                                    <gmd:value xlink:type="simple">
+                                    <gco:Record xsi:type="gco:Real_PropertyType">
+                                    <gco:Real>100</gco:Real>
+                                    </gco:Record>
+                                    </gmd:value>
+                                    </gmd:DQ_QuantitativeResult>
+                                    </gmd:result>
+                                    </gmd:DQ_DomainConsistency>
+                                    </gmd:report>
+                                    <gmd:report xlink:type="simple">
+                                    <gmd:DQ_CompletenessOmission>
+                                    <gmd:nameOfMeasure>
+                                    <gco:CharacterString>Percent of Missing Data</gco:CharacterString>
+                                    </gmd:nameOfMeasure>
+                                    <gmd:measureDescription>
+                                    <gco:CharacterString>Percentage of EASE2 grid cells that lack soil moisture retrieval values relative to the total number of grid cells where soil moisture retrieval was attempted.</gco:CharacterString>
+                                    </gmd:measureDescription>
+                                    <gmd:evaluationMethodType>
+
+                                    <gmd:DQ_EvaluationMethodTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#DQ_EvaluationMethodTypeCode" codeListValue="directInternal">directInternal</gmd:DQ_EvaluationMethodTypeCode>
+                                    </gmd:evaluationMethodType>
+                                    <gmd:result xlink:type="simple">
+                                    <gmd:DQ_QuantitativeResult>
+                                    <gmd:valueUnit xlink:type="simple">
+
+                                    <gml:UnitDefinition gml:id="JPL_ID_2">
+
+                                    <gml:identifier codeSpace="http://jpl.nasa.gov/undefined">*undefined*</gml:identifier>
+
+                                    <gml:quantityType xlink:type="simple">percent</gml:quantityType>
+                                    </gml:UnitDefinition>
+                                    </gmd:valueUnit>
+                                    <gmd:value xlink:type="simple">
+                                    <gco:Record xsi:type="gco:Real_PropertyType">
+                                    <gco:Real>124.850173950195</gco:Real>
+                                    </gco:Record>
+                                    </gmd:value>
+                                    </gmd:DQ_QuantitativeResult>
+                                    </gmd:result>
+                                    </gmd:DQ_CompletenessOmission>
+                                    </gmd:report>
+                                    <gmd:lineage xlink:type="simple">
+                                    <gmd:LI_Lineage>
+                                    <gmd:processStep xlink:type="simple">
+                                    <gmi:LE_ProcessStep>
+                                    <gmd:description>
+                                    <gco:CharacterString>Soil moisture retrieved using default retrieval algorithm from brightness temperatures acquired by the SMAP radiometer during the spacecraft descending pass.  Level 2 granule data are then mosaicked on a daily basis to form the Level 3 product.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:dateTime>
+                                    <gco:DateTime>2017-04-01T15:14:36.393Z</gco:DateTime>
+                                    </gmd:dateTime>
+                                    <gmd:processor xlink:type="simple">
+                                    <gmd:CI_ResponsibleParty>
+                                    <gmd:organisationName>
+                                    <gco:CharacterString>Soil Moisture Active Passive Mission (SMAP) Science Data System (SDS) Operations Facility</gco:CharacterString>
+                                    </gmd:organisationName>
+                                    <gmd:role>
+
+                                    <gmd:CI_RoleCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="processor">processor</gmd:CI_RoleCode>
+                                    </gmd:role>
+                                    </gmd:CI_ResponsibleParty>
+                                    </gmd:processor>
+
+                                    <gmi:processingInformation xlink:type="simple">
+                                    <eos:EOS_Processing>
+
+                                    <gmi:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L3_SM_P_SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:identifier>
+
+                                    <gmi:softwareReference xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>L3_SM_P_SPS</gco:CharacterString>
+                                    </gmd:title>
+
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2014-04-15</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>021</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:softwareReference>
+
+                                    <gmi:documentation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>Algorithm Theoretical Basis Document: SMAP L2 and L3 Radiometer Soil Moisture (Passive) Data Products: L2_SM_P &amp;amp; L3_SM_P</gco:CharacterString>
+                                    </gmd:title>
+
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2012-10-26</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>Preliminary</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:documentation>
+
+                                    <gmi:algorithm xlink:type="simple">
+                                    <eos:EOS_Algorithm>
+
+                                    <gmi:citation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>Soil Moisture Active Passive (SMAP) Radiometer processing algorithm</gco:CharacterString>
+                                    </gmd:title>
+
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2016-10-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>018</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:citation>
+                                    <gmi:description>
+                                    <gco:CharacterString>Level 3 soil moisture product is formed by mosaicking Level 2 soil moisture granule data acquired over one day.</gco:CharacterString>
+                                    </gmi:description>
+
+                                    <eos:additionalCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>Algorithm Theoretical Basis Document: SMAP L2 and L3 Radiometer Soil Moisture (Passive) Data Products: L2_SM_P &amp;amp; L3_SM_P</gco:CharacterString>
+                                    </gmd:title>
+
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2015-10-30</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>Version 1.1</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </eos:additionalCitation>
+                                    </eos:EOS_Algorithm>
+                                    </gmi:algorithm>
+
+                                    <eos:otherProperty xlink:type="simple">
+
+                                    <gco:Record
+                                    xlink:type="simple" xsi:type="eos:EOS_AdditionalAttributes_PropertyType">
+                                    <eos:EOS_AdditionalAttributes>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for ParameterVersionID</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>ParameterVersionID</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>015</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for epochUTCDateTime</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>epochUTCDateTime</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="dateTime">dateTime</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>2000-01-01T11:58:55.816Z</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for epochJulianDate</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>epochJulianDate</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>2.45154e+06</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for timeVariableEpoch</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>timeVariableEpoch</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>J2000</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+                                    </eos:EOS_AdditionalAttributes>
+                                    </gco:Record>
+                                    </eos:otherProperty>
+                                    </eos:EOS_Processing>
+                                    </gmi:processingInformation>
+                                    </gmi:LE_ProcessStep>
+                                    </gmd:processStep>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>A configuration file that specifies the complete set of elements within the input Level 2 SM_P Product that the Radiometer Level 3_SM_P Science Processing Software (SPS) needs in order to function.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_SPS_InputConfig_L2_SM_P.xml</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>InputConfig</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Precomputed longitude at each EASEGrid cell on 36-km grid on Global Cylindrical Projection</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>EZ2Lon_M36_002.float32</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2013-05-09</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>002</gco:CharacterString>
+                                    </gmd:edition>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>EASEGRID_LON_M</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>A configuration file that specifies the source of the values for each of the data elements that comprise the metadata in the output Radiometer Level 3_SM_P  product.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_SPS_MetConfig_L2_SM_P.xml</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>MetConfig</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11545_D_20170330T232733_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11546_A_20170331T001644_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11546_D_20170331T010559_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11547_A_20170331T015513_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11547_D_20170331T024428_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11548_A_20170331T033339_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11548_D_20170331T042254_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11549_A_20170331T051209_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11549_D_20170331T060124_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11550_A_20170331T065034_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11550_D_20170331T073949_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11551_A_20170331T082904_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11551_D_20170331T091819_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11552_A_20170331T100730_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11552_D_20170331T105644_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11553_A_20170331T114559_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11553_D_20170331T123514_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11554_A_20170331T132425_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-03-31</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11554_D_20170331T141340_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11555_A_20170331T150255_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11555_D_20170331T155209_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11556_A_20170331T164120_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11556_D_20170331T173035_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11557_A_20170331T181950_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11557_D_20170331T190905_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11558_A_20170331T195815_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11558_D_20170331T204730_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11559_A_20170331T213645_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11559_D_20170331T222600_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>Passive soil moisture estimates onto a 36-km global Earth-fixed grid, based on radiometer measurements acquired when the SMAP spacecraft is travelling from North to South at approximately 6:00 AM local time.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L2_SM_P_11560_A_20170331T231511_R14010_001.h5</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+
+                                    <gmx:Anchor xlink:type="simple">doi:10.5067/XPJTJT812XFY</gmx:Anchor>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>gov.nasa.esdis</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A Digital Object Identifier (DOI) that provides a persistent interoperable means to locate the SMAP Level 2 SM P data product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>L2_SM_P</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    <gmd:description>
+                                    <gco:CharacterString>A short name used by the Soil Moisture Active Passive (SMAP) mission to identify the Level 2 SM_P product.</gco:CharacterString>
+                                    </gmd:description>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    <gmi:processedLevel xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP Radiometer Level 2 SM P SPS</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:processedLevel>
+                                    <gmi:resolution>
+                                    <gmi:LE_NominalResolution>
+                                    <gmi:groundResolution>
+
+                                    <gco:Distance uom="km">36</gco:Distance>
+                                    </gmi:groundResolution>
+                                    </gmi:LE_NominalResolution>
+                                    </gmi:resolution>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>A configuration file that lists the entire content of the output Radiometer Level 3_SM_P_ product.</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_SPS_OutputConfig_L3_SM_P.xml</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>OutputConfig</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    <gmd:source xlink:type="simple">
+                                    <gmi:LE_Source>
+                                    <gmd:description>
+                                    <gco:CharacterString>A configuration file generated automatically within the SMAP data system that specifies all of the conditions required for each individual run of the Radiometer Level 3 SM P Science Processing Software (SPS).</gco:CharacterString>
+                                    </gmd:description>
+                                    <gmd:sourceCitation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gmx:FileName>SMAP_L3_SM_P_SPS_RunConfig_20170401T151436393.xml</gmx:FileName>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2017-04-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>R14010</gco:CharacterString>
+                                    </gmd:edition>
+
+                                    <gmd:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>RunConfig</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmd:identifier>
+                                    </gmd:CI_Citation>
+                                    </gmd:sourceCitation>
+                                    </gmi:LE_Source>
+                                    </gmd:source>
+                                    </gmd:LI_Lineage>
+                                    </gmd:lineage>
+                                </gmd:DQ_DataQuality>
+                            </gmd:dataQualityInfo>
+                            <gmi:acquisitionInformation xlink:type="simple">
+                                <gmi:MI_AcquisitionInformation>
+                                    <gmi:platform xlink:type="simple">
+                                    <eos:EOS_Platform>
+                                    <gmi:citation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>SMAP Handbook</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2014-07-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>JPL CL#14-2285, JPL 400-1567</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:citation>
+                                    <gmi:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </gmi:identifier>
+                                    <gmi:description>
+                                    <gco:CharacterString>The SMAP observatory houses an L-band radiometer that operates at 1.414 GHz and an L-band radar that operates at 1.225 GHz.  The instruments share a rotating reflector antenna with a 6 meter aperture that scans over a 1000 km swath.  The bus is a 3 axis stabilized spacecraft that provides momentum compensation for the rotating antenna.</gco:CharacterString>
+                                    </gmi:description>
+                                    <gmi:instrument xlink:type="simple">
+                                    <gmi:MI_Instrument>
+                                    <gmi:citation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>SMAP Handbook</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2014-07-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>JPL CL#14-2285, JPL 400-1567</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:citation>
+                                    <gmi:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP SAR</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:identifier>
+                                    <gmi:type>
+                                    <gco:CharacterString>L-Band Synthetic Aperture Radar</gco:CharacterString>
+                                    </gmi:type>
+                                    <gmi:description>
+                                    <gco:CharacterString>The SMAP 1.225 GHz L-Band Radar Instrument</gco:CharacterString>
+                                    </gmi:description>
+                                    </gmi:MI_Instrument>
+                                    </gmi:instrument>
+                                    <gmi:instrument xlink:type="simple">
+                                    <gmi:MI_Instrument>
+                                    <gmi:citation xlink:type="simple">
+                                    <gmd:CI_Citation>
+                                    <gmd:title>
+                                    <gco:CharacterString>SMAP Handbook</gco:CharacterString>
+                                    </gmd:title>
+                                    <gmd:date xlink:type="simple">
+                                    <gmd:CI_Date>
+                                    <gmd:date>
+                                    <gco:Date>2014-07-01</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+
+                                    <gmd:CI_DateTypeCode
+                                    codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                    </gmd:CI_Date>
+                                    </gmd:date>
+                                    <gmd:edition>
+                                    <gco:CharacterString>JPL CL#14-2285, JPL 400-1567</gco:CharacterString>
+                                    </gmd:edition>
+                                    </gmd:CI_Citation>
+                                    </gmi:citation>
+                                    <gmi:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>SMAP RAD</gco:CharacterString>
+                                    </gmd:code>
+                                    </gmd:MD_Identifier>
+                                    </gmi:identifier>
+                                    <gmi:type>
+                                    <gco:CharacterString>L-Band Radiometer</gco:CharacterString>
+                                    </gmi:type>
+                                    <gmi:description>
+                                    <gco:CharacterString>The SMAP 1.414 GHz L-Band Radiometer</gco:CharacterString>
+                                    </gmi:description>
+                                    </gmi:MI_Instrument>
+                                    </gmi:instrument>
+                                    <eos:otherProperty xlink:type="simple">
+                                    <gco:Record
+                                    xlink:type="simple" xsi:type="eos:EOS_AdditionalAttributes_PropertyType">
+                                    <eos:EOS_AdditionalAttributes>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for stopRevNumber</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>stopRevNumber</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="int">int</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>11560</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for startRevNumber</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>startRevNumber</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="int">int</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>10000</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+
+                                    <eos:additionalAttribute xlink:type="simple">
+                                    <eos:EOS_AdditionalAttribute>
+
+                                    <eos:reference xlink:type="simple">
+                                    <eos:EOS_AdditionalAttributeDescription>
+                                    <eos:type>
+
+                                    <eos:EOS_AdditionalAttributeTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                    </eos:type>
+
+                                    <eos:identifier xlink:type="simple">
+                                    <gmd:MD_Identifier>
+                                    <gmd:code>
+                                    <gco:CharacterString>uuid for AntennaRotationRate</gco:CharacterString>
+                                    </gmd:code>
+                                    <gmd:codeSpace>
+                                    <gco:CharacterString>http://smap.jpl.nasa.gov</gco:CharacterString>
+                                    </gmd:codeSpace>
+                                    </gmd:MD_Identifier>
+                                    </eos:identifier>
+                                    <eos:name>
+                                    <gco:CharacterString>AntennaRotationRate</gco:CharacterString>
+                                    </eos:name>
+                                    <eos:dataType>
+
+                                    <eos:EOS_AdditionalAttributeDataTypeCode
+                                    codeList="http://cdn.earthdata.nasa.gov/metadata/resources/Codelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
+                                    </eos:dataType>
+                                    </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                    <gco:CharacterString>14.6</gco:CharacterString>
+                                    </eos:value>
+                                    </eos:EOS_AdditionalAttribute>
+                                    </eos:additionalAttribute>
+                                    </eos:EOS_AdditionalAttributes>
+                                    </gco:Record>
+                                    </eos:otherProperty>
+                                    </eos:EOS_Platform>
+                                    </gmi:platform>
+                                </gmi:MI_AcquisitionInformation>
+                            </gmi:acquisitionInformation>
+                        </gmi:MI_Metadata>
+                    </gmd:has>
+                </gmd:DS_DataSet>
+            </gmd:composedOf>
+            <gmd:seriesMetadata gco:nilReason="missing" xlink:type="simple"/>
+        </gmd:DS_Series>

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
@@ -47,6 +47,26 @@
           response (search/find-metadata :granule format-key params options)]
       (d/assert-metadata-results-match format-key [g1-echo] response))))
 
+(deftest search-smap-granule-with-size-in-echo10
+  (let [coll (d/ingest-concept-with-metadata-file "CMR-4902/4902_smap_iso_collection.xml"
+                                                  {:provider-id "PROV1"
+                                                   :concept-type :collection
+                                                   :native-id "iso-smap-collection"
+                                                   :format-key :iso-smap})
+        ;; The iso smap granule contains transferSize being 22.2031965255737
+        granule (d/ingest-concept-with-metadata-file "CMR-4902/4902_smap_iso_granule.xml"
+                                                     {:provider-id "PROV1"
+                                                      :concept-type :granule
+                                                      :native-id "iso-smap-granule"
+                                                      :format-key :iso-smap})]
+    (index/wait-until-indexed)
+    (let [params {:concept-id (:concept-id granule)}
+          format-key :echo10
+          response (search/find-metadata :granule format-key params)
+          metadata (:metadata (first (:items response)))]
+      ;; Verify that the retrieved echo10 granule contains the correct SizeMBDataGranule.
+      (is (= true (.contains metadata "<SizeMBDataGranule>22.2031965255737</SizeMBDataGranule>"))))))
+
 (deftest search-granules-in-xml-metadata
   (let [c1-echo (d/ingest "PROV1" (dc/collection) {:format :echo10})
         c2-smap (d/ingest "PROV2" (dc/collection) {:format :iso-smap})

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
@@ -58,14 +58,17 @@
                                                      {:provider-id "PROV1"
                                                       :concept-type :granule
                                                       :native-id "iso-smap-granule"
-                                                      :format-key :iso-smap})]
+                                                      :format-key :iso-smap})
+        umm-granule-size (get-in granule [:data-granule :size])]
     (index/wait-until-indexed)
     (let [params {:concept-id (:concept-id granule)}
           format-key :echo10
           response (search/find-metadata :granule format-key params)
           metadata (:metadata (first (:items response)))]
-      ;; Verify that the retrieved echo10 granule contains the correct SizeMBDataGranule.
-      (is (= true (.contains metadata "<SizeMBDataGranule>22.2031965255737</SizeMBDataGranule>"))))))
+      ;; Umm granule size should be the same as the transferSize in the smap granule.
+      ;; The retrieved echo10 granule should contain the same SizeMBDataGranule as the umm granule size.
+      (is (= 22.2031965255737 umm-granule-size))
+      (is (= true (.contains metadata (str "<SizeMBDataGranule>" umm-granule-size "</SizeMBDataGranule>")))))))
 
 (deftest search-granules-in-xml-metadata
   (let [c1-echo (d/ingest "PROV1" (dc/collection) {:format :echo10})

--- a/umm-lib/src/cmr/umm/iso_smap/granule.clj
+++ b/umm-lib/src/cmr/umm/iso_smap/granule.clj
@@ -48,7 +48,12 @@
 (defn- xml-elem->DataGranule
   "Returns a UMM data-granule element from a parsed Granule XML structure"
   [xml-struct]
-  (let [producer-gran-id (cx/string-at-path
+  (let [size (cx/double-at-path
+               xml-struct
+               [:composedOf :DS_DataSet :has :MI_Metadata :distributionInfo :MD_Distribution
+                :distributor :MD_Distributor :distributorTransferOptions :MD_DigitalTransferOptions
+                :transferSize :Real]) 
+        producer-gran-id (cx/string-at-path
                            xml-struct
                            [:composedOf :DS_DataSet :has :MI_Metadata :identificationInfo
                             :MD_DataIdentification :citation :CI_Citation :title :FileName])
@@ -58,7 +63,8 @@
                                 :DQ_DataQuality :lineage :LI_Lineage :processStep :LE_ProcessStep
                                 :dateTime :DateTime])]
     (when (or producer-gran-id production-date-time)
-      (g/map->DataGranule {:producer-gran-id producer-gran-id
+      (g/map->DataGranule {:size size 
+                           :producer-gran-id producer-gran-id
                            :production-date-time production-date-time}))))
 
 (defn- xml-elem->access-value
@@ -104,7 +110,7 @@
        :related-urls (ru/xml-elem->related-urls xml-struct)})))
 
 (defn parse-granule
-  "Parses ECHO10 XML into a UMM Granule record."
+  "Parses SMAP XML into a UMM Granule record."
   [xml]
   (xml-elem->Granule (x/parse-str xml)))
 


### PR DESCRIPTION
Notes based on playing with the EDSC interface and the behaviors observed:
1. Ingest a smap granule with transferSize, retrieve it as echo10 and verify that the echo10 granule contains the SizeMBDataGranule with the same value. This is what needs to be fixed for this ticket.
2. Ingest a smap granule with transferSize, retrieve it as iso19115 is not supported. (existing behavior)
No need to fix for this ticket.
3. Ingest an echo10 granule with SizeMBDataGranule, retrieve it as iso19115, it should contain the transferSize (existing behavior). Make sure it continues to work after the fix.
4. Ingest an echo10 granule with SizeMBDataGranule, retrieve it as iso smap is not supported.(existing behavior). No need to fix for this ticket. So converting size in umm-granule to iso smap element is not needed(deleted the added code).
5. We don't support the ingest of iso mends granule. So the description in the ticket should only apply to iso smap granule, not the iso mends granule. Are we going to support it soon?
