### PR TITLE
CMR-5122 Running cubby cache operations should require a token

### DIFF
--- a/cubby-app/src/cmr/cubby/api/routes.clj
+++ b/cubby-app/src/cmr/cubby/api/routes.clj
@@ -74,13 +74,16 @@
     (GET "/" {context :request-context}
       (get-keys context))
     (DELETE "/" {context :request-context}
+      (acl/verify-ingest-management-permission context :update)
       (delete-all-values context))
     (context "/:key-name" [key-name]
       (GET "/" {context :request-context}
         (get-value context key-name))
       (PUT "/" {context :request-context body :body}
+        (acl/verify-ingest-management-permission context :update)
         (set-value context key-name (slurp body)))
       (DELETE "/" {context :request-context}
+        (acl/verify-ingest-management-permission context :update)
         (delete-value context key-name)))))
 
 (def admin-routes

--- a/system-int-test/src/cmr/system_int_test/system.clj
+++ b/system-int-test/src/cmr/system_int_test/system.clj
@@ -42,7 +42,7 @@
              ;; A map of the components (echo, elastic, db, and message queue) to whether they are
              ;; in-memory or external
              :component-type-map component-type-map}]
-    (transmit-config/system-with-connections sys [:echo-rest :search :access-control :urs :ingest])))
+    (transmit-config/system-with-connections sys [:echo-rest :search :access-control :urs :ingest :cubby])))
 
 (defn- get-component-type-map
   "Returns the component-type-map from dev-system."

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -80,12 +80,12 @@
   (format "http://localhost:%s/reset" (transmit-config/cubby-port)))
 
 (defn cubby-keys-url
-  ""
+  "URL to delete or get all keys"
   []
   (format "http://localhost:%s/keys" (transmit-config/cubby-port)))
 
 (defn cubby-key-name-url
-  ""
+  "URL to get, set, or delete specific keys"
   [key-name]
   (format "http://localhost:%s/keys/%s" (transmit-config/cubby-port) key-name))
 

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -79,6 +79,15 @@
   []
   (format "http://localhost:%s/reset" (transmit-config/cubby-port)))
 
+(defn cubby-keys-url
+  ""
+  []
+  (format "http://localhost:%s/keys" (transmit-config/cubby-port)))
+
+(defn cubby-key-name-url
+  ""
+  [key-name]
+  (format "http://localhost:%s/keys/%s" (transmit-config/cubby-port) key-name))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Metadata DB URLs

--- a/system-int-test/test/cmr/system_int_test/admin/admin_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/admin_permissions_test.clj
@@ -1,15 +1,14 @@
 (ns cmr.system-int-test.admin.admin-permissions-test
   "Verifies the correct administrative permissions are enforced admin only apis"
-  (:require [clojure.test :refer :all]
-            [cmr.system-int-test.utils.ingest-util :as ingest]
-            [cmr.system-int-test.utils.search-util :as search]
-            [cmr.system-int-test.utils.index-util :as index]
-            [cmr.mock-echo.client.echo-util :as e]
-            [cmr.system-int-test.utils.url-helper :as url]
-            [cmr.system-int-test.system :as s]
-            [cmr.system-int-test.utils.index-util :as index-util]
-            [cmr.transmit.config :as transmit-config]
-            [clj-http.client :as client]))
+  (:require
+   [clj-http.client :as client]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.url-helper :as url]
+   [cmr.transmit.cubby :as cubby]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"} {:grant-all-search? false
                                                                  :grant-all-ingest? false}))
@@ -17,19 +16,21 @@
 (defn has-action-permission?
   "Attempts to perform the given action using the url and method with the token. Returns true
   if the action was successful."
-  [url method token]
-  (let [response (client/request {:url url
-                                  :method method
-                                  :query-params {:token token}
-                                  :connection-manager (s/conn-mgr)
-                                  :throw-exceptions false})
-        status (:status response)]
-     ;; Make sure the status returned is success or 401
-    (is (some #{status} [200 201 204 401]))
-    (not= status 401)))
+  ([url method token]
+   (has-action-permission? url method token nil))
+  ([url method token body]
+   (let [response (client/request {:url url
+                                   :method method
+                                   :body body
+                                   :query-params {:token token}
+                                   :connection-manager (s/conn-mgr)
+                                   :throw-exceptions false})
+         status (:status response)]
+      ;; Make sure the status returned is success or 401
+     (is (some #{status} [200 201 204 401]))
+     (not= status 401))))
 
 (deftest ingest-management-permission-test
-
   (let [admin-read-update-group-concept-id (e/get-or-create-group (s/context) "admin-read-update-group")
         admin-read-group-concept-id (e/get-or-create-group (s/context) "admin-read-group")
         admin-update-group-concept-id (e/get-or-create-group (s/context) "admin-update-group")
@@ -41,7 +42,16 @@
         admin-read-token (e/login (s/context) "admin1" [admin-read-group-concept-id group3-concept-id])
         admin-update-token (e/login (s/context) "admin2" [admin-update-group-concept-id group3-concept-id])
         admin-read-update-token (e/login (s/context) "admin3" [admin-read-update-group-concept-id group3-concept-id])
-        prov-admin-token (e/login (s/context) "prov-admin" [prov-admin-group-concept-id group3-concept-id])]
+        prov-admin-token (e/login (s/context) "prov-admin" [prov-admin-group-concept-id group3-concept-id])
+        check-all-permissions (fn [url method]
+                                (is
+                                  (and
+                                   (not (has-action-permission? url method prov-admin-token))
+                                   (not (has-action-permission? url method guest-token))
+                                   (not (has-action-permission? url method user-token))
+                                   (not (has-action-permission? url method admin-read-token))
+                                   (has-action-permission? url method admin-update-token)
+                                   (has-action-permission? url method admin-read-update-token))))]
 
     ;; Grant admin-group-guid admin permission
     (e/grant-group-admin (s/context) admin-read-group-concept-id :read)
@@ -50,29 +60,76 @@
     ;; Grant provider admin permission, but not system permission
     (e/grant-group-provider-admin (s/context) prov-admin-group-concept-id "PROV1" :read :update)
 
-    (are [url]
-      (and
-       (not (has-action-permission? url :post prov-admin-token))
-       (not (has-action-permission? url :post guest-token))
-       (not (has-action-permission? url :post user-token))
-       (not (has-action-permission? url :post admin-read-token))
-       (has-action-permission? url :post admin-update-token)
-       (has-action-permission? url :post admin-read-update-token))
+    (testing "Admin permissions test"
+      (are3 [url methods]
+        (check-all-permissions url methods)
 
-      (url/search-clear-cache-url)
-      (url/search-reset-url)
-      (url/indexer-clear-cache-url)
-      (url/indexer-reset-url)
-      (url/enable-ingest-writes-url)
-      (url/disable-ingest-writes-url)
-      (url/enable-search-writes-url)
-      (url/disable-search-writes-url)
-      (url/enable-access-control-writes-url)
-      (url/disable-access-control-writes-url)
-      (url/mdb-reset-url)
-      (url/index-set-reset-url)
-      (url/cubby-reset-url)
-      (url/reindex-collection-permitted-groups-url)
-      (url/reindex-all-collections-url)
-      (url/cleanup-expired-collections-url)
-      (url/access-control-reindex-acls-url))))
+        "search-clear-cache"
+        (url/search-clear-cache-url) :post
+
+        "search-reset"
+        (url/search-reset-url) :post
+
+        "indexer-clear-cache"
+        (url/indexer-clear-cache-url) :post
+
+        "indexer-reset"
+        (url/indexer-reset-url) :post
+
+        "enable-ingest-writes"
+        (url/enable-ingest-writes-url) :post
+
+        "disable-ingest-write"
+        (url/disable-ingest-writes-url) :post
+
+        "enable-search-writes"
+        (url/enable-search-writes-url) :post
+
+        "disable-search-writes"
+        (url/disable-search-writes-url) :post
+
+        "enable-access-control-writes"
+        (url/enable-access-control-writes-url) :post
+
+        "disable-access-control-writes"
+        (url/disable-access-control-writes-url) :post
+
+        "mdb-reset"
+        (url/mdb-reset-url) :post
+
+        "index-set-reset"
+        (url/index-set-reset-url) :post
+
+        "cubby-reset"
+        (url/cubby-reset-url) :post
+
+        "reindex-collection-permitted-groups"
+        (url/reindex-collection-permitted-groups-url) :post
+
+        "reindex-all-collections"
+        (url/reindex-all-collections-url) :post
+
+        "cleanup-expired-collections"
+        (url/cleanup-expired-collections-url) :post
+
+        "access-control-reindex-acls"
+        (url/access-control-reindex-acls-url) :post))
+
+    (testing "Cubby permission test"
+      (let [tokens [prov-admin-token guest-token
+                    user-token admin-read-token admin-update-token
+                    admin-read-update-token]
+            permissions [false false false false true true]
+            permissions-map (zipmap tokens permissions)]
+        (doseq [token (keys permissions-map)
+                :let [permission (get permissions-map token)]]
+          (cubby/delete-all-values (s/context))
+          (cubby/set-value (s/context) :test-name1 "test-value1")
+          (cubby/set-value (s/context) :test-name2 "test-value2")
+          (is (and
+                (= permission
+                   (has-action-permission? (url/cubby-key-name-url :test-name3) :put token "test-value3"))
+                (= permission
+                   (has-action-permission? (url/cubby-key-name-url :test-name2) :delete token))
+                (= permission
+                   (has-action-permission? (url/cubby-keys-url) :delete token)))))))))

--- a/transmit-lib/src/cmr/transmit/cubby.clj
+++ b/transmit-lib/src/cmr/transmit/cubby.clj
@@ -40,21 +40,24 @@
    (h/request context :cubby {:url-fn (partial key-url key-name)
                               :method :put
                               :raw? raw
-                              :http-options {:body value}})))
+                              :http-options {:body value}
+                              :use-system-token? true})))
 
 (defn delete-value
   "Dissociates the value with the given key."
   ([context key-name]
    (delete-value context key-name false))
   ([context key-name raw]
-   (h/request context :cubby {:url-fn (partial key-url key-name), :method :delete, :raw? raw})))
+   (h/request context :cubby {:url-fn (partial key-url key-name), :method :delete, :raw? raw
+                              :use-system-token? true})))
 
 (defn delete-all-values
   "Deletes all values"
   ([context]
    (delete-all-values context false))
   ([context raw]
-   (h/request context :cubby {:url-fn keys-url, :method :delete, :raw? raw})))
+   (h/request context :cubby {:url-fn keys-url, :method :delete, :raw? raw
+                              :use-system-token? true})))
 
 ;; Defines reset function
 (h/defresetter reset :cubby)


### PR DESCRIPTION
![](https://media1.giphy.com/media/mo8MAe2maHrva/giphy.gif)

This PR puts potentially destructive cubby endpoints behind the ingest management acl for extra security.  These functions are behind the VPN in any case.