### PR TITLE
CMR-4955: Make collection ingest tests to test against the latest umm version

### DIFF
--- a/access-control-app/docs/api.md
+++ b/access-control-app/docs/api.md
@@ -49,7 +49,7 @@ All Access Control API operations require specifying a token obtained from URS o
 
 #### <a name="cmr-revision-id-header"></a> Cmr-Revision-Id Header
 
-The revision id header allows specifying the revision id to use when saving the concept. If the revision id specified is not the latest a HTTP Status code of 409 will be returned indicating a conflict.
+The revision id header allows specifying the revision id to use when saving the concept.  It is optional for all acl update.  The update will be rejected when 1. the revision id specified is not an integer. 2. the revision id specified <= current revision id of the acl - a HTTP Status code of 409 will be returned indicating a conflict.
 
 ***
 

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -7,11 +7,11 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [cmr.acl.core :as acl]
+   [cmr.common-app.config :as common-config]
    [cmr.common-app.test.side-api :as side]
    [cmr.common.mime-types :as mt]
    [cmr.common.util :as util]
    [cmr.common.xml :as cx]
-   [cmr.ingest.config :as icfg]
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.data2.provider-holdings :as ph]
    [cmr.system-int-test.system :as s]
@@ -21,6 +21,7 @@
    [cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.access-control :as ac]
    [cmr.transmit.config :as transmit-config]
+   [cmr.umm-spec.versioning :as umm-versioning]
    [cmr.umm.echo10.echo10-collection :as c]
    [cmr.umm.echo10.echo10-core :as echo10]
    [cmr.umm.echo10.granule :as g])
@@ -631,6 +632,11 @@
 
 ;;; fixture - each test to call this fixture
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defn set-collection-ingest-umm-version-to-current
+  "Set the collection ingest-accept-umm-version to current-collection-version."
+  []
+  (side/eval-form `(common-config/set-collection-umm-version!
+                     umm-versioning/current-collection-version)))
 
 (defn create-provider
   "Creates a provider along with ACLs to create and access the providers data.
@@ -703,8 +709,10 @@
           :grant-all-access-control? grant-all-access-control?})))))
 
 (defn reset-fixture
-  "Resets all the CMR systems then uses the `setup-providers` function to
-  create a testing fixture.
+  "Resets all the CMR systems then uses the `set-collection-ingest-umm-version-to-current`
+  function to set the accepted umm version for collection ingest to the umm-versioning/current-collection-version,
+  so that all the ingest tests are testing against the latest umm version.
+  and uses the `setup-providers` function to create a testing fixture.
 
   For the format of the providers data structure, see `setup-providers`."
   ([]
@@ -714,6 +722,7 @@
   ([providers options]
    (fn [f]
      (dev-sys-util/reset)
+     (set-collection-ingest-umm-version-to-current)
      (when-not (empty? providers)
       (setup-providers providers options))
      (f))))


### PR DESCRIPTION
Some ingest tests are currently testing against cmr.common-app.config/collection-umm-version, which is the accepted collection ingest umm version.  We should make our ingest tests testing against the latest umm version, which is cmr.umm-spec.versioning/current-collection-version. 

1. Set the collection-umm-version to current-collection-version in the ingest/reset-fixture, which is used in most of the ingest tests. 
Most of the collection ingest tests are not specifying the umm version, so it makes use of the collection-umm-version. By setting it to current-collection-version in the test environment, these ingest tests will test against the current-collection-version. Note: during the test, I changed the default value of cmr.common-app.config/collection-umm-version to "1.11", which doesn't exist, to make sure no tests are using the default value. 

2. Modified an acl doc for CMR-4906.

