### PR TITLE
CMR-5135: Improvements to the distribution and references fields in opendata response.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -168,7 +168,8 @@
         {short-name :ShortName version-id :Version entry-title :EntryTitle
          collection-data-type :CollectionDataType summary :Abstract
          temporal-keywords :TemporalKeywords platforms :Platforms
-         related-urls :RelatedUrls collection-temporal-extents :TemporalExtents} collection
+         related-urls :RelatedUrls collection-temporal-extents :TemporalExtents
+         publication-references :PublicationReferences} collection
         parsed-version-id (collection-util/parse-version-id version-id)
         doi (get-in collection [:DOI :DOI])
         doi-lowercase (util/safe-lowercase doi)
@@ -182,6 +183,8 @@
                                collection-data-type)
         entry-id (eid/entry-id short-name version-id)
         opendata-related-urls (map opendata/related-url->opendata-related-url related-urls)
+        opendata-references (keep opendata/publication-reference->opendata-reference
+                                  publication-references)
         personnel (opendata/opendata-email-contact collection)
         platforms (map util/map-keys->kebab-case platforms)
         kms-index (kf/get-kms-index context)
@@ -350,6 +353,7 @@
             :summary summary
             :metadata-format (name (mt/format-key format))
             :related-urls (map json/generate-string opendata-related-urls)
+            :publication-references opendata-references
             :update-time update-time
             :insert-time insert-time
             :created-at created-at

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -29,17 +29,30 @@
 (defn related-url->opendata-related-url
   "Returns the opendata related url for the given collection related url"
   [related-url]
-  (let [{:keys [Title Description Type Subtype URL]} related-url
+  (let [{:keys [Description Type Subtype URL]} related-url
         MimeType (get-in related-url [:GetService :MimeType])
         size (get-in related-url [:GetData :Size])]
-    ;; See CMR-3446. The current UMM JSON RelatedUrlType is flawed in that there can be multiple
-    ;; URLs, but only a single Title, MimeType and FileSize. This model doesn't make sense.
-    ;; Talked to Erich and he said that we are going to change the model.
-    ;; So for now, we make the assumption that there is only one URL in each RelatedUrlType.
     {:type Type
      :sub-type Subtype
      :url URL
      :description Description
      :mime-type MimeType
-     :title Title
      :size size}))
+
+(def doi-base-url
+  "The base DOI URL."
+  "https://doi.org")
+
+(defn- doi->url
+  "Converts a DOI into a URL if it is not already a URL."
+  [doi]
+  (if (re-matches #"http.*" doi)
+    doi
+    (format "%s/%s" doi-base-url doi)))
+
+(defn publication-reference->opendata-reference
+  "Returns an opendata reference for the given collection publication reference. Opendata only
+  allows a string for a publication reference, so we'll use the DOI of the publication reference."
+  [publication-reference]
+  (when-let [doi (-> publication-reference :DOI :DOI)]
+    (doi->url doi)))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -410,6 +410,7 @@
           ;; field in the opendata format.
           :science-keywords-flat (m/stored m/string-field-mapping)
           :related-urls (m/stored m/string-field-mapping)
+          :publication-references (m/stored m/string-field-mapping)
           :contact-email (m/stored m/string-field-mapping)
           :personnel (m/stored m/string-field-mapping)
 

--- a/system-int-test/src/cmr/system_int_test/data2/opendata.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/opendata.clj
@@ -74,7 +74,7 @@
   (let [{:keys [format-key concept-id data-format provider-id]} collection
         collection (data-core/mimic-ingest-retrieve-metadata-conversion collection)
         {:keys [short-name keywords projects related-urls summary entry-title organizations
-                access-value personnel]} collection
+                access-value personnel publication-references]} collection
         spatial-representation (get-in collection [:spatial-coverage :spatial-representation])
         ;; ECSE-158 - We will use UMM-C's DataDates to get insert-time, update-time for DIF9/DIF10.
         ;; DIF9 doesn't support DataDates in umm-spec-lib:
@@ -93,7 +93,7 @@
         end-date (when end-date (str/replace (str end-date) #"\.000Z" "Z"))
         shapes (map (partial umm-s/set-coordinate-system spatial-representation)
                     (get-in collection [:spatial-coverage :geometries]))
-        distribution (not-empty (odrh/distribution related-urls))
+        distribution (not-empty (map odrh/related-url->distribution related-urls))
         project-sn (not-empty (map :short-name projects))
         personnel (person-with-email personnel)
         contact-point (contact-point personnel)
@@ -117,7 +117,8 @@
                             :distribution distribution
                             :landingPage (odrh/landing-page related-urls)
                             :language [odrh/LANGUAGE_CODE]
-                            :references (not-empty (map :url related-urls))
+                            :references (not-empty
+                                         (map ru/related-url->encoded-url publication-references))
                             :issued (when insert-time (str insert-time))})))
 
 (defn collections->expected-opendata


### PR DESCRIPTION
![data-dot-gov](https://user-images.githubusercontent.com/4248343/45957623-71a63700-bfe3-11e8-8131-5535f0997efa.png)

Made changes to no longer export a MIME-type for access URLs since only download URLs are supposed to have a MIME-type. Added the description field to all of the distributions. Changed the references field to only include DOIs from Publication References instead of duplicating the list of distributions.

Before:
```
    "references" : [ "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png", "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/", "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html", "https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006", "https://search.earthdata.nasa.gov/search?q=AIRX3STD+006", "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&version=1.1.1&request=GetCapabilities", "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG:4326&WIDTH=720&HEIGHT=360&LAYERS=AIRX3STD_TOTH2OVAP_A&TRANSPARENT=TRUE&FORMAT=image/png&bbox=-180,-90,180,90", "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCapabilities", "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCoverage&CRS=EPSG:4326&format=netCDF&resx=1.0&resy=1.0&BBOX=-179.5,-89.5,179.5,89.5&Coverage=AIRX3STD:CO_VMR_A&Time=2013-08-11", "https://airs.jpl.nasa.gov/index.html", "https://disc.gsfc.nasa.gov/information/documents?title=AIRS%20Documentation", "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf", "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf" ]
    "distribution" : [ {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://search.earthdata.nasa.gov/search?q=AIRX3STD+006",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&version=1.1.1&request=GetCapabilities",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG:4326&WIDTH=720&HEIGHT=360&LAYERS=AIRX3STD_TOTH2OVAP_A&TRANSPARENT=TRUE&FORMAT=image/png&bbox=-180,-90,180,90",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCapabilities",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCoverage&CRS=EPSG:4326&format=netCDF&resx=1.0&resy=1.0&BBOX=-179.5,-89.5,179.5,89.5&Coverage=AIRX3STD:CO_VMR_A&Time=2013-08-11",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://airs.jpl.nasa.gov/index.html",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://disc.gsfc.nasa.gov/information/documents?title=AIRS%20Documentation",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf",
      "mediaType" : "application/octet-stream"
    }, {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf",
      "mediaType" : "application/octet-stream"
    } ]
```
After:
```
    "references" : [ "https://doi.org/10.1117/1.JRS.8.084994", "https://doi.org/10.5194/acp-14-399-2014" ],
    "distribution" : [ {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png",
      "description" : "Sample data of the \"AIRS/Aqua Level 3 daily standard physical retrieval product (Without HSB)\"."
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/",
      "description" : "Access the data via HTTP."
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html",
      "description" : "Access the data via the OPeNDAP protocol."
    }, {
      "accessURL" : "https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006",
      "description" : "Use the Simple Subset Wizard (SSW) to submit subset requests for data sets across multiple data centers from a single unified interface."
    }, {
      "accessURL" : "https://search.earthdata.nasa.gov/search?q=AIRX3STD+006",
      "description" : "Use the Earthdata Search to find and retrieve data sets across multiple data centers."
    }, {
      "accessURL" : "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&version=1.1.1&request=GetCapabilities",
      "description" : "NASA GES DISC AIRS Gridded L3 data Web Map Service."
    }, {
      "accessURL" : "https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?LAYERS=AIRX3STD_TOTH2OVAP_A&TRANSPARENT=TRUE&HEIGHT=360&VERSION=1.1.1&WIDTH=720&SRS=EPSG%3A4326&bbox=-180%2C-90%2C180%2C90&FORMAT=image%2Fpng&service=WMS&REQUEST=GetMap",
      "description" : "Get map example for NASA GES DISC AIRS Gridded L3 data Web Map Service."
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&version=1.0.0&request=GetCapabilities",
      "description" : "NASA GES DISC AIRS Gridded L3 data Web Coverage Service."
    }, {
      "accessURL" : "https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?Coverage=AIRX3STD%3ACO_VMR_A&resy=1.0&BBOX=-179.5%2C-89.5%2C179.5%2C89.5&CRS=EPSG%3A4326&request=GetCoverage&version=1.0.0&resx=1.0&service=WCS&Time=2013-08-11&format=netCDF",
      "description" : "Get Coverage data example for NASA GES DISC AIRS Gridded L3 data Web Coverage Service."
    }, {
      "accessURL" : "https://airs.jpl.nasa.gov/index.html",
      "description" : "AIRS home page at NASA/JPL. General information on the AIRS instrument, algorithms, and other AIRS-related activities can be found."
    }, {
      "accessURL" : "https://disc.gsfc.nasa.gov/information/documents?title=AIRS+Documentation",
      "description" : "AIRS Documentation Page"
    }, {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf",
      "description" : "README Document"
    }, {
      "accessURL" : "https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf",
      "description" : "AIRS Version 6 Processing Files Description Document."
    } ]
```