### PR TITLE
CMR-5031 Temporal extents not getting picked up for 2 SMAP datasets

### DIFF
--- a/umm-lib/resources/data/iso_smap/granule_with_multiple_extents.xml
+++ b/umm-lib/resources/data/iso_smap/granule_with_multiple_extents.xml
@@ -318,6 +318,10 @@
                       </gmd:polygon>
                     </gmd:EX_BoundingPolygon>
                   </gmd:geographicElement>
+                </gmd:EX_Extent>
+              </gmd:extent>
+              <gmd:extent>
+                <gmd:EX_Extent>
                   <gmd:temporalElement>
                     <gmd:EX_TemporalExtent>
                       <gmd:extent>

--- a/umm-lib/resources/data/iso_smap/sample_smap_iso_granule.xml
+++ b/umm-lib/resources/data/iso_smap/sample_smap_iso_granule.xml
@@ -318,6 +318,10 @@
                       </gmd:polygon>
                     </gmd:EX_BoundingPolygon>
                   </gmd:geographicElement>
+                </gmd:EX_Extent>
+              </gmd:extent>
+              <gmd:extent>
+                <gmd:EX_Extent>
                   <gmd:temporalElement>
                     <gmd:EX_TemporalExtent>
                       <gmd:extent>

--- a/umm-lib/src/cmr/umm/iso_smap/granule/temporal.clj
+++ b/umm-lib/src/cmr/umm/iso_smap/granule/temporal.clj
@@ -20,18 +20,19 @@
 (defn xml-elem->Temporal
   "Returns a UMM GranuleTemporal from a parsed XML structure"
   [xml-struct]
-  (let [temporal-elem (cx/element-at-path
+  (let [temporal-elems (cx/elements-at-path
                         xml-struct
                         [:composedOf :DS_DataSet :has :MI_Metadata :identificationInfo
-                         :MD_DataIdentification :extent :EX_Extent])
-        single-date-time (cx/datetime-at-path
-                           temporal-elem
-                           [:temporalElement :EX_TemporalExtent :extent :TimeInstant :timePosition])
-        range-date-time (xml-elem->RangeDateTime temporal-elem)]
-    (when (or single-date-time range-date-time)
-      (g/map->GranuleTemporal {:range-date-time range-date-time
-                               :single-date-time single-date-time}))))
-
+                         :MD_DataIdentification :extent :EX_Extent])]
+    (first
+     (for [elem temporal-elems
+           :let [single-date-time (cx/datetime-at-path
+                                   elem
+                                   [:temporalElement :EX_TemporalExtent :extent :TimeInstant :timePosition])
+                 range-date-time (xml-elem->RangeDateTime elem)]
+           :when (or single-date-time range-date-time)]
+       (g/map->GranuleTemporal {:range-date-time range-date-time
+                                :single-date-time single-date-time})))))
 
 (defn generate-temporal
   "Generates the temporal element from a UMM granule temporal record."
@@ -59,4 +60,3 @@
             (x/element :gmd:extent {}
                        (x/element :gml:TimeInstant {:gml:id "swathTemporalExtent"}
                                   (x/element :gml:timePosition {} (str single-date-time))))))))))
-

--- a/umm-lib/test/cmr/umm/test/iso_smap/granule.clj
+++ b/umm-lib/test/cmr/umm/test/iso_smap/granule.clj
@@ -98,6 +98,9 @@
 (def sample-granule-xml
   (slurp (io/file (io/resource "data/iso_smap/sample_smap_iso_granule.xml"))))
 
+(def multiple-extents-granule-xml
+  (slurp (io/file (io/resource "data/iso_smap/granule_with_multiple_extents.xml"))))
+
 (def expected-temporal
   (umm-g/map->GranuleTemporal
     {:range-date-time
@@ -143,6 +146,8 @@
     (is (= expected-granule (g/parse-granule sample-granule-xml))))
   (testing "parse temporal"
     (is (= expected-temporal (g/parse-temporal sample-granule-xml))))
+  (testing "parse multiple extents, temporal"
+    (is (= expected-temporal (g/parse-temporal multiple-extents-granule-xml))))
   (testing "parse access value"
     (is (= 32.0 (g/parse-access-value sample-granule-xml)))))
 
@@ -160,4 +165,3 @@
                  "\"http://www.isotc211.org/2005/gmd\":hierarchyLevelName, "
                  "\"http://www.isotc211.org/2005/gmd\":contact}' is expected.")]
            (g/validate-xml (s/replace sample-granule-xml "fileIdentifier" "XXXX"))))))
-


### PR DESCRIPTION
This PR is for changing the granule iso smap -> umm mapping such that when multiple extents are provided, it will map the first temporal it finds, instead of the only the first extent.  

Before, if there was no temporal extent in the first element of extents, the temporal mapping would be nil even if the subsequent extents included a temporal extent.