### PR TITLE
CMR-4906: Added Cmr-Revision-Id header for ACL update.

### DIFF
--- a/access-control-app/docs/api.md
+++ b/access-control-app/docs/api.md
@@ -47,6 +47,10 @@ Content-Type is a standard HTTP header that specifies the content type of the bo
 
 All Access Control API operations require specifying a token obtained from URS or ECHO. The token should be specified using the `Echo-Token` header.
 
+#### <a name="cmr-revision-id-header"></a> Cmr-Revision-Id Header
+
+The revision id header allows specifying the revision id to use when saving the concept. If the revision id specified is not the latest a HTTP Status code of 409 will be returned indicating a conflict.
+
 ***
 
 ### <a name="responses"></a> Responses

--- a/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
@@ -177,7 +177,7 @@
             acl-concept-id
             {:group_permissions [{:permissions [:read]
                                   :user_type :registered}]
-             :catalog_item_identity {:name "coll1 read and order"
+             :catalog_item_identity {:name "coll1 read only"
                                      :collection_applicable true
                                      :provider_id "PROV1"}})
 

--- a/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
@@ -3,6 +3,7 @@
   (require
    [cheshire.core :as json]
    [clj-time.core :as t]
+   [clojure.string :as string]
    [clojure.test :refer :all]
    [cmr.access-control.int-test.fixtures :as fixtures]
    [cmr.access-control.test.util :as u]
@@ -94,6 +95,14 @@
         ;; local helpers to make the body of the test cleaner
         create-acl #(:concept_id (ac/create-acl (u/conn-context) % {:token token}))
         update-acl #(ac/update-acl (u/conn-context) %1 %2 {:token token})
+        update-acl-invalid-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
+                                                                               :cmr-revision-id "invalid"})
+        update-acl-invalid-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
+                                                                               :cmr-revision-id "invalid"})
+        update-acl-conflict-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
+                                                                               :cmr-revision-id 2})
+        update-acl-working-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
+                                                                               :cmr-revision-id 3})
         get-collection-permissions #(get-permissions %1 coll1)
         get-granule-permissions #(get-permissions %1 gran1)
         ;;remove some ACLs created in fixtures which we dont want polluting tests
@@ -137,6 +146,52 @@
             :guest []
             :registered ["read" "order"]
             "user1" ["read" "order"]))
+
+        (testing "update acl with revision-id"
+          ;; invalid revision-id
+          (try
+            (update-acl-invalid-revision-id
+              acl-concept-id
+              {:group_permissions [{:permissions [:read :order]
+                                    :user_type :registered}]
+               :catalog_item_identity {:name "coll1 read and order"
+                                       :collection_applicable true
+                                       :provider_id "PROV1"}})
+            (catch Exception e
+              (is (= true
+                     (string/includes?  e "{:errors [\"Invalid revision-id [invalid]. Cmr-Revision-id in the header must be a positive integer.\"]}")))))
+
+          ;; conflict revision-id: The previous test already updates the acl to revision 2,
+          (try
+            (update-acl-conflict-revision-id
+              acl-concept-id
+              {:group_permissions [{:permissions [:read :order]
+                                    :user_type :registered}]
+               :catalog_item_identity {:name "coll1 read and order"
+                                       :collection_applicable true
+                                       :provider_id "PROV1"}})
+            (catch Exception e
+              (is (= true
+                     (string/includes?  e "Expected revision-id of [3] got [2]")))))
+
+          ;; working revision-id: 3, as expected.
+          (update-acl-working-revision-id
+            acl-concept-id
+            {:group_permissions [{:permissions [:read]
+                                  :user_type :registered}]
+             :catalog_item_identity {:name "coll1 read and order"
+                                     :collection_applicable true
+                                     :provider_id "PROV1"}})
+
+          (are3 [user permissions]
+            (is (= {coll1 permissions}
+                   (get-collection-permissions user)))
+            "for guest users"
+            :guest []
+            "for registered"
+            :registered ["read"]
+            "for user1"
+            "user1" ["read"]))
 
         (testing "acls granting access to specific groups"
 

--- a/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
@@ -97,8 +97,6 @@
         update-acl #(ac/update-acl (u/conn-context) %1 %2 {:token token})
         update-acl-invalid-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
                                                                                :cmr-revision-id "invalid"})
-        update-acl-invalid-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
-                                                                               :cmr-revision-id "invalid"})
         update-acl-conflict-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token
                                                                                :cmr-revision-id 2})
         update-acl-working-revision-id #(ac/update-acl (u/conn-context) %1 %2 {:token token

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -133,7 +133,7 @@
   (acl-schema/validate-acl-json body)
   (->> (json/parse-string body)
        util/map-keys->kebab-case
-       (acl-service/update-acl ctx concept-id)
+       (acl-service/update-acl ctx concept-id (get headers "cmr-revision-id"))
        util/map-keys->snake_case
        api-response))
 

--- a/access-control-app/src/cmr/access_control/services/messages.clj
+++ b/access-control-app/src/cmr/access_control/services/messages.clj
@@ -17,3 +17,7 @@
   [managing-group-id]
   (format "Managing group id [%s] is invalid, no group with this concept id can be found." 
           managing-group-id))
+
+(defn invalid-revision-id
+  [revision-id]
+  (format "Invalid revision-id [%s]. Cmr-Revision-id in the header must be a positive integer." revision-id))

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -40,6 +40,9 @@
 (def token-header
   "echo-token")
 
+(def revision-id-header
+  "cmr-revision-id")
+
 (def user-id-header
   "user-id")
 

--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -158,9 +158,12 @@
        (~fn-name context# concept-id# item# nil))
       ([context# concept-id# item# options#]
        (let [options# (merge options# ~default-options)
-             {raw?# :raw? token# :token http-options# :http-options} options#
+             {raw?# :raw? token# :token revision-id# :cmr-revision-id http-options# :http-options} options#
              token# (or token# (:token context#))
-             headers# (when token# {config/token-header token#})]
+             headers# (when token# {config/token-header token#})
+             headers# (if revision-id#
+                        (assoc headers# config/revision-id-header revision-id#)
+                        headers#)]
          (request context# ~app-name
                   {:url-fn #(~url-fn % concept-id#)
                    :method :put


### PR DESCRIPTION
Will need to add tests. Demo worked. Not sure where to add the tests. Looks like the current ACL related tests are just some ingest tests that test some ACL indirectly?