### PR TITLE
CMR-5129: Fixes issue with missing orbit information for granules

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -47,6 +47,7 @@
 (defn orbit->circular-latitude-range
   "Compute a circular latitude range from the start and end latitudes of an orbit."
   [orbit]
+  (info "Orbit:" (pr-str orbit))
   (let [{:keys [^double start-lat ^double end-lat start-direction end-direction]} orbit
         start-lat (if (= :desc start-direction)
                     (- 180.0 start-lat)
@@ -62,6 +63,8 @@
 
 (defn spatial->elastic
   [parent-collection granule]
+  (info "Parent collection:" (pr-str parent-collection))
+  (info "Granule model:" (pr-str granule))
   (when-let [gsr (csk/->kebab-case-keyword (get-in parent-collection [:SpatialExtent :GranuleSpatialRepresentation]))]
     (cond
       (or (= gsr :geodetic) (= gsr :cartesian))

--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -47,7 +47,6 @@
 (defn orbit->circular-latitude-range
   "Compute a circular latitude range from the start and end latitudes of an orbit."
   [orbit]
-  (info "Orbit:" (pr-str orbit))
   (let [{:keys [^double start-lat ^double end-lat start-direction end-direction]} orbit
         start-lat (if (= :desc start-direction)
                     (- 180.0 start-lat)
@@ -63,8 +62,6 @@
 
 (defn spatial->elastic
   [parent-collection granule]
-  (info "Parent collection:" (pr-str parent-collection))
-  (info "Granule model:" (pr-str granule))
   (when-let [gsr (csk/->kebab-case-keyword (get-in parent-collection [:SpatialExtent :GranuleSpatialRepresentation]))]
     (cond
       (or (= gsr :geodetic) (= gsr :cartesian))

--- a/spatial-lib/src/cmr/spatial/encoding/gmd.clj
+++ b/spatial-lib/src/cmr/spatial/encoding/gmd.clj
@@ -9,12 +9,12 @@
   (:require
    [clojure.data.xml :as x]
    [clojure.string :as str]
-   [cmr.common.xml :as cx]
    [cmr.common.util :as util]
    [cmr.common.validations.core :as v]
-   [cmr.spatial.validation :as sv]
+   [cmr.common.xml :as cx]
    [cmr.spatial.encoding.gml :as gml]
-   [cmr.spatial.mbr :as mbr]))
+   [cmr.spatial.mbr :as mbr]
+   [cmr.spatial.validation :as sv]))
 
 (declare decode-geo-content)
 
@@ -34,10 +34,6 @@
 (defmulti decode-geo-content
   "Decode the content of a gmd:geographicElement"
   :tag)
-
-(defmethod decode-geo-content :default
-  [_]
-  nil)
 
 (defmethod encode cmr.spatial.mbr.Mbr
   [geometry]

--- a/umm-lib/src/cmr/umm/iso_smap/spatial.clj
+++ b/umm-lib/src/cmr/umm/iso_smap/spatial.clj
@@ -4,6 +4,7 @@
    [cmr.spatial.encoding.gmd :as gmd]
    [cmr.spatial.polygon :as poly]
    [cmr.spatial.ring-relations :as rr]
+   [cmr.umm.iso-smap.granule.orbit]
    [cmr.umm.umm-spatial :as umm-s]))
 
 ;; Because GML parsing assumes anti-clockwise order, but ISO SMAP

--- a/umm-lib/src/cmr/umm/iso_smap/spatial.clj
+++ b/umm-lib/src/cmr/umm/iso_smap/spatial.clj
@@ -4,8 +4,10 @@
    [cmr.spatial.encoding.gmd :as gmd]
    [cmr.spatial.polygon :as poly]
    [cmr.spatial.ring-relations :as rr]
-   [cmr.umm.iso-smap.granule.orbit]
-   [cmr.umm.umm-spatial :as umm-s]))
+   [cmr.umm.umm-spatial :as umm-s]
+
+   ;; Needed in order to pull in multi-method definitions for orbit gmd/encode and gmd/decode
+   [cmr.umm.iso-smap.granule.orbit]))
 
 ;; Because GML parsing assumes anti-clockwise order, but ISO SMAP
 ;; expects points in clockwise order, we need to flip the point order


### PR DESCRIPTION
  ![](https://media2.giphy.com/media/l3vRmBRTi4OacwYp2/giphy-tumblr.gif)
Also removed the default implementation of decode-geo-content since we never expect it to be called. An exception will now be thrown if a definition is missing making it much easier to debug.