### PR TITLE
CMR-5098 Fixes index rebalancing for old deleted collections.

### DIFF
--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -10,7 +10,6 @@
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
    [cmr.system-int-test.system :as s]
-   [cmr.metadata-db.int-test.utility :as mdb-util]
    [cmr.metadata-db.services.concept-service :as concept-service]
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
@@ -486,7 +485,7 @@
      (ingest/delete-concept deleted-coll-concept)
      (index/wait-until-indexed)
      (side/eval-form `(tk/advance-time! ~(* (concept-service/days-to-keep-tombstone) 24 3600)))
-     (is (= 204 (mdb-util/old-revision-concept-cleanup)))
+     (is (= 204 (:status (mdb/cleanup-old-revisions))))
 
      ;; Rebalance to small-collections
      (bootstrap/start-rebalance-collection (:concept-id deleted-coll) {:target "small-collections"})


### PR DESCRIPTION
When a collection has been deleted, along with its tombstone the index rebalancing for that collection would fail on the collection validation not finding a collection.  This would prevent removal of old unused indices. 