### PR TITLE
CMR-5106 Changing Entry Title of a collection causes it to disappear from searches until the ACL is re-created

### DIFF
--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -170,9 +170,6 @@
         ;; do frequently change, so to prevent temporary loss of permissions concept ids are used
         ;; when present.  There really shouldn't be a case where entry-tiles exist and concept-ids do
         ;; not.
-        ; (gc/and-conds (remove nil? [(or entry-titles-cond colls-in-prov-cond)
-        ;                             access-value-cond
-        ;                             temporal-cond]))
         (gc/and-conds (remove nil? [(or concept-ids-cond entry-titles-cond)
                                     access-value-cond
                                     temporal-cond])))

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -152,7 +152,6 @@
         (gc/or-conds [concept-ids-cond entry-titles-cond])
         (or concept-ids-cond entry-titles-cond)))))
 
-
 (defn collection-identifier->query-condition
   "Converts an acl collection identifier to an query condition. Switches implementations based
   on whether the user's query contained collection ids. This implementation assumes the query-coll-ids
@@ -165,9 +164,12 @@
             access-value-cond (some-> (access-value->query-condition access-value)
                                       q/->CollectionQueryCondition)
             temporal-cond (some-> temporal temporal->query-condition q/->CollectionQueryCondition)]
-
         ;; If there's no entry title condition the other conditions must be scoped by provider
-        (gc/and-conds (remove nil? [(or entry-titles-cond colls-in-prov-cond)
+        ;; In anycase we want to use concept ids instead of entry-titles, because entry-titles can and
+        ;; do frequently change, so to prevent temporary loss of permissions concept ids are used
+        ;; when present.  There really shouldn't be a case where entry-tiles exist and concept-ids do
+        ;; not.
+        (gc/and-conds (remove nil? [(or colls-in-prov-cond entry-titles-cond)
                                     access-value-cond
                                     temporal-cond])))
       ;; No other collection info provided so every collection in provider is possible

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -158,9 +158,10 @@
   passed in are limited to the provider of the collection identifier."
   [context query-coll-ids provider-id collection-identifier]
   (let [colls-in-prov-cond (provider->collection-condition query-coll-ids provider-id)]
-    (if-let [{:keys [entry-titles access-value temporal]} collection-identifier]
+    (if-let [{:keys [concept-ids entry-titles access-value temporal]} collection-identifier]
       (let [entry-titles-cond (provider+entry-titles->collection-condition
                                 context query-coll-ids provider-id entry-titles)
+            concept-ids-cond (provider->collection-condition concept-ids provider-id)
             access-value-cond (some-> (access-value->query-condition access-value)
                                       q/->CollectionQueryCondition)
             temporal-cond (some-> temporal temporal->query-condition q/->CollectionQueryCondition)]
@@ -169,7 +170,10 @@
         ;; do frequently change, so to prevent temporary loss of permissions concept ids are used
         ;; when present.  There really shouldn't be a case where entry-tiles exist and concept-ids do
         ;; not.
-        (gc/and-conds (remove nil? [(or colls-in-prov-cond entry-titles-cond)
+        ; (gc/and-conds (remove nil? [(or entry-titles-cond colls-in-prov-cond)
+        ;                             access-value-cond
+        ;                             temporal-cond]))
+        (gc/and-conds (remove nil? [(or concept-ids-cond entry-titles-cond)
                                     access-value-cond
                                     temporal-cond])))
       ;; No other collection info provided so every collection in provider is possible

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -51,7 +51,7 @@
   [context coll-ids-by-prov _ acls]
   (filter (fn [acl]
             (let [{{:keys [provider-id] :as cii} :catalog-item-identity} acl
-                  acl-coll-ids(map string/trim (get-in cii [:collection-identifier :concept-ids]))]
+                  acl-coll-ids (map string/trim (get-in cii [:collection-identifier :concept-ids]))]
               (and (:granule-applicable cii)
                    ;; applies to a provider the user is searching
                    (coll-ids-by-prov provider-id)

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -159,18 +159,12 @@
   [context query-coll-ids provider-id collection-identifier]
   (let [colls-in-prov-cond (provider->collection-condition query-coll-ids provider-id)]
     (if-let [{:keys [concept-ids entry-titles access-value temporal]} collection-identifier]
-      (let [entry-titles-cond (provider+entry-titles->collection-condition
-                                context query-coll-ids provider-id entry-titles)
-            concept-ids-cond (provider->collection-condition concept-ids provider-id)
+      (let [concept-ids-cond (provider->collection-condition concept-ids provider-id)
             access-value-cond (some-> (access-value->query-condition access-value)
                                       q/->CollectionQueryCondition)
             temporal-cond (some-> temporal temporal->query-condition q/->CollectionQueryCondition)]
-        ;; If there's no entry title condition the other conditions must be scoped by provider
-        ;; In anycase we want to use concept ids instead of entry-titles, because entry-titles can and
-        ;; do frequently change, so to prevent temporary loss of permissions concept ids are used
-        ;; when present.  There really shouldn't be a case where entry-tiles exist and concept-ids do
-        ;; not.
-        (gc/and-conds (remove nil? [(or concept-ids-cond entry-titles-cond)
+
+        (gc/and-conds (remove nil? [(or concept-ids-cond colls-in-prov-cond)
                                     access-value-cond
                                     temporal-cond])))
       ;; No other collection info provided so every collection in provider is possible

--- a/search-app/src/cmr/search/services/acls/granule_acls.clj
+++ b/search-app/src/cmr/search/services/acls/granule_acls.clj
@@ -164,7 +164,8 @@
                                       q/->CollectionQueryCondition)
             temporal-cond (some-> temporal temporal->query-condition q/->CollectionQueryCondition)]
 
-        (gc/and-conds (remove nil? [(or concept-ids-cond colls-in-prov-cond)
+        (gc/and-conds (remove nil? [concept-ids-cond
+                                    colls-in-prov-cond
                                     access-value-cond
                                     temporal-cond])))
       ;; No other collection info provided so every collection in provider is possible

--- a/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
@@ -348,9 +348,6 @@
                                                 :native-id "coll1"}))
         coll2 (d/ingest "PROV1" (dc/collection {:entry-title "coll2"
                                                 :native-id "coll2"}))
-        coll1-edited (-> coll1
-                         (assoc :entry-title "coll1-edited")
-                         (assoc :revision-id 2))
         gran1 (make-gran 1 coll1)
         gran2 (make-gran 2 coll1)
         gran3 (make-gran 3 coll2)
@@ -368,12 +365,14 @@
                                                         :concept-id (map :concept-id all-colls)}))
     (d/assert-refs-match [] (search/find-refs :granule {:token guest-token
                                                         :concept-id (map :concept-id all-colls)}))
+    ;; Update entry-title in collection.
     (d/ingest "PROV1" (dc/collection {:entry-title "coll1-edited"
                                       :native-id "coll1"}))
 
     (index/wait-until-indexed)
     (dev-sys-util/clear-caches)
 
+    ;; Confirm change in entry-title has not affected granule search.
     (d/assert-refs-match [gran1 gran2 gran3 gran4] (search/find-refs
                                                     :granule
                                                     {:token user1-token

--- a/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/granule.clj
@@ -338,3 +338,47 @@
                            :collection {:token user1-token
                                         :has-granules-created-at ["1975-01-01T10:00:00Z,"]})]
           (d/assert-refs-match [coll3 coll4 coll51 coll52 coll53] refs-result))))))
+
+(deftest granule-search-changed-entry-titles-test
+  (let [group1-concept-id (e/get-or-create-group (s/context) "group1")
+        guest-token (e/login-guest (s/context))
+        user1-token (e/login (s/context) "user1" [group1-concept-id])
+        user2-token (e/login (s/context) "user2")
+        coll1 (d/ingest "PROV1" (dc/collection {:entry-title "coll1"
+                                                :native-id "coll1"}))
+        coll2 (d/ingest "PROV1" (dc/collection {:entry-title "coll2"
+                                                :native-id "coll2"}))
+        coll1-edited (-> coll1
+                         (assoc :entry-title "coll1-edited")
+                         (assoc :revision-id 2))
+        gran1 (make-gran 1 coll1)
+        gran2 (make-gran 2 coll1)
+        gran3 (make-gran 3 coll2)
+        gran4 (make-gran 4 coll2)
+        all-colls [coll1 coll2]]
+
+    (index/wait-until-indexed)
+    (e/grant-group (s/context) group1-concept-id (e/gran-catalog-item-id
+                                                   "PROV1" (e/coll-id ["coll1" "coll2"])))
+    (d/assert-refs-match [gran1 gran2 gran3 gran4] (search/find-refs
+                                                    :granule
+                                                    {:token user1-token
+                                                     :concept-id (map :concept-id all-colls)}))
+    (d/assert-refs-match [] (search/find-refs :granule {:token user2-token
+                                                        :concept-id (map :concept-id all-colls)}))
+    (d/assert-refs-match [] (search/find-refs :granule {:token guest-token
+                                                        :concept-id (map :concept-id all-colls)}))
+    (d/ingest "PROV1" (dc/collection {:entry-title "coll1-edited"
+                                      :native-id "coll1"}))
+
+    (index/wait-until-indexed)
+    (dev-sys-util/clear-caches)
+
+    (d/assert-refs-match [gran1 gran2 gran3 gran4] (search/find-refs
+                                                    :granule
+                                                    {:token user1-token
+                                                     :concept-id (map :concept-id all-colls)}))
+    (d/assert-refs-match [] (search/find-refs :granule {:token user2-token
+                                                        :concept-id (map :concept-id all-colls)}))
+    (d/assert-refs-match [] (search/find-refs :granule {:token guest-token
+                                                        :concept-id (map :concept-id all-colls)}))))


### PR DESCRIPTION
This fixes granule searching, the prior PR only fixed collection searches.