### PR TITLE
CMR-5081: collection render without granule change

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -27,6 +27,7 @@
     [commons-io]]
   :dependencies [
     [commons-io "2.6"]
+    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
     [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
     [org.clojure/clojure "1.8.0"]

--- a/collection-renderer-lib/resources/collection_preview/collection_preview.erb
+++ b/collection-renderer-lib/resources/collection_preview/collection_preview.erb
@@ -42,7 +42,7 @@ metadata =  JSON.parse(umm_json)
     </header>
 
     <div class="row row-content">
-      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: metadata, relative_root_url: relative_root_url, edsc_url: edsc_url, concept_id: concept_id } %>
+      <%= render partial: 'cmr_metadata_preview/metadata_preview', locals: { metadata: metadata, relative_root_url: relative_root_url, edsc_url: edsc_url, concept_id: concept_id, additional_information: additional_information } %>
     </div>
   </main>
 

--- a/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
+++ b/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
@@ -128,13 +128,19 @@
 
 (defn render-collection
   "Renders a UMM-C collection record and returns the HTML as a string."
-  [context collection concept-id]
-  (let [umm-json (umm-json/umm->json
-                  (vm/migrate-umm context
-                                  :collection
-                                  umm-version/current-collection-version
-                                  (context->preview-gem-umm-version context)
-                                  collection))]
+  ([context collection concept-id]
+   (render-collection
+    context
+    collection
+    concept-id
+    (get-additional-information context concept-id)))
+  ([context collection concept-id additional_information]
+   (let [umm-json (umm-json/umm->json
+                   (vm/migrate-umm context
+                                   :collection
+                                   umm-version/current-collection-version
+                                   (context->preview-gem-umm-version context)
+                                   collection))]
     (render-erb (context->jruby-runtime context)
                 collection-preview-erb
                 ;; Arguments for collection preview. See the ERB file for documentation.
@@ -142,4 +148,4 @@
                  "relative_root_url" (context->relative-root-url context)
                  "edsc_url" (search-edsc-url)
                  "concept_id" concept-id
-                 "additional_information" (get-additional-information context concept-id)})))
+                 "additional_information" additional_information}))))

--- a/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
+++ b/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
@@ -134,7 +134,7 @@
     collection
     concept-id
     (get-additional-information context concept-id)))
-  ([context collection concept-id additional_information]
+  ([context collection concept-id additional-information]
    (let [umm-json (umm-json/umm->json
                    (vm/migrate-umm context
                                    :collection
@@ -148,4 +148,4 @@
                  "relative_root_url" (context->relative-root-url context)
                  "edsc_url" (search-edsc-url)
                  "concept_id" concept-id
-                 "additional_information" additional_information}))))
+                 "additional_information" additional-information}))))

--- a/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
+++ b/collection-renderer-lib/test/cmr/collection_renderer/test/services/collection_renderer.clj
@@ -6,6 +6,7 @@
    [cmr.collection-renderer.services.collection-renderer :as cr]
    [cmr.common.lifecycle :as l]
    [cmr.common.test.test-check-ext :as ext :refer [defspec]]
+   [cmr.common.util :as util :refer [are3]]
    [cmr.umm-spec.test.expected-conversion :as expected-conversion]
    [cmr.umm-spec.test.umm-generators :as umm-gen]
    [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
@@ -25,7 +26,7 @@
 (deftest render-default-collection
   (testing "Get returned HTML"
     (let [coll expected-conversion/example-collection-record
-          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
+          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1" {})]
       (is (string/includes? html (:EntryTitle coll))))))
 
 ;; This checks that we can render any UMM collection without getting an exception.
@@ -33,19 +34,39 @@
 (defspec render-any-umm-collection 10
   (testing "Render without exception"
     (for-all [umm-record (gen/no-shrink umm-gen/umm-c-generator)]
-      (let [^String html (cr/render-collection (renderer-context) umm-record "C1234-PROV1")]
+      (let [^String html (cr/render-collection (renderer-context) umm-record "C1234-PROV1" {})]
         (and html (string/includes? html (:EntryTitle umm-record)))))))
 
 (deftest render-title-as-entry-title
   (testing "Verify that the title of the html is the entry title"
     (let [coll expected-conversion/example-collection-record
-          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
+          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1" {})]
       (is (string/includes? html (str "<title>" (:EntryTitle coll) "</title>"))))))
 
 (deftest render-edsc-link
-  (testing "Verify that the correct EDSC url is rendered"
-    (let [coll expected-conversion/example-collection-record
-          ^String html (cr/render-collection (renderer-context) coll "C1234-PROV1")]
-      (is (string/includes?
-           html
-           "https://search.earthdata.nasa.gov/search/granules?p=C1234-PROV1")))))
+  (testing "Render EDSC links for collections with and without granules"
+    (are3 [additional-information expected]
+          (is (= expected
+                 (string/includes?
+                  (cr/render-collection (renderer-context) expected-conversion/example-collection-record "C1234-PROV1" additional-information)
+                  "https://search.earthdata.nasa.gov/search/granules?p=C1234-PROV1")))
+
+          "Render collection with granules"
+          {"granule_count" 1}
+          true
+
+          "Render collection without granules"
+          {"granule_count" 0}
+          false
+
+          "Render collection with negative granules"
+          {"granule_count" -1}
+          false
+
+          "Render collection without granule_count"
+          {}
+          false
+
+          "Test nil granule_count"
+          {"granule_count" nil}
+          false)))


### PR DESCRIPTION
Collections without granules should not render the _SEARCH FOR GRANULES FROM THIS COLLECTION_ button. This results in:

**Without granules:**
![without_granules](https://user-images.githubusercontent.com/11383467/46086247-b19d2380-c175-11e8-9f26-3ca0a0e6371a.png)

**With granules:**
![with_granules](https://user-images.githubusercontent.com/11383467/46086256-b7930480-c175-11e8-94ef-6d057fb125b9.png)