### PR TITLE
CMR-4954 decouple access-control from echo in dev-system

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/fixtures.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/fixtures.clj
@@ -142,7 +142,7 @@
   (fn [f]
     (e/grant-system-group-permissions-to-admin-group (conn-context))
     (doseq [provider-guid provider-guids]
-      (e/grant-system-group-permissions-to-admin-group (conn-context) provider-guid))
+      (e/grant-provider-group-permissions-to-admin-group (conn-context) provider-guid))
     (f)))
 
 ;;These two vars will be rebinded dynamically when the fixtures are setup for each test and

--- a/access-control-app/int-test/cmr/access_control/int_test/fixtures.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/fixtures.clj
@@ -107,7 +107,7 @@
      (mock-echo-client/reset (conn-context))
      (mdb/reset (conn-context))
      (ac/reset (conn-context) {:bootstrap-data? true})
-     (e/grant-system-group-permissions-to-admin-group (conn-context) :create :read )
+     (e/grant-system-group-permissions-to-admin-group (conn-context) :create :read)
      (doseq [[provider-guid provider-id] provider-map]
        (mdb/create-provider (assoc (conn-context) :token (config/echo-system-token))
                             {:provider-id provider-id})

--- a/access-control-app/src/cmr/access_control/services/acl_authorization.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_authorization.clj
@@ -25,7 +25,7 @@
                                       (qm/string-condition :target schema/provider-object-acl-target)))
         condition (gc/or system-condition prov-condition)
         acls (acl-util/get-acls-by-condition context condition)]
-    (filterv #(acl/acl-matches-sids-and-permission? sids "read" (acl/echo-style-acl %)) acls)))
+    (filterv #(acl/acl-matches-sids-and-permission? sids "read" %) acls)))
 
 (defn- provider-read-acl->condition
   "Returns an elastic query condition that matches ACLs which the user has permission to read."
@@ -64,8 +64,7 @@
   [context action target]
   (let [condition (qm/string-condition :identity-type index/system-identity-type-name true false)
         system-acls (acl-util/get-acls-by-condition context condition)
-        any-acl-system-acl (acl/echo-style-acl
-                             (first (filter #(= target (:target (:system-identity %))) system-acls)))
+        any-acl-system-acl (first (filter #(= target (:target (:system-identity %))) system-acls))
         sids (auth-util/get-sids context)]
     (acl/acl-matches-sids-and-permission? sids (name action) any-acl-system-acl)))
 
@@ -76,8 +75,7 @@
         provider-id-condition (qm/string-condition :provider provider-id)
         conditions (gc/and-conds [provider-identity-condition provider-id-condition])
         provider-acls (acl-util/get-acls-by-condition context conditions)
-        prov-acl (acl/echo-style-acl
-                   (first (filter #(= target (:target (:provider-identity %))) provider-acls)))
+        prov-acl (first (filter #(= target (:target (:provider-identity %))) provider-acls))
         sids (auth-util/get-sids context)]
     (acl/acl-matches-sids-and-permission? sids (name action) prov-acl)))
 
@@ -86,14 +84,13 @@
   [context action concept-id]
   (let [condition (qm/string-condition :concept-id concept-id true false)
         returned-acl (first (acl-util/get-acls-by-condition context condition))
-        echo-acl (acl/echo-style-acl returned-acl)
         sids (auth-util/get-sids context)]
     ;; read is special, if the user has any permission for the acl
     ;; then the user has permission to read
     (if (= action :read)
-      (some #(acl/acl-matches-sids-and-permission? sids % echo-acl)
+      (some #(acl/acl-matches-sids-and-permission? sids % returned-acl)
             ["create" "read" "update" "delete"])
-      (acl/acl-matches-sids-and-permission? sids (name action) echo-acl))))
+      (acl/acl-matches-sids-and-permission? sids (name action) returned-acl))))
 
 (defn- permission-denied-message
   "Returns permission denied message for given user and action."

--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -190,13 +190,13 @@
   "Returns true if the ECHO-style acl specifically identifies the given provider id."
   [provider-id acl]
   (or
-    (-> acl :provider-object-identity :provider-id (= provider-id))
+    (-> acl :provider-identity :provider-id (= provider-id))
     (-> acl :catalog-item-identity :provider-id (= provider-id))))
 
 (defn- ingest-management-acl?
   "Returns true if the ACL targets a provider INGEST_MANAGEMENT_ACL."
   [acl]
-  (-> acl :provider-object-identity :target (= schema/ingest-management-acl-target)))
+  (-> acl :provider-identity :target (= schema/ingest-management-acl-target)))
 
 (defn- concept-permissions-granted-by-acls
   "Returns the set of permission keywords (:read, :order, and :update) granted on concept
@@ -246,7 +246,7 @@
 (defn system-permissions-granted-by-acls
   "Returns a set of permission keywords granted on the system target to the given sids by the given acls."
   [system-object-target sids acls]
-  (let [relevant-acls (filter #(-> % :system-object-identity :target (= system-object-target))
+  (let [relevant-acls (filter #(-> % :system-identity :target (= system-object-target))
                               acls)]
     (set
       (for [permission [:create :read :update :delete]
@@ -266,7 +266,7 @@
   "Returns all permissions granted to provider target for given sids and acls."
   [provider-id target sids acls]
   (collect-permissions (fn [acl permission]
-                         (and (= target (:target (:provider-object-identity acl)))
+                         (and (= target (:target (:provider-identity acl)))
                               (acl/acl-matches-sids-and-permission? sids (name permission) acl)))
                        acls))
 

--- a/access-control-app/src/cmr/access_control/services/auth_util.clj
+++ b/access-control-app/src/cmr/access_control/services/auth_util.clj
@@ -61,7 +61,7 @@
   (when-let [provider-id (:provider-id group)]
     (when-not (= "CMR" provider-id)
       (seq
-        (filter #(= provider-id (-> % :provider-object-identity :provider-id))
+        (filter #(= provider-id (-> % :provider-identity :provider-id))
                 (get-provider-level-group-acls context permission))))))
 
 (defn- get-instance-acls
@@ -79,8 +79,8 @@
    (when (or legacy-guid concept-id)
      (let [acls (mapcat #(acl/get-permitting-acls context :single-instance-object "GROUP_MANAGEMENT" %) permissions)]
        (seq (filter
-             #(or (= concept-id (get-in % [:single-instance-object-identity :target-guid]))
-                  (= legacy-guid (get-in % [:single-instance-object-identity :target-guid])))
+             #(or (= concept-id (get-in % [:single-instance-identity :target-id]))
+                  (= legacy-guid (get-in % [:single-instance-identity :target-id])))
              acls))))))
 
 (defn- describe-group
@@ -104,6 +104,7 @@
   [context action-description permission group]
   (when-not (transmit-config/echo-system-token? context)
     (let [context (put-sids-in-context context)]
+      (proto-repl.saved-values/save 3)
       (when-not (or (get-instance-acls context action-description group)
                     (get-provider-acls context permission group)
                     (get-system-level-group-acls context permission))
@@ -148,7 +149,7 @@
             (seq (get-system-level-group-acls context :read)))
       query
       ;; Otherwise, we need to filter the results to only the providers visible to the current user.
-      (let [provider-ids (map #(-> % :provider-object-identity :provider-id)
+      (let [provider-ids (map #(-> % :provider-identity :provider-id)
                               (get-provider-level-group-acls context :read))]
         (if (seq provider-ids)
           (update-in query [:condition] (fn [condition]

--- a/access-control-app/src/cmr/access_control/services/auth_util.clj
+++ b/access-control-app/src/cmr/access_control/services/auth_util.clj
@@ -104,7 +104,6 @@
   [context action-description permission group]
   (when-not (transmit-config/echo-system-token? context)
     (let [context (put-sids-in-context context)]
-      (proto-repl.saved-values/save 3)
       (when-not (or (get-instance-acls context action-description group)
                     (get-provider-acls context permission group)
                     (get-system-level-group-acls context permission))

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -15,8 +15,7 @@
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as util]
    [cmr.transmit.access-control :as access-control]
-   [cmr.transmit.config :as config]
-   [cmr.transmit.echo.acls :as echo-acls]))
+   [cmr.transmit.config :as config]))
 
 (def acl-cache-key
   "The key used to store the acl cache in the system cache map."
@@ -109,7 +108,7 @@
  (do
    (def context (cmr.access-control.test.util/conn-context))
    (process-search-for-acls (assoc context :token (config/echo-system-token)) [:system-object :provider-object])
-   (echo-acls/get-acls-by-types context [:system-object :provider-object])
+   (cmr.transmit.echo.acls/get-acls-by-types context [:system-object :provider-object])
    (get-acls context [:system-object :provider-object])))
 
 (defn get-acls

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -13,6 +13,8 @@
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
+   [cmr.common.util :as util]
+   [cmr.transmit.access-control :as access-control]
    [cmr.transmit.echo.acls :as echo-acls]))
 
 (def acl-cache-key
@@ -54,10 +56,32 @@
                         :keys-to-track acl-keys-to-track}))
                      object-identity-types))
 
+(def identity-string-map
+  {:system-object "system"
+   :provider-object "provider"
+   :single-instance-object "single_instance"
+   :catalog-item "catalog_item"})
+
+(defn- object-identity-types->identity-strings
+  "Converts object identity types to the identity strings expected from access control"
+  [object-identity-types]
+  (map identity-string-map object-identity-types))
+
 (defn- context->cached-object-identity-types
   "Gets the object identity types configured in the acl cache in the context."
   [context]
   (:object-identity-types (cache/context->cache context acl-cache-key)))
+
+(defn- process-search-for-acls
+  "Calls acl search endpoint using converting object-identity-types
+   and processes response and formats it for get-acls"
+  [context object-identity-types]
+  (map (comp :acl util/map-keys->kebab-case)
+       (get
+        (access-control/search-for-acls context {:identity-type (object-identity-types->identity-strings
+                                                                 object-identity-types)
+                                                 :include-full-acl true})
+        :items)))
 
 (defn expire-consistent-cache-hashes
   "Forces the cached hash codes of an ACL consistent cache to expire so that subsequent requests for
@@ -72,15 +96,22 @@
   caller is responsible for catching and logging the exception."
   [context]
   (let [cache (cache/context->cache context acl-cache-key)
-        updated-acls (echo-acls/get-acls-by-types
+        updated-acls (process-search-for-acls
                        ;; All of the object identity types needed by the application are fetched. We want
                        ;; the cache to contain all of the acls needed.
                        context (context->cached-object-identity-types context))]
     (cache/set-value cache acl-cache-key updated-acls)))
 
+(comment
+ (do
+   (def context (cmr.access-control.test.util/conn-context))
+   (process-search-for-acls context [:system-object :provider-object])))
+   ; (get-acls context [:system-object :provider-object])))
+
 (defn get-acls
   "Gets the current acls limited to a specific set of object identity types."
   [context object-identity-types]
+  (proto-repl.saved-values/save 15)
   (if-let [cache (cache/context->cache context acl-cache-key)]
     ;; Check that we're caching the requested object identity types
     ;; Otherwise we'd just silently fail to find any acls.
@@ -91,25 +122,25 @@
       (do
         (info (str "The application is not configured to cache acls of the "
                    "following object-identity-types so we will fetch them "
-                   "from ECHO each time they are needed. "
+                   "from access-control each time they are needed. "
                    (pr-str not-cached-oits)))
-        (echo-acls/get-acls-by-types context object-identity-types))
+        (process-search-for-acls context object-identity-types))
       ;; Fetch ACLs using a cache
       (filter
         (fn [acl]
-          (some #(get acl (echo-acls/acl-type->acl-key %))
+          (some #(get acl (access-control/acl-type->acl-key %))
                 object-identity-types))
         (cache/get-value
           cache
           acl-cache-key
-          #(echo-acls/get-acls-by-types
-             context
-             ;; All of the object identity types needed by the application are
-             ;; fetched. We want the cache to contain all of the acls needed.
-             (context->cached-object-identity-types context)))))
+          #(process-search-for-acls
+            context
+            ;; All of the object identity types needed by the application are
+            ;; fetched. We want the cache to contain all of the acls needed.
+            (context->cached-object-identity-types context)))))
 
     ;; No cache is configured. Directly fetch the acls.
-    (echo-acls/get-acls-by-types context object-identity-types)))
+    (process-search-for-acls context object-identity-types)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Job for refreshing ACLs in the cache.

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -82,7 +82,8 @@
         (access-control/search-for-acls (assoc context :token (config/echo-system-token))
                                         {:identity-type (object-identity-types->identity-strings
                                                          object-identity-types)
-                                         :include-full-acl true})
+                                         :include-full-acl true
+                                         :page-size 2000})
         :items)))
 
 (defn expire-consistent-cache-hashes

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -148,8 +148,8 @@
            ;; Find acls for this user and permission type
            (filter (partial acl-matches-sids-and-permission?
                             (context->sids context)
-                            permission-type))))
-           ; seq))
+                            permission-type))
+           seq))
     (catch Exception e
       (info "Caught exception getting permitting ACLs: " (.getMessage e))
       (if (re-matches #".*status 401.*" (.getMessage e))

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -105,7 +105,6 @@
 (defn- ace-matches-sid?
   "Returns true if the ACE is applicable to the SID."
   [sid group-permission]
-  (proto-repl.saved-values/save 10)
   (or
     (= (keyword sid) (keyword (:user-type group-permission)))
     (= sid (:group-id group-permission))))
@@ -113,7 +112,6 @@
 (defn acl-matches-sids-and-permission?
   "Returns true if the acl is applicable to any of the sids."
   [sids permission acl]
-  (proto-repl.saved-values/save 11)
   (some (fn [sid]
           (some (fn [group-permission]
                   (and (ace-matches-sid? sid group-permission)
@@ -144,7 +142,6 @@
   [context object-identity-type target permission-type]
   (try
     (let [acl-oit-key (access-control/acl-type->acl-key object-identity-type)]
-      (proto-repl.saved-values/save 16)
       (->> (acl-fetcher/get-acls context [object-identity-type])
            ;; Find acls on INGEST_MANAGEMENT
            (filter #(= target (get-in % [acl-oit-key :target])))

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -104,19 +104,21 @@
 
 (defn- ace-matches-sid?
   "Returns true if the ACE is applicable to the SID."
-  [sid ace]
+  [sid group-permission]
+  (proto-repl.saved-values/save 10)
   (or
-    (= (keyword sid) (keyword (:user-type ace)))
-    (= sid (:group-guid ace))))
+    (= (keyword sid) (keyword (:user-type group-permission)))
+    (= sid (:group-id group-permission))))
 
 (defn acl-matches-sids-and-permission?
   "Returns true if the acl is applicable to any of the sids."
   [sids permission acl]
+  (proto-repl.saved-values/save 11)
   (some (fn [sid]
-          (some (fn [ace]
-                  (and (ace-matches-sid? sid ace)
-                       (some #(= % permission) (:permissions ace))))
-                (:aces acl)))
+          (some (fn [group-permission]
+                  (and (ace-matches-sid? sid group-permission)
+                       (some #(= % (name permission)) (:permissions group-permission))))
+                (:group-permissions acl)))
         sids))
 
 (def token-imp-cache-key
@@ -141,15 +143,16 @@
   * permission-type = :read"
   [context object-identity-type target permission-type]
   (try
-    (let [acl-oit-key (echo-acls/acl-type->acl-key object-identity-type)]
+    (let [acl-oit-key (access-control/acl-type->acl-key object-identity-type)]
+      (proto-repl.saved-values/save 16)
       (->> (acl-fetcher/get-acls context [object-identity-type])
            ;; Find acls on INGEST_MANAGEMENT
            (filter #(= target (get-in % [acl-oit-key :target])))
            ;; Find acls for this user and permission type
            (filter (partial acl-matches-sids-and-permission?
                             (context->sids context)
-                            permission-type))
-           seq))
+                            permission-type))))
+           ; seq))
     (catch Exception e
       (info "Caught exception getting permitting ACLs: " (.getMessage e))
       (if (re-matches #".*status 401.*" (.getMessage e))
@@ -165,7 +168,7 @@
   [context permission-type object-identity-type provider-id]
   ;; Performance optimization here of returning true if it's the system user.
   (or (transmit-config/echo-system-token? context)
-      (let [acl-oit-key (echo-acls/acl-type->acl-key object-identity-type)]
+      (let [acl-oit-key (access-control/acl-type->acl-key object-identity-type)]
         (->> (get-permitting-acls context
                                   object-identity-type
                                   "INGEST_MANAGEMENT_ACL"

--- a/common-app-lib/src/cmr/common_app/services/search/datetime_helper.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/datetime_helper.clj
@@ -20,12 +20,13 @@
 (defn utc-time->elastic-time
   "Convert utc clj time to elasticsearch time string."
   [tm]
-  (-> (f/formatters :date-time)
-      (f/unparse tm)
-      (s/replace #"Z" "-0000")))
+  (if (string? tm)
+    (s/replace tm #"Z" "-0000")
+    (-> (f/formatters :date-time)
+        (f/unparse tm)
+        (s/replace #"Z" "-0000"))))
 
 (defn datetime->string
   "Convert a Joda datetime to a datetime string formatted as :date-time-no-ms"
   [dt]
   (f/unparse (f/formatters :date-time-no-ms) dt))
-

--- a/indexer-app/int-test/cmr/indexer/test/data/concepts/collection_acls.clj
+++ b/indexer-app/int-test/cmr/indexer/test/data/concepts/collection_acls.clj
@@ -32,17 +32,17 @@
 
 (deftest test-get-coll-permitted-group-ids
   (testing "group access"
-    (let [acl1 {:group-permissions [(group-ace "read-order" :read :order)
-                                    (group-ace "order" :order)
-                                    (group-ace "just-read" :read)
-                                    (group-ace "order-read" :order :read)
+    (let [acl1 {:group-permissions [(group-ace "read-order" "read" "order")
+                                    (group-ace "order" "order")
+                                    (group-ace "just-read" "read")
+                                    (group-ace "order-read" "order" "read")
                                     (group-ace "no-permit")]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:group-permissions [(group-ace "group2" :read)]
+          acl2 {:group-permissions [(group-ace "group2" "read")]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
-          acl3 {:group-permissions [(group-ace "group3" :read)]
+          acl3 {:group-permissions [(group-ace "group3" "read")]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2 acl3)]
@@ -50,11 +50,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "guest access"
-    (let [acl1 {:group-permissions [(group-ace "group1" :read)
-                                    (user-type-ace :guest :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" "read")
+                                    (user-type-ace :guest "order" "read")]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:group-permissions [(user-type-ace :registered :order)]
+          acl2 {:group-permissions [(user-type-ace :registered "order")]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]
@@ -62,11 +62,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "registered user access"
-    (let [acl1 {:group-permissions [(group-ace "group1" :read)
-                                    (user-type-ace :registered :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" "read")
+                                    (user-type-ace :registered "order" "read")]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:group-permissions [(user-type-ace :guest :order)]
+          acl2 {:group-permissions [(user-type-ace :guest "order")]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]
@@ -74,11 +74,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "registered user access"
-    (let [acl1 {:group-permissions [(group-ace "group1" :read)
-                                    (user-type-ace :registered :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" "read")
+                                    (user-type-ace :registered "order" "read")]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
-          acl2 {:group-permissions [(user-type-ace :guest :read)]
+          acl2 {:group-permissions [(user-type-ace :guest "read")]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]

--- a/indexer-app/int-test/cmr/indexer/test/data/concepts/collection_acls.clj
+++ b/indexer-app/int-test/cmr/indexer/test/data/concepts/collection_acls.clj
@@ -19,7 +19,7 @@
 (defn group-ace
   [group-guid & permissions]
   {:permissions permissions
-   :group-guid group-guid})
+   :group-id group-guid})
 
 (defn user-type-ace
   [user-type & permissions]
@@ -32,17 +32,17 @@
 
 (deftest test-get-coll-permitted-group-ids
   (testing "group access"
-    (let [acl1 {:aces [(group-ace "read-order" :read :order)
-                       (group-ace "order" :order)
-                       (group-ace "just-read" :read)
-                       (group-ace "order-read" :order :read)
-                       (group-ace "no-permit")]
+    (let [acl1 {:group-permissions [(group-ace "read-order" :read :order)
+                                    (group-ace "order" :order)
+                                    (group-ace "just-read" :read)
+                                    (group-ace "order-read" :order :read)
+                                    (group-ace "no-permit")]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:aces [(group-ace "group2" :read)]
+          acl2 {:group-permissions [(group-ace "group2" :read)]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
-          acl3 {:aces [(group-ace "group3" :read)]
+          acl3 {:group-permissions [(group-ace "group3" :read)]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2 acl3)]
@@ -50,11 +50,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "guest access"
-    (let [acl1 {:aces [(group-ace "group1" :read)
-                       (user-type-ace :guest :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" :read)
+                                    (user-type-ace :guest :order :read)]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:aces [(user-type-ace :registered :order)]
+          acl2 {:group-permissions [(user-type-ace :registered :order)]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]
@@ -62,11 +62,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "registered user access"
-    (let [acl1 {:aces [(group-ace "group1" :read)
-                       (user-type-ace :registered :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" :read)
+                                    (user-type-ace :registered :order :read)]
                 :catalog-item-identity {:provider-id "PROV1"
                                         :collection-applicable true}}
-          acl2 {:aces [(user-type-ace :guest :order)]
+          acl2 {:group-permissions [(user-type-ace :guest :order)]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]
@@ -74,11 +74,11 @@
              (get-coll-permitted-group-ids context "PROV1" {:fake-coll "foo"})))))
 
   (testing "registered user access"
-    (let [acl1 {:aces [(group-ace "group1" :read)
-                       (user-type-ace :registered :order :read)]
+    (let [acl1 {:group-permissions [(group-ace "group1" :read)
+                                    (user-type-ace :registered :order :read)]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
-          acl2 {:aces [(user-type-ace :guest :read)]
+          acl2 {:group-permissions [(user-type-ace :guest :read)]
                 :catalog-item-identity {:provider-id "PROV2"
                                         :collection-applicable true}}
           context (context-with-acls acl1 acl2)]

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -148,9 +148,7 @@
                 created-at revision-date deleted format extra-fields
                 tag-associations variable-associations service-associations]} concept
         collection (remove-index-irrelevant-defaults collection)
-        collection (merge
-                    {:concept-id concept-id}
-                    collection)
+        collection (merge {:concept-id concept-id} collection)
         {short-name :ShortName version-id :Version entry-title :EntryTitle
          collection-data-type :CollectionDataType summary :Abstract
          temporal-keywords :TemporalKeywords platforms :Platforms
@@ -392,6 +390,7 @@
                 native-id revision-date deleted format]} concept
         ;; only used to get default ACLs for tombstones
         tombstone-umm (umm-collection/map->UMM-C {:EntryTitle entry-title})
+        tombstone-umm (merge {:concept-id concept-id} tombstone-umm)
         tombstone-permitted-group-ids (get-coll-permitted-group-ids context
                                                                     provider-id tombstone-umm)]
     {:concept-id concept-id

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -123,11 +123,11 @@
        ;; Find only acls that are applicable to this collection
        (filter (partial umm-matchers/coll-applicable-acl? provider-id coll))
        ;; Get the permissions they grant
-       (mapcat :aces)
+       (mapcat :group-permissions)
        ;; Find permissions that grant read
        (filter #(some (partial = :read) (:permissions %)))
        ;; Get the group guids or user type of those permissions
-       (map #(or (:group-guid %) (some-> % :user-type name)))
+       (map #(or (:group-id %) (some-> % :user-type name)))
        distinct))
 
 (defn- associations->gzip-base64-str

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -125,7 +125,7 @@
        ;; Get the permissions they grant
        (mapcat :group-permissions)
        ;; Find permissions that grant read
-       (filter #(some (partial = :read) (:permissions %)))
+       (filter #(some (partial = "read") (:permissions %)))
        ;; Get the group guids or user type of those permissions
        (map #(or (:group-id %) (some-> % :user-type name)))
        distinct))
@@ -148,6 +148,9 @@
                 created-at revision-date deleted format extra-fields
                 tag-associations variable-associations service-associations]} concept
         collection (remove-index-irrelevant-defaults collection)
+        collection (merge
+                    {:concept-id concept-id}
+                    collection)
         {short-name :ShortName version-id :Version entry-title :EntryTitle
          collection-data-type :CollectionDataType summary :Abstract
          temporal-keywords :TemporalKeywords platforms :Platforms

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -271,10 +271,9 @@
   "Gets the system administrator group"
   [context]
   (->> (ac/search-for-groups context {:legacy_guid (config/administrators-group-legacy-guid) :token (config/echo-system-token)})
-      :items
-      (map #(assoc (:acl %) :revision_id (:revision_id %) :concept_id (:concept_id %)))
-      (first)))
-
+       :items
+       (map #(assoc (:acl %) :revision_id (:revision_id %) :concept_id (:concept_id %)))
+       (first)))
 
 (def guest-read-ace
   "A CMR style access control entry granting guests read access."

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -86,15 +86,15 @@
     (case mask
       ;; The granule just needs to intersect with the date range.
       "intersect" (q/map->TemporalCondition {:start-date start-date
-                                             :stop-date stop-date
+                                             :end-date stop-date
                                              :exclusive? false})
       ;; Disjoint is intersects negated.
-      "disjoint" (cqm/->NegatedCondition (temporal->query-condition)
-                                         (assoc temporal-filter :mask :intersect))
+      "disjoint" (cqm/->NegatedCondition (temporal->query-condition
+                                          (assoc temporal-filter :mask "intersect")))
       ;; The granules temporal must start and end within the temporal range
       "contains" (gc/and-conds [(cqm/date-range-condition :start-date start-date stop-date false)
-                                (cqm/->ExistCondition :stop-date)
-                                (cqm/date-range-condition :stop-date start-date stop-date false)]))))
+                                (cqm/->ExistCondition :end-date)
+                                (cqm/date-range-condition :end-date start-date stop-date false)]))))
 
 (defmulti provider->collection-condition
   "Converts a provider id from an ACL into a collection query condition that will find all collections

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -69,10 +69,10 @@
 (defn- access-value->query-condition
   "Converts an access value filter from an ACL into a query condition."
   [access-value-filter]
-  (when-let [{:keys [include-undefined min-value max-value]} access-value-filter]
+  (when-let [{:keys [include-undefined-value min-value max-value]} access-value-filter]
     (let [value-cond (when (or min-value max-value)
                        (cqm/numeric-range-condition :access-value min-value max-value))
-          include-undefined-cond (when include-undefined
+          include-undefined-cond (when include-undefined-value
                                    (cqm/->NegatedCondition
                                      (cqm/->ExistCondition :access-value)))]
       (if (and value-cond include-undefined-cond)
@@ -82,23 +82,19 @@
 (defn- temporal->query-condition
   "Converts a temporal filter from an ACL into a query condition"
   [temporal-filter]
-  (when-not (= :acquisition (:temporal-field temporal-filter))
-    (errors/internal-error!
-      (str "Found acl with unsupported temporal field " (:temporal-field temporal-filter))))
-
-  (let [{:keys [start-date end-date mask]} temporal-filter]
+  (let [{:keys [start-date stop-date mask]} temporal-filter]
     (case mask
       ;; The granule just needs to intersect with the date range.
-      :intersect (q/map->TemporalCondition {:start-date start-date
-                                             :end-date end-date
+      "intersect" (q/map->TemporalCondition {:start-date start-date
+                                             :stop-date stop-date
                                              :exclusive? false})
       ;; Disjoint is intersects negated.
-      :disjoint (cqm/->NegatedCondition (temporal->query-condition
-                                         (assoc temporal-filter :mask :intersect)))
+      "disjoint" (cqm/->NegatedCondition (temporal->query-condition)
+                                         (assoc temporal-filter :mask :intersect))
       ;; The granules temporal must start and end within the temporal range
-      :contains (gc/and-conds [(cqm/date-range-condition :start-date start-date end-date false)
-                               (cqm/->ExistCondition :end-date)
-                               (cqm/date-range-condition :end-date start-date end-date false)]))))
+      "contains" (gc/and-conds [(cqm/date-range-condition :start-date start-date stop-date false)
+                                (cqm/->ExistCondition :stop-date)
+                                (cqm/date-range-condition :stop-date start-date stop-date false)]))))
 
 (defmulti provider->collection-condition
   "Converts a provider id from an ACL into a collection query condition that will find all collections
@@ -257,7 +253,8 @@
   [context coll-identifier concept]
   (if coll-identifier
     (let [collection-concept-id (:collection-concept-id concept)
-          collection (coll-cache/get-collection context collection-concept-id)]
+          collection (merge {:concept-id collection-concept-id}
+                            (coll-cache/get-collection context collection-concept-id))]
       (when-not collection
         (errors/internal-error!
           (format "Collection with id %s was in a granule but was not found using collection cache."

--- a/search-app/test/cmr/search/test/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/services/acls/granule_acls.clj
@@ -10,7 +10,7 @@
   ([min-v max-v]
    (access-value min-v max-v nil))
   ([min-v max-v include-undefined?]
-   {:include-undefined include-undefined?
+   {:include-undefined-value include-undefined?
     :min-value min-v
     :max-value max-v}))
 
@@ -21,7 +21,6 @@
   ([entry-titles access-value-filter]
    {:entry-titles entry-titles
     :access-value access-value-filter}))
-
 
 (defn gran-id
   "Creates an ACL granule identifier"

--- a/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
@@ -145,21 +145,25 @@
                                                  :access-value 12.0}))
         ;; PROV4
         ;; group3 has permission to read this collection revision
-        coll11-1 (d/ingest "PROV4" (dc/collection {:entry-title "coll11-entry-title"
-                                                   :native-id "coll11"}))
+        coll11-1 (d/ingest "PROV4" (dc/collection {:entry-title "coll11"
+                                                   :native-id "coll11"
+                                                   :access-value 32.0}))
         ;; tombstone
-        coll11-2 (assoc (ingest/delete-concept (d/item->concept coll11-1))
-                        :entry-title "coll11-entry-title"
+        coll11-2 (assoc (ingest/delete-concept (d/item->concept coll11-1) {:token "mock-echo-system-token"})
+                        :entry-title "coll11"
                         :deleted true
                         :revision-id 2)
         ;; no permissions to read this revision since entry-title has changed
         coll11-3 (d/ingest "PROV4" (dc/collection {:entry-title "coll11"
-                                                   :native-id "coll11"}))
+                                                   :native-id "coll11"
+                                                   :access-value 34.0}))
         ;; group 3 has permission to read this collection revision
-        coll12-1 (d/ingest "PROV4" (dc/collection {:entry-title "coll12-entry-title"
+        coll12-1 (d/ingest "PROV4" (dc/collection {:entry-title "coll12"
+                                                   :access-value 32.0
                                                    :native-id "coll12"}))
         ;; no permissions to read this collection since entry-title has changed
         coll12-2 (d/ingest "PROV4" (dc/collection {:entry-title "coll12"
+                                                   :access-value 34.0
                                                    :native-id "coll12"}))
         ;; no permision to see this tombstone since it has same entry-title as coll12-2
         coll12-3 (assoc (ingest/delete-concept (d/item->concept coll12-2))
@@ -197,8 +201,7 @@
     (e/grant-group (s/context) group2-concept-id (e/coll-catalog-item-id
                                                   "PROV2" (e/coll-id ["coll6" "coll8"])))
     (e/grant-group (s/context) group3-concept-id (e/coll-catalog-item-id
-                                                  "PROV4" (e/coll-id ["coll11-entry-title"
-                                                                      "coll12-entry-title"])))
+                                                  "PROV4" (e/coll-id nil {:min-value 30 :max-value 33})))
 
     (ingest/reindex-collection-permitted-groups (tc/echo-system-token))
     (index/wait-until-indexed)
@@ -259,7 +262,6 @@
                          (format "collections.atom?token=%s&page_size=100" guest-token))]
           (is (= coll-atom (:results (search/find-concepts-atom :collection {:token guest-token
                                                                              :page-size 100}))))))
-
       (testing "by concept id"
         (let [concept-ids (map :concept-id all-colls)
               coll-atom (da/collections->expected-atom
@@ -271,6 +273,7 @@
                                       :collection {:token guest-token
                                                    :page-size 100
                                                    :concept-id concept-ids})))))))
+
     (testing "JSON ACL enforcement"
       (testing "all items"
         (let [coll-json (da/collections->expected-atom
@@ -315,7 +318,7 @@
 
         ;; only permissioned revisions are returned - including tombstones
         "provider-id all-revisions=true"
-        [coll11-1 coll11-2 coll12-1]
+        [coll11-1 coll12-1]
         {:provider-id "PROV4" :all-revisions true :token user4-token}
 
         ;; none of the revisions are readable by guest users

--- a/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
@@ -155,16 +155,17 @@
     (e/grant-guest (s/context) (e/gran-catalog-item-id "PROV1" (e/coll-id ["collnonexist"])))
     ;; coll 2 has no granule permissions
     ;; Permits granules with access values.
-    (e/grant-guest (s/context) (e/gran-catalog-item-id "PROV1" nil (e/gran-id {:min-value 10
-                                                                                   :max-value 20
-                                                                                   :include_undefined_value true})))
+    (e/grant-guest (s/context) (e/gran-catalog-item-id "PROV1" nil
+                                                       (e/gran-id {:min-value 10
+                                                                   :max-value 20
+                                                                   :include_undefined_value true})))
 
     ;; -- PROV2 --
     ;; Combined collection identifier and granule identifier
     (e/grant-guest
       (s/context)
       (e/gran-catalog-item-id "PROV2" (e/coll-id ["coll7"]) (e/gran-id {:min-value 30
-                                                                            :max-value 40})))
+                                                                        :max-value 40})))
     (e/grant-registered-users
       (s/context)
       (e/gran-catalog-item-id "PROV2" (e/coll-id ["coll3"] {:min-value 1 :max-value 3})))

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule.clj
@@ -79,10 +79,10 @@
     ;; Set current time
     (dev-sys-util/freeze-time! (tu/n->date-time-string now-n))
 
-    (grant-temporal :collection group1-concept-id :intersect 0 5)
-    (grant-temporal :collection group2-concept-id :intersect 5 9)
-    (grant-temporal :collection group3-concept-id :disjoint 3 5)
-    (grant-temporal :collection group4-concept-id :contains 3 7)
+    (grant-temporal :collection group1-concept-id "intersect" 0 5)
+    (grant-temporal :collection group2-concept-id "intersect" 5 9)
+    (grant-temporal :collection group3-concept-id "disjoint" 3 5)
+    (grant-temporal :collection group4-concept-id "contains" 3 7)
 
     ;; Create collections
     (let [coll1 (single-date-coll 1 :echo10)
@@ -234,10 +234,10 @@
 
     ;; Users have access to the collection
     (e/grant-registered-users (s/context) (e/coll-catalog-item-id "PROV1"))
-    (grant-temporal :granule group1-concept-id :intersect 0 5)
-    (grant-temporal :granule group2-concept-id :intersect 5 9)
-    (grant-temporal :granule group3-concept-id :disjoint 3 5)
-    (grant-temporal :granule group4-concept-id :contains 3 7)
+    (grant-temporal :granule group1-concept-id "intersect" 0 5)
+    (grant-temporal :granule group2-concept-id "intersect" 5 9)
+    (grant-temporal :granule group3-concept-id "disjoint" 3 5)
+    (grant-temporal :granule group4-concept-id "contains" 3 7)
 
     ;; Create granules
     (let [gran1 (single-date-gran 1 :echo10)

--- a/system-int-test/test/cmr/system_int_test/virtual_product/translation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/virtual_product/translation_test.clj
@@ -271,7 +271,7 @@
 ;; 10 (default search page size) granules on a single collection during the translation
 (deftest translate-granule-entries-more-than-default-page-size-test
   (let [coll (d/ingest "PROV"
-                        (dc/collection {:entry-title "MISR Level 2 Aerosol parameters V002"}))
+                       (dc/collection {:entry-title "MISR Level 2 Aerosol parameters V002"}))
         grans (make-grans coll 12)
         gran->entry (fn [g]
                       {:concept-id (:concept-id g)

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -140,6 +140,13 @@
 
 ;;; ACL Functions
 
+(def acl-type->acl-key
+  "A map of the acl object identity type to the field within the acl that stores the object."
+  {:catalog-item :catalog-item-identity
+   :system-object :system-identity
+   :provider-object :provider-identity
+   :single-instance-object :single-instance-identity})
+
 (defn acl-root-url
   "Returns the URL of the ACL API root."
   [ctx]

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -193,9 +193,9 @@
 (defn search-for-acls
   "Search for ACLs."
   ([context params]
-    (search-for-acls context params nil))
+   (search-for-acls context params nil))
   ([context params options]
-    (search-for-acls* context params (merge options {:method :post}))))
+   (search-for-acls* context params (merge options {:method :post}))))
 
 (h/defdestroyer delete-acl :access-control acl-concept-id-url)
 (h/defgetter get-acl :access-control acl-concept-id-url)

--- a/transmit-lib/src/cmr/transmit/echo/acls.clj
+++ b/transmit-lib/src/cmr/transmit/echo/acls.clj
@@ -90,7 +90,3 @@
              (validate-and-filter-acls acls)
              acls)
        (r/unexpected-status-error! status body)))))
-
-
-
-

--- a/umm-spec-lib/test/cmr/umm_spec/test/acl_matchers.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/acl_matchers.clj
@@ -18,7 +18,7 @@
   [min-v max-v include-undefined]
   {:access-value {:min-value min-v
                   :max-value max-v
-                  :include-undefined include-undefined}})
+                  :include-undefined-value include-undefined}})
 
 (defn collection
   "Helper function for creating a collection"
@@ -177,9 +177,8 @@
   "Creates a temporal between the two given N times"
   [mask start-n end-n]
   {:start-date (tu/n->date-time start-n)
-   :end-date (tu/n->date-time end-n)
-   :mask mask
-   :temporal-field :acquisition})
+   :stop-date (tu/n->date-time end-n)
+   :mask mask})
 
 (defn coll-w-temporal
   "Helper for creating a collection with temporal at given n and end date times. end-n can be nil
@@ -202,82 +201,82 @@
                                      {:temporal tf}}))))
 
         "Collection with no temporal"
-        false (temporal-filter :intersect 1 3) (collection)
+        false (temporal-filter "intersect" 1 3) (collection)
 
         ;; Intersects Mask
         "Intersects - Collection is exact match"
-        true (temporal-filter :intersect 1 3) (coll-w-temporal 1 3)
+        true (temporal-filter "intersect" 1 3) (coll-w-temporal 1 3)
         "Contains - Collection start matches range start and end within"
-        true (temporal-filter :intersect 1 4) (coll-w-temporal 1 2)
+        true (temporal-filter "intersect" 1 4) (coll-w-temporal 1 2)
         "Contains - Collection end matches range end and starts within"
-        true (temporal-filter :intersect 1 4) (coll-w-temporal 2 4)
+        true (temporal-filter "intersect" 1 4) (coll-w-temporal 2 4)
         "Intersects - Collection contained within temporal range"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 3 4)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 3 4)
         "Intersects - temporal within collection"
-        true (temporal-filter :intersect 3 4) (coll-w-temporal 2 5)
+        true (temporal-filter "intersect" 3 4) (coll-w-temporal 2 5)
         "Intersects - collection end = start"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 1 2)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 1 2)
         "Intersects - collection start = end"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 7 8)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 7 8)
         "Intersects - collection before with no end date"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 1 nil)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 1 nil)
         "Intersects - collection start and end equal range end"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 7 7)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 7 7)
         "Intersects - collection start and end equal range start"
-        true (temporal-filter :intersect 2 7) (coll-w-temporal 2 2)
+        true (temporal-filter "intersect" 2 7) (coll-w-temporal 2 2)
         "Intersects - collection after temporal range"
-        false (temporal-filter :intersect 1 3) (coll-w-temporal 4 5)
+        false (temporal-filter "intersect" 1 3) (coll-w-temporal 4 5)
         "Intersects - collection before temporal range"
-        false (temporal-filter :intersect 2 4) (coll-w-temporal 0 1)
+        false (temporal-filter "intersect" 2 4) (coll-w-temporal 0 1)
 
         ;; Disjoint Mask (The opposite of intersects)
         "Disjoint - Collection is exact match"
-        false (temporal-filter :disjoint 1 3) (coll-w-temporal 1 3)
+        false (temporal-filter "disjoint" 1 3) (coll-w-temporal 1 3)
         "Contains - Collection start matches range start and end within"
-        false (temporal-filter :disjoint 1 4) (coll-w-temporal 1 2)
+        false (temporal-filter "disjoint" 1 4) (coll-w-temporal 1 2)
         "Contains - Collection end matches range end and starts within"
-        false (temporal-filter :disjoint 1 4) (coll-w-temporal 2 4)
+        false (temporal-filter "disjoint" 1 4) (coll-w-temporal 2 4)
         "Disjoint - Collection contained within temporal range"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 3 4)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 3 4)
         "Disjoint - temporal within collection"
-        false (temporal-filter :disjoint 3 4) (coll-w-temporal 2 5)
+        false (temporal-filter "disjoint" 3 4) (coll-w-temporal 2 5)
         "Disjoint - collection end = start"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 1 2)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 1 2)
         "Disjoint - collection start = end"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 7 8)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 7 8)
         "Disjoint - collection before with no end date"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 1 nil)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 1 nil)
         "Disjoin - collection start and end equal range end"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 7 7)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 7 7)
         "Disjoint - collection start and end equal range start"
-        false (temporal-filter :disjoint 2 7) (coll-w-temporal 2 2)
+        false (temporal-filter "disjoint" 2 7) (coll-w-temporal 2 2)
         "Disjoint - collection after temporal range"
-        true (temporal-filter :disjoint 1 3) (coll-w-temporal 4 5)
+        true (temporal-filter "disjoint" 1 3) (coll-w-temporal 4 5)
         "Disjoint - collection before temporal range"
-        true (temporal-filter :disjoint 2 4) (coll-w-temporal 0 1)
+        true (temporal-filter "disjoint" 2 4) (coll-w-temporal 0 1)
 
         ;; Contains
         "Contains - Collection is exact match"
-        true (temporal-filter :contains 1 3) (coll-w-temporal 1 3)
+        true (temporal-filter "contains" 1 3) (coll-w-temporal 1 3)
         "Contains - Collection start matches range start and end within"
-        true (temporal-filter :contains 1 4) (coll-w-temporal 1 2)
+        true (temporal-filter "contains" 1 4) (coll-w-temporal 1 2)
         "Contains - Collection end matches range end and starts within"
-        true (temporal-filter :contains 1 4) (coll-w-temporal 2 4)
+        true (temporal-filter "contains" 1 4) (coll-w-temporal 2 4)
         "Contains - Collection contained within temporal range"
-        true (temporal-filter :contains 2 7) (coll-w-temporal 3 4)
+        true (temporal-filter "contains" 2 7) (coll-w-temporal 3 4)
         "Contains - temporal within collection"
-        false (temporal-filter :contains 3 4) (coll-w-temporal 2 5)
+        false (temporal-filter "contains" 3 4) (coll-w-temporal 2 5)
         "Contains - collection end = start"
-        false (temporal-filter :contains 2 7) (coll-w-temporal 1 2)
+        false (temporal-filter "contains" 2 7) (coll-w-temporal 1 2)
         "Contains - collection start = end"
-        false (temporal-filter :contains 2 7) (coll-w-temporal 7 8)
+        false (temporal-filter "contains" 2 7) (coll-w-temporal 7 8)
         "Contains - collection start and end equal range end"
-        true (temporal-filter :contains 2 7) (coll-w-temporal 7 7)
+        true (temporal-filter "contains" 2 7) (coll-w-temporal 7 7)
         "Contains - collection start and end equal range start"
-        true (temporal-filter :contains 2 7) (coll-w-temporal 2 2)
+        true (temporal-filter "contains" 2 7) (coll-w-temporal 2 2)
         "Contains - collection before with no end date"
-        false (temporal-filter :contains 2 7) (coll-w-temporal 1 nil)
+        false (temporal-filter "contains" 2 7) (coll-w-temporal 1 nil)
         "Contains - collection after temporal range"
-        false (temporal-filter :contains 1 3) (coll-w-temporal 4 5)
+        false (temporal-filter "contains" 1 3) (coll-w-temporal 4 5)
         "Contains - collection before temporal range"
-        false (temporal-filter :contains 2 4) (coll-w-temporal 0 1)))
+        false (temporal-filter "contains" 2 4) (coll-w-temporal 0 1)))


### PR DESCRIPTION
Remove logic relying on echo acls from CMR, instead rely on CMR acls.