### PR TITLE
CMR-5080: log size of metadata to be ingested

### DIFF
--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -10,6 +10,7 @@
     [org.slf4j/slf4j-api]
     [ring/ring-codec]]
   :dependencies [
+    [com.clojure-goes-fast/clj-memory-meter "0.1.1"]
     [clj-http "2.3.0"]
     [commons-codec/commons-codec "1.11"]
     [commons-io "2.6"]
@@ -100,4 +101,3 @@
             "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})
-

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -10,7 +10,6 @@
     [org.slf4j/slf4j-api]
     [ring/ring-codec]]
   :dependencies [
-    [com.clojure-goes-fast/clj-memory-meter "0.1.1"]
     [clj-http "2.3.0"]
     [commons-codec/commons-codec "1.11"]
     [commons-io "2.6"]

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -1,7 +1,6 @@
 (ns cmr.ingest.api.core
   "Supports the ingest API definitions."
   (:require
-   [clj-memory-meter.core :as memory-meter]
    [clojure.data.xml :as xml]
    [clojure.string :as string]
    [cmr.acl.core :as acl]
@@ -206,7 +205,8 @@
 (defn metadata->concept
   "Create a metadata concept from the given metadata"
   [concept-type metadata content-type headers]
-  (info (format "Size of metadata to be ingested: [%s]" (memory-meter/measure metadata)))
+  (info (format "Size of metadata (in bytes) to be ingested: [%s]"
+                (-> metadata (.getBytes "UTF-8") alength)))
   (-> {:metadata metadata
        :format (mt/keep-version content-type)
        :native-id (:name metadata)

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.api.core
   "Supports the ingest API definitions."
   (:require
+   [clj-memory-meter.core :as memory-meter]
    [clojure.data.xml :as xml]
    [clojure.string :as string]
    [cmr.acl.core :as acl]
@@ -205,6 +206,7 @@
 (defn metadata->concept
   "Create a metadata concept from the given metadata"
   [concept-type metadata content-type headers]
+  (info (format "Size of metadata to be ingested: [%s]" (memory-meter/measure metadata)))
   (-> {:metadata metadata
        :format (mt/keep-version content-type)
        :native-id (:name metadata)


### PR DESCRIPTION
I picked `metadata->concept` because it is used in all ingest functions. It can be moved easily