### PR TITLE
CMR-4884: Added alternative xpath for ISOMends Platforms.

### DIFF
--- a/umm-spec-lib/resources/example-data/iso19115/ISOExample-NOAA-Instrument-XPath.xml
+++ b/umm-spec-lib/resources/example-data/iso19115/ISOExample-NOAA-Instrument-XPath.xml
@@ -1745,18 +1745,12 @@
                 </gmi:MI_Operation>
             </gmi:operation>
             <gmi:platform>
-                <eos:EOS_Platform id="AQUA">
+                <gmi:MI_Platform>
                     <gmi:identifier>
                         <gmd:MD_Identifier>
                             <gmd:code>
-                                <gco:CharacterString>AQUA</gco:CharacterString>
+                                <gco:CharacterString>NOAA-18 &gt; National Oceanic &amp; Atmospheric Administration-18</gco:CharacterString>
                             </gmd:code>
-                            <gmd:codeSpace>
-                                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
-                            </gmd:codeSpace>
-                            <gmd:description>
-                                <gco:CharacterString>Earth Observing System, AQUA</gco:CharacterString>
-                            </gmd:description>
                         </gmd:MD_Identifier>
                     </gmi:identifier>
                     <!-- This is UMM Platform Type -->
@@ -1764,51 +1758,15 @@
                         <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>
                     </gmi:description>
                     <gmi:instrument xlink:href="#MODIS2"/>
-                    <eos:otherProperty>
-                        <gco:Record>
-                            <eos:AdditionalAttributes>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="platformInformation">platformInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>PlatformCaracteristicAquaName</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Platform Characteristics Aqua Description</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="Integer">Integer</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Degrees</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>40</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                            </eos:AdditionalAttributes>
-                        </gco:Record>
-                    </eos:otherProperty>
-                </eos:EOS_Platform>
+                </gmi:MI_Platform>
             </gmi:platform>
             <gmi:platform>
-                <eos:EOS_Platform id="TERRA">
+                <gmi:MI_Platform>
                     <gmi:identifier>
                         <gmd:MD_Identifier>
                             <gmd:code>
-                                <gco:CharacterString>TERRA</gco:CharacterString>
+                                <gco:CharacterString>NOAA-18-2 &gt; National Oceanic &amp; Atmospheric Administration-18-2</gco:CharacterString>
                             </gmd:code>
-                            <gmd:codeSpace>
-                                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
-                            </gmd:codeSpace>
-                            <gmd:description>
-                                <gco:CharacterString>Earth Observing System, TERRA (AM-1)</gco:CharacterString>
-                            </gmd:description>
                         </gmd:MD_Identifier>
                     </gmi:identifier>
                     <!-- This is UMM Platform Type -->
@@ -1816,52 +1774,15 @@
                         <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>
                     </gmi:description>
                     <gmi:instrument xlink:href="#MODIS1"/>
-                    <eos:otherProperty>
-                        <gco:Record>
-                            <eos:AdditionalAttributes>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="platformInformation">platformInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>PlatformCaracteristicTerraName</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Platform Characteristics Terra Description</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="Integer">Integer</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Degrees</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>50</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                            </eos:AdditionalAttributes>
-                        </gco:Record>
-                    </eos:otherProperty>
-                </eos:EOS_Platform>
+                </gmi:MI_Platform>
             </gmi:platform>
             <gmi:platform>
-                <eos:EOS_Platform id="Aircraft1">
+                <gmi:MI_Platform>
                     <gmi:identifier>
                         <gmd:MD_Identifier>
                             <gmd:code>
-                                <gco:CharacterString>B-200</gco:CharacterString>
+                                <gco:CharacterString>NOAA-18-3 &gt; National Oceanic &amp; Atmospheric Administration-18-3</gco:CharacterString>
                             </gmd:code>
-                            <gmd:codeSpace>
-                                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
-                            </gmd:codeSpace>
-                            <gmd:description>
-                                <gco:CharacterString>Beechcraft King Air B-200</gco:CharacterString>
-                            </gmd:description>
                         </gmd:MD_Identifier>
                     </gmi:identifier>
                     <!-- This is UMM Platform Type -->
@@ -1869,38 +1790,7 @@
                         <gco:CharacterString>Aircraft</gco:CharacterString>
                     </gmi:description>
                     <gmi:instrument xlink:href="#Instrument3"/>
-                    <eos:otherProperty>
-                        <gco:Record>
-                            <eos:AdditionalAttributes>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="platformInformation">platformInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>Tail Number</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Aircraft Tail Number</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Not Applicable</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>EER2365876</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                            </eos:AdditionalAttributes>
-                        </gco:Record>
-                    </eos:otherProperty>
-                </eos:EOS_Platform>
+                </gmi:MI_Platform>
             </gmi:platform>
         </gmi:MI_AcquisitionInformation>
     </gmi:acquisitionInformation>

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -93,6 +93,15 @@
   (str identifier-base-xpath "[gmd:codeSpace/gco:CharacterString='gov.nasa.esdis.umm.collectiondatatype']"
        "/gmd:code/gco:CharacterString"))
 
+(def platform-alternative-xpath
+  (str "/gmi:MI_Metadata/gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:platform"
+       "/gmi:MI_Platform"))
+
+(def instrument-alternative-xpath
+  "NOAA instrument xpath"
+  (str "/gmi:MI_Metadata/gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument"
+       "/gmi:MI_Instrument"))
+
 (defn- descriptive-keywords-type-not-equal
   "Returns the descriptive keyword values for the given parent element for all keyword types excepting
   those given"
@@ -236,6 +245,8 @@
         citation-el (first (select doc citation-base-xpath))
         id-el (first (select doc identifier-base-xpath))
         extent-info (iso-util/get-extent-info-map doc)
+        alt-xpath-options {:plat-alt-xpath platform-alternative-xpath
+                           :inst-alt-xpath instrument-alternative-xpath}
         [abstract version-description] (parse-abstract-version-description md-data-id-el sanitize?)]
     (merge
      (data-contact/parse-contacts doc sanitize?) ; DataCenters, ContactPersons, ContactGroups
@@ -274,7 +285,7 @@
                         (char-string-value
                          md-data-id-el "gmd:processingLevel/gmd:MD_Identifier/gmd:description")}
       :Distributions (dru/parse-distributions doc sanitize?)
-      :Platforms (platform/parse-platforms doc "" sanitize?)
+      :Platforms (platform/parse-platforms doc "" sanitize? alt-xpath-options)
       :Projects (project/parse-projects doc projects-xpath sanitize?)
 
       :PublicationReferences (parse-publication-references doc md-data-id-el sanitize?)

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/instrument.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/instrument.clj
@@ -13,11 +13,6 @@
   (str "/gmi:MI_Metadata/gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument"
        "/eos:EOS_Instrument"))
 
-(def instrument-alternative-xpath
-  "NOAA instrument xpath"
-  (str "/gmi:MI_Metadata/gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument"
-       "/gmi:MI_Instrument"))
-
 (def composed-of-xpath
   (str instrument-xpath "/eos:sensor/eos:EOS_Sensor"))
 
@@ -136,8 +131,12 @@
 (defn xml-elem->instruments-mapping
   "Returns the instrument id to Instrument mapping by parsing the given xml element.
    Alternatively, in NOAA case, it will return the list of instruments when they are not associated with platforms"
-  [doc base-xpath]
-  (if-let [instruments (select doc (str base-xpath instrument-xpath))] 
-    (into {} (map (partial xml-elem->instrument-mapping doc base-xpath) instruments))
-    (let [instruments (select doc (str base-xpath instrument-alternative-xpath))]
-      (map #((partial xml-elem->instrument-mapping doc base-xpath) % {:alt-xpath? true}) instruments))))
+  ([doc base-xpath]
+   ;; This is the iso-smap case where alternative xpath doesn't apply.
+   (into {}
+         (map (partial xml-elem->instrument-mapping doc base-xpath) (select doc (str base-xpath instrument-xpath)))))
+  ([doc base-xpath inst-alt-xpath]
+   (if-let [instruments (select doc (str base-xpath instrument-xpath))]
+     (into {} (map (partial xml-elem->instrument-mapping doc base-xpath) instruments))
+     (let [instruments (select doc (str base-xpath inst-alt-xpath))]
+       (map #((partial xml-elem->instrument-mapping doc base-xpath) % {:alt-xpath? true}) instruments)))))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/platform.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/platform.clj
@@ -49,7 +49,10 @@
                              (select doc (str base-xpath platforms-xpath))))]
      (or (seq platforms) (when sanitize? su/not-provided-platforms))))
   ([doc base-xpath sanitize? alt-xpath-options]
-   ;; This is isomends case where alternative xpath exist for both instrments and platforms.
+   ;; This is isomends case where alternative xpath exist for both instruments and platforms.
+   ;; Note: I'm leaving this parse-platforms function in iso_shared because the current implementation
+   ;; for isomends alternative xpath is just temporary. Once the relationship between the platforms
+   ;; and instruments is established, it will be changed.
    (let [inst-alt-xpath (:inst-alt-xpath alt-xpath-options)
          plat-alt-xpath (:plat-alt-xpath alt-xpath-options)
          plat-elems (select doc (str base-xpath platforms-xpath))

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/platform.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/platform.clj
@@ -1,6 +1,7 @@
 (ns cmr.umm-spec.xml-to-umm-mappings.iso-shared.platform
   "Functions for parsing UMM platform records out of ISO SMAP XML documents."
   (:require
+    [clojure.string :as string]
     [cmr.common.util :as util]
     [cmr.common.xml.parse :refer :all]
     [cmr.common.xml.simple-xpath :refer [select text]]
@@ -15,29 +16,52 @@
 
 (defn xml-elem->platform
   "Returns platform record using the platform element and instrument-id/instrument-record mapping"
-  [doc base-xpath instruments-mapping platform-elem]
-  (let [platform-id (get-in platform-elem [:attrs :id])
-        instrument-ids (keep #(get-in % [:attrs :xlink/href]) (select platform-elem "gmi:instrument"))
-        instruments (->> (concat
-                          (map (partial get instruments-mapping) instrument-ids)
-                          (filter #(= platform-id (:mounted-on-id %)) (vals instruments-mapping)))
-                         (map #(dissoc % :mounted-on-id))
-                         distinct
-                         seq)]
-    (util/remove-nil-keys
-      {:ShortName (value-of platform-elem iso/short-name-xpath)
-       :LongName (value-of platform-elem iso/long-name-xpath)
-       :Type (without-default-value-of platform-elem "gmi:description/gco:CharacterString")
-       :Characteristics (char-and-opsmode/parse-characteristics platform-elem)
-       :Instruments instruments})))
+  ([doc base-xpath instruments-mapping platform-elem]
+   (let [platform-id (get-in platform-elem [:attrs :id])
+         instrument-ids (keep #(get-in % [:attrs :xlink/href]) (select platform-elem "gmi:instrument"))
+         instruments (->> (concat
+                            (map (partial get instruments-mapping) instrument-ids)
+                            (filter #(= platform-id (:mounted-on-id %)) (vals instruments-mapping)))
+                           (map #(dissoc % :mounted-on-id))
+                           distinct
+                           seq)]
+     (util/remove-nil-keys
+       {:ShortName (value-of platform-elem iso/short-name-xpath)
+        :LongName (value-of platform-elem iso/long-name-xpath)
+        :Type (without-default-value-of platform-elem "gmi:description/gco:CharacterString")
+        :Characteristics (char-and-opsmode/parse-characteristics platform-elem)
+        :Instruments instruments})))
+   ([doc base-xpath platform-elem]
+    ;; This is the case when platform-elem is from alternative path. This platform will only contain ShortName and LongName.
+    (when-let [short-long-name (value-of platform-elem iso/short-name-xpath)]
+     (let [short-long-name-list (string/split short-long-name #">")]
+       (util/remove-nil-keys
+         {:ShortName (string/trim (first short-long-name-list))
+          :LongName (when-let [long-name (second short-long-name-list)]
+                      (string/trim long-name))})))))
 
 (defn parse-platforms
   "Returns the platforms parsed from the given xml document."
-  [doc base-xpath sanitize?]
-  (let [instruments-mapping (inst/xml-elem->instruments-mapping doc base-xpath)
-        platforms (if (or (map? instruments-mapping) (nil? (seq instruments-mapping)))
-                    (seq (map #(xml-elem->platform doc base-xpath instruments-mapping %)
-                              (select doc (str base-xpath platforms-xpath))))
-                    ;; NOAA case when instruments are not associated with any platforms.
-                    (seq (map #(assoc % :Instruments instruments-mapping) su/not-provided-platforms)))]
-    (or (seq platforms) (when sanitize? su/not-provided-platforms))))
+  ([doc base-xpath sanitize?]
+   ;; This is iso-smap case, where alternative xpath for instruments and platforms doesn't apply.
+   (let [instruments-mapping (inst/xml-elem->instruments-mapping doc base-xpath)
+         platforms (seq (map #(xml-elem->platform doc base-xpath instruments-mapping %)
+                             (select doc (str base-xpath platforms-xpath))))]
+     (or (seq platforms) (when sanitize? su/not-provided-platforms))))
+  ([doc base-xpath sanitize? alt-xpath-options]
+   ;; This is isomends case where alternative xpath exist for both instrments and platforms.
+   (let [inst-alt-xpath (:inst-alt-xpath alt-xpath-options)
+         plat-alt-xpath (:plat-alt-xpath alt-xpath-options)
+         plat-elems (select doc (str base-xpath platforms-xpath))
+         instruments-mapping (inst/xml-elem->instruments-mapping doc base-xpath inst-alt-xpath)
+         platforms (if (or (map? instruments-mapping) (nil? (seq instruments-mapping)))
+                     (seq (map #(xml-elem->platform doc base-xpath instruments-mapping %) plat-elems))
+                     ;; NOAA case when instruments are not associated with any platforms.
+                     ;; Platforms are the combination of platforms from alternative xpath
+                     ;; and the not-provided-platforms that contain the instruments from alternative xpath.
+                     (let [plat-elems (select doc (str base-xpath plat-alt-xpath))
+                           plats-alt-xpath (seq (map #(xml-elem->platform doc base-xpath %) plat-elems))
+                           not-provided-plats (seq (map #(assoc % :Instruments instruments-mapping)
+                                                        su/not-provided-platforms))]
+                       (into [] (concat plats-alt-xpath not-provided-plats))))]
+     (or (seq platforms) (when sanitize? su/not-provided-platforms)))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/noaa_instrument_xpath_test.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/noaa_instrument_xpath_test.clj
@@ -12,8 +12,12 @@
 (def test-context (lkt/setup-context-for-test))
 
 (def expected-noaa-platforms
-  (let [instruments [(cmn/map->InstrumentType {:ShortName "AMSR2" :LongName "Advanced Microwave Scanning Radiometer 2"})]]
-    (seq (map #(assoc % :Instruments instruments) util/not-provided-platforms))))
+  (let [plats-alt [(cmn/map->PlatformType {:ShortName "NOAA-18" :LongName "National Oceanic & Atmospheric Administration-18"})
+                   (cmn/map->PlatformType {:ShortName "NOAA-18-2" :LongName "National Oceanic & Atmospheric Administration-18-2"})
+                   (cmn/map->PlatformType {:ShortName "NOAA-18-3" :LongName "National Oceanic & Atmospheric Administration-18-3"})]
+        instrs-alt [(cmn/map->InstrumentType {:ShortName "AMSR2" :LongName "Advanced Microwave Scanning Radiometer 2"})]
+        not-provided-plats (seq (map #(assoc % :Instruments instrs-alt) util/not-provided-platforms))]
+    (into [] (concat plats-alt not-provided-plats))))
 
 (defn noaa-example-file
   "Returns an example ISO19115 metadata file with NOAA instrument xpath."


### PR DESCRIPTION
Note: I made a mistake in CMR-4885 when adding alternative xpath for ISOMends Instruments. I did it for both ISOMends and ISOSmap, which made ISOSmap parsing inefficient. I included the fix in this PR.