### PR TITLE
CMR-5080: Log metadata-size-bytes with provider info, after successful ingest

### DIFF
--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -44,11 +44,15 @@
     (common-enabled/validate-write-enabled request-context "ingest")
     (let [concept (api-core/body->concept! :collection provider-id native-id body content-type headers)
           validation-options (get-validation-options headers)
+          ;; Log the ingest attempt
+          _ (info (format "Ingesting collection %s from client %s"
+                          (api-core/concept->loggable-string concept)
+                          (:client-id request-context)))
           save-collection-result (ingest/save-collection
                                   request-context
                                   (api-core/set-user-id concept request-context headers)
                                   validation-options)]
-      ;;Log the size of the metadata after successful ingest.
+      ;; Log the successful ingest, with the metadata size in bytes.
       (api-core/log-concept-with-metadata-size 
         (assoc concept :entry-title (:entry-title save-collection-result)) request-context)
       (api-core/generate-ingest-response headers

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -48,9 +48,9 @@
                                   request-context
                                   (api-core/set-user-id concept request-context headers)
                                   validation-options)]
-      (info (format "Ingesting collection %s from client %s"
-              (api-core/concept->loggable-string (assoc concept :entry-title (:entry-title save-collection-result)))
-              (:client-id request-context)))
+      ;;Log the size of the metadata after successful ingest.
+      (api-core/log-concept-with-metadata-size 
+        (assoc concept :entry-title (:entry-title save-collection-result)) request-context)
       (api-core/generate-ingest-response headers
                                          (api-core/contextualize-warnings
                                           ;; entry-title is added just for the logging above.

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -236,8 +236,7 @@
   [concept request-context]
   (let [metadata-size-bytes (-> (:metadata concept) (.getBytes "UTF-8") alength)
         concept (assoc concept :metadata-size-bytes metadata-size-bytes)]
-    (info (format "Ingesting %s %s from client %s"
-                  (name (:concept-type concept)) 
+    (info (format "Successfully ingested %s from client %s"
                   (concept->loggable-string concept)
                   (:client-id request-context)))))
 

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -205,8 +205,6 @@
 (defn metadata->concept
   "Create a metadata concept from the given metadata"
   [concept-type metadata content-type headers]
-  (info (format "Size of metadata (in bytes) to be ingested: [%s]"
-                (-> metadata (.getBytes "UTF-8") alength)))
   (-> {:metadata metadata
        :format (mt/keep-version content-type)
        :native-id (:name metadata)
@@ -232,6 +230,16 @@
   "Returns a string with information about the concept as a loggable string."
   [concept]
   (pr-str (dissoc concept :metadata)))
+
+(defn log-concept-with-metadata-size
+  "Log the concept with metadata-size-bytes added, and metadata removed."
+  [concept request-context]
+  (let [metadata-size-bytes (-> (:metadata concept) (.getBytes "UTF-8") alength)
+        concept (assoc concept :metadata-size-bytes metadata-size-bytes)]
+    (info (format "Ingesting %s %s from client %s"
+                  (name (:concept-type concept)) 
+                  (concept->loggable-string concept)
+                  (:client-id request-context)))))
 
 (defn set-default-error-format [default-response-format handler]
   "Ring middleware to add a default format to the exception-info created during exceptions. This

--- a/ingest-app/src/cmr/ingest/api/granules.clj
+++ b/ingest-app/src/cmr/ingest/api/granules.clj
@@ -65,10 +65,11 @@
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
-    (let [concept (api-core/body->concept! :granule provider-id native-id body content-type headers)]
-      (info (format "Ingesting granule %s from client %s"
-                    (api-core/concept->loggable-string concept) (:client-id request-context)))
-      (api-core/generate-ingest-response headers (ingest/save-granule request-context concept)))))
+    (let [concept (api-core/body->concept! :granule provider-id native-id body content-type headers)
+          save-granule-result (ingest/save-granule request-context concept)]
+      ;;Log the size of the metadata after successful ingest.
+      (api-core/log-concept-with-metadata-size concept request-context)
+      (api-core/generate-ingest-response headers save-granule-result))))
 
 (defn delete-granule
   [provider-id native-id request]

--- a/ingest-app/src/cmr/ingest/api/granules.clj
+++ b/ingest-app/src/cmr/ingest/api/granules.clj
@@ -66,8 +66,12 @@
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
     (let [concept (api-core/body->concept! :granule provider-id native-id body content-type headers)
+          ;; Log the ingest attempt
+          _ (info (format "Ingesting granule %s from client %s"
+                          (api-core/concept->loggable-string concept) 
+                          (:client-id request-context)))
           save-granule-result (ingest/save-granule request-context concept)]
-      ;;Log the size of the metadata after successful ingest.
+      ;; Log the successful ingest, with the metadata size in bytes.
       (api-core/log-concept-with-metadata-size concept request-context)
       (api-core/generate-ingest-response headers save-granule-result))))
 

--- a/ingest-app/src/cmr/ingest/api/services.clj
+++ b/ingest-app/src/cmr/ingest/api/services.clj
@@ -31,8 +31,12 @@
     (common-enabled/validate-write-enabled request-context "ingest")
     (let [concept (validate-and-prepare-service-concept concept)
           concept-with-user-id (api-core/set-user-id concept request-context headers)
+          ;; Log the ingest attempt
+          _ (info (format "Ingesting service %s from client %s"
+                          (api-core/concept->loggable-string concept-with-user-id) 
+                          (:client-id request-context)))
           save-service-result (ingest/save-service request-context concept-with-user-id)]
-      ;;Log the size of the metadata after successful ingest.
+      ;; Log the successful ingest, with the metadata size in bytes. 
       (api-core/log-concept-with-metadata-size concept-with-user-id request-context)
       (api-core/generate-ingest-response headers save-service-result))))
 

--- a/ingest-app/src/cmr/ingest/api/services.clj
+++ b/ingest-app/src/cmr/ingest/api/services.clj
@@ -29,10 +29,12 @@
     (acl/verify-ingest-management-permission
       request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
-    (let [concept (validate-and-prepare-service-concept concept)]
-      (->> (api-core/set-user-id concept request-context headers)
-           (ingest/save-service request-context)
-           (api-core/generate-ingest-response headers)))))
+    (let [concept (validate-and-prepare-service-concept concept)
+          concept-with-user-id (api-core/set-user-id concept request-context headers)
+          save-service-result (ingest/save-service request-context concept-with-user-id)]
+      ;;Log the size of the metadata after successful ingest.
+      (api-core/log-concept-with-metadata-size concept-with-user-id request-context)
+      (api-core/generate-ingest-response headers save-service-result))))
 
 (defn delete-service
   "Deletes the service with the given provider id and native id."

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -36,8 +36,12 @@
     (common-enabled/validate-write-enabled request-context "ingest")
     (let [concept (validate-and-prepare-variable-concept concept)
           concept-with-user-id (api-core/set-user-id concept request-context headers)
+          ;; Log the ingest attempt
+          _ (info (format "Ingesting service %s from client %s"
+                          (api-core/concept->loggable-string concept-with-user-id) 
+                          (:client-id request-context)))
           save-variable-result (ingest/save-variable request-context concept-with-user-id)]
-      ;;Log the size of the metadata after successful ingest.
+      ;; Log the successful ingest, with the metadata size in bytes. 
       (api-core/log-concept-with-metadata-size concept-with-user-id request-context)
       (api-core/generate-ingest-response headers save-variable-result))))
 

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -34,10 +34,12 @@
     (acl/verify-ingest-management-permission
       request-context :update :provider-object provider-id)
     (common-enabled/validate-write-enabled request-context "ingest")
-    (let [concept (validate-and-prepare-variable-concept concept)]
-      (->> (api-core/set-user-id concept request-context headers)
-           (ingest/save-variable request-context)
-           (api-core/generate-ingest-response headers)))))
+    (let [concept (validate-and-prepare-variable-concept concept)
+          concept-with-user-id (api-core/set-user-id concept request-context headers)
+          save-variable-result (ingest/save-variable request-context concept-with-user-id)]
+      ;;Log the size of the metadata after successful ingest.
+      (api-core/log-concept-with-metadata-size concept-with-user-id request-context)
+      (api-core/generate-ingest-response headers save-variable-result))))
 
 (defn delete-variable
   "Deletes the variable with the given provider id and native id."


### PR DESCRIPTION
This PR is addressing  three issues:
1. Logging other concept info together with the metadata-size-bytes, specifically provider info so that Catalino could get all the metadata size ingested for a given provider.
2. Logging the metadata size only after successful ingest.
3. Make sure we log both the attempt and the success of ingest. The difference is at the attempt, the metadata-size-bytes is not logged. Currently granule ingest is logged at the attempt, collection ingest is logged at the success, service and variable ingest are not logged.  These all need to be changed.

The log will look sth like:
[a83aa11a-281a-48c0-b2fe-f232231074f7] INFO [cmr.ingest.api.core] - Successfully ingested concept {:format "application/echo10+xml", :native-id "20040618200000-OSISAF-L3C_GHRSST-SSTsubskin-SEVIRI_SST-ssteqc_meteosat08_20040618_200000-v02.0-fv01.0.nc", :concept-type :granule, :provider-id "PODAAC", :metadata-size-bytes 2574} from client unknown

As to whether the file is always UTF-8 encoded, I'm not sure. I'm just using the same code Mark used before to calculate the size, which was approved by the team. 