### PR TITLE
CMR-5057, CMR-5058, CMR-5059: Added support of GranuleUR, CollectionReference and ProviderDates in UMM-G

### DIFF
--- a/system-int-test/src/cmr/system_int_test/data2/core.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/core.clj
@@ -18,7 +18,7 @@
    [cmr.umm-spec.legacy :as umm-legacy]
    [cmr.umm-spec.test.location-keywords-helper :as lkt]
    [cmr.umm-spec.umm-spec-core :as umm-spec]
-   [cmr.umm-spec.versioning :as ver]
+   [cmr.umm-spec.versioning :as versioning]
    [cmr.umm.umm-core :as umm]))
 
 (defn- item->native-id
@@ -40,7 +40,7 @@
                                    :version version})
     (if (= :umm-json format-key)
       (mime-types/format->mime-type {:format format-key
-                                     :version (ver/current-version concept-type)})
+                                     :version (versioning/current-version concept-type)})
       (mime-types/format->mime-type format-key))))
 
 (defn item->concept

--- a/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
@@ -1,5 +1,5 @@
 (ns cmr.system-int-test.search.umm-json-search-test
-  "Integration test for UMMJSON format search"
+  "Integration test for UMM-JSON format search"
   (:require
    [clojure.test :refer :all]
    [cmr.common.mime-types :as mt]

--- a/umm-spec-lib/resources/example-data/umm-json/granule/v1.4/GranuleExample.json
+++ b/umm-spec-lib/resources/example-data/umm-json/granule/v1.4/GranuleExample.json
@@ -1,0 +1,255 @@
+{
+  "GranuleUR": "Unique_Granule_UR",
+  "ProviderDates": [{
+    "Date": "2018-07-19T00:00:00Z",
+    "Type": "Create"
+  }, {
+    "Date": "2018-08-19T01:00:00Z",
+    "Type": "Insert"
+  }, {
+    "Date": "2018-09-19T02:00:00Z",
+    "Type": "Update"
+  }, {
+    "Date": "2030-08-19T03:00:00Z",
+    "Type": "Delete"
+  }],
+  "CollectionReference": {
+      "ShortName": "CollectionShortName",
+      "Version": "Version"
+  },
+  "AccessConstraints": {
+    "Description" : "Public Access",
+    "Value": 42
+  },
+  "DataGranule": {
+    "ArchiveAndDistributionInformation": [{
+      "Name": "GranuleZipFile",
+      "Size": 23,
+      "SizeUnit": "KB",
+      "Format": "ZIP",
+      "MimeType": "application/zip",
+      "Checksum": {
+        "Value": "E51569BF48DD0FD0640C6503A46D4753",
+        "Algorithm": "MD5"
+      },
+      "Files": [{
+        "Name": "GranuleFileName1",
+        "Size": 10,
+        "SizeUnit": "KB",
+        "Format": "NETCDF-4",
+        "MimeType": "application/x-netcdf",
+        "FormatType": "Native",
+        "Checksum": {
+          "Value": "E51569BF48DD0FD0640C6503A46D4754",
+          "Algorithm": "MD5"
+        }
+      }, {
+        "Name": "GranuleFileName2",
+        "Size": 1,
+        "SizeUnit": "KB",
+        "Format": "ASCII",
+        "MimeType": "text/plain",
+        "FormatType": "NA"
+      }]
+    }, {
+      "Name": "SupportedGranuleFileNotInPackage",
+      "Size": 11,
+      "SizeUnit": "KB",
+      "Format": "NETCDF-CF",
+      "FormatType": "Supported",
+      "MimeType": "application/x-netcdf",
+      "Checksum": {
+        "Value": "E51569BF48DD0FD0640C6503A46D4755",
+        "Algorithm": "MD5"
+      }
+    }],
+    "ReprocessingPlanned": "The Reprocessing Planned Statement Value",
+    "ReprocessingActual": "The Reprocessing Actual Statement Value",
+    "DayNightFlag" : "Unspecified",
+    "ProductionDateTime" : "2018-07-19T12:01:01Z",
+    "Identifiers": [{
+      "Identifier": "SMAP_L3_SM_P_20150407_R13080_001.h5",
+      "IdentifierType": "ProducerGranuleId"
+    }, {
+      "Identifier": "LocalVersionIdValue",
+      "IdentifierType": "LocalVersionId"
+    }, {
+      "Identifier": "FeatureIdValue1",
+      "IdentifierType": "FeatureId"
+    }, {
+      "Identifier": "FeatureIdValue2",
+      "IdentifierType": "FeatureId"
+    }, {
+      "Identifier": "1234",
+      "IdentifierType": "Other",
+      "IdentifierName": "SomeIdentifier"
+    },{
+      "Identifier": "CRIDValue",
+      "IdentifierType": "CRID"
+    }]
+  },
+  "PGEVersionClass": {
+    "PGEName": "A PGE Name",
+    "PGEVersion": "6.0.27"
+  },
+  "TemporalExtent": {
+    "RangeDateTime": {
+      "BeginningDateTime": "2018-07-17T00:00:00.000Z",
+      "EndingDateTime": "2018-07-17T23:59:59.999Z"
+    }
+  },
+  "SpatialExtent": {
+    "GranuleLocalities": ["GranuleLocality1", "GranuleLocality2"],
+    "HorizontalSpatialDomain": {
+      "ZoneIdentifier": "ZoneIdentifier 1",
+      "Geometry": {
+        "Points": [{
+          "Longitude": -77,
+          "Latitude": 88
+        }, {
+          "Longitude":10,
+          "Latitude": 10
+        }],
+        "BoundingRectangles": [{
+          "WestBoundingCoordinate": -180,
+          "NorthBoundingCoordinate": 85.04450225830078,
+          "EastBoundingCoordinate": 180,
+          "SouthBoundingCoordinate": -85.04450225830078
+        }],
+        "GPolygons": [{
+          "Boundary" : {
+            "Points": [ {"Longitude":-10, "Latitude":-10}, {"Longitude":10, "Latitude":-10}, {"Longitude":10, "Latitude":10}, {"Longitude":-10, "Latitude":10}, {"Longitude":-10, "Latitude":-10}]
+          },
+          "ExclusiveZone": {
+            "Boundaries": [{
+              "Points": [{"Longitude":-5, "Latitude":-5}, {"Longitude":-1, "Latitude":-5}, {"Longitude":-1, "Latitude":-1}, {"Longitude":-5, "Latitude":-1}, {"Longitude":-5, "Latitude":-5}]
+            }, {
+              "Points": [{"Longitude":0, "Latitude":0}, {"Longitude":5, "Latitude":0}, {"Longitude":5, "Latitude":5}, {"Longitude":0, "Latitude":5}, {"Longitude":0, "Latitude":0}]
+            }]
+          }
+        }],
+        "Lines": [{
+          "Points": [ {"Longitude":-100, "Latitude":-70}, {"Longitude":-88, "Latitude":-66}]
+        }]
+      }
+    },
+    "VerticalSpatialDomains": [{
+      "Type": "Atmosphere Layer",
+      "Value": "Atmosphere Profile"
+    }, {
+      "Type": "Pressure",
+      "Value": "100",
+      "Unit": "HectoPascals"
+    }, {
+      "Type": "Altitude",
+      "MinimumValue": "10",
+      "MaximumValue": "100",
+      "Unit": "Meters"
+    }]
+  },
+  "OrbitCalculatedSpatialDomains": [{
+    "OrbitalModelName": "OrbitalModelName",
+    "BeginOrbitNumber": 99263,
+    "EndOrbitNumber": 99263,
+    "EquatorCrossingLongitude":88.92,
+    "EquatorCrossingDateTime": "2018-08-16T16:22:21.000Z"
+  }],
+  "MeasuredParameters": [{
+    "ParameterName": "Parameter Name",
+    "QAStats": {
+      "QAPercentMissingData": 10,
+      "QAPercentOutOfBoundsData": 20,
+      "QAPercentInterpolatedData": 30,
+      "QAPercentCloudCover": 40
+    },
+    "QAFlags": {
+      "AutomaticQualityFlag": "Passed",
+      "AutomaticQualityFlagExplanation": "Automatic Quality Flag Explanation",
+      "OperationalQualityFlag": "Passed",
+      "OperationalQualityFlagExplanation": "Operational Quality Flag Explanation",
+      "ScienceQualityFlag": "Passed",
+      "ScienceQualityFlagExplanation": "Science Quality Flag Explanation"
+    }
+  }],
+  "Platforms": [{
+    "ShortName": "Aqua",
+    "Instruments": [{
+      "ShortName": "AMSR-E",
+      "Characteristics": [{
+        "Name": "InstrumentCaracteristicName1",
+        "Value": "150"
+      }, {
+        "Name": "InstrumentCaracteristicName2",
+        "Value": "22F"
+      }],
+      "ComposedOf": [{
+        "ShortName": "AMSR-E_ChildInstrument",
+        "Characteristics": [{
+          "Name": "ChildInstrumentCharacteristicName3",
+          "Value": "250"
+        }],
+        "OperationalModes": ["Mode3"]
+      }],
+      "OperationalModes": ["Mode1", "Mode2"]
+    }]
+  }],
+  "Projects": [{
+    "ShortName": "Project1",
+    "Campaigns": ["Campaign1"]
+  }, {
+    "ShortName": "Project2",
+    "Campaigns": ["Campaign2", "Campaign3"]
+  }],
+  "AdditionalAttributes": [{
+    "Name": "AdditionalAttribute1 Name1",
+    "Values": ["AdditionalAttribute1 Value3", "AdditionalAttribute1 Value4"]
+  }, {
+    "Name": "EVI1KM16DAYQCLASSPERCENTAGE",
+    "Values": ["EVI1KM16DAYQCLASSPERCENTAGE Value5", "EVI1KM16DAYQCLASSPERCENTAGE Value6"]
+  }, {
+    "Name": "QAFRACTIONGOODQUALITY",
+    "Values": ["QAFRACTIONGOODQUALITY Value7", "QAFRACTIONGOODQUALITY Value8"]
+  }, {
+    "Name": "QAFRACTIONNOTPRODUCEDCLOUD",
+    "Values": ["QAFRACTIONNOTPRODUCEDCLOUD Value9", "QAFRACTIONNOTPRODUCEDCLOUD Value10"]
+  }],
+  "InputGranules": ["InputGranule1", "InputGranule2"],
+   "TilingIdentificationSystem": {
+    "TilingIdentificationSystemName": "MODIS Tile EASE",
+    "Coordinate1": {
+      "MinimumValue": -100,
+      "MaximumValue": -50
+    },
+    "Coordinate2": {
+      "MinimumValue": 50,
+      "MaximumValue": 100
+    }
+  },
+  "CloudCover": 60,
+  "RelatedUrls": [{
+    "URL": "https://daac.ornl.gov/daacdata/islscp_ii/vegetation/erbe_albedo_monthly_xdeg/data/erbe_albedo_1deg_1986.zip",
+    "Type": "GET DATA",
+    "Description": "This link provides direct download access to the granule.",
+    "Format": "ZIP",
+    "MimeType": "application/zip",
+    "Size": 395.673,
+    "SizeUnit": "KB"
+  }, {
+    "URL": "https://daac.ornl.gov/ISLSCP_II/guides/erbe_albedo_monthly_xdeg.html",
+    "Type": "VIEW RELATED INFORMATION",
+    "Subtype": "USER'S GUIDE",
+    "Description": "ORNL DAAC Data Set Documentation",
+    "Format": "HTML",
+    "MimeType": "text/html"
+  }, {
+    "URL": "https://webmap.ornl.gov/sdat/pimg/957_1.png",
+    "Type": "GET RELATED VISUALIZATION",
+    "Description": "ISLSCP II EARTH RADIATION BUDGET EXPERIMENT (ERBE) MONTHLY ALBEDO, 1986-1990",
+    "Format": "PNG",
+    "MimeType": "image/png",
+    "Size": 10,
+    "SizeUnit": "MB"
+  }],
+  "NativeProjectionNames": ["MODIS Sinusoidal System", "Sinusoidal"],
+  "GridMappingNames": ["Sinusoidal", "Lambert Azimuthal Equal-Area"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/umm_g/granule.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_g/granule.clj
@@ -17,6 +17,7 @@
   "Returns a UMM DataProviderTimestamps from a parsed XML structure"
   [umm-g]
   (let [provider-dates (:ProviderDates umm-g)
+        ;; umm-lib Granule model does not have create-time, so ignore it for now.
         ; create-time (get-date-by-type provider-dates "Create")
         insert-time (get-date-by-type provider-dates "Insert")
         update-time (get-date-by-type provider-dates "Update")

--- a/umm-spec-lib/src/cmr/umm_spec/umm_g/granule.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_g/granule.clj
@@ -8,6 +8,25 @@
    [cmr.common.util :as util])
   (:import cmr.umm.umm_granule.UmmGranule))
 
+(defn- get-date-by-type
+  "Returns the date of the given type from the given provider dates"
+  [provider-dates date-type]
+  (some #(when (= date-type (:Type %)) (:Date %)) provider-dates))
+
+(defn- umm-g->DataProviderTimestamps
+  "Returns a UMM DataProviderTimestamps from a parsed XML structure"
+  [umm-g]
+  (let [provider-dates (:ProviderDates umm-g)
+        ; create-time (get-date-by-type provider-dates "Create")
+        insert-time (get-date-by-type provider-dates "Insert")
+        update-time (get-date-by-type provider-dates "Update")
+        delete-time (get-date-by-type provider-dates "Delete")]
+    (g/map->DataProviderTimestamps
+     {;;:create-time create-time
+      :insert-time insert-time
+      :update-time update-time
+      :delete-time delete-time})))
+
 (defn- umm-g->CollectionRef
   "Returns a UMM ref element from a parsed UMM-G JSON"
   [umm-g-json]
@@ -21,7 +40,7 @@
   [umm-g-json]
   (let [coll-ref (umm-g->CollectionRef umm-g-json)]
     (g/map->UmmGranule {:granule-ur (:GranuleUR umm-g-json)
-                        ; :data-provider-timestamps data-provider-timestamps
+                        :data-provider-timestamps (umm-g->DataProviderTimestamps umm-g-json)
                         :collection-ref coll-ref
                         ; :data-granule (xml-elem->DataGranule umm-g-json)
                         ; :access-value (cx/double-at-path umm-g-json [:RestrictionFlag])

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_g/granule.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_g/granule.clj
@@ -1,0 +1,77 @@
+(ns cmr.umm-spec.test.umm-g.granule
+  "Tests parsing and generating UMM-G granule."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :refer [for-all]]
+   [cmr.common.date-time-parser :as p]
+   [cmr.common.test.test-check-ext :refer [defspec]]
+   [cmr.umm-spec.umm-spec-core :as core]
+   [cmr.umm.test.generators.granule :as gran-gen]
+   [cmr.umm.umm-granule :as umm-lib-g]))
+
+(def umm-g-coll-refs
+  "Generator for UMM-G granule collection ref. It does not support entry-id,
+  only entry title, short name & version."
+  (gen/one-of [gran-gen/coll-refs-w-entry-title gran-gen/coll-refs-w-short-name-version]))
+
+(def umm-g-granules
+  "Generator for UMM-G granule"
+  (gen/fmap #(assoc % :collection-ref (gen/generate umm-g-coll-refs)) gran-gen/granules))
+
+(defn- umm->expected-parsed
+  "Modifies the UMM record for testing UMM-G. As the fields are added to UMM-G support for
+  parsing and generating in cmr.umm-spec.umm-g.granule, the fields should be taken off the
+  excluded list below."
+  [gran]
+  (-> gran
+      (dissoc :data-granule)
+      (dissoc :access-value)
+      (dissoc :temporal)
+      (dissoc :spatial-coverage)
+      (dissoc :related-urls)
+      (dissoc :orbit-calculated-spatial-domains)
+      (dissoc :platform-refs)
+      (dissoc :project-refs)
+      (dissoc :product-specific-attributes)
+      (dissoc :cloud-cover)
+      (dissoc :two-d-coordinate-system)
+      (dissoc :measured-parameters)
+      umm-lib-g/map->UmmGranule))
+
+(defspec generate-granule-is-valid-umm-g-test 100
+  (for-all [granule umm-g-granules]
+    (let [metadata (core/generate-metadata {} granule :umm-json)]
+      (empty? (core/validate-metadata :granule :umm-json metadata)))))
+
+(defspec generate-and-parse-umm-g-granule-test 100
+  (for-all [granule (gen/no-shrink  umm-g-granules)]
+    (let [umm-g-metadata (core/generate-metadata {} granule :umm-json)
+          parsed (core/parse-metadata {} :granule :umm-json umm-g-metadata)
+          expected-parsed (umm->expected-parsed granule)]
+      (= parsed expected-parsed))))
+
+(def sample-umm-g-granule
+  (slurp (io/file (io/resource "example-data/umm-json/granule/v1.4/GranuleExample.json"))))
+
+(def expected-granule
+  (umm-lib-g/map->UmmGranule
+   {:granule-ur "Unique_Granule_UR"
+    :data-provider-timestamps (umm-lib-g/map->DataProviderTimestamps
+                               {:insert-time (p/parse-datetime "2018-08-19T01:00:00Z")
+                                :update-time (p/parse-datetime "2018-09-19T02:00:00Z")
+                                :delete-time (p/parse-datetime "2030-08-19T03:00:00Z")})
+    :collection-ref (umm-lib-g/map->CollectionRef
+                     {:entry-title nil
+                      :short-name "CollectionShortName"
+                      :version-id "Version"})
+    :data-granule nil
+    :access-value nil
+    :temporal nil
+    :spatial-coverage nil
+    :related-urls nil}))
+
+(deftest parse-granule-test
+  (testing "parse granule"
+    (is (= expected-granule (core/parse-metadata {} :granule :umm-json sample-umm-g-granule)))))


### PR DESCRIPTION
Added support of GranuleUR, CollectionReference and ProviderDates in UMM-G. 
Set up basic umm-spec-lib to do roundtrip test from umm-lib Granule model to UMM-G then back to umm-lib Granule model.