### PR TITLE
CMR-4992: Update rebalancing-collections to support moving from a separate index to a the small collections index.

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -52,10 +52,10 @@ CMR_DB_URL=thin:@localhost:1521:orcl CMR_BOOTSTRAP_DB_PASSWORD=****** java -cp t
 
 ### Start Rebalancing a Collection
 
-Starts moving all the granules in a specified collection from the small collections index into their own separate index. The work is performed asynchronously in the background. The job should be monitored through the bootstrap application's logs and using the status endpoint detailed below. This also supports a `synchronous=true` query parameter to cause the collection reindexing to happen synchronously with the request. This is mostly for testing purposes.
+Starts moving all the granules in a specified collection from its current index to the target index. If no target is provided the default is to move the granules from the small collections index into their own separate index. The work is performed asynchronously in the background. The job should be monitored through the bootstrap application's logs and using the status endpoint detailed below. The two valid values for the `target` query parameter are `separate-index` and `small-collections`. This also supports a `synchronous=true` query parameter to cause the collection reindexing to happen synchronously with the request. This is mostly for testing purposes.
 
 ```
-curl -i -XPOST http://localhost:3006/rebalancing_collections/C5-PROV1/start
+curl -i -XPOST http://localhost:3006/rebalancing_collections/C5-PROV1/start?target=separate-index
 
 HTTP/1.1 200 OK
 {"message":"Rebalancing started for collection C5-PROV1"}
@@ -75,7 +75,7 @@ HTTP/1.1 200 OK
 
 ### Finalize a Rebalancing Collection
 
-Finalizes a rebalancing collection. Removes the collection from the list of rebalancing collections in the index set and deletes all granules from the small collections index for the specified collection.
+Finalizes a rebalancing collection. Removes the collection from the list of rebalancing collections in the index set. If the target was a separate index this call deletes all granules from the small collections index for the specified collection. If the target was small collections the collection specific index will be removed from the index-set, but the index will not be deleted since this could cause errors until search caches have all been refreshed. The caller is expected to manually delete the index after a period of time.
 
 ```
 curl -i -XPOST  http://localhost:3006/rebalancing_collections/C5-PROV1/finalize

--- a/bootstrap-app/src/cmr/bootstrap/api/rebalancing.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/rebalancing.clj
@@ -8,8 +8,9 @@
 (defn start-collection
   "Kicks off rebalancing the granules in the collection into their own index."
   [context concept-id params]
-  (let [dispatcher (api-util/get-dispatcher context params :index-collection)]
-    (service/start-rebalance-collection context dispatcher concept-id)
+  (let [dispatcher (api-util/get-dispatcher context params :index-collection)
+        target (get params :target "separate-index")]
+    (service/start-rebalance-collection context dispatcher concept-id target)
     {:status 200
      :body {:message (msg/rebalancing-started concept-id)}}))
 

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -8,7 +8,7 @@
    [cmr.bootstrap.services.dispatch.core :as dispatch]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer [debug info warn error]]
    [cmr.common.rebalancing-collections :as rebalancing-collections]
    [cmr.common.services.errors :as errors]
    [cmr.indexer.data.index-set :as indexer-index-set]
@@ -133,6 +133,8 @@
   index."
   [context dispatcher concept-id target]
   (let [target (or target "separate-index")]
+    (info (format "Starting to rebalance granules for collection [%s] to target [%s]."
+                  concept-id target))
     (rebalancing-collections/validate-target target concept-id)
     (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
     ;; This will throw an exception if the collection is already rebalancing
@@ -165,6 +167,8 @@
   (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
   (let [fetched-index-set (index-set/get-index-set context indexer-index-set/index-set-id)
         target (get-in fetched-index-set [:index-set :granule :rebalancing-targets (keyword concept-id)])]
+    (info (format "Finalizing rebalancing granules for collection [%s] to target [%s]."
+                  concept-id target))
     (rebalancing-collections/validate-target target concept-id)
     ;; This will throw an exception if the collection is not rebalancing
     (index-set/finalize-rebalancing-collection context indexer-index-set/index-set-id concept-id)

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -165,29 +165,48 @@
         :completion-message (format "Completed reindex of [%s] for rebalancing granule indexes."
                                     concept-id)}))))
 
+(def index-set-id
+  "This code relies on the assumption that the index set ID continues to be hardcoded to 1."
+  1)
+
+(defn- validate-finalize-target
+  "Validates the target is one of the two allowed values."
+  [target]
+  (when-not (or (= "small-collections" target)
+                (= "separate-index" target))
+    (errors/throw-service-errors
+     :bad-request
+     [(str "Invalid target index [" target "]. Only separate-index or small-collections are "
+           "allowed. The collection may not be marked for rebalancing.")])))
+
 (defn finalize-rebalance-collection
   "Finalizes collection rebalancing."
   [context concept-id]
   (validate-collection context (:provider-id (concepts/parse-concept-id concept-id)) concept-id)
-  ;; This will throw an exception if the collection is not rebalancing
-  (index-set/finalize-rebalancing-collection context indexer-index-set/index-set-id concept-id)
-  ;; Clear the cache so that the newest index set data will be used.
-  ;; This clears embedded caches so the indexer cache in this bootstrap app will be cleared.
-  (cache/reset-caches context)
+  (let [fetched-index-set (index-set/get-index-set context index-set-id)
+        target (get-in fetched-index-set [:index-set :granule :rebalancing-targets (keyword concept-id)])]
+    (println "The target is: " target)
+    (println "The index set rebalancing-targets are:" (pr-str (get-in fetched-index-set [:index-set :granule :rebalancing-targets])))
+    (validate-finalize-target target)
+    ;; This will throw an exception if the collection is not rebalancing
+    (index-set/finalize-rebalancing-collection context indexer-index-set/index-set-id concept-id)
+    ;; Clear the cache so that the newest index set data will be used.
+    ;; This clears embedded caches so the indexer cache in this bootstrap app will be cleared.
+    (cache/reset-caches context)
 
-  ;; There is a race condition as noted here: https://wiki.earthdata.nasa.gov/display/CMR/Rebalancing+Collection+Indexes+Approach
-  ;; "There's a period of time during which the different indexer applications may be processing
-  ;; granules for this very collection and may have already decided which index its going to. It's
-  ;; possible that the indexer will index a granule into small collections after the bootstrap has
-  ;; issued the delete. The next step to verify should identify if the race conditions has occurred. "
-  ;; The sleep here decreases the probability of the race condition giving time for
-  ;; indexer to finish indexing any granule currently being processed.
-  ;; This doesn't remove the race condition. We still have steps in the overall process to detect it
-  ;; and resolve it. (manual fixes if necessary)
-  (wait-until-index-set-hash-cache-times-out)
-
-  ;; Remove all granules from small collections for this collection.
-  (rebalance-util/delete-collection-granules-from-small-collections context concept-id))
+    ;; There is a race condition as noted here: https://wiki.earthdata.nasa.gov/display/CMR/Rebalancing+Collection+Indexes+Approach
+    ;; "There's a period of time during which the different indexer applications may be processing
+    ;; granules for this very collection and may have already decided which index its going to. It's
+    ;; possible that the indexer will index a granule into small collections after the bootstrap has
+    ;; issued the delete. The next step to verify should identify if the race conditions has occurred. "
+    ;; The sleep here decreases the probability of the race condition giving time for
+    ;; indexer to finish indexing any granule currently being processed.
+    ;; This doesn't remove the race condition. We still have steps in the overall process to detect it
+    ;; and resolve it. (manual fixes if necessary)
+    (wait-until-index-set-hash-cache-times-out)
+    (println "CDD: The target is:" target)
+    (when (= "separate-index" target)
+      (rebalance-util/delete-collection-granules-from-small-collections context concept-id))))
 
 (defn rebalance-status
   "Returns a map of counts of granules in the collection in metadata db, the small collections index,

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
@@ -1,5 +1,6 @@
 (ns cmr.bootstrap.services.dispatch.impl.message-queue
-  "Functions implementing the dispatch protocol to support synchronous calls."
+  "Functions implementing the dispatch protocol to support bootstrap operations using a message
+  queue."
   (:require
    [cmr.bootstrap.config :as config]
    [cmr.bootstrap.data.bulk-index :as bulk-index]

--- a/common-lib/src/cmr/common/rebalancing_collections.clj
+++ b/common-lib/src/cmr/common/rebalancing_collections.clj
@@ -1,0 +1,23 @@
+(ns cmr.common.rebalancing-collections
+  "Functions used in multiple applications for working with collections that are in the process of
+  moving their granules from the small collections index to a separate index or vice versa."
+  (:require
+   [cmr.common.services.errors :as errors]))
+
+(def allowed-targets
+  "The potential targets for a rebalancing collections operation."
+  ["separate-index" "small-collections"])
+
+(defn validate-target
+  "Validates the target is set to one of the allowed values."
+  [target concept-id]
+  (if (nil? target)
+    (errors/throw-service-errors
+     :bad-request
+     [(format "The index set does not contain the rebalancing collection [%s]"
+              concept-id)])
+    (when-not (some #{target} allowed-targets)
+      (errors/throw-service-errors
+       :bad-request
+       [(format "Invalid target index [%s]. Only separate-index or small-collections are allowed."
+                target)]))))

--- a/index-set-app/README.md
+++ b/index-set-app/README.md
@@ -40,16 +40,15 @@ curl -i -H "Accept: application/json" -H "Content-type: application/json" -XPOST
 
 ### Mark a collection as rebalancing
 
-There are multiple granule indexes for performance. Larger collections are split out into their own indexes. Smaller collections are grouped in a small_collections index. Marking a collection as rebalancing adds the collection to a list of collections are are being moved out of small collections. It also creates the new granule index.
+There are multiple granule indexes for performance. Larger collections are split out into their own indexes. Smaller collections are grouped in a small_collections index. When calling the endpoint the `target` query parameter is required, and it has two valid values, `separate-index` and `small-collections`. In either case the collection is added to the list of collections being rebalanced. If `target=separate-index` a new granule index is created in addition to updating the index-set.
 
-    curl -XPOST http://localhost:3005/index-sets/3/rebalancing-collections/C5-PROV1/start
+    curl -XPOST http://localhost:3005/index-sets/3/rebalancing-collections/C5-PROV1/start?target=separate-index
 
 ### Finalize a rebalancing collection
 
-Finalizing a rebalancing collection removes the collection from the list of collections are are being moved out of small collections.
+Finalizing a rebalancing collection removes the collection from the list of collections are are being rebalanced and updates the index-set appropriately based on what the target destination was set to on the call to start.
 
     curl -XPOST http://localhost:3005/index-sets/3/rebalancing-collections/C5-PROV1/finalize
-
 
 ### Reset for dev purposes
 

--- a/index-set-app/int-test/cmr/index_set/int_test/invalid_data_crud_tests.clj
+++ b/index-set-app/int-test/cmr/index_set/int_test/invalid_data_crud_tests.clj
@@ -72,8 +72,3 @@
     (let [{:keys [status errors]} (util/create-index-set util/index-set-w-invalid-idx-prop)]
       (is (= 400 status))
       (is (re-find #"MapperParsingException\[mapping \[collection\]\]" (first errors))))))
-
-
-
-
-

--- a/index-set-app/int-test/cmr/index_set/int_test/utility.clj
+++ b/index-set-app/int-test/cmr/index_set/int_test/utility.clj
@@ -184,6 +184,7 @@
   (let [response (client/request
                   {:method :post
                    :url (start-rebalance-collection-url id concept-id)
+                   :query-params {:target "separate-index"}
                    :headers {transmit-config/token-header (transmit-config/echo-system-token)}
                    :accept :json
                    :throw-exceptions false})

--- a/index-set-app/int-test/cmr/index_set/int_test/valid_data_crud_tests.clj
+++ b/index-set-app/int-test/cmr/index_set/int_test/valid_data_crud_tests.clj
@@ -187,7 +187,3 @@
   (testing "reset index-set app"
     (let [{:keys [status]} (util/reset)]
       (is (= 204 status)))))
-
-
-
-

--- a/index-set-app/int-test/cmr/index_set/int_test/valid_data_crud_tests.clj
+++ b/index-set-app/int-test/cmr/index_set/int_test/valid_data_crud_tests.clj
@@ -123,7 +123,7 @@
     (assert-rebalancing-collections []))
   (testing "Add collection that is already an index"
     (is (= {:status 400
-            :errors ["The collection [C4-PROV3] already has a separate granule index"]}
+            :errors ["The collection [C4-PROV3] already has a separate granule index."]}
            (select-keys (util/mark-collection-as-rebalancing util/sample-index-set-id "C4-PROV3")
                         [:status :errors])))
     (assert-rebalancing-collections []))

--- a/index-set-app/src/cmr/index_set/api/routes.clj
+++ b/index-set-app/src/cmr/index_set/api/routes.clj
@@ -1,23 +1,24 @@
 (ns cmr.index-set.api.routes
   "Defines the HTTP URL routes for the application."
-  (:require [compojure.route :as route]
-            [compojure.core :refer :all]
-            [ring.middleware.json :as ring-json]
-            [ring.middleware.params :as params]
-            [ring.middleware.nested-params :as nested-params]
-            [ring.middleware.keyword-params :as keyword-params]
-            [cheshire.core :as json]
-            [ring.util.response :as r]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.api.errors :as errors]
-            [cmr.common.cache :as cache]
-            [clojure.walk :as walk]
-            [cheshire.core :as json]
-            [cmr.index-set.services.index-service :as index-svc]
-            [cmr.common.api.context :as context]
-            [cmr.acl.core :as acl]
-            [cmr.common-app.api.routes :as common-routes]
-            [cmr.common-app.api.health :as common-health]))
+  (:require
+   [cheshire.core :as json]
+   [cheshire.core :as json]
+   [clojure.walk :as walk]
+   [cmr.acl.core :as acl]
+   [cmr.common-app.api.health :as common-health]
+   [cmr.common-app.api.routes :as common-routes]
+   [cmr.common.api.context :as context]
+   [cmr.common.api.errors :as errors]
+   [cmr.common.cache :as cache]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.index-set.services.index-service :as index-svc]
+   [compojure.core :refer :all]
+   [compojure.route :as route]
+   [ring.middleware.json :as ring-json]
+   [ring.middleware.keyword-params :as keyword-params]
+   [ring.middleware.nested-params :as nested-params]
+   [ring.middleware.params :as params]
+   [ring.util.response :as r]))
 
 (defn- build-routes [system]
   (routes

--- a/index-set-app/src/cmr/index_set/api/routes.clj
+++ b/index-set-app/src/cmr/index_set/api/routes.clj
@@ -55,9 +55,9 @@
           (context "/rebalancing-collections/:concept-id" [concept-id]
 
             ;; Marks the collection as rebalancing in the index set.
-            (POST "/start" {request-context :request-context}
+            (POST "/start" {request-context :request-context params :params}
               (acl/verify-ingest-management-permission request-context :update)
-              (index-svc/mark-collection-as-rebalancing request-context id concept-id)
+              (index-svc/mark-collection-as-rebalancing request-context id concept-id (:target params))
               {:status 200})
 
             ;; Marks the collection as completed rebalancing

--- a/index-set-app/src/cmr/index_set/data/elasticsearch.clj
+++ b/index-set-app/src/cmr/index_set/data/elasticsearch.clj
@@ -84,7 +84,6 @@
     (let [result (doc/search conn index-name idx-mapping-type "fields" "index-set-id")]
       (map #(-> % :fields :index-set-id) (get-in result [:hits :hits])))))
 
-
 (defn get-index-sets
   "Fetch all index-sets in elastic."
   [{:keys [conn]} index-name idx-mapping-type]

--- a/index-set-app/src/cmr/index_set/services/index_service.clj
+++ b/index-set-app/src/cmr/index_set/services/index_service.clj
@@ -127,13 +127,11 @@
 (defn validate-requested-index-set
   "Verify input index-set is valid."
   [context index-set allow-update?]
-
   (when-not allow-update?
     (when-let [error (index-set-existence-check context index-set)]
       (errors/throw-service-error :conflict error))
     (when-let [error (id-name-existence-check index-set)]
       (errors/throw-service-error :invalid-data error)))
-
   (when-let [error (index-set-id-validation index-set)]
     (errors/throw-service-error :invalid-data error))
   (when-let [error (index-cfg-validation index-set)]

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -46,7 +46,6 @@
         search-using-small-collections (filter #(some (set [%]) moving-to-separate-index)
                                                rebalancing-collections)
         index-names-map (get-in fetched-index-set [:index-set :concepts])]
-    (println "CDD: lots of stuff rebalancing-targets-map" rebalancing-targets-map "moving-to-separate-index:" moving-to-separate-index "search-using-small-collections" search-using-small-collections)
     {:index-names index-names-map
      :rebalancing-collections search-using-small-collections}))
 

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -40,12 +40,13 @@
         ;; target of a separate granule index continues to use the small collections index for now.
         rebalancing-targets-map (get-in fetched-index-set [:index-set :granule :rebalancing-targets])
         moving-to-separate-index (keep (fn [[k v]]
-                                         (when (= :separate-index v)
-                                           k))
+                                         (when (= "separate-index" v)
+                                           (name k)))
                                        rebalancing-targets-map)
-        search-using-small-collections (remove #(some (set [%]) moving-to-separate-index)
+        search-using-small-collections (filter #(some (set [%]) moving-to-separate-index)
                                                rebalancing-collections)
         index-names-map (get-in fetched-index-set [:index-set :concepts])]
+    (println "CDD: lots of stuff rebalancing-targets-map" rebalancing-targets-map "moving-to-separate-index:" moving-to-separate-index "search-using-small-collections" search-using-small-collections)
     {:index-names index-names-map
      :rebalancing-collections search-using-small-collections}))
 

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -152,7 +152,7 @@
    (start-rebalance-collection collection-id {}))
   ([collection-id options]
    (let [synchronous (get options :synchronous true)
-         target (get options :target :separate-index)
+         target (get options :target "separate-index")
          headers (get options :headers {transmit-config/token-header (transmit-config/echo-system-token)})
          response (client/request
                    {:method :post

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -20,10 +20,10 @@
   "Call the bootstrap app to bulk index concepts with revision dates later than the given datetime."
   ([date-time]
    (bulk-index-after-date-time date-time {transmit-config/token-header (transmit-config/echo-system-token)}))
-  ([date-time headers] 
+  ([date-time headers]
    (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-after-date-time-url date-time)
                      :content-type :json
@@ -40,7 +40,7 @@
   ([provider-id concept-type concept-ids headers]
    (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-concepts-url)
                      :body (json/generate-string {:provider_id provider-id
@@ -55,12 +55,12 @@
 (defn bulk-delete-concepts
   "Call the bootstrap app to bulk delete concepts by id."
   ([provider-id concept-type concept-ids]
-   (bulk-delete-concepts 
+   (bulk-delete-concepts
      provider-id concept-type concept-ids {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([provider-id concept-type concept-ids headers]
    (let [response (client/request
                     {:method :delete
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-concepts-url)
                      :body (json/generate-string {:provider_id provider-id
@@ -77,7 +77,7 @@
   ([bulk-index-url headers]
     (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :url bulk-index-url
                      :content-type :json
                      :accept :json
@@ -92,7 +92,7 @@
   ([]
    (bulk-index-variables {transmit-config/token-header (transmit-config/echo-system-token)} nil nil))
   ([headers _ _]
-   (bulk-index-by-url (url/bulk-index-variables-url) headers)) 
+   (bulk-index-by-url (url/bulk-index-variables-url) headers))
   ([provider-id]
    (bulk-index-variables provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([provider-id headers]
@@ -117,7 +117,7 @@
   ([provider-id headers]
    (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-provider-url)
                      :body (json/generate-string {:provider_id provider-id})
@@ -135,7 +135,7 @@
   ([provider-id collection-id headers]
    (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-collection-url)
                      :body (json/generate-string {:provider_id provider-id :collection_id collection-id})
@@ -149,15 +149,16 @@
 (defn start-rebalance-collection
   "Call the bootstrap app to kickoff rebalancing a collection."
   ([collection-id]
-   (start-rebalance-collection collection-id true))
-  ([collection-id synchronous]
-   (start-rebalance-collection 
-     collection-id synchronous {transmit-config/token-header (transmit-config/echo-system-token)}))
-  ([collection-id synchronous headers]
-   (let [response (client/request
+   (start-rebalance-collection collection-id {}))
+  ([collection-id options]
+   (let [synchronous (get options :synchronous true)
+         target (get options :target :separate-index)
+         headers (get options :headers {transmit-config/token-header (transmit-config/echo-system-token)})
+         response (client/request
                    {:method :post
+                    :query-params {:synchronous synchronous
+                                   :target target}
                     :headers headers
-                    :query-params {:synchronous synchronous}
                     :url (url/start-rebalance-collection-url collection-id)
                     :accept :json
                     :throw-exceptions false
@@ -168,7 +169,7 @@
 (defn finalize-rebalance-collection
   "Call the bootstrap app to finalize rebalancing a collection."
   ([collection-id]
-   (finalize-rebalance-collection 
+   (finalize-rebalance-collection
      collection-id {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([collection-id headers]
    (let [response (client/request
@@ -232,7 +233,7 @@
   ([headers]
    (let [response (client/request
                     {:method :post
-                     :headers headers 
+                     :headers headers
                      :query-params {:synchronous true}
                      :url (url/bulk-index-system-concepts-url)
                      :accept :json

--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -79,7 +79,7 @@
                              "] is already in the small collections index.")]}
               (bootstrap/start-rebalance-collection
                (:concept-id coll2) {:synchronous false
-                                    :target :small-collections}))))
+                                    :target "small-collections"}))))
      (testing "Starting target of small collections when already rebalancing to separate index"
        (bootstrap/start-rebalance-collection (:concept-id coll2))
        (is (= {:status 400
@@ -87,17 +87,17 @@
                              (:concept-id coll2)"]")]}
               (bootstrap/start-rebalance-collection
                (:concept-id coll2) {:synchronous false
-                                    :target :small-collections}))))
+                                    :target "small-collections"}))))
      (testing "Starting target of separate index when already rebalancing to small collections"
        (bootstrap/finalize-rebalance-collection (:concept-id coll2))
        (index/wait-until-indexed)
-       (bootstrap/start-rebalance-collection (:concept-id coll2) {:target :small-collections})
+       (bootstrap/start-rebalance-collection (:concept-id coll2) {:target "small-collections"})
        (is (= {:status 400
                :errors [(str "The index set already contains rebalancing collection ["
                              (:concept-id coll2)"]")]}
               (bootstrap/start-rebalance-collection
                (:concept-id coll2) {:synchronous false
-                                    :target :separate-index})))))))
+                                    :target "separate-index"})))))))
 
 (defn count-by-params
   "Returns the number of granules found by the given params"

--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -1,7 +1,7 @@
 (ns cmr.system-int-test.bootstrap.rebalance-collections-test
   "Tests rebalancing granule indexes by moving collections's granules from the small collections
    index to separate collection indexes"
-  (require
+  (:require
    [clojure.test :refer :all]
    [clj-http.client :as client]
    [cmr.system-int-test.data2.collection :as dc]
@@ -51,6 +51,12 @@
        (is (= {:status 400
                :errors ["Collection [C1-PROV1] does not exist."]}
               (bootstrap/start-rebalance-collection "C1-PROV1" {:synchronous false}))))
+     (testing "Invalid target"
+       (is (= {:status 400
+               :errors [(str "Invalid target index [small-fry]. Only separate-index or "
+                             "small-collections are allowed.")]}
+              (bootstrap/start-rebalance-collection (:concept-id coll1) {:synchronous false
+                                                                         :target "small-fry"}))))
      (testing "Finalizing not started collection"
        (is (= {:status 400
                :errors [(str "The index set does not contain the rebalancing collection ["

--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -71,11 +71,11 @@
      (testing "Starting already rebalanced collection"
        (is (= {:status 400
                :errors [(str "The collection [" (:concept-id coll1)
-                             "] already has a separate granule index")]}
+                             "] already has a separate granule index.")]}
               (bootstrap/start-rebalance-collection (:concept-id coll1) {:synchronous false}))))
      (testing "Starting with a target of small collections when already in small collections"
        (is (= {:status 400
-               :errors [(str "The collection [" (:concept-id coll1)
+               :errors [(str "The collection [" (:concept-id coll2)
                              "] is already in the small collections index.")]}
               (bootstrap/start-rebalance-collection
                (:concept-id coll2) {:synchronous false
@@ -146,22 +146,6 @@
     (if (= (:concept-id coll-holding) (:concept-id coll))
       (update coll-holding :granule-count + num)
       coll-holding)))
-
-; (defn dec-provider-holdings-for-coll
-;   "Decrements the number of granules expected for a collection in the expected provider holdings"
-;   [expected-provider-holdings coll num]
-;   (for [coll-holding expected-provider-holdings]
-;     (if (= (:concept-id coll-holding) (:concept-id coll))
-;       (update coll-holding :granule-count - num)
-;       coll-holding)))
-;
-; (defn set-provider-holdings-for-coll
-;   "Overwrites the number of granules expected for a collection in the expected provider holdings"
-;   [expected-provider-holdings coll num]
-;   (for [coll-holding expected-provider-holdings]
-;     (if (= (:concept-id coll-holding) (:concept-id coll))
-;       (assoc coll-holding :granule-count num)
-;       coll-holding)))
 
 ;; Rebalances a single collection with a single granule
 (deftest simple-rebalance-collection-test

--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -82,7 +82,7 @@
      (testing "Starting with a target of small collections when already in small collections"
        (is (= {:status 400
                :errors [(str "The collection [" (:concept-id coll2)
-                             "] is already in the small collections index.")]}
+                             "] does not have a separate granule index.")]}
               (bootstrap/start-rebalance-collection
                (:concept-id coll2) {:synchronous false
                                     :target "small-collections"}))))

--- a/transmit-lib/src/cmr/transmit/index_set.clj
+++ b/transmit-lib/src/cmr/transmit/index_set.clj
@@ -45,27 +45,29 @@
 
 (defn- submit-rebalancing-collection-request
   "A helper function for submitting a request to modify the list of rebalancing collections."
-  [context index-set-id concept-id url-fn]
-  (h/request context :index-set
-             {:url-fn #(url-fn % index-set-id concept-id)
-              :method :post
-              :http-options {:headers {config/token-header (config/echo-system-token)}}
-              :response-handler (fn [_request {:keys [status body]}]
-                                  (cond
-                                    (= status 200) nil
-                                    (= status 400) (errors/throw-service-errors :bad-request (:errors body))
-                                    :else (errors/internal-error!
-                                           (str "Unexpected status code:"
-                                                status " response:" (pr-str body)))))}))
+  [context index-set-id concept-id url-fn target]
+  (let [query-params (when target {:target (name target)})]
+    (h/request context :index-set
+               {:url-fn #(url-fn % index-set-id concept-id)
+                :method :post
+                :http-options {:headers {config/token-header (config/echo-system-token)}
+                               :query-params query-params}
+                :response-handler (fn [_request {:keys [status body]}]
+                                    (cond
+                                      (= status 200) nil
+                                      (= status 400) (errors/throw-service-errors :bad-request (:errors body))
+                                      :else (errors/internal-error!
+                                             (str "Unexpected status code:"
+                                                  status " response:" (pr-str body)))))})))
 
 (defn add-rebalancing-collection
   "Adds the specified collection to the set of rebalancing collections in the index set."
-  [context index-set-id concept-id]
+  [context index-set-id concept-id target]
   (submit-rebalancing-collection-request context index-set-id concept-id
-                                         start-rebalance-collection-url))
+                                         start-rebalance-collection-url target))
 
 (defn finalize-rebalancing-collection
   "Finalizes the rebalancing collection specified in the index set application."
   [context index-set-id concept-id]
   (submit-rebalancing-collection-request context index-set-id concept-id
-                                         finalize-rebalance-collection-url))
+                                         finalize-rebalance-collection-url nil))


### PR DESCRIPTION
![rebalance](https://user-images.githubusercontent.com/4248343/42237543-19b25fc2-7ecc-11e8-878a-a2e555429a95.jpeg)

There are almost 70 collections that have 0 or a small number of granules today that currently have their own granule indexes. This happens when a collection that previously had a large (> 300,000) number of granules is deleted, or the majority of the granules within the collection have been deleted.

The reason we want to clean this up is that there is overhead with managing the shards in Elasticsearch, and when there are almost empty shards the nodes can become imbalanced. After this PR we'll be able to clean up almost 700 of the 3200 shards in Elasticsearch today.