### PR TITLE
CMR-5098: Ensure we can remove collection indexes for collections which do not exist in Oracle

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
@@ -25,6 +25,7 @@
   (let [dispatcher (api-util/get-dispatcher context params :index-collection)
         provider-id (get provider-id-collection-map "provider_id")
         collection-id (get provider-id-collection-map "collection_id")
+        _ (service/validate-collection context provider-id collection-id)
         result (service/index-collection
                 context dispatcher provider-id collection-id)]
     {:status 202

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -51,7 +51,7 @@
      :bad-request
      [(format "Provider: [%s] does not exist in the system" provider-id)])))
 
-(defn- validate-collection
+(defn validate-collection
    "Validates to be bulk_indexed collection exists in cmr else an exception is thrown."
    [context provider-id collection-id]
    (let [provider (get-provider context provider-id)]
@@ -76,7 +76,6 @@
   ([context dispatcher provider-id collection-id]
    (index-collection context dispatcher provider-id collection-id nil))
   ([context dispatcher provider-id collection-id options]
-   (validate-collection context provider-id collection-id)
    (dispatch/index-collection dispatcher context provider-id collection-id options)))
 
 (defn index-system-concepts


### PR DESCRIPTION

![pastedgraphic-1](https://user-images.githubusercontent.com/4248343/45095941-55eaf780-b0ed-11e8-99ad-601def6cc383.png)

This also fixes the test which attempted to delete revisions from the database as part of the setup.