### PR TITLE
CMR-4948: Return correct facet count when outside of facet size range.

### DIFF
--- a/search-app/src/cmr/search/services/query_execution.clj
+++ b/search-app/src/cmr/search/services/query_execution.clj
@@ -140,10 +140,18 @@
   [context query]
   [context (related-item-resolver/resolve-related-item-conditions query context)])
 
+(defn- update-facets
+  "Update the orig-facets-with-count using the info in the all-facets-with-count."
+  [orig-facets-with-count all-facets-with-count]
+  (for [title-val (map :title orig-facets-with-count)]
+    (some #(when (= title-val (:title %)) %) all-facets-with-count)))
+
 (defn- get-facets-with-count
   "Extract out the facet part that contains title and count, amoung other things: 
   [{:title \"t1\" :count 0} {:title \"NonExist\" :count 0} {:title \"t3\" :count 1}]
-  from the facets result."
+  from the facets result.  Note: facets-result is the result from a particular field, 
+  so there is only one child under :facets :children, which is why we use first to 
+  get to the child."
   [facets-result]
   (-> facets-result
       (get-in [:facets :children])
@@ -174,9 +182,7 @@
         orig-facets-with-count (get-facets-with-count facets-for-field)
         all-facets-with-count  (get-facets-with-count all-facets-for-field)
         ;; replace the original facets with the facets in all-facets that have the same :title.
-        updated-orig-facets-with-count
-         (for [title-val (map :title orig-facets-with-count)]
-           (some #(when (= title-val (:title %)) %) all-facets-with-count))
+        updated-orig-facets-with-count (update-facets orig-facets-with-count all-facets-with-count)
         updated-orig-first-facets-children
          (assoc orig-first-facets-children :children updated-orig-facets-with-count)]
     ;;Return the facets-for-field with the first facets children being the updated-orig-first-facets-children

--- a/search-app/src/cmr/search/services/query_execution.clj
+++ b/search-app/src/cmr/search/services/query_execution.clj
@@ -199,14 +199,14 @@
                   (assoc :page-size 0))
         facets-size-map (:facets-size query)
         facets-size-for-field (field facets-size-map)
-        facets-for-field (common-qe/execute-query context query)
-        query-with-all-facets-size
-         (assoc query :facets-size (merge facets-size-map {field fv2rf/UNLIMITED_TERMS_SIZE}))]
+        facets-for-field (common-qe/execute-query context query)]
     ;; Check if any facet contains 0 count, if so, and the
     ;; facets-size-for-field is not showing all facets, then we will try to
     ;; call get-facets-for-field again - with the query being query-with-all-facets-size.
     (if (get-facets-for-field-again? facets-size-for-field facets-for-field)
-      (let [all-facets-for-field (get-facets-for-field context query-with-all-facets-size field)]
+      (let [query-with-all-facets-size
+             (assoc query :facets-size (merge facets-size-map {field fv2rf/UNLIMITED_TERMS_SIZE}))
+            all-facets-for-field (get-facets-for-field context query-with-all-facets-size field)]
         (update-facets-for-field facets-for-field all-facets-for-field))
       facets-for-field)))
 

--- a/search-app/src/cmr/search/services/query_execution.clj
+++ b/search-app/src/cmr/search/services/query_execution.clj
@@ -140,16 +140,61 @@
   [context query]
   [context (related-item-resolver/resolve-related-item-conditions query context)])
 
+(defn- get-facets-for-field-again?
+  "Check to see if any facet count in facets-for-field is 0
+  and that facets-size-for-field is not set to return all facets."
+  [facets-size-for-field facets-for-field]
+  (let [facets (:children (first (get-in facets-for-field [:facets :children])))]
+    (and (or (nil? facets-size-for-field)
+             (< (Integer. facets-size-for-field) fv2rf/UNLIMITED_TERMS_SIZE))
+         (some #(= 0 (:count %)) facets))))
+
+(defn- update-facets-for-field
+  "Update the counts in facets-for-field with the counts in all-facets-for-field.
+  orig-facets-with-count is like: 
+  [{:title \"t1\" :count 0} {:title \"NonExist\" :count 0} {:title \"t3\" :count 1}]
+  all-facets-with-count is like:
+  [{:title \"t1\" :count 1} {:title \"NonExist\" :count 0} {:title \"t3\" :count 1} 
+   {:title \"t4\" :count 2} {:title \"t5\" :count 1}]
+  updated-orig-facets-with-count is:
+  [{:title \"t1\" :count 1} {:title \"NonExist\" :count 0} {:title \"t3\" :count 1}]"
+  [facets-for-field all-facets-for-field]
+  (let [orig-first-facets-children (first (get-in facets-for-field [:facets :children]))
+        orig-facets-with-count (:children orig-first-facets-children)
+        all-facets-with-count  (-> all-facets-for-field
+                                   (get-in [:facets :children])
+                                   first
+                                   :children)
+        ;; replace the original facets with the facets in all-facets that have the same :title.
+        updated-orig-facets-with-count
+         (for [title-val (map :title orig-facets-with-count)]
+           (some #(when (= title-val (:title %)) %) all-facets-with-count))
+        updated-orig-first-facets-children
+         (assoc orig-first-facets-children :children updated-orig-facets-with-count)]
+    ;;Return the facets-for-field with the first facets children being the updated-orig-first-facets-children
+    (assoc-in facets-for-field [:facets :children] [updated-orig-first-facets-children])))
+
 (defn- get-facets-for-field
   "Returns the facets search result on the given field by executing an elasticsearch query
-   with the given field removed from the filter to only retrieve the facet info on that field."
+  with the given field removed from the filter to only retrieve the facet info on that field."
   [context query field]
   (let [query (-> query
                   (facet-condition-resolver/adjust-facet-query field)
                   (assoc :result-features [:facets-v2])
                   (assoc :facet-fields [field])
-                  (assoc :page-size 0))]
-    (common-qe/execute-query context query)))
+                  (assoc :page-size 0))
+        facets-size-map (:facets-size query)
+        facets-size-for-field (field facets-size-map)
+        facets-for-field (common-qe/execute-query context query)
+        query-with-all-facets-size
+         (assoc query :facets-size (merge facets-size-map {field fv2rf/UNLIMITED_TERMS_SIZE}))]
+    ;; Check if any facet contains 0 count, if so, and the
+    ;; facets-size-for-field is not showing all facets, then we will try to
+    ;; call get-facets-for-field again - with the query being query-with-all-facets-size.
+    (if (get-facets-for-field-again? facets-size-for-field facets-for-field)
+      (let [all-facets-for-field (get-facets-for-field context query-with-all-facets-size field)]
+        (update-facets-for-field facets-for-field all-facets-for-field))
+      facets-for-field)))
 
 (defn- merge-facets
   "Returns the facets by merging the two lists of facets and sort the fields in the correct order.

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
@@ -120,6 +120,9 @@
   (testing "Facets size applied for facets, with selecting facet that exists, but outside of the facets size range."
     (is (= fr/expected-v2-facets-apply-links-with-selecting-facet-outside-of-facets-size
            (search-and-return-v2-facets {:facets-size {:platform 1} :platform-h ["diadem-1D"]}))))
+  (testing "Facets size applied for facets, with selecting facet that exists, without specifying facets size."
+    (is (= fr/expected-v2-facets-apply-links-with-selecting-facet-without-facets-size
+           (search-and-return-v2-facets {:platform-h ["diadem-1D"]}))))
   (testing "Facets size applied for facets, with selecting facet that doesn't exist."
     (is (= fr/expected-v2-facets-apply-links-with-facets-size-and-non-existing-selecting-facet
            (search-and-return-v2-facets {:facets-size {:platform 1} :platform-h ["Non-Exist"]}))))

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
@@ -83,6 +83,7 @@
    `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
      true))
   (let [token (e/login (s/context) "user1")
+        ;;_ (println "!!!!!!!!platforms are: " (fu/platforms fu/FROM_KMS 2 2 1))
         coll1 (fu/make-coll 1 "PROV1"
                             (fu/science-keywords sk1 sk2)
                             (fu/projects "proj1" "PROJ2")
@@ -117,6 +118,12 @@
   (testing "Facets size applied for facets"
     (is (= fr/expected-v2-facets-apply-links-with-facets-size 
            (search-and-return-v2-facets {:facets-size {:platform 1}}))))
+  (testing "Facets size applied for facets, with selecting facet that exists, but outside of the facets size range."
+    (is (= fr/expected-v2-facets-apply-links-with-selecting-facet-outside-of-facets-size
+           (search-and-return-v2-facets {:facets-size {:platform 1} :platform-h ["diadem-1D"]}))))
+  (testing "Facets size applied for facets, with selecting facet that doesn't exist."
+    (is (= fr/expected-v2-facets-apply-links-with-facets-size-and-non-existing-selecting-facet
+           (search-and-return-v2-facets {:facets-size {:platform 1} :platform-h ["Non-Exist"]}))))
   (testing "Empty facets size applied for facets"
     (is (= [(str facets-size-error-msg " but was [{:instrument \"\"}].")]
            (search-and-return-v2-facets-errors {:facets-size {:instrument ""}}))))

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
@@ -83,7 +83,6 @@
    `(cmr.search.services.query-execution.facets.collection-v2-facets/set-include-variable-facets!
      true))
   (let [token (e/login (s/context) "user1")
-        ;;_ (println "!!!!!!!!platforms are: " (fu/platforms fu/FROM_KMS 2 2 1))
         coll1 (fu/make-coll 1 "PROV1"
                             (fu/science-keywords sk1 sk2)
                             (fu/projects "proj1" "PROJ2")

--- a/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
@@ -1125,3 +1125,148 @@
                {:remove
                 "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&page_size=0&include_facets=v2"},
                :has_children false}]}]})
+
+(def expected-v2-facets-apply-links-with-selecting-facet-without-facets-size 
+  "Expected facets to be returned in the facets v2 response. The structure of the v2 facet response
+  is documented in https://wiki.earthdata.nasa.gov/display/CMR/Updated+facet+response. This response
+  is generated for the search
+  http://localhost:3003/collections.json?page_size=0&platform_h[]=existingPlat&include_facets=v2
+  without any query parameters selected and with a couple of collections that have science keywords,
+  projects, platforms, instruments, organizations, and processing levels in their metadata. This
+  tests that the applied parameter is set to false correctly and that the generated links specify a
+  a link to add each search parameter to apply that value to a search."
+{:title "Browse Collections",
+           :type "group",
+           :has_children true,
+           :children
+           [{:title "Keywords",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "Popular",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Popular"},
+               :has_children true}
+              {:title "Topic1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
+               :has_children true}]}
+            {:title "Platforms",
+             :type "group",
+             :applied true,
+             :has_children true,
+             :children
+             [{:title "diadem-1D",
+               :type "filter",
+               :applied true,
+               :count 2,
+               :links
+               {:remove
+                "http://localhost:3003/collections.json?page_size=0&include_facets=v2"},
+               :has_children false}
+              {:title "DMSP 5B/F3",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&platform_h%5B%5D=DMSP+5B%2FF3"},
+               :has_children false}]}
+            {:title "Instruments",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "ATM",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&instrument_h%5B%5D=ATM"},
+               :has_children false}
+              {:title "lVIs",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&instrument_h%5B%5D=lVIs"},
+               :has_children false}]}
+            {:title "Organizations",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "DOI/USGS/CMG/WHSC",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&data_center_h%5B%5D=DOI%2FUSGS%2FCMG%2FWHSC"},
+               :has_children false}]}
+            {:title "Projects",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "proj1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&project_h%5B%5D=proj1"},
+               :has_children false}
+              {:title "PROJ2",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&project_h%5B%5D=PROJ2"},
+               :has_children false}]}
+            {:title "Processing levels",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "PL1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&processing_level_id_h%5B%5D=PL1"},
+               :has_children false}]}
+            {:title "Measurements",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "Measurement1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},
+               :has_children true}
+              {:title "Measurement2",
+               :type "filter",
+               :applied false,
+               :count 1,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement2"},
+               :has_children true}]}]})

--- a/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
@@ -945,3 +945,183 @@
                {:apply
                 "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement2"},
                :has_children true}]}]})
+
+(def expected-v2-facets-apply-links-with-selecting-facet-outside-of-facets-size 
+  "Expected facets to be returned in the facets v2 response. The structure of the v2 facet response
+  is documented in https://wiki.earthdata.nasa.gov/display/CMR/Updated+facet+response. This response
+  is generated for the search
+  http://localhost:3003/collections.json?page_size=0&platform_h[]=diadem-1D&include_facets=v2&facets_size[platform]=1
+  without any query parameters selected and with a couple of collections that have science keywords,
+  projects, platforms, instruments, organizations, and processing levels in their metadata. This
+  tests that the applied parameter is set to false correctly and that the generated links specify a
+  a link to add each search parameter to apply that value to a search."
+  {:title "Browse Collections",
+           :type "group",
+           :has_children true,
+           :children
+           [{:title "Keywords",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "Popular",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Popular"},
+               :has_children true}
+              {:title "Topic1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
+               :has_children true}]}
+            {:title "Platforms",
+             :type "group",
+             :applied true,
+             :has_children true,
+             :children
+             [{:title "diadem-1D",
+               :type "filter",
+               :applied true,
+               :count 2,
+               :links
+               {:remove
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&page_size=0&include_facets=v2"},
+               :has_children false}
+              {:title "DMSP 5B/F3",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&platform_h%5B%5D=DMSP+5B%2FF3"},
+               :has_children false}]}
+            {:title "Instruments",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "ATM",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&instrument_h%5B%5D=ATM"},
+               :has_children false}
+              {:title "lVIs",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&instrument_h%5B%5D=lVIs"},
+               :has_children false}]}
+            {:title "Organizations",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "DOI/USGS/CMG/WHSC",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&data_center_h%5B%5D=DOI%2FUSGS%2FCMG%2FWHSC"},
+               :has_children false}]}
+            {:title "Projects",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "proj1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&project_h%5B%5D=proj1"},
+               :has_children false}
+              {:title "PROJ2",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&project_h%5B%5D=PROJ2"},
+               :has_children false}]}
+            {:title "Processing levels",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "PL1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&processing_level_id_h%5B%5D=PL1"},
+               :has_children false}]}
+            {:title "Measurements",
+             :type "group",
+             :applied false,
+             :has_children true,
+             :children
+             [{:title "Measurement1",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},
+               :has_children true}
+              {:title "Measurement2",
+               :type "filter",
+               :applied false,
+               :count 1,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement2"},
+               :has_children true}]}]})
+
+(def expected-v2-facets-apply-links-with-facets-size-and-non-existing-selecting-facet 
+  "Expected facets to be returned in the facets v2 response. The structure of the v2 facet response
+  is documented in https://wiki.earthdata.nasa.gov/display/CMR/Updated+facet+response. This response
+  is generated for the search
+  http://localhost:3003/collections.json?page_size=0&platform_h[]=Non-Exist&include_facets=v2&facets_size[platform]=1
+  without any query parameters selected and with a couple of collections that have science keywords,
+  projects, platforms, instruments, organizations, and processing levels in their metadata. This
+  tests that the applied parameter is set to false correctly and that the generated links specify a
+  a link to add each search parameter to apply that value to a search."
+{:title "Browse Collections",
+           :type "group",
+           :has_children true,
+           :children
+           [{:title "Platforms",
+             :type "group",
+             :applied true,
+             :has_children true,
+             :children
+             [{:title "DMSP 5B/F3",
+               :type "filter",
+               :applied false,
+               :count 2,
+               :links
+               {:apply
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=Non-Exist&page_size=0&include_facets=v2&platform_h%5B%5D=DMSP+5B%2FF3"},
+               :has_children false}
+              {:title "Non-Exist",
+               :type "filter",
+               :applied true,
+               :count 0,
+               :links
+               {:remove
+                "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&page_size=0&include_facets=v2"},
+               :has_children false}]}]})


### PR DESCRIPTION
Currently, when a selected facet is outside of the facet size range, the count is assigned 0. 
As the facets_size increases, this count could change, we need to fix the inconsistency.

1. For each selected facet, say platform, instrument,   If the returned facet-result includes any 0 counts,
and the facets_size for the field is not 10000, then send the query to ES again, with facets_size increased to 10000 for the field, to insure all facets are returned for that field.

2. Update the original facet-result using the counts in the new facet-result. 

