### PR TITLE
CMR-5039 Error found by MMT when updating their tests to use CMR access-control-app 

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/umm_spec_core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_spec_core.clj
@@ -152,4 +152,4 @@
      mt/dif (dif-util/parse-access-constraints metadata true)
      mt/dif10 (dif-util/parse-access-constraints metadata true)
      mt/iso19115 (iso19115-2-to-umm/parse-access-constraints metadata true)
-     mt/iso-smap nil)))
+     nil)))


### PR DESCRIPTION
Adds default expression to parse-collection-access-value, metadata MMT was using was causing a failure to the get-or-lazy-get call in acl-matcher because the assoc-lazy call was using parse-collection-access-value which had no condition for umm-json. Instead of throwing an error, the lazy-get will now return a nil.