### PR TITLE
CMR-5136: Encode references for opendata format.

### DIFF
--- a/common-lib/src/cmr/common/test/url_util.clj
+++ b/common-lib/src/cmr/common/test/url_util.clj
@@ -1,0 +1,13 @@
+(ns cmr.common.test.url-util
+  "Contains utilities for testing with URLs."
+  (:require [clojure.string :as str]))
+
+(defn url->comparable-url
+  "Convert URL to a set consisting of the base-url and the url-parameters for comparison."
+  [url]
+  (when url
+    (let [split-url (str/split url #"\?" 2)
+          base-url (first split-url)
+          url-params (when-let [params (second split-url)]
+                       (str/split params #"\&"))]
+      (reduce conj #{base-url} url-params))))

--- a/common-lib/src/cmr/common/test/url_util.clj
+++ b/common-lib/src/cmr/common/test/url_util.clj
@@ -1,13 +1,13 @@
 (ns cmr.common.test.url-util
   "Contains utilities for testing with URLs."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as string]))
 
 (defn url->comparable-url
   "Convert URL to a set consisting of the base-url and the url-parameters for comparison."
   [url]
   (when url
-    (let [split-url (str/split url #"\?" 2)
+    (let [split-url (string/split url #"\?" 2)
           base-url (first split-url)
           url-params (when-let [params (second split-url)]
-                       (str/split params #"\&"))]
+                       (string/split params #"\&"))]
       (reduce conj #{base-url} url-params))))

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -243,7 +243,7 @@
                             :distribution (distribution related-urls)
                             :landingPage (landing-page related-urls)
                             :language  [LANGUAGE_CODE]
-                            :references (not-empty (distinct (map :url related-urls)))
+                            :references (not-empty (distinct (map #(ru/related-url->encoded-url (:url %)) related-urls)))
                             :issued (not-empty insert-time)})))
 
 (defn- results->opendata

--- a/system-int-test/resources/cmr-5136-opendata-related-urls.xml
+++ b/system-int-test/resources/cmr-5136-opendata-related-urls.xml
@@ -1,0 +1,540 @@
+<DIF xmlns="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/ https://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/dif_v10.2.xsd">
+    <Entry_ID>
+        <Short_Name>AIRX3STD</Short_Name>
+        <Version>006</Version>
+    </Entry_ID>
+    <Entry_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006 (AIRX3STD) at GES DISC</Entry_Title>
+    <Dataset_Citation>
+        <Dataset_Creator>AIRS Science Team/Joao Texeira</Dataset_Creator>
+        <Dataset_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006</Dataset_Title>
+        <Dataset_Series_Name>AIRX3STD</Dataset_Series_Name>
+        <Dataset_Release_Date>2013-03-12</Dataset_Release_Date>
+        <Dataset_Release_Place>Greenbelt, MD, USA</Dataset_Release_Place>
+        <Dataset_Publisher>Goddard Earth Sciences Data and Information Services Center (GES DISC)</Dataset_Publisher>
+        <Version>006</Version>
+        <Data_Presentation_Form>Digital Science Data</Data_Presentation_Form>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>doi:10.5067/Aqua/AIRS/DATA301</Identifier>
+        </Persistent_Identifier>
+        <Online_Resource>https://disc.gsfc.nasa.gov/datacollection/AIRX3STD_006.html</Online_Resource>
+    </Dataset_Citation>
+    <Personnel>
+        <Role>METADATA AUTHOR</Role>
+        <Contact_Person>
+            <First_Name>ED</First_Name>
+            <Last_Name>ESFANDIARI</Last_Name>
+            <Address>
+                <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                <Street_Address>Code 610.2</Street_Address>
+                <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                <City>Greenbelt</City>
+                <State_Province>MD</State_Province>
+                <Postal_Code>20771</Postal_Code>
+                <Country>USA</Country>
+            </Address>
+            <Phone>
+                <Number>301-614-5960</Number>
+                <Type>Telephone</Type>
+            </Phone>
+            <Phone>
+                <Number>301-614-5268</Number>
+                <Type>Fax</Type>
+            </Phone>
+            <Email>asghar.e.esfandiari@nasa.gov</Email>
+        </Contact_Person>
+    </Personnel>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ALTITUDE</Term>
+        <Variable_Level_1>TROPOPAUSE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC PRESSURE</Term>
+        <Variable_Level_1>SURFACE PRESSURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC TEMPERATURE</Term>
+        <Variable_Level_1>SURFACE TEMPERATURE</Variable_Level_1>
+        <Variable_Level_2>AIR TEMPERATURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC TEMPERATURE</Term>
+        <Variable_Level_1>UPPER AIR TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>TOTAL PRECIPITABLE WATER</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>WATER VAPOR</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD HEIGHT</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD TOP PRESSURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD TOP TEMPERATURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD VERTICAL DISTRIBUTION</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>LAND SURFACE</Topic>
+        <Term>SURFACE RADIATIVE PROPERTIES</Term>
+        <Variable_Level_1>EMISSIVITY</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>OCEANS</Topic>
+        <Term>OCEAN TEMPERATURE</Term>
+        <Variable_Level_1>SEA SURFACE TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>LAND SURFACE</Topic>
+        <Term>SURFACE THERMAL PROPERTIES</Term>
+        <Variable_Level_1>SKIN TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>AIR QUALITY</Term>
+        <Variable_Level_1>CARBON MONOXIDE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ALTITUDE</Term>
+        <Variable_Level_1>GEOPOTENTIAL HEIGHT</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>HUMIDITY</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR PROFILES</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD MICROPHYSICS</Variable_Level_1>
+        <Variable_Level_2>CLOUD LIQUID WATER/ICE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC RADIATION</Term>
+        <Variable_Level_1>OUTGOING LONGWAVE RADIATION</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC CHEMISTRY</Term>
+        <Variable_Level_1>CARBON AND HYDROCARBON COMPOUNDS</Variable_Level_1>
+        <Variable_Level_2>METHANE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC CHEMISTRY</Term>
+        <Variable_Level_1>OXYGEN COMPOUNDS</Variable_Level_1>
+        <Variable_Level_2>OZONE</Variable_Level_2>
+    </Science_Keywords>
+    <ISO_Topic_Category>CLIMATOLOGY/METEOROLOGY/ATMOSPHERE</ISO_Topic_Category>
+    <ISO_Topic_Category>IMAGERY/BASE MAPS/EARTH COVER</ISO_Topic_Category>
+    <ISO_Topic_Category>ENVIRONMENT</ISO_Topic_Category>
+    <ISO_Topic_Category>GEOSCIENTIFIC INFORMATION</ISO_Topic_Category>
+    <Ancillary_Keyword>ATMOSPHERE</Ancillary_Keyword>
+    <Ancillary_Keyword>CALIBRATED</Ancillary_Keyword>
+    <Ancillary_Keyword>GEOLOCATED</Ancillary_Keyword>
+    <Ancillary_Keyword>TEMPERATURE</Ancillary_Keyword>
+    <Ancillary_Keyword>CLOUD</Ancillary_Keyword>
+    <Ancillary_Keyword>EOSDIS</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Ozone</Ancillary_Keyword>
+    <Ancillary_Keyword>Global Gridded</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Water Vapor Burden</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Cloud Liquid Water</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Carbon Monoxide</Ancillary_Keyword>
+    <Ancillary_Keyword>Spectral IR Surface Emissivities</Ancillary_Keyword>
+    <Ancillary_Keyword>Spectral Microwave Surface Emissivities</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Ozone Burden</Ancillary_Keyword>
+    <Ancillary_Keyword>Outgoing Longwave Radiation Flux</Ancillary_Keyword>
+    <Ancillary_Keyword>Clear Sky Outgoing Longwave Radiation Flux</Ancillary_Keyword>
+    <Ancillary_Keyword>Relative Humidity Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Cloud Layer Pressure At Coarse Cloud Resolution</Ancillary_Keyword>
+    <Ancillary_Keyword>Cloud Layer Pressure At Fine Cloud Resolution</Ancillary_Keyword>
+    <Ancillary_Keyword>Water Vapor Mass Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Tropopause Height</Ancillary_Keyword>
+    <Ancillary_Keyword>Tropopause Temperature</Ancillary_Keyword>
+    <Ancillary_Keyword>Effective Methane Volume Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Effective Carbon Monoxide Volume Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Cloud Liquid Water</Ancillary_Keyword>
+    <Platform>
+        <Type>Earth Observation Satellites</Type>
+        <Short_Name>Aqua</Short_Name>
+        <Long_Name>Earth Observing System, Aqua</Long_Name>
+        <Instrument>
+            <Short_Name>AIRS</Short_Name>
+            <Long_Name>Atmospheric Infrared Sounder</Long_Name>
+        </Instrument>
+        <Instrument>
+            <Short_Name>AMSU-A</Short_Name>
+            <Long_Name>Advanced Microwave Sounding Unit-A</Long_Name>
+        </Instrument>
+    </Platform>
+    <Temporal_Coverage>
+        <Range_DateTime>
+            <Beginning_Date_Time>2002-08-31</Beginning_Date_Time>
+            <Ending_Date_Time>2016-09-25</Ending_Date_Time>
+        </Range_DateTime>
+    </Temporal_Coverage>
+    <Dataset_Progress>COMPLETE</Dataset_Progress>
+    <Spatial_Coverage>
+        <Granule_Spatial_Representation>CARTESIAN</Granule_Spatial_Representation>
+        <Geometry>
+            <Coordinate_System>CARTESIAN</Coordinate_System>
+            <Bounding_Rectangle>
+                <Southernmost_Latitude>-90.0</Southernmost_Latitude>
+                <Northernmost_Latitude>90.0</Northernmost_Latitude>
+                <Westernmost_Longitude>-180.0</Westernmost_Longitude>
+                <Easternmost_Longitude>180.0</Easternmost_Longitude>
+            </Bounding_Rectangle>
+        </Geometry>
+    </Spatial_Coverage>
+    <Location>
+        <Location_Category>GEOGRAPHIC REGION</Location_Category>
+        <Location_Type>GLOBAL</Location_Type>
+    </Location>
+    <Data_Resolution>
+        <Latitude_Resolution>1 degree</Latitude_Resolution>
+        <Longitude_Resolution>1 degree</Longitude_Resolution>
+        <Horizontal_Resolution_Range>100 km - &lt; 250 km or approximately 1 degree - &lt; 2.5 degrees</Horizontal_Resolution_Range>
+        <Temporal_Resolution>Twice per day; day and night; Orbital repeat cycle 16 days</Temporal_Resolution>
+    </Data_Resolution>
+    <Project>
+        <Short_Name>Aqua</Short_Name>
+        <Long_Name>Earth Observing System (EOS), Aqua</Long_Name>
+    </Project>
+    <Quality>The quality of data products, described in the associated references, provide information about numerous validation studies conducted and papers written documenting the excellence of the products using radiosondes, ground truth, other satellites, and model analysis products. There are however several limitations of the version-6 retrieval products. One is a spurious dry daytime moisture bias. In addition, there are some erroneous water vapor features in the upper stratosphere near the top limit of the AIRS determination. For trace gases, the total column CO and total column methane (CH4) are dominated by the initial guess and should not be used for research purposes. The total ozone product is good, but has some limitations  where it is too low over the warm oceanic pool and a bit too high over most land areas. Occasionally in the tropical ocean the algorithm confuses silicates from dust storms blowing off the African continent toward the Americas for high levels of ozone.
+
+The value for each grid box is the sum of the values that fall within the 1x1 area divided by the number of points in the box.
+
+For AIRS/AMSU: This product stopped after September 24, 2016 as the power to the AMSU-A2 instrument on Aqua was lost. For data after this time use AIRS2RET.006 (AIRS-only) .</Quality>
+    <Access_Constraints>None</Access_Constraints>
+    <Dataset_Language>English</Dataset_Language>
+    <Originating_Center>GES DISC</Originating_Center>
+    <Organization>
+        <Organization_Type>ARCHIVER</Organization_Type>
+        <Organization_Name>
+            <Short_Name>NASA/GSFC/SED/ESD/GCDC/GESDISC</Short_Name>
+            <Long_Name>Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Global Change Data Center, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA</Long_Name>
+        </Organization_Name>
+        <Organization_URL>https://disc.gsfc.nasa.gov/</Organization_URL>
+        <Personnel>
+            <Role>DATA CENTER CONTACT</Role>
+            <Contact_Group>
+                <Name>GES DISC HELP DESK SUPPORT GROUP</Name>
+                <Address>
+                    <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                    <Street_Address>Code 610.2</Street_Address>
+                    <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                    <City>Greenbelt</City>
+                    <State_Province>MD</State_Province>
+                    <Postal_Code>20771</Postal_Code>
+                    <Country>USA</Country>
+                </Address>
+                <Phone>
+                    <Number>301-614-5224</Number>
+                    <Type>Telephone</Type>
+                </Phone>
+                <Phone>
+                    <Number>301-614-5268</Number>
+                    <Type>Fax</Type>
+                </Phone>
+                <Email>gsfc-help-disc@lists.nasa.gov</Email>
+            </Contact_Group>
+        </Personnel>
+    </Organization>
+    <Distribution>
+        <Distribution_Media>Online Archive</Distribution_Media>
+        <Distribution_Size>376.1 MB per file</Distribution_Size>
+        <Distribution_Format>HDF-EOS</Distribution_Format>
+        <Fees>None</Fees>
+    </Distribution>
+    <Multimedia_Sample>
+        <File>airx3std.jpg</File>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png</URL>
+        <Format>JPEG</Format>
+        <Caption>Sample data of AIRX3STD</Caption>
+        <Description>Sample data of the "AIRS/Aqua Level 3 daily standard physical retrieval product (Without HSB)".</Description>
+    </Multimedia_Sample>
+    <Reference>
+        <Author>Joel Susskind, John, M. Blaisdell, and Lena Iredell</Author>
+        <Publication_Date>2014/03/31</Publication_Date>
+        <Title>Improved methodology for surface and atmospheric soundings, error estimates, and quality control procedures: the atmospheric infrared sounder science team version-6 retrieval algorithm</Title>
+        <Series>J. Appl. Rem. Sens.</Series>
+        <Volume>8</Volume>
+        <Issue>1</Issue>
+        <Pages>34</Pages>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.1117/1.JRS.8.084994</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Reference>
+        <Author>B.H. Kahn, et.al.</Author>
+        <Publication_Date>2014/01/10</Publication_Date>
+        <Title>The Atmospheric Infrared Sounder Version 6 Cloud Products</Title>
+        <Series>Atmospheric Chemistry and Physics</Series>
+        <Volume>14</Volume>
+        <Issue>1</Issue>
+        <Pages>399-426</Pages>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.5194/acp-14-399-2014</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Summary>
+        <Abstract>The Atmospheric Infrared Sounder (AIRS) is a grating spectrometer (R = 1200) aboard the second Earth Observing System (EOS) polar-orbiting platform, EOS Aqua. In combination with the Advanced Microwave Sounding Unit (AMSU) and the Humidity Sounder for Brazil (HSB), AIRS constitutes an innovative atmospheric sounding group of visible, infrared, and microwave sensors. The AIRS Level 3 Daily Gridded Product contains standard retrieval means, standard deviations and input counts. Each file covers a temporal period of 24 hours for either the descending (equatorial crossing North to South @1:30 AM local time) or ascending (equatorial crossing South to North @1:30 PM local time) orbit. The data starts at the international dateline and progresses westward (as do the subsequent orbits of the satellite) so that neighboring gridded cells of data are no more than a swath of time apart (about 90 minutes). The two parts of a scan line crossing the dateline are included in separate L3 files, according to the date, so that data points in a grid box are always coincident in time. The edge of the AIRS Level 3 gridded cells is at the date line (the 180E/W longitude boundary). When plotted, this produces a map with 0 degrees longitude in the center of the image unless the bins are reordered. This method is preferred because the left (West) side of the image and the right (East) side of the image contain data farthest apart in time. The gridding scheme used by AIRS is the same as used by TOVS Pathfinder to create Level 3 products. The daily Level 3 products have gores between satellite paths where there is no coverage for that day. The geophysical parameters have been averaged and binned into 1 x 1 deg grid cells, from -180.0 to +180.0 deg longitude and from -90.0 to +90.0 deg latitude. For each grid map of 4-byte floating-point mean values there is a corresponding 4-byte floating-point map of standard deviation and a 2-byte integer grid map of counts. The counts map provides the user with the number of points per bin that were included in the mean and can be used to generate custom multi-day maps from the daily gridded products. The thermodynamic parameters are: Skin Temperature (land and sea surface), Air Temperature at the surface, Profiles of Air Temperature and Water Vapor, Tropopause Characteristics, Column Precipitable Water, Cloud Amount/Frequency, Cloud Height, Cloud Top Pressure, Cloud Top Temperature, Reflectance, Emissivity, Surface Pressure, Cloud Vertical Distribution. The trace gases parameters are: Total Amounts and Vertical Profiles of Carbon Monoxide, Methane, and Ozone. The actual names of the variables in the data files should be inferred from the Processing File Description document.</Abstract>
+    </Summary>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>DATA TREE</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/</URL>
+        <Description>Access the data via HTTP.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>OPENDAP DATA</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html</URL>
+        <Description>Access the data via the OPeNDAP protocol.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GOTO WEB TOOL</Type>
+            <Subtype>SIMPLE SUBSET WIZARD (SSW)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006</URL>
+        <Description>Use the Simple Subset Wizard (SSW) to submit subset requests for data sets across multiple data centers from a single unified interface.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>Earthdata Search</Subtype>
+        </URL_Content_Type>
+        <URL>https://search.earthdata.nasa.gov/search?q=AIRX3STD+006</URL>
+        <Description>Use the Earthdata Search to find and retrieve data sets across multiple data centers.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB MAP SERVICE (WMS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&amp;version=1.1.1&amp;request=GetCapabilities</URL>
+        <Description>NASA GES DISC AIRS Gridded L3 data Web Map Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB MAP SERVICE (WMS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&amp;VERSION=1.1.1&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;WIDTH=720&amp;HEIGHT=360&amp;LAYERS=AIRX3STD_TOTH2OVAP_A&amp;TRANSPARENT=TRUE&amp;FORMAT=image/png&amp;bbox=-180,-90,180,90</URL>
+        <Description>Get map example for NASA GES DISC AIRS Gridded L3 data Web Map Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB COVERAGE SERVICE (WCS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&amp;version=1.0.0&amp;request=GetCapabilities</URL>
+        <Description>NASA GES DISC AIRS Gridded L3 data Web Coverage Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB COVERAGE SERVICE (WCS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&amp;version=1.0.0&amp;request=GetCoverage&amp;CRS=EPSG:4326&amp;format=netCDF&amp;resx=1.0&amp;resy=1.0&amp;BBOX=-179.5,-89.5,179.5,89.5&amp;Coverage=AIRX3STD:CO_VMR_A&amp;Time=2013-08-11</URL>
+        <Description>Get Coverage data example for NASA GES DISC AIRS Gridded L3 data Web Coverage Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>PROJECT HOME PAGE</Type>
+        </URL_Content_Type>
+        <URL>https://airs.jpl.nasa.gov/index.html</URL>
+        <Description>AIRS home page at NASA/JPL. General information on the AIRS instrument, algorithms, and other AIRS-related activities can be found.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+        </URL_Content_Type>
+        <URL>https://disc.gsfc.nasa.gov/information/documents?title=AIRS%20Documentation</URL>
+        <Description>AIRS Documentation Page</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>READ-ME</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf</URL>
+        <Description>README Document</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>GENERAL DOCUMENTATION</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf</URL>
+        <Description>AIRS Version 6 Processing Files Description Document.</Description>
+    </Related_URL>
+    <Originating_Metadata_Node>GCMD</Originating_Metadata_Node>
+    <Metadata_Name>CEOS IDN DIF</Metadata_Name>
+    <Metadata_Version>VERSION 10.2</Metadata_Version>
+    <DIF_Revision_History>2016-01-28, Ed Esfandiari - Modified fields for DIF10.2 compatibility.
+      2016-03-30, Ed Esfandiari - Added index.html to https://airs.jpl.nasa.gov/ to avoid broken link.
+      2016-03-30, Ed Esfandiari - Changed _V006.html to _006.html (landing page).
+      2016-03-31, Ed Esfandiari - Removed "sci" from "disc.sci.gsfc.nasa.gov" links.
+      2016-04-15, Ed Esfandiari - Misc. changes to Titles, Summary, etc..
+      2016-12-05, Ed Esfandiari - Changed Plone document links to docserver.
+      2017-09-27, Ed Esfandiari - Added temporal end date.</DIF_Revision_History>
+    <Metadata_Dates>
+        <Metadata_Creation>2013-02-14</Metadata_Creation>
+        <Metadata_Last_Revision>2018-05-21</Metadata_Last_Revision>
+        <Metadata_Future_Review>2016-07-01</Metadata_Future_Review>
+        <Data_Creation>Not provided</Data_Creation>
+        <Data_Last_Revision>Not provided</Data_Last_Revision>
+    </Metadata_Dates>
+    <Product_Level_Id>3</Product_Level_Id>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.disc</Group>
+            <Name>Data Granularity</Name>
+            <Description>The time coverage of individual data granules.</Description>
+            <Value>1 day</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.uuid</Name>
+            <Value>2b9d4ac2-3143-4a02-aacf-be728da1b858</Value>
+        </Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.extraction_date</Name>
+            <Value>2015-12-22 13:28:23</Value>
+        </Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.keyword_version</Name>
+            <Value>8.1</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>DIF9.0-to-DIF10-Converter</Name>
+            <Value>2015-12-28T18:06:58Z</Value>
+            <Value>Version:-3.0</Value>
+            <Value>Target:10.2</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Discipline</Name>
+            <Value>EARTH SCIENCE</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>IDN_Node.Short_Name</Name>
+            <Value>ECHO</Value>
+            <Value>USA/NASA</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>IDN_Node.UUID</Name>
+            <Value>2efb470f-61f8-4046-b2ee-ebed27e2f310</Value>
+            <Value>9ae20472-ba4c-4b01-8d97-857b73fa3c95</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Dataset_Citation.DOI</Name>
+            <Value>10.5067/Aqua/AIRS/DATA301</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Metadata_Version</Name>
+            <Value>VERSION 9.8.4</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Dataset_Language</Name>
+            <Value>English</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.tool</Name>
+            <Value>2018-05-21:docbuilder</Value>
+        </Metadata>
+    </Extended_Metadata>
+</DIF>

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -10,6 +10,7 @@
    [cmr.common-app.config :as common-config]
    [cmr.common-app.test.side-api :as side]
    [cmr.common.mime-types :as mt]
+   [cmr.common.test.url-util :as uu]
    [cmr.common.util :as util :refer [are2 are3]]
    [cmr.common.xml :as cx]
    [cmr.search.validators.opendata :as opendata-json]
@@ -680,6 +681,33 @@
                                            {:dataset-id "Dataset1"}
                                            {:url-extension "json"})
                 [:status :results])))))))
+
+(deftest opendata-search-result
+  (testing "opendata references are url encoded"
+    (let [concept (d/ingest-concept-with-metadata-file
+                   "cmr-5136-opendata-related-urls.xml"
+                   {:provider-id "PROV1"
+                    :concept-type :collection
+                    :format-key :dif10
+                    :native-id "cmr-5136-related-url-test"})
+          _ (index/wait-until-indexed)
+          opendata (search/find-concepts-opendata :collection {:concept_id (:concept-id concept)})
+          references (:references (first (get-in opendata [:results :dataset])))]
+      (is (= (set (map uu/url->comparable-url
+                       ["https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png"
+                        "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/"
+                        "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html"
+                        "https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006"
+                        "https://search.earthdata.nasa.gov/search?q=AIRX3STD+006"
+                        "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&version=1.1.1&request=GetCapabilities"
+                        "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG%3A4326&WIDTH=720&HEIGHT=360&LAYERS=AIRX3STD_TOTH2OVAP_A&TRANSPARENT=TRUE&FORMAT=image%2Fpng&bbox=-180%2C-90%2C180%2C90"
+                        "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCapabilities"
+                        "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCoverage&CRS=EPSG%3A4326&format=netCDF&resx=1.0&resy=1.0&BBOX=-179.5%2C-89.5%2C179.5%2C89.5&Coverage=AIRX3STD%3ACO_VMR_A&Time=2013-08-11"
+                        "https://airs.jpl.nasa.gov/index.html"
+                        "https://disc.gsfc.nasa.gov/information/documents?title=AIRS+Documentation"
+                        "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf"
+                        "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf"]))
+             (set (map uu/url->comparable-url references)))))))
 
 (deftest formats-have-scores-test
   (let [coll1 (d/ingest "PROV1" (dc/collection {:short-name "ABC!XYZ" :entry-title "Foo"}))]

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -10,7 +10,7 @@
    [cmr.common-app.config :as common-config]
    [cmr.common-app.test.side-api :as side]
    [cmr.common.mime-types :as mt]
-   [cmr.common.test.url-util :as uu]
+   [cmr.common.test.url-util :as url-util]
    [cmr.common.util :as util :refer [are2 are3]]
    [cmr.common.xml :as cx]
    [cmr.search.validators.opendata :as opendata-json]
@@ -693,7 +693,7 @@
           _ (index/wait-until-indexed)
           opendata (search/find-concepts-opendata :collection {:concept_id (:concept-id concept)})
           references (:references (first (get-in opendata [:results :dataset])))]
-      (is (= (set (map uu/url->comparable-url
+      (is (= (set (map url-util/url->comparable-url
                        ["https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png"
                         "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/"
                         "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html"
@@ -707,7 +707,7 @@
                         "https://disc.gsfc.nasa.gov/information/documents?title=AIRS+Documentation"
                         "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf"
                         "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf"]))
-             (set (map uu/url->comparable-url references)))))))
+             (set (map url-util/url->comparable-url references)))))))
 
 (deftest formats-have-scores-test
   (let [coll1 (d/ingest "PROV1" (dc/collection {:short-name "ABC!XYZ" :entry-title "Foo"}))]

--- a/umm-lib/src/cmr/umm/related_url_helper.clj
+++ b/umm-lib/src/cmr/umm/related_url_helper.clj
@@ -1,7 +1,8 @@
 (ns cmr.umm.related-url-helper
   "Contains functions for categorizing UMM related urls."
   (:require
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   [ring.util.codec :as codec]))
 
 (def DOCUMENTATION_MIME_TYPES
   "Mime Types that indicate the RelatedURL is of documentation type"
@@ -86,3 +87,28 @@
   "Returns a sequence of atom links for the given related urls"
   [related-urls]
   (map related-url->atom-link related-urls))
+
+(defn- url-encoded?
+  "Test to see if url is encoded."
+  [url]
+  (not (= url (codec/url-decode url))))
+
+(defn- encode-url
+  "Encode the query portion of the url."
+  [url]
+  (let [split-url (string/split url #"\?")
+        base-url (first split-url)
+        params (apply str (rest split-url))]
+    (if (not-empty params)
+      (->> params
+           codec/form-decode
+           codec/form-encode
+           (str base-url "?"))
+      url)))
+
+(defn related-url->encoded-url
+  "Test to see if the url is encoded. If not, encode it."
+  [related-url]
+  (if (and related-url (not (url-encoded? related-url)))
+    (encode-url related-url)
+    related-url))

--- a/umm-lib/src/cmr/umm/related_url_helper.clj
+++ b/umm-lib/src/cmr/umm/related_url_helper.clj
@@ -88,18 +88,13 @@
   [related-urls]
   (map related-url->atom-link related-urls))
 
-(defn- url-encoded?
-  "Test to see if url is encoded."
-  [url]
-  (not (= url (codec/url-decode url))))
-
 (defn- encode-url
   "Encode the query portion of the url."
   [url]
-  (let [split-url (string/split url #"\?")
+  (let [split-url (string/split url #"\?" 2)
         base-url (first split-url)
-        params (apply str (rest split-url))]
-    (if (not-empty params)
+        params (second split-url)]
+    (if params
       (->> params
            codec/form-decode
            codec/form-encode
@@ -107,8 +102,8 @@
       url)))
 
 (defn related-url->encoded-url
-  "Test to see if the url is encoded. If not, encode it."
+  "Ensure URL is encoded."
   [related-url]
-  (if (and related-url (not (url-encoded? related-url)))
+  (if related-url
     (encode-url related-url)
     related-url))

--- a/umm-lib/test/cmr/umm/test/related_url_helper.clj
+++ b/umm-lib/test/cmr/umm/test/related_url_helper.clj
@@ -2,9 +2,9 @@
   "Tests functions that categorize related urls."
   (:require
    [clojure.test :refer :all]
-   [cmr.common.test.url-util :as uu]
+   [cmr.common.test.url-util :as url-util]
    [cmr.common.util :as util :refer [are3]]
-   [cmr.umm.related-url-helper :as ru]
+   [cmr.umm.related-url-helper :as related-url-helper]
    [cmr.umm.umm-collection :as umm-c]))
 
 (deftest categorize-related-urls
@@ -26,16 +26,16 @@
                          {:type "GET SERVICE"
                           :url "http://camex.nsstc.nasa.gov/camex3/"})
           related-urls [downloadable-url browse-url documentation-url metadata-url]]
-      (is (= [downloadable-url] (ru/downloadable-urls related-urls)))
-      (is (= [browse-url] (ru/browse-urls related-urls)))
-      (is (= [documentation-url] (ru/documentation-urls related-urls)))
-      (is (= [metadata-url] (ru/metadata-urls related-urls))))))
+      (is (= [downloadable-url] (related-url-helper/downloadable-urls related-urls)))
+      (is (= [browse-url] (related-url-helper/browse-urls related-urls)))
+      (is (= [documentation-url] (related-url-helper/documentation-urls related-urls)))
+      (is (= [metadata-url] (related-url-helper/metadata-urls related-urls))))))
 
 (deftest related-url->encoded-url
   (testing "encode related urls"
     (are3 [expected-url url-to-encode]
-          (is (= (uu/url->comparable-url expected-url)
-                 (uu/url->comparable-url (ru/related-url->encoded-url url-to-encode))))
+          (is (= (url-util/url->comparable-url expected-url)
+                 (url-util/url->comparable-url (related-url-helper/related-url->encoded-url url-to-encode))))
 
           "URL with no query string"
           "https://cmr.earthdata.nasa.gov/search/collections.umm_json?"
@@ -61,7 +61,7 @@
           "https://example.org/example?arithmetic=1%2B2%2B3%2B4&slashes=a%2Fb%2Fc&spaces=a+b+c&spaces=a+b+c&spaces=a+b+c"
           "https://example.org/example?arithmetic=1%2B2%2B3%2B4&slashes=a/b/c&spaces=a%20b%20c&spaces=a+b+c&spaces=a b c"
 
-          "Plus signs/spaces remaing spaces and arithmetic plus sign encodings remain encoded"
+          "Plus signs/spaces remain spaces and arithmetic plus sign encodings remain encoded"
           "https://plus-signs.plus/addition?arithmetic=1%2B2%2B3&spaces=a+b+c&spaces=a+b+c"
           "https://plus-signs.plus/addition?arithmetic=1%2B2%2B3&spaces=a%20b%20c&spaces=a+b+c"
 


### PR DESCRIPTION
* Check if related url is already encoded
* If so, skip. If not, encode it.
* Encode only the query '?' portion of the URL.