### PR TITLE
CMR-5138: Use Granule's start/end date for issued/modified in opendata.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -174,8 +174,8 @@
           {start2 :granule-start-date-stored end2 :granule-end-date-stored} gt2]
       {:granule-start-date-stored (if (< (compare start1 start2) 0) start1 start2)
        :granule-end-date-stored (when (and end1 end2) ;; If either is nil return nil
-                           ;; else return max time
-                           (if (> (compare end1 end2) 0) end1 end2))})
+                                  ;; else return max time
+                                  (if (> (compare end1 end2) 0) end1 end2))})
     (or gt1 gt2)))
 
 (defn- merge-coll-gran-aggregates

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -93,10 +93,10 @@
                              (get-in bucket [:max-temporal :value]))
                  some-with-no-end (> (get-in bucket [:no-end-date :doc_count]) 0)]]
        [concept-id
-        {:granule-start-date earliest-start
+        {:granule-start-date-stored earliest-start
          ;; Max end date will be nil if there are some that have no end date. This indicates they go on
          ;; forever.
-         :granule-end-date (when-not some-with-no-end latest-end)}]))))
+         :granule-end-date-stored (when-not some-with-no-end latest-end)}]))))
 
 (defn- fetch-coll-gran-aggregates
   "Searches across all the granule indexes to aggregate by collection. Returns a map of collection
@@ -151,8 +151,8 @@
   (util/map-values
    (fn [aggregate-map]
      (-> aggregate-map
-         (update :granule-start-date joda-time->cachable-value)
-         (update :granule-end-date joda-time->cachable-value)))
+         (update :granule-start-date-stored joda-time->cachable-value)
+         (update :granule-end-date-stored joda-time->cachable-value)))
    coll-gran-aggregates))
 
 (defn- cached-value->coll-gran-aggregates
@@ -161,8 +161,8 @@
   (util/map-values
    (fn [aggregate-map]
      (-> aggregate-map
-         (update :granule-start-date cached-value->joda-time)
-         (update :granule-end-date cached-value->joda-time)))
+         (update :granule-start-date-stored cached-value->joda-time)
+         (update :granule-end-date-stored cached-value->joda-time)))
    cached-value))
 
 (defn- merge-granule-times
@@ -170,10 +170,10 @@
   [gt1 gt2]
 
   (if (and gt1 gt2)
-    (let [{start1 :granule-start-date end1 :granule-end-date} gt1
-          {start2 :granule-start-date end2 :granule-end-date} gt2]
-      {:granule-start-date (if (< (compare start1 start2) 0) start1 start2)
-       :granule-end-date (when (and end1 end2) ;; If either is nil return nil
+    (let [{start1 :granule-start-date-stored end1 :granule-end-date-stored} gt1
+          {start2 :granule-start-date-stored end2 :granule-end-date-stored} gt2]
+      {:granule-start-date-stored (if (< (compare start1 start2) 0) start1 start2)
+       :granule-end-date-stored (when (and end1 end2) ;; If either is nil return nil
                            ;; else return max time
                            (if (> (compare end1 end2) 0) end1 end2))})
     (or gt1 gt2)))

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -79,14 +79,16 @@
   [context concept-id collection]
   (let [start-date (spec-time/collection-start-date collection)
         end-date (spec-time/normalized-end-date collection)
-        {:keys [granule-start-date-stored granule-end-date-stored]} (cgac/get-coll-gran-aggregates context concept-id)
+        {:keys [granule-start-date-stored granule-end-date-stored]} 
+               (cgac/get-coll-gran-aggregates context concept-id)
         last-3-days (t/interval (t/minus (tk/now) (t/days 3)) (tk/now))
-        granule-end-date-stored (if (and granule-end-date-stored (t/within? last-3-days granule-end-date-stored))
-                           ;; If the granule end date is within the last 3 days we indicate that
-                           ;; the collection has no end date. This allows NRT collections to be
-                           ;; found even if the collection has been reindexed recently.
-                           nil
-                           granule-end-date-stored)
+        granule-end-date-stored (if (and granule-end-date-stored 
+                                         (t/within? last-3-days granule-end-date-stored))
+                                  ;; If the granule end date is within the last 3 days we indicate that
+                                  ;; the collection has no end date. This allows NRT collections to be
+                                  ;; found even if the collection has been reindexed recently.
+                                  nil
+                                  granule-end-date-stored)
         coll-start (index-util/date->elastic start-date)
         coll-end (index-util/date->elastic end-date)]
     (merge {:start-date coll-start
@@ -255,14 +257,16 @@
         coordinate-system (get-in collection [:SpatialExtent :HorizontalSpatialDomain
                                               :Geometry :CoordinateSystem])
         permitted-group-ids (get-coll-permitted-group-ids context provider-id collection)
-        {:keys [granule-start-date-stored granule-end-date-stored]} (cgac/get-coll-gran-aggregates context concept-id)
+        {:keys [granule-start-date-stored granule-end-date-stored]} 
+               (cgac/get-coll-gran-aggregates context concept-id)
         last-3-days (t/interval (t/minus (tk/now) (t/days 3)) (tk/now))
-        granule-end-date-stored (when-not (and granule-end-date-stored (t/within? last-3-days granule-end-date-stored))
-                           ;; If the granule end date is within the last 3 days we indicate that
-                           ;; the collection has no end date. This allows NRT collections to be
-                           ;; found even if the collection has been reindexed recently.
-                           ;; otherwise, use granule-end-date-stored
-                           granule-end-date-stored)
+        granule-end-date-stored (when-not (and granule-end-date-stored 
+                                               (t/within? last-3-days granule-end-date-stored))
+                                  ;; If the granule end date is within the last 3 days we indicate that
+                                  ;; the collection has no end date. This allows NRT collections to be
+                                  ;; found even if the collection has been reindexed recently.
+                                  ;; otherwise, use granule-end-date-stored
+                                  granule-end-date-stored)
         humanized-values (humanizer/collection-humanizers-elastic context collection)
         tags (map tag/tag-association->elastic-doc tag-associations)
         has-granules (some? (cgac/get-coll-gran-aggregates context concept-id))]

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -79,25 +79,25 @@
   [context concept-id collection]
   (let [start-date (spec-time/collection-start-date collection)
         end-date (spec-time/normalized-end-date collection)
-        {:keys [granule-start-date granule-end-date]} (cgac/get-coll-gran-aggregates context concept-id)
+        {:keys [granule-start-date-stored granule-end-date-stored]} (cgac/get-coll-gran-aggregates context concept-id)
         last-3-days (t/interval (t/minus (tk/now) (t/days 3)) (tk/now))
-        granule-end-date (if (and granule-end-date (t/within? last-3-days granule-end-date))
+        granule-end-date-stored (if (and granule-end-date-stored (t/within? last-3-days granule-end-date-stored))
                            ;; If the granule end date is within the last 3 days we indicate that
                            ;; the collection has no end date. This allows NRT collections to be
                            ;; found even if the collection has been reindexed recently.
                            nil
-                           granule-end-date)
+                           granule-end-date-stored)
         coll-start (index-util/date->elastic start-date)
         coll-end (index-util/date->elastic end-date)]
     (merge {:start-date coll-start
             :end-date coll-end
             :ongoing (determine-ongoing-date end-date)}
-           (or (when granule-start-date
-                 {:granule-start-date (index-util/date->elastic granule-start-date)
-                  :granule-end-date (index-util/date->elastic granule-end-date)})
+           (or (when granule-start-date-stored
+                 {:granule-start-date-stored (index-util/date->elastic granule-start-date-stored)
+                  :granule-end-date-stored (index-util/date->elastic granule-end-date-stored)})
                ;; Use the collection start and end date if there are no granule start and end dates.
-               {:granule-start-date coll-start
-                :granule-end-date coll-end}))))
+               {:granule-start-date-stored coll-start
+                :granule-end-date-stored coll-end}))))
 
 (defn- assoc-nil-if
   "Set value to nil if the predicate is true
@@ -255,14 +255,14 @@
         coordinate-system (get-in collection [:SpatialExtent :HorizontalSpatialDomain
                                               :Geometry :CoordinateSystem])
         permitted-group-ids (get-coll-permitted-group-ids context provider-id collection)
-        {:keys [granule-start-date granule-end-date]} (cgac/get-coll-gran-aggregates context concept-id)
+        {:keys [granule-start-date-stored granule-end-date-stored]} (cgac/get-coll-gran-aggregates context concept-id)
         last-3-days (t/interval (t/minus (tk/now) (t/days 3)) (tk/now))
-        granule-end-date (when-not (and granule-end-date (t/within? last-3-days granule-end-date))
+        granule-end-date-stored (when-not (and granule-end-date-stored (t/within? last-3-days granule-end-date-stored))
                            ;; If the granule end date is within the last 3 days we indicate that
                            ;; the collection has no end date. This allows NRT collections to be
                            ;; found even if the collection has been reindexed recently.
-                           ;; otherwise, use granule-end-date
-                           granule-end-date)
+                           ;; otherwise, use granule-end-date-stored
+                           granule-end-date-stored)
         humanized-values (humanizer/collection-humanizers-elastic context collection)
         tags (map tag/tag-association->elastic-doc tag-associations)
         has-granules (some? (cgac/get-coll-gran-aggregates context concept-id))]
@@ -319,9 +319,9 @@
             ;; added so that we can respect all collection temporal ranges in search
             ;; when limit_to_granules is set and there are no granules for the collection.
             :limit-to-granules-temporals
-            (if granule-start-date
-              [{:start-date (index-util/date->elastic granule-start-date)
-                :end-date (index-util/date->elastic granule-end-date)}]
+            (if granule-start-date-stored
+              [{:start-date (index-util/date->elastic granule-start-date-stored)
+                :end-date (index-util/date->elastic granule-end-date-stored)}]
               temporal-extents)
             :science-keywords (map #(sk/science-keyword->elastic-doc kms-index %)
                                    (:ScienceKeywords collection))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -317,8 +317,10 @@
 
           ;; Temporal range of min and max granule values or the same as collection start and end date
           ;; if the collection has not granules.
-          :granule-start-date             (m/stored m/date-field-mapping)
-          :granule-end-date               (m/stored m/date-field-mapping)
+          :granule-start-date             m/date-field-mapping
+          :granule-end-date               m/date-field-mapping
+          :granule-start-date-stored             (m/stored m/date-field-mapping)
+          :granule-end-date-stored               (m/stored m/date-field-mapping)
 
           :has-granules (m/stored m/bool-field-mapping)
           :has-granules-or-cwic (m/stored m/bool-field-mapping)
@@ -375,7 +377,7 @@
           :temporals temporal-mapping
 
           ;; nested mapping for limit_to_granules case.
-          ;; it either contains [{:start-date granule-start-date :end-date granule-end-date}]
+          ;; it either contains [{:start-date granule-start-date-stored :end-date granule-end-date-stored}]
           ;; or when there're no granules, contains all the temporal ranges within the collection
           :limit-to-granules-temporals temporal-mapping
 

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -317,8 +317,8 @@
 
           ;; Temporal range of min and max granule values or the same as collection start and end date
           ;; if the collection has not granules.
-          :granule-start-date             m/date-field-mapping
-          :granule-end-date               m/date-field-mapping
+          :granule-start-date             (m/stored m/date-field-mapping)
+          :granule-end-date               (m/stored m/date-field-mapping)
 
           :has-granules (m/stored m/bool-field-mapping)
           :has-granules-or-cwic (m/stored m/bool-field-mapping)

--- a/indexer-app/test/cmr/indexer/test/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/test/cmr/indexer/test/data/collection_granule_aggregation_cache.clj
@@ -30,10 +30,10 @@
                      :no-end-date {:doc_count 1}}]}}})
 
 (def sample-coll-gran-aggregates
-  {"C1-PROV1" {:granule-start-date (t/date-time 2003)
-               :granule-end-date (t/date-time 2008)}
-   "C2-PROV1" {:granule-start-date (t/date-time 2001)
-               :granule-end-date nil}})
+  {"C1-PROV1" {:granule-start-date-stored (t/date-time 2003)
+               :granule-end-date-stored (t/date-time 2008)}
+   "C2-PROV1" {:granule-start-date-stored (t/date-time 2001)
+               :granule-end-date-stored nil}})
 
 
 (deftest parse-aggregations-response-test
@@ -71,8 +71,8 @@
 (def granule-dates
   "Generator of maps containing granule start and end dates where end date is optional"
   (gen/fmap (fn [[start end]]
-              {:granule-start-date start
-               :granule-end-date end})
+              {:granule-start-date-stored start
+               :granule-end-date-stored end})
             ;; generate 1 to 2 dates as longs in order from smallest to largest.
             (gen/fmap sort (gen/vector gen/s-pos-int 1 2))))
 
@@ -86,26 +86,26 @@
   [merged cg1 cg2]
   (every?
    true?
-   (for [[coll {:keys [granule-start-date granule-end-date]}] merged
+   (for [[coll {:keys [granule-start-date-stored granule-end-date-stored]}] merged
          :let [gt1 (get cg1 coll)
                gt2 (get cg2 coll)]]
      (if (and gt1 gt2)
-       (let [{cg1-start :granule-start-date cg1-end :granule-end-date} gt1
-             {cg2-start :granule-start-date cg2-end :granule-end-date} gt2]
+       (let [{cg1-start :granule-start-date-stored cg1-end :granule-end-date-stored} gt1
+             {cg2-start :granule-start-date-stored cg2-end :granule-end-date-stored} gt2]
 
          (and ;The start date is equal the smaller of the two
-              (= granule-start-date (min cg1-start cg2-start))
+              (= granule-start-date-stored (min cg1-start cg2-start))
 
               (or ;The granule end date is nil if one of the others is nil
-                  (and (nil? granule-end-date) (or (nil? cg1-end) (nil? cg2-end)))
+                  (and (nil? granule-end-date-stored) (or (nil? cg1-end) (nil? cg2-end)))
                   ;; else all three are present and granule end date is equal to the largest date.
-                  (and (some? granule-end-date) (some? cg1-end) (some? cg2-end)
-                       (= granule-end-date (max cg1-end cg2-end))))))
+                  (and (some? granule-end-date-stored) (some? cg1-end) (some? cg2-end)
+                       (= granule-end-date-stored (max cg1-end cg2-end))))))
 
 
-       (let [{start :granule-start-date end :granule-end-date} (or gt1 gt2)]
-         (and (= granule-start-date start)
-              (= granule-end-date end)))))))
+       (let [{start :granule-start-date-stored end :granule-end-date-stored} (or gt1 gt2)]
+         (and (= granule-start-date-stored start)
+              (= granule-end-date-stored end)))))))
 
 (defspec merging-collection-granule-aggrates-spec 100
   (for-all [[cg1 cg2] (gen/tuple collection-granule-aggregate-gen collection-granule-aggregate-gen)]

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -80,8 +80,8 @@
                          "publication-references"
                          "start-date"
                          "end-date"
-                         "granule-start-date"
-                         "granule-end-date"
+                         "granule-start-date-stored"
+                         "granule-end-date-stored"
                          "ords-info"
                          "ords"
                          "personnel"
@@ -131,17 +131,17 @@
           [personnel] :personnel
           [start-date] :start-date
           [end-date] :end-date
-          [granule-start-date] :granule-start-date
-          [granule-end-date] :granule-end-date
+          [granule-start-date-stored] :granule-start-date-stored
+          [granule-end-date-stored] :granule-end-date-stored
           [archive-center] :archive-center} :fields} elastic-result
         personnel (json/decode personnel true)
         related-urls  (map #(json/decode % true) related-urls)
         start-date (when start-date (str/replace (str start-date) #"\+0000" "Z"))
         end-date (when end-date (str/replace (str end-date) #"\+0000" "Z"))
-        granule-start-date (when granule-start-date
-                             (str/replace (str granule-start-date) #"\+0000" "Z"))
-        granule-end-date (when granule-end-date
-                             (str/replace (str granule-end-date) #"\+0000" "Z"))]
+        granule-start-date-stored (when granule-start-date-stored
+                                    (str/replace (str granule-start-date-stored) #"\+0000" "Z"))
+        granule-end-date-stored (when granule-end-date-stored
+                                  (str/replace (str granule-end-date-stored) #"\+0000" "Z"))]
     (merge {:id concept-id
             :title entry-title
             :short-name short-name
@@ -156,8 +156,8 @@
             :personnel personnel
             :start-date start-date
             :end-date end-date
-            :granule-start-date granule-start-date
-            :granule-end-date granule-end-date
+            :granule-start-date-stored granule-start-date-stored
+            :granule-end-date-stored granule-end-date-stored
             :provider-id provider-id
             :science-keywords-flat science-keywords-flat
             :entry-title entry-title
@@ -231,7 +231,7 @@
 (defn- get-issued-modified-time
   "Get collection's issued/modified time. Parameter time could be either
   the collection's insert-time or update-time. Parameter gran-time could be either
-  granule-start-date or granule-end-date.
+  granule-start-date-stored or granule-end-date-stored.
   when insert-time/update-time is nil or default value, get issued/modified time
   from collection's earliest granule's start-date, and latest granule's end-date."
   [time gran-time]
@@ -245,9 +245,9 @@
   (let [{:keys [id summary short-name project-sn update-time insert-time provider-id
                 science-keywords-flat entry-title opendata-format start-date end-date
                 related-urls publication-references personnel shapes archive-center
-                granule-start-date granule-end-date]} item
-        issued-time (get-issued-modified-time insert-time granule-start-date)
-        modified-time (get-issued-modified-time update-time granule-end-date)]
+                granule-start-date-stored granule-end-date-stored]} item
+        issued-time (get-issued-modified-time insert-time granule-start-date-stored)
+        modified-time (get-issued-modified-time update-time granule-end-date-stored)]
     ;; All fields are required unless otherwise noted
     (util/remove-nil-keys {:title (or entry-title umm-spec-util/not-provided)
                            :description (not-empty summary)

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -18,6 +18,7 @@
    [cmr.search.services.query-execution.granule-counts-results-feature :as gcrf]
    [cmr.search.services.url-helper :as url]
    [cmr.spatial.serialize :as srl]
+   [cmr.umm-spec.date-util :as umm-spec-date-util]
    [cmr.umm-spec.util :as umm-spec-util]
    [cmr.umm.related-url-helper :as ru]))
 
@@ -79,6 +80,8 @@
                          "publication-references"
                          "start-date"
                          "end-date"
+                         "granule-start-date"
+                         "granule-end-date"
                          "ords-info"
                          "ords"
                          "personnel"
@@ -128,11 +131,17 @@
           [personnel] :personnel
           [start-date] :start-date
           [end-date] :end-date
+          [granule-start-date] :granule-start-date
+          [granule-end-date] :granule-end-date
           [archive-center] :archive-center} :fields} elastic-result
         personnel (json/decode personnel true)
         related-urls  (map #(json/decode % true) related-urls)
         start-date (when start-date (str/replace (str start-date) #"\+0000" "Z"))
-        end-date (when end-date (str/replace (str end-date) #"\+0000" "Z"))]
+        end-date (when end-date (str/replace (str end-date) #"\+0000" "Z"))
+        granule-start-date (when granule-start-date
+                             (str/replace (str granule-start-date) #"\+0000" "Z"))
+        granule-end-date (when granule-end-date
+                             (str/replace (str granule-end-date) #"\+0000" "Z"))]
     (merge {:id concept-id
             :title entry-title
             :short-name short-name
@@ -147,6 +156,8 @@
             :personnel personnel
             :start-date start-date
             :end-date end-date
+            :granule-start-date granule-start-date
+            :granule-end-date granule-end-date
             :provider-id provider-id
             :science-keywords-flat science-keywords-flat
             :entry-title entry-title
@@ -217,17 +228,31 @@
   [project-short-names]
   (conj project-short-names "geospatial"))
 
+(defn- get-issued-modified-time
+  "Get collection's issued/modified time. Parameter time could be either
+  the collection's insert-time or update-time. Parameter gran-time could be either
+  granule-start-date or granule-end-date.
+  when insert-time/update-time is nil or default value, get issued/modified time
+  from collection's earliest granule's start-date, and latest granule's end-date."
+  [time gran-time]
+  (if (and (not-empty time) (not= time (str umm-spec-date-util/parsed-default-date)))
+    time
+    gran-time))
+
 (defn- result->opendata
   "Converts a search result item to opendata."
   [context concept-type item]
   (let [{:keys [id summary short-name project-sn update-time insert-time provider-id
                 science-keywords-flat entry-title opendata-format start-date end-date
-                related-urls publication-references personnel shapes archive-center]} item]
+                related-urls publication-references personnel shapes archive-center
+                granule-start-date granule-end-date]} item
+        issued-time (get-issued-modified-time insert-time granule-start-date)
+        modified-time (get-issued-modified-time update-time granule-end-date)]
     ;; All fields are required unless otherwise noted
     (util/remove-nil-keys {:title (or entry-title umm-spec-util/not-provided)
                            :description (not-empty summary)
                            :keyword (keywords science-keywords-flat)
-                           :modified (or update-time (generate-end-date end-date))
+                           :modified (or modified-time (generate-end-date end-date))
                            :publisher (publisher provider-id archive-center)
                            :contactPoint (contact-point personnel)
                            :identifier id
@@ -242,7 +267,7 @@
                            :language  [LANGUAGE_CODE]
                            :references (not-empty
                                         (map ru/related-url->encoded-url publication-references))
-                           :issued (not-empty insert-time)})))
+                           :issued (not-empty issued-time)})))
 
 (defn- results->opendata
   "Convert search results to opendata."

--- a/system-int-test/resources/CMR-5138-DIF10-DataDates-Equal-NotProvided.xml
+++ b/system-int-test/resources/CMR-5138-DIF10-DataDates-Equal-NotProvided.xml
@@ -1,0 +1,541 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DIF xmlns="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/ https://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/dif_v10.2.xsd">
+    <Entry_ID>
+        <Short_Name>AIRX3STD</Short_Name>
+        <Version>006</Version>
+    </Entry_ID>
+    <Entry_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006 (AIRX3STD) at GES DISC</Entry_Title>
+    <Dataset_Citation>
+        <Dataset_Creator>AIRS Science Team/Joao Texeira</Dataset_Creator>
+        <Dataset_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006</Dataset_Title>
+        <Dataset_Series_Name>AIRX3STD</Dataset_Series_Name>
+        <Dataset_Release_Date>2013-03-12</Dataset_Release_Date>
+        <Dataset_Release_Place>Greenbelt, MD, USA</Dataset_Release_Place>
+        <Dataset_Publisher>Goddard Earth Sciences Data and Information Services Center (GES DISC)</Dataset_Publisher>
+        <Version>006</Version>
+        <Data_Presentation_Form>Digital Science Data</Data_Presentation_Form>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>doi:10.5067/Aqua/AIRS/DATA301</Identifier>
+        </Persistent_Identifier>
+        <Online_Resource>https://disc.gsfc.nasa.gov/datacollection/AIRX3STD_006.html</Online_Resource>
+    </Dataset_Citation>
+    <Personnel>
+        <Role>METADATA AUTHOR</Role>
+        <Contact_Person>
+            <First_Name>ED</First_Name>
+            <Last_Name>ESFANDIARI</Last_Name>
+            <Address>
+                <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                <Street_Address>Code 610.2</Street_Address>
+                <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                <City>Greenbelt</City>
+                <State_Province>MD</State_Province>
+                <Postal_Code>20771</Postal_Code>
+                <Country>USA</Country>
+            </Address>
+            <Phone>
+                <Number>301-614-5960</Number>
+                <Type>Telephone</Type>
+            </Phone>
+            <Phone>
+                <Number>301-614-5268</Number>
+                <Type>Fax</Type>
+            </Phone>
+            <Email>asghar.e.esfandiari@nasa.gov</Email>
+        </Contact_Person>
+    </Personnel>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ALTITUDE</Term>
+        <Variable_Level_1>TROPOPAUSE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC PRESSURE</Term>
+        <Variable_Level_1>SURFACE PRESSURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC TEMPERATURE</Term>
+        <Variable_Level_1>SURFACE TEMPERATURE</Variable_Level_1>
+        <Variable_Level_2>AIR TEMPERATURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC TEMPERATURE</Term>
+        <Variable_Level_1>UPPER AIR TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>TOTAL PRECIPITABLE WATER</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>WATER VAPOR</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD HEIGHT</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD TOP PRESSURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD TOP TEMPERATURE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD PROPERTIES</Variable_Level_1>
+        <Variable_Level_2>CLOUD VERTICAL DISTRIBUTION</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>LAND SURFACE</Topic>
+        <Term>SURFACE RADIATIVE PROPERTIES</Term>
+        <Variable_Level_1>EMISSIVITY</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>OCEANS</Topic>
+        <Term>OCEAN TEMPERATURE</Term>
+        <Variable_Level_1>SEA SURFACE TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>LAND SURFACE</Topic>
+        <Term>SURFACE THERMAL PROPERTIES</Term>
+        <Variable_Level_1>SKIN TEMPERATURE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>AIR QUALITY</Term>
+        <Variable_Level_1>CARBON MONOXIDE</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ALTITUDE</Term>
+        <Variable_Level_1>GEOPOTENTIAL HEIGHT</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR INDICATORS</Variable_Level_1>
+        <Variable_Level_2>HUMIDITY</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC WATER VAPOR</Term>
+        <Variable_Level_1>WATER VAPOR PROFILES</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>CLOUDS</Term>
+        <Variable_Level_1>CLOUD MICROPHYSICS</Variable_Level_1>
+        <Variable_Level_2>CLOUD LIQUID WATER/ICE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC RADIATION</Term>
+        <Variable_Level_1>OUTGOING LONGWAVE RADIATION</Variable_Level_1>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC CHEMISTRY</Term>
+        <Variable_Level_1>CARBON AND HYDROCARBON COMPOUNDS</Variable_Level_1>
+        <Variable_Level_2>METHANE</Variable_Level_2>
+    </Science_Keywords>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC CHEMISTRY</Term>
+        <Variable_Level_1>OXYGEN COMPOUNDS</Variable_Level_1>
+        <Variable_Level_2>OZONE</Variable_Level_2>
+    </Science_Keywords>
+    <ISO_Topic_Category>CLIMATOLOGY/METEOROLOGY/ATMOSPHERE</ISO_Topic_Category>
+    <ISO_Topic_Category>IMAGERY/BASE MAPS/EARTH COVER</ISO_Topic_Category>
+    <ISO_Topic_Category>ENVIRONMENT</ISO_Topic_Category>
+    <ISO_Topic_Category>GEOSCIENTIFIC INFORMATION</ISO_Topic_Category>
+    <Ancillary_Keyword>ATMOSPHERE</Ancillary_Keyword>
+    <Ancillary_Keyword>CALIBRATED</Ancillary_Keyword>
+    <Ancillary_Keyword>GEOLOCATED</Ancillary_Keyword>
+    <Ancillary_Keyword>TEMPERATURE</Ancillary_Keyword>
+    <Ancillary_Keyword>CLOUD</Ancillary_Keyword>
+    <Ancillary_Keyword>EOSDIS</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Ozone</Ancillary_Keyword>
+    <Ancillary_Keyword>Global Gridded</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Water Vapor Burden</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Cloud Liquid Water</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Carbon Monoxide</Ancillary_Keyword>
+    <Ancillary_Keyword>Spectral IR Surface Emissivities</Ancillary_Keyword>
+    <Ancillary_Keyword>Spectral Microwave Surface Emissivities</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Column Ozone Burden</Ancillary_Keyword>
+    <Ancillary_Keyword>Outgoing Longwave Radiation Flux</Ancillary_Keyword>
+    <Ancillary_Keyword>Clear Sky Outgoing Longwave Radiation Flux</Ancillary_Keyword>
+    <Ancillary_Keyword>Relative Humidity Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Cloud Layer Pressure At Coarse Cloud Resolution</Ancillary_Keyword>
+    <Ancillary_Keyword>Cloud Layer Pressure At Fine Cloud Resolution</Ancillary_Keyword>
+    <Ancillary_Keyword>Water Vapor Mass Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Tropopause Height</Ancillary_Keyword>
+    <Ancillary_Keyword>Tropopause Temperature</Ancillary_Keyword>
+    <Ancillary_Keyword>Effective Methane Volume Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Effective Carbon Monoxide Volume Mixing Ratio Profile</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Integrated Cloud Liquid Water</Ancillary_Keyword>
+    <Platform>
+        <Type>Earth Observation Satellites</Type>
+        <Short_Name>Aqua</Short_Name>
+        <Long_Name>Earth Observing System, Aqua</Long_Name>
+        <Instrument>
+            <Short_Name>AIRS</Short_Name>
+            <Long_Name>Atmospheric Infrared Sounder</Long_Name>
+        </Instrument>
+        <Instrument>
+            <Short_Name>AMSU-A</Short_Name>
+            <Long_Name>Advanced Microwave Sounding Unit-A</Long_Name>
+        </Instrument>
+    </Platform>
+    <Temporal_Coverage>
+        <Range_DateTime>
+            <Beginning_Date_Time>2002-08-31</Beginning_Date_Time>
+            <Ending_Date_Time>2016-09-25</Ending_Date_Time>
+        </Range_DateTime>
+    </Temporal_Coverage>
+    <Dataset_Progress>COMPLETE</Dataset_Progress>
+    <Spatial_Coverage>
+        <Granule_Spatial_Representation>CARTESIAN</Granule_Spatial_Representation>
+        <Geometry>
+            <Coordinate_System>CARTESIAN</Coordinate_System>
+            <Bounding_Rectangle>
+                <Southernmost_Latitude>-90.0</Southernmost_Latitude>
+                <Northernmost_Latitude>90.0</Northernmost_Latitude>
+                <Westernmost_Longitude>-180.0</Westernmost_Longitude>
+                <Easternmost_Longitude>180.0</Easternmost_Longitude>
+            </Bounding_Rectangle>
+        </Geometry>
+    </Spatial_Coverage>
+    <Location>
+        <Location_Category>GEOGRAPHIC REGION</Location_Category>
+        <Location_Type>GLOBAL</Location_Type>
+    </Location>
+    <Data_Resolution>
+        <Latitude_Resolution>1 degree</Latitude_Resolution>
+        <Longitude_Resolution>1 degree</Longitude_Resolution>
+        <Horizontal_Resolution_Range>100 km - &lt; 250 km or approximately 1 degree - &lt; 2.5 degrees</Horizontal_Resolution_Range>
+        <Temporal_Resolution>Twice per day; day and night; Orbital repeat cycle 16 days</Temporal_Resolution>
+    </Data_Resolution>
+    <Project>
+        <Short_Name>Aqua</Short_Name>
+        <Long_Name>Earth Observing System (EOS), Aqua</Long_Name>
+    </Project>
+    <Quality>The quality of data products, described in the associated references, provide information about numerous validation studies conducted and papers written documenting the excellence of the products using radiosondes, ground truth, other satellites, and model analysis products. There are however several limitations of the version-6 retrieval products. One is a spurious dry daytime moisture bias. In addition, there are some erroneous water vapor features in the upper stratosphere near the top limit of the AIRS determination. For trace gases, the total column CO and total column methane (CH4) are dominated by the initial guess and should not be used for research purposes. The total ozone product is good, but has some limitations  where it is too low over the warm oceanic pool and a bit too high over most land areas. Occasionally in the tropical ocean the algorithm confuses silicates from dust storms blowing off the African continent toward the Americas for high levels of ozone. 
+
+The value for each grid box is the sum of the values that fall within the 1x1 area divided by the number of points in the box. 
+
+For AIRS/AMSU: This product stopped after September 24, 2016 as the power to the AMSU-A2 instrument on Aqua was lost. For data after this time use AIRS2RET.006 (AIRS-only) .</Quality>
+    <Access_Constraints>None</Access_Constraints>
+    <Dataset_Language>English</Dataset_Language>
+    <Originating_Center>GES DISC</Originating_Center>
+    <Organization>
+        <Organization_Type>ARCHIVER</Organization_Type>
+        <Organization_Name>
+            <Short_Name>NASA/GSFC/SED/ESD/GCDC/GESDISC</Short_Name>
+            <Long_Name>Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Global Change Data Center, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA</Long_Name>
+        </Organization_Name>
+        <Organization_URL>https://disc.gsfc.nasa.gov/</Organization_URL>
+        <Personnel>
+            <Role>DATA CENTER CONTACT</Role>
+            <Contact_Group>
+                <Name>GES DISC HELP DESK SUPPORT GROUP</Name>
+                <Address>
+                    <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                    <Street_Address>Code 610.2</Street_Address>
+                    <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                    <City>Greenbelt</City>
+                    <State_Province>MD</State_Province>
+                    <Postal_Code>20771</Postal_Code>
+                    <Country>USA</Country>
+                </Address>
+                <Phone>
+                    <Number>301-614-5224</Number>
+                    <Type>Telephone</Type>
+                </Phone>
+                <Phone>
+                    <Number>301-614-5268</Number>
+                    <Type>Fax</Type>
+                </Phone>
+                <Email>gsfc-help-disc@lists.nasa.gov</Email>
+            </Contact_Group>
+        </Personnel>
+    </Organization>
+    <Distribution>
+        <Distribution_Media>Online Archive</Distribution_Media>
+        <Distribution_Size>376.1 MB per file</Distribution_Size>
+        <Distribution_Format>HDF-EOS</Distribution_Format>
+        <Fees>None</Fees>
+    </Distribution>
+    <Multimedia_Sample>
+        <File>airx3std.jpg</File>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png</URL>
+        <Format>JPEG</Format>
+        <Caption>Sample data of AIRX3STD</Caption>
+        <Description>Sample data of the "AIRS/Aqua Level 3 daily standard physical retrieval product (Without HSB)".</Description>
+    </Multimedia_Sample>
+    <Reference>
+        <Author>Joel Susskind, John, M. Blaisdell, and Lena Iredell</Author>
+        <Publication_Date>2014/03/31</Publication_Date>
+        <Title>Improved methodology for surface and atmospheric soundings, error estimates, and quality control procedures: the atmospheric infrared sounder science team version-6 retrieval algorithm</Title>
+        <Series>J. Appl. Rem. Sens.</Series>
+        <Volume>8</Volume>
+        <Issue>1</Issue>
+        <Pages>34</Pages>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.1117/1.JRS.8.084994</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Reference>
+        <Author>B.H. Kahn, et.al.</Author>
+        <Publication_Date>2014/01/10</Publication_Date>
+        <Title>The Atmospheric Infrared Sounder Version 6 Cloud Products</Title>
+        <Series>Atmospheric Chemistry and Physics</Series>
+        <Volume>14</Volume>
+        <Issue>1</Issue>
+        <Pages>399-426</Pages>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.5194/acp-14-399-2014</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Summary>
+        <Abstract>The Atmospheric Infrared Sounder (AIRS) is a grating spectrometer (R = 1200) aboard the second Earth Observing System (EOS) polar-orbiting platform, EOS Aqua. In combination with the Advanced Microwave Sounding Unit (AMSU) and the Humidity Sounder for Brazil (HSB), AIRS constitutes an innovative atmospheric sounding group of visible, infrared, and microwave sensors. The AIRS Level 3 Daily Gridded Product contains standard retrieval means, standard deviations and input counts. Each file covers a temporal period of 24 hours for either the descending (equatorial crossing North to South @1:30 AM local time) or ascending (equatorial crossing South to North @1:30 PM local time) orbit. The data starts at the international dateline and progresses westward (as do the subsequent orbits of the satellite) so that neighboring gridded cells of data are no more than a swath of time apart (about 90 minutes). The two parts of a scan line crossing the dateline are included in separate L3 files, according to the date, so that data points in a grid box are always coincident in time. The edge of the AIRS Level 3 gridded cells is at the date line (the 180E/W longitude boundary). When plotted, this produces a map with 0 degrees longitude in the center of the image unless the bins are reordered. This method is preferred because the left (West) side of the image and the right (East) side of the image contain data farthest apart in time. The gridding scheme used by AIRS is the same as used by TOVS Pathfinder to create Level 3 products. The daily Level 3 products have gores between satellite paths where there is no coverage for that day. The geophysical parameters have been averaged and binned into 1 x 1 deg grid cells, from -180.0 to +180.0 deg longitude and from -90.0 to +90.0 deg latitude. For each grid map of 4-byte floating-point mean values there is a corresponding 4-byte floating-point map of standard deviation and a 2-byte integer grid map of counts. The counts map provides the user with the number of points per bin that were included in the mean and can be used to generate custom multi-day maps from the daily gridded products. The thermodynamic parameters are: Skin Temperature (land and sea surface), Air Temperature at the surface, Profiles of Air Temperature and Water Vapor, Tropopause Characteristics, Column Precipitable Water, Cloud Amount/Frequency, Cloud Height, Cloud Top Pressure, Cloud Top Temperature, Reflectance, Emissivity, Surface Pressure, Cloud Vertical Distribution. The trace gases parameters are: Total Amounts and Vertical Profiles of Carbon Monoxide, Methane, and Ozone. The actual names of the variables in the data files should be inferred from the Processing File Description document.</Abstract>
+    </Summary>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>DATA TREE</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/</URL>
+        <Description>Access the data via HTTP.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>OPENDAP DATA</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html</URL>
+        <Description>Access the data via the OPeNDAP protocol.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GOTO WEB TOOL</Type>
+            <Subtype>SIMPLE SUBSET WIZARD (SSW)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006</URL>
+        <Description>Use the Simple Subset Wizard (SSW) to submit subset requests for data sets across multiple data centers from a single unified interface.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>Earthdata Search</Subtype>
+        </URL_Content_Type>
+        <URL>https://search.earthdata.nasa.gov/search?q=AIRX3STD+006</URL>
+        <Description>Use the Earthdata Search to find and retrieve data sets across multiple data centers.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB MAP SERVICE (WMS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&amp;version=1.1.1&amp;request=GetCapabilities</URL>
+        <Description>NASA GES DISC AIRS Gridded L3 data Web Map Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB MAP SERVICE (WMS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc1.gsfc.nasa.gov/daac-bin/wms_airs?service=WMS&amp;VERSION=1.1.1&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;WIDTH=720&amp;HEIGHT=360&amp;LAYERS=AIRX3STD_TOTH2OVAP_A&amp;TRANSPARENT=TRUE&amp;FORMAT=image/png&amp;bbox=-180,-90,180,90</URL>
+        <Description>Get map example for NASA GES DISC AIRS Gridded L3 data Web Map Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB COVERAGE SERVICE (WCS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&amp;version=1.0.0&amp;request=GetCapabilities</URL>
+        <Description>NASA GES DISC AIRS Gridded L3 data Web Coverage Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>WEB COVERAGE SERVICE (WCS)</Subtype>
+        </URL_Content_Type>
+        <URL>https://acdisc.gesdisc.eosdis.nasa.gov/daac-bin/wcsAIRSL3?service=WCS&amp;version=1.0.0&amp;request=GetCoverage&amp;CRS=EPSG:4326&amp;format=netCDF&amp;resx=1.0&amp;resy=1.0&amp;BBOX=-179.5,-89.5,179.5,89.5&amp;Coverage=AIRX3STD:CO_VMR_A&amp;Time=2013-08-11</URL>
+        <Description>Get Coverage data example for NASA GES DISC AIRS Gridded L3 data Web Coverage Service.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>PROJECT HOME PAGE</Type>
+        </URL_Content_Type>
+        <URL>https://airs.jpl.nasa.gov/index.html</URL>
+        <Description>AIRS home page at NASA/JPL. General information on the AIRS instrument, algorithms, and other AIRS-related activities can be found.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+        </URL_Content_Type>
+        <URL>https://disc.gsfc.nasa.gov/information/documents?title=AIRS%20Documentation</URL>
+        <Description>AIRS Documentation Page</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>READ-ME</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/README.AIRS_V6.pdf</URL>
+        <Description>README Document</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>GENERAL DOCUMENTATION</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/AIRS/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithms/V6_Released_Processing_Files_Description.pdf</URL>
+        <Description>AIRS Version 6 Processing Files Description Document.</Description>
+    </Related_URL>
+    <Originating_Metadata_Node>GCMD</Originating_Metadata_Node>
+    <Metadata_Name>CEOS IDN DIF</Metadata_Name>
+    <Metadata_Version>VERSION 10.2</Metadata_Version>
+    <DIF_Revision_History>2016-01-28, Ed Esfandiari - Modified fields for DIF10.2 compatibility.
+      2016-03-30, Ed Esfandiari - Added index.html to https://airs.jpl.nasa.gov/ to avoid broken link.
+      2016-03-30, Ed Esfandiari - Changed _V006.html to _006.html (landing page).
+      2016-03-31, Ed Esfandiari - Removed "sci" from "disc.sci.gsfc.nasa.gov" links.
+      2016-04-15, Ed Esfandiari - Misc. changes to Titles, Summary, etc..
+      2016-12-05, Ed Esfandiari - Changed Plone document links to docserver.
+      2017-09-27, Ed Esfandiari - Added temporal end date.</DIF_Revision_History>
+    <Metadata_Dates>
+        <Metadata_Creation>2013-02-14</Metadata_Creation>
+        <Metadata_Last_Revision>2018-05-21</Metadata_Last_Revision>
+        <Metadata_Future_Review>2016-07-01</Metadata_Future_Review>
+        <Data_Creation>Not provided</Data_Creation>
+        <Data_Last_Revision>Not provided</Data_Last_Revision>
+    </Metadata_Dates>
+    <Product_Level_Id>3</Product_Level_Id>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.disc</Group>
+            <Name>Data Granularity</Name>
+            <Description>The time coverage of individual data granules.</Description>
+            <Value>1 day</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.uuid</Name>
+            <Value>2b9d4ac2-3143-4a02-aacf-be728da1b858</Value>
+        </Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.extraction_date</Name>
+            <Value>2015-12-22 13:28:23</Value>
+        </Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.keyword_version</Name>
+            <Value>8.1</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>DIF9.0-to-DIF10-Converter</Name>
+            <Value>2015-12-28T18:06:58Z</Value>
+            <Value>Version:-3.0</Value>
+            <Value>Target:10.2</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Discipline</Name>
+            <Value>EARTH SCIENCE</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>IDN_Node.Short_Name</Name>
+            <Value>ECHO</Value>
+            <Value>USA/NASA</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>IDN_Node.UUID</Name>
+            <Value>2efb470f-61f8-4046-b2ee-ebed27e2f310</Value>
+            <Value>9ae20472-ba4c-4b01-8d97-857b73fa3c95</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Dataset_Citation.DOI</Name>
+            <Value>10.5067/Aqua/AIRS/DATA301</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Metadata_Version</Name>
+            <Value>VERSION 9.8.4</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>Original.Dataset_Language</Name>
+            <Value>English</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.tool</Name>
+            <Value>2018-05-21:docbuilder</Value>
+        </Metadata>
+    </Extended_Metadata>
+</DIF>

--- a/system-int-test/resources/CMR-5138-DIF10-DataDates-Provided.xml
+++ b/system-int-test/resources/CMR-5138-DIF10-DataDates-Provided.xml
@@ -1,0 +1,382 @@
+<DIF xmlns="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/ https://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/dif_v10.2.xsd">
+    <Entry_ID>
+        <Short_Name>OMSO2</Short_Name>
+        <Version>003</Version>
+    </Entry_ID>
+    <Entry_Title>OMI/Aura Sulphur Dioxide (SO2) Total Column 1-orbit L2 Swath 13x24 km V003 (OMSO2) at GES DISC</Entry_Title>
+    <Dataset_Citation>
+        <Dataset_Creator>Can Li, Nickolay A. Krotkov, and Joanna Joiner</Dataset_Creator>
+        <Dataset_Title>OMI/Aura Sulphur Dioxide (SO2) Total Column 1-orbit L2 Swath 13x24 km V003</Dataset_Title>
+        <Dataset_Series_Name>OMSO2</Dataset_Series_Name>
+        <Dataset_Release_Date>2006-12-20</Dataset_Release_Date>
+        <Dataset_Release_Place>Greenbelt, MD, USA</Dataset_Release_Place>
+        <Dataset_Publisher>Goddard Earth Sciences Data and Information Services Center (GES DISC)</Dataset_Publisher>
+        <Version>003</Version>
+        <Data_Presentation_Form>Digital Science Data</Data_Presentation_Form>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.5067/Aura/OMI/DATA2022</Identifier>
+        </Persistent_Identifier>
+        <Online_Resource>https://disc.gsfc.nasa.gov/datacollection/OMSO2_003.html</Online_Resource>
+    </Dataset_Citation>
+    <Personnel>
+        <Role>INVESTIGATOR</Role>
+        <Contact_Person>
+            <First_Name>NICKOLAY</First_Name>
+            <Middle_Name>A</Middle_Name>
+            <Last_Name>KROTKOV, PH. D</Last_Name>
+            <Address>
+                <Street_Address>NASA</Street_Address>
+                <Street_Address>Goddard Space Flight Center</Street_Address>
+                <Street_Address>Mailstop 613.3</Street_Address>
+                <City>Greenbelt</City>
+                <State_Province>MD</State_Province>
+                <Postal_Code>20771</Postal_Code>
+                <Country>USA</Country>
+            </Address>
+            <Phone>
+                <Number>301-614-5553</Number>
+                <Type>Telephone</Type>
+            </Phone>
+            <Phone>
+                <Number>301-614-5903</Number>
+                <Type>Fax</Type>
+            </Phone>
+            <Email>Nickolay.A.Krotkov@nasa.gov</Email>
+        </Contact_Person>
+    </Personnel>
+    <Personnel>
+        <Role>INVESTIGATOR</Role>
+        <Contact_Person>
+            <First_Name>KAI</First_Name>
+            <Last_Name>YANG, PH. D</Last_Name>
+            <Address>
+                <Street_Address>Department of Atmospheric and Oceanic Science</Street_Address>
+                <Street_Address>University of Maryland</Street_Address>
+                <City>College Park</City>
+                <State_Province>MD</State_Province>
+                <Postal_Code>20742</Postal_Code>
+                <Country>USA</Country>
+            </Address>
+            <Phone>
+                <Number>301-338-8898</Number>
+                <Type>Fax</Type>
+            </Phone>
+            <Email>kaiyang@umd.edu</Email>
+        </Contact_Person>
+    </Personnel>
+    <Personnel>
+        <Role>INVESTIGATOR</Role>
+        <Contact_Person>
+            <First_Name>ARLIN</First_Name>
+            <Middle_Name>J.</Middle_Name>
+            <Last_Name>KRUEGER, PH. D</Last_Name>
+            <Email>akrueger@umbc.edu</Email>
+        </Contact_Person>
+    </Personnel>
+    <Personnel>
+        <Role>METADATA AUTHOR</Role>
+        <Contact_Person>
+            <First_Name>JEROME</First_Name>
+            <Middle_Name>M.</Middle_Name>
+            <Last_Name>ALFRED</Last_Name>
+            <Address>
+                <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                <Street_Address>Code 610.2</Street_Address>
+                <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                <City>Greenbelt</City>
+                <State_Province>MD</State_Province>
+                <Postal_Code>20771</Postal_Code>
+                <Country>USA</Country>
+            </Address>
+            <Phone>
+                <Number>301-286-8337</Number>
+                <Type>Telephone</Type>
+            </Phone>
+            <Email>jerome.m.alfred@nasa.gov</Email>
+        </Contact_Person>
+    </Personnel>
+    <Science_Keywords>
+        <Category>EARTH SCIENCE</Category>
+        <Topic>ATMOSPHERE</Topic>
+        <Term>ATMOSPHERIC CHEMISTRY</Term>
+        <Variable_Level_1>SULFUR COMPOUNDS</Variable_Level_1>
+        <Variable_Level_2>SULFUR DIOXIDE</Variable_Level_2>
+    </Science_Keywords>
+    <ISO_Topic_Category>CLIMATOLOGY/METEOROLOGY/ATMOSPHERE</ISO_Topic_Category>
+    <Ancillary_Keyword>Atmospheric Chemistry</Ancillary_Keyword>
+    <Ancillary_Keyword>Total Column Sulfur Dioxide (SO2)</Ancillary_Keyword>
+    <Ancillary_Keyword>Air Quality</Ancillary_Keyword>
+    <Ancillary_Keyword>Pollutant</Ancillary_Keyword>
+    <Ancillary_Keyword>EOSDIS</Ancillary_Keyword>
+    <Ancillary_Keyword>BEDI</Ancillary_Keyword>
+    <Ancillary_Keyword>Agriculture and Forestry</Ancillary_Keyword>
+    <Ancillary_Keyword>Climate</Ancillary_Keyword>
+    <Ancillary_Keyword>Disasters</Ancillary_Keyword>
+    <Ancillary_Keyword>Human Health</Ancillary_Keyword>
+    <Ancillary_Keyword>Transportation</Ancillary_Keyword>
+    <Ancillary_Keyword>Weather</Ancillary_Keyword>
+    <Platform>
+        <Type>Earth Observation Satellites</Type>
+        <Short_Name>Aura</Short_Name>
+        <Long_Name>Earth Observing System, Aura</Long_Name>
+        <Instrument>
+            <Short_Name>OMI</Short_Name>
+            <Long_Name>Ozone Monitoring Instrument</Long_Name>
+        </Instrument>
+    </Platform>
+    <Temporal_Coverage>
+        <Ends_At_Present_Flag>true</Ends_At_Present_Flag>
+        <Range_DateTime>
+            <Beginning_Date_Time>2004-10-01</Beginning_Date_Time>
+        </Range_DateTime>
+    </Temporal_Coverage>
+    <Dataset_Progress>IN WORK</Dataset_Progress>
+    <Spatial_Coverage>
+        <Spatial_Coverage_Type>Orbit</Spatial_Coverage_Type>
+        <Granule_Spatial_Representation>ORBIT</Granule_Spatial_Representation>
+        <Geometry>
+            <Coordinate_System>GEODETIC</Coordinate_System>
+            <Bounding_Rectangle>
+                <Southernmost_Latitude>-90.0</Southernmost_Latitude>
+                <Northernmost_Latitude>90.0</Northernmost_Latitude>
+                <Westernmost_Longitude>-180.0</Westernmost_Longitude>
+                <Easternmost_Longitude>180.0</Easternmost_Longitude>
+            </Bounding_Rectangle>
+        </Geometry>
+        <Orbit_Parameters>
+            <Swath_Width>2600</Swath_Width>
+            <Period>98.83</Period>
+            <Inclination_Angle>98.22</Inclination_Angle>
+            <Number_Of_Orbits>1</Number_Of_Orbits>
+            <Start_Circular_Latitude>-90</Start_Circular_Latitude>
+        </Orbit_Parameters>
+    </Spatial_Coverage>
+    <Location>
+        <Location_Category>GEOGRAPHIC REGION</Location_Category>
+        <Location_Type>GLOBAL</Location_Type>
+    </Location>
+    <Data_Resolution>
+        <Latitude_Resolution>13 km</Latitude_Resolution>
+        <Longitude_Resolution>24 km</Longitude_Resolution>
+        <Horizontal_Resolution_Range>10 km - &lt; 50 km or approximately .09 degree - &lt; .5 degree</Horizontal_Resolution_Range>
+        <Vertical_Resolution>80 km</Vertical_Resolution>
+        <Temporal_Resolution>98 minutes</Temporal_Resolution>
+        <Temporal_Resolution_Range>Hourly - &lt; Daily</Temporal_Resolution_Range>
+    </Data_Resolution>
+    <Project>
+        <Short_Name>Aura</Short_Name>
+        <Long_Name>Earth Observing System (EOS), Aura</Long_Name>
+    </Project>
+    <Quality>The 'version 003' product is the second public release. It is based on an improved Level 1B radiance calibration. For details, please see related documents.</Quality>
+    <Access_Constraints>None</Access_Constraints>
+    <Use_Constraints>This Data set (version 003/second public release) is better than the earlier version but it is not fully validated yet. Before using it in any publication please contact algorithm team lead for the current known problems and updates.</Use_Constraints>
+    <Dataset_Language>English</Dataset_Language>
+    <Originating_Center>OMI SIPS</Originating_Center>
+    <Organization>
+        <Organization_Type>ARCHIVER</Organization_Type>
+        <Organization_Name>
+            <Short_Name>NASA/GSFC/SED/ESD/GCDC/GESDISC</Short_Name>
+            <Long_Name>Goddard Earth Sciences Data and Information Services Center (formerly Goddard DAAC), Global Change Data Center, Earth Sciences Division, Science and Exploration Directorate, Goddard Space Flight Center, NASA</Long_Name>
+        </Organization_Name>
+        <Organization_URL>https://disc.gsfc.nasa.gov/</Organization_URL>
+        <Personnel>
+            <Role>DATA CENTER CONTACT</Role>
+            <Contact_Group>
+                <Name>GES DISC HELP DESK SUPPORT GROUP</Name>
+                <Address>
+                    <Street_Address>Goddard Earth Sciences Data and Information Services Center</Street_Address>
+                    <Street_Address>Code 610.2</Street_Address>
+                    <Street_Address>NASA Goddard Space Flight Center</Street_Address>
+                    <City>Greenbelt</City>
+                    <State_Province>MD</State_Province>
+                    <Postal_Code>20771</Postal_Code>
+                    <Country>USA</Country>
+                </Address>
+                <Phone>
+                    <Number>301-614-5224</Number>
+                    <Type>Telephone</Type>
+                </Phone>
+                <Phone>
+                    <Number>301-614-5268</Number>
+                    <Type>Fax</Type>
+                </Phone>
+                <Email>gsfc-help-disc@lists.nasa.gov</Email>
+            </Contact_Group>
+        </Personnel>
+    </Organization>
+    <Distribution>
+        <Distribution_Media>Online Archive</Distribution_Media>
+        <Distribution_Size>26 MB per file</Distribution_Size>
+        <Distribution_Format>HDF-EOS5</Distribution_Format>
+        <Fees>None</Fees>
+    </Distribution>
+    <Multimedia_Sample>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/OMSO2_003.png</URL>
+        <Format>PNG</Format>
+        <Caption>OMSO2 sample image</Caption>
+    </Multimedia_Sample>
+    <Reference>
+        <Author>Li, C., Krotkov, N. A., Carn, S., Zhang, Y., Spurr, R. J. D., and Joiner, J.</Author>
+        <Publication_Date>2017</Publication_Date>
+        <Title>New-generation NASA Aura Ozone Monitoring Instrument (OMI) volcanic SO2 dataset: Algorithm description, initial results, and continuation with the Suomi-NPP Ozone Mapping and Profiler Suite (OMPS)</Title>
+        <Series>Atmos. Meas. Tech.</Series>
+        <Volume>10</Volume>
+        <Pages>445-458</Pages>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.5194/amt-10-445-2017</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Reference>
+        <Author>Li, C., J. Joiner, N. A. Krotkov, and P. K. Bhartia</Author>
+        <Publication_Date>2013</Publication_Date>
+        <Title>A fast and sensitive new satellite SO2 retrieval algorithm based on principal component analysis: Application to the Ozone Monitoring Instrument</Title>
+        <Series>Geophys. Res. Lett.</Series>
+        <Volume>40</Volume>
+        <Persistent_Identifier>
+            <Type>DOI</Type>
+            <Identifier>10.1002/2013GL058134</Identifier>
+        </Persistent_Identifier>
+    </Reference>
+    <Summary>
+        <Abstract>The Aura Ozone Monitoring Instrument (OMI) Sulfur Dioxide Product 'OMSO2' Version 3 is now available to the public from the NASA Goddard Earth Sciences Data and Information Services Center (GES DISC). The OMSO2 product contains three values of SO2 Vertical column corresponding to three a-priori vertical profiles used in the retrieval algorithm. It also contains quality flags, geolocation and other ancillary information. The lead scientist for the OMSO2 product is Nickolay Kroktov. The shortname for this Level-2 OMI total column SO2 product is OMSO2.
+
+The OMSO2 files are stored in the version 5 EOS Hierarchical Data Format (HDF-EOS5). Each file contains data from the day lit portion of an orbit (~53 minutes). There are approximately 14 orbits per day. The maximum file size for the OMSO2 data product is approximately 21 MB.</Abstract>
+    </Summary>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>DATA TREE</Subtype>
+        </URL_Content_Type>
+        <URL>https://aura.gesdisc.eosdis.nasa.gov/data/Aura_OMI_Level2/OMSO2.003/</URL>
+        <Title>Online Archive</Title>
+        <Description>Access the data via HTTP.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GET DATA</Type>
+            <Subtype>Earthdata Search</Subtype>
+        </URL_Content_Type>
+        <URL>https://search.earthdata.nasa.gov/search?q=OMSO2_003</URL>
+        <Title>EARTHDATA Search</Title>
+        <Description>Use the Earthdata Search to find and retrieve data sets across multiple data centers.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>USE SERVICE API</Type>
+            <Subtype>OPENDAP DATA</Subtype>
+        </URL_Content_Type>
+        <URL>https://aura.gesdisc.eosdis.nasa.gov/opendap/Aura_OMI_Level2/OMSO2.003/contents.html</URL>
+        <Title>OPeNDAP</Title>
+        <Description>Access the data via the OPeNDAP protocol.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>GOTO WEB TOOL</Type>
+            <Subtype>SIMPLE SUBSET WIZARD (SSW)</Subtype>
+        </URL_Content_Type>
+        <URL>https://disc.gsfc.nasa.gov/SSW/#keywords=OMSO2</URL>
+        <Title>Simple Subset Wizard</Title>
+        <Description>Use the Simple Subset Wizard (SSW) to submit subset requests for data sets across multiple data centers from a single unified interface.</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>READ-ME</Subtype>
+        </URL_Content_Type>
+        <URL>https://aura.gesdisc.eosdis.nasa.gov/data/Aura_OMI_Level2/OMSO2.003/doc/README.OMSO2.pdf</URL>
+        <Title>User's Guide</Title>
+        <Description>README Document</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>READ-ME</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/OMI/3.3_ScienceDataProductDocumentation/3.3.2_ProductRequirements_Designs/README.OMI_DUG.pdf</URL>
+        <Title>User's Guide</Title>
+        <Description>OMI Data User's Guide</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>ALGORITHM THEORETICAL BASIS DOCUMENT (ATBD)</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/OMI/3.3_ScienceDataProductDocumentation/3.3.4_ProductGenerationAlgorithm/ATBD-OMI-04.pdf</URL>
+        <Description>OMI Algorithm Theoretical Basis Documents</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>PI DOCUMENTATION</Subtype>
+        </URL_Content_Type>
+        <URL>https://docserver.gesdisc.eosdis.nasa.gov/repository/Mission/OMI/3.3_ScienceDataProductDocumentation/3.3.2_ProductRequirements_Designs/OMSO2_FileSpec.pdf</URL>
+        <Description>File Specification Document</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>PROJECT HOME PAGE</Type>
+        </URL_Content_Type>
+        <URL>https://aura.gsfc.nasa.gov/</URL>
+        <Title>Project Home Page</Title>
+        <Description>Aura Project Home Page</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>PROJECT HOME PAGE</Type>
+        </URL_Content_Type>
+        <URL>http://projects.knmi.nl/omi/research/news/newsWrap.php?language=only_enhttps://www.knmi.nl/omitimeFrame=latesthttps://www.knmi.nl/omichoise=page</URL>
+        <Title>Project Home Page</Title>
+        <Description>OMI KNMI Home Page</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>PROJECT HOME PAGE</Type>
+        </URL_Content_Type>
+        <URL>https://so2.gsfc.nasa.gov/</URL>
+        <Title>Project Home Page</Title>
+        <Description>SO2 Monitoring Home Page</Description>
+    </Related_URL>
+    <Related_URL>
+        <URL_Content_Type>
+            <Type>VIEW RELATED INFORMATION</Type>
+            <Subtype>PUBLICATIONS</Subtype>
+        </URL_Content_Type>
+        <URL>http://projects.knmi.nl/omi/research/documents/</URL>
+        <Title>Publications</Title>
+    </Related_URL>
+    <IDN_Node>
+        <Short_Name>USA/NASA</Short_Name>
+    </IDN_Node>
+    <Originating_Metadata_Node>GCMD</Originating_Metadata_Node>
+    <Metadata_Name>CEOS IDN DIF</Metadata_Name>
+    <Metadata_Version>VERSION 10.2</Metadata_Version>
+    <DIF_Revision_History>2008-05-16, S. Ritz updated Summary and Related URLs.2008-06-03, S. Ritz updated Publication links.2008-06-13, S. Ritz added MIRADOR and WHOM links.2009-08-31, S. Ritz updated Summary link.2015-06-02, J. Johnson: cleaned up Science Keywords and Project.2016-08-04, J. Alfred updated to DIF 10.2 format.  2017-03-30, Ed Esfandiari - Added BEDI SBA related ancillary keywords. 2017-05-19, J. Alfred - Updated Get Data Related URLs. 2017-08-10, J. Alfred - Cleaned up related URLs.
+2017-10-20, J. Johnson: implemented ARC finding suggestions.
+2018-05-07, J. Johnson: added Start_Circular_Latitude = -180 to Orbit_Parameters in Spatial_Coverage, 2018-05-10, J.Alfred added Start_Circular_Latitude = -90  to Orbit_Parameters in Spatial_Coverage.</DIF_Revision_History>
+    <Metadata_Dates>
+        <Metadata_Creation>2007-03-28</Metadata_Creation>
+        <Metadata_Last_Revision>2018-05-07</Metadata_Last_Revision>
+        <Data_Creation>2014-09-24</Data_Creation>
+        <Data_Last_Revision>2014-09-24</Data_Last_Revision>
+    </Metadata_Dates>
+    <Product_Level_Id>2</Product_Level_Id>
+    <Collection_Data_Type>SCIENCE_QUALITY</Collection_Data_Type>
+    <Extended_Metadata>
+        <Metadata>
+            <Name>Data Granularity</Name>
+            <Description>The time coverage of individual data granules.</Description>
+            <Value>98.8 minutes</Value>
+        </Metadata>
+    </Extended_Metadata>
+    <Extended_Metadata>
+        <Metadata>
+            <Group>gov.nasa.gsfc.gcmd</Group>
+            <Name>metadata.tool</Name>
+            <Value>2017-12-29:docbuilder;2018-05-07:docbuilder</Value>
+        </Metadata>
+    </Extended_Metadata>
+</DIF>

--- a/system-int-test/resources/CMR-5138-DIF9-DataDates-Not-Exist.xml
+++ b/system-int-test/resources/CMR-5138-DIF9-DataDates-Not-Exist.xml
@@ -1,0 +1,336 @@
+
+<DIF xmlns="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/ http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/dif_v9.9.3.xsd">
+  <Entry_ID>ASAC_2201_HCL_0.5</Entry_ID>
+  <Entry_Title>0.5 hour 1 M HCl extraction data for the Windmill Islands marine sediments</Entry_Title>
+  <Data_Set_Citation>
+    <Dataset_Creator>Snape, I., Riddle, M.J., Gore, D., Stark, J.S., Scouller, R. and Stark, S.C.</Dataset_Creator>
+    <Dataset_Title>0.5 hour 1 M HCl extraction data for the Windmill Islands marine sediments</Dataset_Title>
+    <Dataset_Series_Name>CAASM Metadata</Dataset_Series_Name>
+    <Dataset_Release_Date>2004-08-02</Dataset_Release_Date>
+    <Dataset_Publisher>Australian Antarctic Data Centre</Dataset_Publisher>
+    <Dataset_DOI>doi:10.4225/15/5747A30D1F767</Dataset_DOI>
+    <Online_Resource>https://data.aad.gov.au/aadc/metadata/metadata_redirect.cfm?md=/AMD/AU/ASAC_2201_HCL_0.5</Online_Resource>
+  </Data_Set_Citation>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <Role>TECHNICAL CONTACT</Role>
+    <First_Name>IAN</First_Name>
+    <Last_Name>SNAPE</Last_Name>
+    <Email>ian.snape@aad.gov.au</Email>
+    <Phone>+61 3 6232 3591</Phone>
+    <Fax>+61 3 6232 3158</Fax>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <First_Name>MARTIN</First_Name>
+    <Middle_Name>J.</Middle_Name>
+    <Last_Name>RIDDLE</Last_Name>
+    <Email>martin.riddle@aad.gov.au</Email>
+    <Phone>+61 3 6232 3573</Phone>
+    <Fax>+61 3 6232 3351</Fax>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>DIF AUTHOR</Role>
+    <First_Name>DAVE</First_Name>
+    <Middle_Name>J.</Middle_Name>
+    <Last_Name>CONNELL</Last_Name>
+    <Email>dave.connell@aad.gov.au</Email>
+    <Phone>+61 3 6232 3244</Phone>
+    <Fax>+61 3 6232 3351</Fax>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <First_Name>DAMIAN</First_Name>
+    <Last_Name>GORE</Last_Name>
+    <Email>damian.gore@mq.edu.au</Email>
+    <Phone>+61 2 9850 8391</Phone>
+    <Fax>+61 2 9850 8420</Fax>
+    <Contact_Address>
+      <Address>Department of Physical Geography</Address>
+      <Address>Macquarie University</Address>
+      <City>Marsfield</City>
+      <Province_or_State>New South Wales</Province_or_State>
+      <Postal_Code>2109</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <First_Name>JONATHAN</First_Name>
+    <Middle_Name>SEAN</Middle_Name>
+    <Last_Name>STARK</Last_Name>
+    <Email>jonny.stark@aad.gov.au</Email>
+    <Phone>+61 3 6232 3589</Phone>
+    <Fax>+61 3 6232 3158</Fax>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <Role>TECHNICAL CONTACT</Role>
+    <First_Name>REBECCA</First_Name>
+    <Last_Name>SCOULLER</Last_Name>
+    <Email>beck.scouller@aad.gov.au</Email>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Personnel>
+    <Role>INVESTIGATOR</Role>
+    <First_Name>SCOTT</First_Name>
+    <Middle_Name>CHARLES</Middle_Name>
+    <Last_Name>STARK</Last_Name>
+    <Email>scott.stark@aad.gov.au</Email>
+    <Phone>+61 3 6232 3169</Phone>
+    <Fax>+61 3 6232 3351</Fax>
+    <Contact_Address>
+      <Address>Australian Antarctic Division</Address>
+      <Address>203 Channel Highway</Address>
+      <City>Kingston</City>
+      <Province_or_State>Tasmania</Province_or_State>
+      <Postal_Code>7050</Postal_Code>
+      <Country>Australia</Country>
+    </Contact_Address>
+  </Personnel>
+  <Discipline>
+    <Discipline_Name>EARTH SCIENCE</Discipline_Name>
+  </Discipline>
+  <Parameters>
+    <Category>EARTH SCIENCE</Category>
+    <Topic>HUMAN DIMENSIONS</Topic>
+    <Term>ENVIRONMENTAL IMPACTS</Term>
+    <Variable_Level_1>HEAVY METALS CONCENTRATION</Variable_Level_1>
+  </Parameters>
+  <Parameters>
+    <Category>EARTH SCIENCE</Category>
+    <Topic>OCEANS</Topic>
+    <Term>MARINE SEDIMENTS</Term>
+  </Parameters>
+  <Parameters>
+    <Category>EARTH SCIENCE</Category>
+    <Topic>OCEANS</Topic>
+    <Term>MARINE SEDIMENTS</Term>
+    <Variable_Level_1>SEDIMENT CHEMISTRY</Variable_Level_1>
+  </Parameters>
+  <ISO_Topic_Category>ENVIRONMENT</ISO_Topic_Category>
+  <ISO_Topic_Category>GEOSCIENTIFIC INFORMATION</ISO_Topic_Category>
+  <ISO_Topic_Category>OCEANS</ISO_Topic_Category>
+  <Keyword>ANTIMONY</Keyword>
+  <Keyword>ARSENIC</Keyword>
+  <Keyword>BIOAVAILABLE METALS</Keyword>
+  <Keyword>CADMIUM</Keyword>
+  <Keyword>CHROMIUM</Keyword>
+  <Keyword>COPPER</Keyword>
+  <Keyword>IRON</Keyword>
+  <Keyword>KINETICS</Keyword>
+  <Keyword>LEAD</Keyword>
+  <Keyword>LOCATION</Keyword>
+  <Keyword>MANGANESE</Keyword>
+  <Keyword>MESS</Keyword>
+  <Keyword>MULTIVARIATE ANALYSIS</Keyword>
+  <Keyword>NICKEL</Keyword>
+  <Keyword>PACS</Keyword>
+  <Keyword>REPLICATE</Keyword>
+  <Keyword>SILVER</Keyword>
+  <Keyword>SITE</Keyword>
+  <Keyword>TIN</Keyword>
+  <Keyword>WINDMILL ISLANDS</Keyword>
+  <Keyword>ZINC</Keyword>
+  <Sensor_Name>
+    <Short_Name>SEDIMENT CORERS</Short_Name>
+  </Sensor_Name>
+  <Source_Name>
+    <Short_Name>LABORATORY</Short_Name>
+  </Source_Name>
+  <Source_Name>
+    <Short_Name>FIELD SURVEYS</Short_Name>
+  </Source_Name>
+  <Temporal_Coverage>
+    <Start_Date>1997-10-01</Start_Date>
+    <Stop_Date>1999-03-31</Stop_Date>
+  </Temporal_Coverage>
+  <Data_Set_Progress>COMPLETE</Data_Set_Progress>
+  <Spatial_Coverage>
+    <Southernmost_Latitude>-66.0</Southernmost_Latitude>
+    <Northernmost_Latitude>-66.0</Northernmost_Latitude>
+    <Westernmost_Longitude>110.0</Westernmost_Longitude>
+    <Easternmost_Longitude>110.0</Easternmost_Longitude>
+  </Spatial_Coverage>
+  <Location>
+    <Location_Category>CONTINENT</Location_Category>
+    <Location_Type>ANTARCTICA</Location_Type>
+    <Detailed_Location>Windmill Islands</Detailed_Location>
+  </Location>
+  <Location>
+    <Location_Category>GEOGRAPHIC REGION</Location_Category>
+    <Location_Type>POLAR</Location_Type>
+  </Location>
+  <Quality>The dates provided in temporal coverage are approximate only.  Years are correct.
+
+See the referenced paper for full details on steps taken to ensure quality of data.
+
+To assess extraction efficiency for a range of sediment types, four marine sediments were analysed in detail.  Two international certified reference materials (CRMs) and two well-characterised Antarctic sediments were chosen to compare and contrast moderately to strongly contaminated samples (based on total metal digest), with clean samples of similar matrices.  One CRM was an uncontaminated continental shelf mud (MESS-2), and the other a contaminated harbour mud (PACS-2) (NRCC, 2002).  The two Antarctic sediments were collected as part of a regional hierarchical survey (Stark et al., 2003).  One Antarctic sample was from an area of known metal pollution in Brown Bay (BB), which is adjacent to the 'Old' Casey Station waste disposal site (Snape et al., 2001; Stark et al., 2003).  The second Antarctic sample was from a non-impacted control site from O'Brien Bay (OBB), 3 km south of Casey Station and the disposal site (Fig. 1).  The Antarctic samples, OBB and BB, have similar matrices, proportions of mud (less than 63 microns; 19% and 22% respectively) and total organic carbon contents (1.9% and 2.3% respectively). Both MESS and PACS are sieved, homogenised and dried CRMs that have been ground to ~50 microns (NRCC, 2002).  In contrast, OBB and BB were only sieved to less than 2 mm, thereby removing only the very largest particles (less than or equal to 3%).  The Antarctic samples were collected using acid-washed PVC coring tubes.  The samples were kept frozen at -20 degrees C until wet-sieved with a small amount of clean filtered (0.45 microns cellulose nitrate) O'Brien Bay seawater through 2 mm nylon mesh held in a plastic sieve unit.  The sediments were then oven-dried to constant weight at 103 degrees C (Loring and Rantala 1992), and stored in Nalgene HDPE bottles until analysis.</Quality>
+  <Access_Constraints>The data are available for download from the url given below.</Access_Constraints>
+  <Use_Constraints>This data set conforms to the PICCCBY Attribution License
+(http://creativecommons.org/licenses/by/3.0/).
+
+Please follow instructions listed in the citation reference provided at http://data.aad.gov.au/aadc/metadata/citation.cfm?entry_id=ASAC_2201_HCL_0.5 when using these data.</Use_Constraints>
+  <Data_Set_Language>ENGLISH</Data_Set_Language>
+  <Originating_Center>Australian Antarctic Division</Originating_Center>
+  <Data_Center>
+    <Data_Center_Name>
+      <Short_Name>AU/AADC</Short_Name>
+      <Long_Name>Australian Antarctic Data Centre, Australia</Long_Name>
+    </Data_Center_Name>
+    <Data_Center_URL>http://data.aad.gov.au</Data_Center_URL>
+    <Personnel>
+      <Role>DATA CENTER CONTACT</Role>
+      <First_Name>DATA OFFICER</First_Name>
+      <Last_Name>AADC</Last_Name>
+      <Email>metadata@aad.gov.au</Email>
+      <Phone>+61 3 6232 3244</Phone>
+      <Fax>+61 3 6232 3351</Fax>
+      <Contact_Address>
+        <Address>Australian Antarctic Division</Address>
+        <Address>203 Channel Highway</Address>
+        <City>Kingston</City>
+        <Province_or_State>Tasmania</Province_or_State>
+        <Postal_Code>7050</Postal_Code>
+        <Country>Australia</Country>
+      </Contact_Address>
+    </Personnel>
+  </Data_Center>
+  <Distribution>
+    <Distribution_Media>HTTP</Distribution_Media>
+    <Distribution_Size>3 kb</Distribution_Size>
+    <Distribution_Format>csv</Distribution_Format>
+    <Fees>free</Fees>
+  </Distribution>
+  <Reference>
+    <Author>Snape, I., Scouller, R.C., Stark, S.C., Stark, J., Riddle, M.J., Gore, D.B.</Author>
+    <Publication_Date>2004</Publication_Date>
+    <Title>Characterisation of the dilute HCl extraction method for the identification of metal contamination in Antarctic marine sediments</Title>
+    <Series>Chemosphere</Series>
+    <Volume>57</Volume>
+    <Issue>6</Issue>
+    <Pages>491-504</Pages>
+    <DOI>doi:10.1016/j.chemosphere.2004.05.042</DOI></Reference>
+  <Summary>
+    <Abstract>These results are for the 0.5 hour extraction of HCl.
+
+See also the metadata records for the 4 hour extraction of HCl, and the time trial data for 1 M HCl extractions.
+
+A regional survey of potential contaminants in marine or estuarine sediments is often one of the first steps in a post-disturbance environmental impact assessment. Of the many different chemical extraction or digestion procedures that have been proposed to quantify metal contamination, partial acid extractions are probably the best overall compromise between selectivity, sensitivity, precision, cost and expediency.  The extent to which measured metal concentrations relate to the anthropogenic fraction that is bioavailable is contentious, but is one of the desired outcomes of an assessment or prediction of biological impact.  As part of a regional survey of metal contamination associated with Australia's past waste management activities in Antarctica, we wanted to identify an acid type and extraction protocol that would allow a reasonable definition of the anthropogenic bioavailable fraction for a large number of samples.  From a kinetic study of the 1 M HCl extraction of two certified Certified Reference Materials (MESS-2 and PACS-2) and two Antarctic marine sediments, we concluded that a 4 hour extraction time allows the equilibrium dissolution of relatively labile metal contaminants, but does not favour the extraction of natural geogenic metals.  In a regional survey of 88 marine samples from the Casey Station area of East Antarctica, the 4 h extraction procedure correlated best with biological data, and most clearly identified those sediments thought to be contaminated by runoff from abandoned waste disposal sites.  Most importantly the 4 hour extraction provided better definition of the low to moderately contaminated locations by picking up small differences in anthropogenic metal concentrations.  For the purposes of inter-regional comparison, we recommend a 4 hour 1 M HCl acid extraction as a standard method for assessing metal contamination in Antarctica.
+
+The fields in this dataset are
+
+Location
+Site
+Replicate
+Antimony
+Arsenic
+Cadmium
+Chromium
+Copper
+Iron
+Lead
+Manganese
+Nickel
+Silver
+Tin
+Zinc</Abstract>
+  </Summary>
+  <Related_URL>
+    <URL_Content_Type>
+      <Type>GET DATA</Type>
+    </URL_Content_Type>
+    <URL>http://data.aad.gov.au/aadc/portal/download_file.cfm?file_id=1677</URL>
+    <Description>Download point for the data</Description>
+  </Related_URL>
+  <Related_URL>
+    <URL_Content_Type>
+      <Type>VIEW PROJECT HOME PAGE</Type>
+    </URL_Content_Type>
+    <URL>https://secure3.aad.gov.au/proms/public/projects/report_project_public.cfm?project_no=2201</URL>
+    <Description>Public information for ASAC project 2201</Description>
+  </Related_URL>
+  <Related_URL>
+    <URL_Content_Type>
+      <Type>VIEW RELATED INFORMATION</Type>
+    </URL_Content_Type>
+    <URL>http://data.aad.gov.au/aadc/metadata/citation.cfm?entry_id=ASAC_2201_HCL_0.5</URL>
+    <Description>Citation reference for this metadata record and dataset</Description>
+  </Related_URL>
+  <IDN_Node>
+    <Short_Name>AMD/AU</Short_Name>
+  </IDN_Node>
+  <IDN_Node>
+    <Short_Name>CEOS</Short_Name>
+  </IDN_Node>
+  <IDN_Node>
+    <Short_Name>AMD</Short_Name>
+  </IDN_Node>
+  <Originating_Metadata_Node>AADC</Originating_Metadata_Node>
+  <Metadata_Name>CEOS IDN DIF</Metadata_Name>
+  <Metadata_Version>VERSION 9.7</Metadata_Version>
+  <DIF_Creation_Date>2004-07-30</DIF_Creation_Date>
+  <Last_DIF_Revision_Date>2015-11-29</Last_DIF_Revision_Date>
+  <DIF_Revision_History>2016-03-10 - record updated by Dave Connell - basic updates.</DIF_Revision_History>
+  <Extended_Metadata>
+    <Metadata>
+      <Group>gov.nasa.gsfc.gcmd</Group>
+      <Name>metadata.uuid</Name>
+      <Value>f4d30361-f1bd-4c44-9d23-99208fe35b7d</Value>
+    </Metadata>
+    <Metadata>
+      <Group>gov.nasa.gsfc.gcmd</Group>
+      <Name>metadata.extraction_date</Name>
+      <Value>2015-11-29 18:23:23</Value>
+    </Metadata>
+    <Metadata>
+      <Group>gov.nasa.gsfc.gcmd</Group>
+      <Name>metadata.keyword_version</Name>
+      <Value>8.1</Value>
+    </Metadata>
+    <Metadata>
+      <Group>gov.nasa.gsfc.gcmd</Group>
+      <Name>GranuleSpatialRepresentation</Name>
+      <Value>CARTESIAN</Value>
+    </Metadata>
+  </Extended_Metadata>
+</DIF>

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -690,10 +690,46 @@
                     :concept-type :collection
                     :format-key :dif10
                     :native-id "cmr-5136-related-url-test"})
+          concept-5138-1
+                  (d/ingest-concept-with-metadata-file
+                   "CMR-5138-DIF10-DataDates-Equal-NotProvided.xml"
+                   {:provider-id "PROV1"
+                    :concept-type :collection
+                    :format-key :dif10
+                    :native-id "CMR-5138-DataDates-NotProvided-test"})
+          concept-5138-2
+                  (d/ingest-concept-with-metadata-file
+                   "CMR-5138-DIF10-DataDates-Provided.xml"
+                   {:provider-id "PROV1"
+                    :concept-type :collection
+                    :format-key :dif10
+                    :native-id "CMR-5138-DataDates-Provided-test"})
+          concept-5138-3
+                  (d/ingest-concept-with-metadata-file
+                   "CMR-5138-DIF9-DataDates-Not-Exist.xml"
+                   {:provider-id "PROV1"
+                    :concept-type :collection
+                    :format-key :dif
+                    :native-id "CMR-5138-DataDates-NotExist-test"})
           _ (index/wait-until-indexed)
           opendata (search/find-concepts-opendata :collection {:concept_id (:concept-id concept)})
           opendata-coll (first (get-in opendata [:results :dataset]))
-          {:keys [references distribution]} opendata-coll]
+          {:keys [references distribution]} opendata-coll
+          opendata-5138-1 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-1)})
+          opendata-5138-2 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-2)})
+          opendata-5138-3 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-3)})
+          opendata-coll-5138-1 (first (get-in opendata-5138-1 [:results :dataset]))
+          opendata-coll-5138-2 (first (get-in opendata-5138-2 [:results :dataset]))
+          opendata-coll-5138-3 (first (get-in opendata-5138-3 [:results :dataset]))]
+      (testing "issued modified are correct for DataDates being Not provided."
+        (is (= "1997-10-01T00:00:00Z" (:issued opendata-coll-5138-1)))
+        (is (= "1999-03-31T23:59:59Z" (:modified opendata-coll-5138-1))))
+      (testing "issued modified are correct for DataDates that are provided."
+        (is (= "2014-09-24T00:00:00.000Z" (:issued opendata-coll-5138-2)))
+        (is (= "2014-09-24T00:00:00.000Z" (:modified opendata-coll-5138-2))))
+      (testing "issued modified are correct for missing DataDates"
+        (is (= "1997-10-01T00:00:00Z" (:issued opendata-coll-5138-3)))
+        (is (= "1999-03-31T23:59:59Z" (:modified opendata-coll-5138-3))))
       (testing "references are correct"
         (is (= #{"https://doi.org/10.1117/1.JRS.8.084994" "https://doi.org/10.5194/acp-14-399-2014"}
                (set references))))


### PR DESCRIPTION
For opendata collection search, when the collection's Creation Date and Last Modified Date are not present, or when they are equal to the default 1970 date, use collection's earliest granule's start date and latest granule's end date. If the collection has no granules, we should leave Creation Date blank and Last Modified Date blank(but since it's a required field, we are adding a default currently, which is different from the 1970 date).  This is what the ticket asked.

In this PR:
1. We always use granule-start-date and granule-end-date regardless of if the collection has granules. When collection doesn't have granules, these dates contain the earliest and the latest of the collection's TemporalExtent data. @chris-durbin thinks we might just want to do it this way. If we decide we want to still do what ticket asks, I could pull has-granules and check it. But because of the following, it can't be achieved right now as it will always be false. 
2. We still need to update the index periodically to reflect the latest granule-start-date and granule-end-date which is obtained from elastic search through collection-granule-aggregation.  This is a lot more work, Chris said we might want to have a separate ticket for this :)

