### PR TITLE
CMR-5217: Refactor granule-start-date-stored and granule-end-date-stored

### DIFF
--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -93,10 +93,10 @@
                              (get-in bucket [:max-temporal :value]))
                  some-with-no-end (> (get-in bucket [:no-end-date :doc_count]) 0)]]
        [concept-id
-        {:granule-start-date-stored earliest-start
+        {:granule-start-date earliest-start
          ;; Max end date will be nil if there are some that have no end date. This indicates they go on
          ;; forever.
-         :granule-end-date-stored (when-not some-with-no-end latest-end)}]))))
+         :granule-end-date (when-not some-with-no-end latest-end)}]))))
 
 (defn- fetch-coll-gran-aggregates
   "Searches across all the granule indexes to aggregate by collection. Returns a map of collection
@@ -151,8 +151,8 @@
   (util/map-values
    (fn [aggregate-map]
      (-> aggregate-map
-         (update :granule-start-date-stored joda-time->cachable-value)
-         (update :granule-end-date-stored joda-time->cachable-value)))
+         (update :granule-start-date joda-time->cachable-value)
+         (update :granule-end-date joda-time->cachable-value)))
    coll-gran-aggregates))
 
 (defn- cached-value->coll-gran-aggregates
@@ -161,8 +161,8 @@
   (util/map-values
    (fn [aggregate-map]
      (-> aggregate-map
-         (update :granule-start-date-stored cached-value->joda-time)
-         (update :granule-end-date-stored cached-value->joda-time)))
+         (update :granule-start-date cached-value->joda-time)
+         (update :granule-end-date cached-value->joda-time)))
    cached-value))
 
 (defn- merge-granule-times
@@ -170,12 +170,12 @@
   [gt1 gt2]
 
   (if (and gt1 gt2)
-    (let [{start1 :granule-start-date-stored end1 :granule-end-date-stored} gt1
-          {start2 :granule-start-date-stored end2 :granule-end-date-stored} gt2]
-      {:granule-start-date-stored (if (< (compare start1 start2) 0) start1 start2)
-       :granule-end-date-stored (when (and end1 end2) ;; If either is nil return nil
-                                  ;; else return max time
-                                  (if (> (compare end1 end2) 0) end1 end2))})
+    (let [{start1 :granule-start-date end1 :granule-end-date} gt1
+          {start2 :granule-start-date end2 :granule-end-date} gt2]
+      {:granule-start-date (if (< (compare start1 start2) 0) start1 start2)
+       :granule-end-date (when (and end1 end2) ;; If either is nil return nil
+                           ;; else return max time
+                           (if (> (compare end1 end2) 0) end1 end2))})
     (or gt1 gt2)))
 
 (defn- merge-coll-gran-aggregates

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -319,8 +319,8 @@
           ;; if the collection has not granules.
           :granule-start-date             m/date-field-mapping
           :granule-end-date               m/date-field-mapping
-          :granule-start-date-stored             (m/stored m/date-field-mapping)
-          :granule-end-date-stored               (m/stored m/date-field-mapping)
+          :granule-start-date-stored      (m/stored m/date-field-mapping)
+          :granule-end-date-stored        (m/stored m/date-field-mapping)
 
           :has-granules (m/stored m/bool-field-mapping)
           :has-granules-or-cwic (m/stored m/bool-field-mapping)

--- a/indexer-app/test/cmr/indexer/test/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/test/cmr/indexer/test/data/collection_granule_aggregation_cache.clj
@@ -30,10 +30,10 @@
                      :no-end-date {:doc_count 1}}]}}})
 
 (def sample-coll-gran-aggregates
-  {"C1-PROV1" {:granule-start-date-stored (t/date-time 2003)
-               :granule-end-date-stored (t/date-time 2008)}
-   "C2-PROV1" {:granule-start-date-stored (t/date-time 2001)
-               :granule-end-date-stored nil}})
+  {"C1-PROV1" {:granule-start-date (t/date-time 2003)
+               :granule-end-date (t/date-time 2008)}
+   "C2-PROV1" {:granule-start-date (t/date-time 2001)
+               :granule-end-date nil}})
 
 
 (deftest parse-aggregations-response-test
@@ -71,8 +71,8 @@
 (def granule-dates
   "Generator of maps containing granule start and end dates where end date is optional"
   (gen/fmap (fn [[start end]]
-              {:granule-start-date-stored start
-               :granule-end-date-stored end})
+              {:granule-start-date start
+               :granule-end-date end})
             ;; generate 1 to 2 dates as longs in order from smallest to largest.
             (gen/fmap sort (gen/vector gen/s-pos-int 1 2))))
 
@@ -86,26 +86,26 @@
   [merged cg1 cg2]
   (every?
    true?
-   (for [[coll {:keys [granule-start-date-stored granule-end-date-stored]}] merged
+   (for [[coll {:keys [granule-start-date granule-end-date]}] merged
          :let [gt1 (get cg1 coll)
                gt2 (get cg2 coll)]]
      (if (and gt1 gt2)
-       (let [{cg1-start :granule-start-date-stored cg1-end :granule-end-date-stored} gt1
-             {cg2-start :granule-start-date-stored cg2-end :granule-end-date-stored} gt2]
+       (let [{cg1-start :granule-start-date cg1-end :granule-end-date} gt1
+             {cg2-start :granule-start-date cg2-end :granule-end-date} gt2]
 
          (and ;The start date is equal the smaller of the two
-              (= granule-start-date-stored (min cg1-start cg2-start))
+              (= granule-start-date (min cg1-start cg2-start))
 
               (or ;The granule end date is nil if one of the others is nil
-                  (and (nil? granule-end-date-stored) (or (nil? cg1-end) (nil? cg2-end)))
+                  (and (nil? granule-end-date) (or (nil? cg1-end) (nil? cg2-end)))
                   ;; else all three are present and granule end date is equal to the largest date.
-                  (and (some? granule-end-date-stored) (some? cg1-end) (some? cg2-end)
-                       (= granule-end-date-stored (max cg1-end cg2-end))))))
+                  (and (some? granule-end-date) (some? cg1-end) (some? cg2-end)
+                       (= granule-end-date (max cg1-end cg2-end))))))
 
 
-       (let [{start :granule-start-date-stored end :granule-end-date-stored} (or gt1 gt2)]
-         (and (= granule-start-date-stored start)
-              (= granule-end-date-stored end)))))))
+       (let [{start :granule-start-date end :granule-end-date} (or gt1 gt2)]
+         (and (= granule-start-date start)
+              (= granule-end-date end)))))))
 
 (defspec merging-collection-granule-aggrates-spec 100
   (for-all [[cg1 cg2] (gen/tuple collection-granule-aggregate-gen collection-granule-aggregate-gen)]

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -61,7 +61,9 @@
                           :author :authors
                           :doi :doi-stored
                           :service-name :service-names
-                          :service-concept-id :service-concept-ids}]
+                          :service-concept-id :service-concept-ids
+                          :granule-start-date :granule-start-date-stored
+                          :granule-end-date :granule-end-date-stored}]
     (if (use-doc-values-fields)
       (merge default-mappings spatial-doc-values-field-mappings)
       default-mappings)))
@@ -129,7 +131,9 @@
    :measurements :measurement
    :authors :author
    :service-names :service-name
-   :service-concept-ids :service-concept-id})
+   :service-concept-ids :service-concept-id
+   :granule-start-date-stored :granule-start-date
+   :granule-end-date-stored :granule-end-date})
 
 (defmethod q2e/elastic-field->query-field-mappings :granule
   [_]

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -5,7 +5,7 @@
    [clj-time.core :as time]
    [clj-time.format :as f]
    [clojure.set :as set]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.walk :as walk]
    [cmr.common-app.services.search :as qs]
    [cmr.common-app.services.search.elastic-results-to-query-results :as elastic-results]
@@ -81,8 +81,8 @@
                          "start-date"
                          "end-date"
                          "revision-date"
-                         "granule-start-date-stored"
-                         "granule-end-date-stored"
+                         "granule-start-date"
+                         "granule-end-date"
                          "ords-info"
                          "ords"
                          "personnel"
@@ -133,18 +133,18 @@
           [start-date] :start-date
           [end-date] :end-date
           [revision-date] :revision-date
-          [granule-start-date-stored] :granule-start-date-stored
-          [granule-end-date-stored] :granule-end-date-stored
+          [granule-start-date] :granule-start-date
+          [granule-end-date] :granule-end-date
           [archive-center] :archive-center} :fields} elastic-result
         personnel (json/decode personnel true)
         related-urls  (map #(json/decode % true) related-urls)
-        start-date (when start-date (str/replace (str start-date) #"\+0000" "Z"))
-        end-date (when end-date (str/replace (str end-date) #"\+0000" "Z"))
-        revision-date (when revision-date (str/replace (str revision-date) #"\+0000" "Z"))
-        granule-start-date-stored (when granule-start-date-stored
-                                    (str/replace (str granule-start-date-stored) #"\+0000" ".000Z"))
-        granule-end-date-stored (when granule-end-date-stored
-                                  (str/replace (str granule-end-date-stored) #"\+0000" ".000Z"))]
+        start-date (when start-date (string/replace (str start-date) #"\+0000" "Z"))
+        end-date (when end-date (string/replace (str end-date) #"\+0000" "Z"))
+        revision-date (when revision-date (string/replace (str revision-date) #"\+0000" "Z"))
+        granule-start-date (when granule-start-date
+                             (string/replace (str granule-start-date) #"\+0000" ".000Z"))
+        granule-end-date (when granule-end-date
+                           (string/replace (str granule-end-date) #"\+0000" ".000Z"))]
     (merge {:id concept-id
             :title entry-title
             :short-name short-name
@@ -160,8 +160,8 @@
             :start-date start-date
             :end-date end-date
             :revision-date revision-date
-            :granule-start-date-stored granule-start-date-stored
-            :granule-end-date-stored granule-end-date-stored
+            :granule-start-date granule-start-date
+            :granule-end-date granule-end-date
             :provider-id provider-id
             :science-keywords-flat science-keywords-flat
             :entry-title entry-title
@@ -235,7 +235,7 @@
 (defn- get-issued-modified-time
   "Get collection's issued/modified time. Parameter time could be either
   the collection's insert-time or update-time. Parameter gran-time could be either
-  granule-start-date-stored or granule-end-date-stored.
+  granule-start-date or granule-end-date.
   when insert-time/update-time is nil or default value, get issued/modified time
   from collection's earliest granule's start-date, and latest granule's end-date."
   [time gran-time]
@@ -249,12 +249,12 @@
   (let [{:keys [id summary short-name project-sn update-time insert-time provider-id
                 science-keywords-flat entry-title opendata-format start-date end-date
                 related-urls publication-references personnel shapes archive-center
-                revision-date granule-start-date-stored granule-end-date-stored]} item
-        issued-time (get-issued-modified-time insert-time granule-start-date-stored)
+                revision-date granule-start-date granule-end-date]} item
+        issued-time (get-issued-modified-time insert-time granule-start-date)
         ;; if issued-time is default date, set it to nil.
         issued-time (when-not (= issued-time (str umm-spec-date-util/parsed-default-date))
                       issued-time)
-        modified-time (get-issued-modified-time update-time granule-end-date-stored)]
+        modified-time (get-issued-modified-time update-time granule-end-date)]
     ;; All fields are required unless otherwise noted
     (util/remove-nil-keys {:title (or entry-title umm-spec-util/not-provided)
                            :description (not-empty summary)

--- a/system-int-test/src/cmr/system_int_test/data2/opendata.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/opendata.clj
@@ -72,7 +72,7 @@
   ingest. If umm-json leave as is since parse-concept will convert to echo10."
   [collection]
   (let [{:keys [format-key concept-id data-format provider-id]} collection
-        ;; Normally :revision-date field doesn't exist in collection. Only when 
+        ;; Normally :revision-date field doesn't exist in collection. Only when
         ;; it's needed to populate modified field, this field is manually added
         ;; in the test from umm-json result.
         revision-date (:revision-date collection)
@@ -128,9 +128,9 @@
                             :language [odrh/LANGUAGE_CODE]
                             :references (not-empty
                                          (map ru/related-url->encoded-url publication-references))
-                            :issued (when (and insert-time 
-                                               (not= (str date-util/parsed-default-date) 
-                                                      (str/replace (str insert-time) #"Z" ".000Z")))
+                            :issued (when (and insert-time
+                                               (not= (str date-util/parsed-default-date)
+                                                     (str/replace (str insert-time) #"Z" ".000Z")))
                                       (str insert-time))})))
 
 (defn collections->expected-opendata

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -211,7 +211,7 @@
 (deftest collection-umm-json-metadata-cache-test
   (let [accepted-version (common-config/collection-umm-version)
         _ (side/eval-form `(common-config/set-collection-umm-version!
-                          umm-version/current-collection-version))
+                            umm-version/current-collection-version))
         c1-r1-echo (d/ingest "PROV1" (du/umm-spec-collection {:entry-title "c1-echo"})
                              {:format :echo10})
         c1-r2-echo (d/ingest "PROV1" (du/umm-spec-collection {:entry-title "c1-echo"
@@ -253,7 +253,7 @@
       (assert-cache-state {c1-r2-echo [:echo10 latest-umm-format]
                            c2-echo [:echo10 latest-umm-format]
                            c10-umm-json [latest-umm-format]}))
-  (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))
+   (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))
 
 ;; Tests that we can ingest and find items in different formats
 (deftest multi-format-search-test
@@ -603,7 +603,7 @@
         umm-json-coll5 (search/find-concepts-umm-json :collection {:concept_id (:concept-id coll5)})
         revision-date-coll5 (-> umm-json-coll5
                                 (get-in [:results :items])
-                                 first
+                                first
                                  (get-in [:meta :revision-date]))
         ;; Normally coll5 doesn't contain the :revision-date field. Only when this field is needed
         ;; to populate modified field, we add it to coll5 so that it can be used for the "expected" in opendata.clj.
@@ -738,7 +738,7 @@
         (is (= "2014-09-24T00:00:00.000Z" (:issued opendata-coll-5138-2)))
         (is (= "2014-09-24T00:00:00.000Z" (:modified opendata-coll-5138-2))))
       (testing "issued modified are correct for no DataDates and no Temporal_Coverage"
-        (is (= (get-in umm-json-coll-5138-3 [:meta :revision-date]) 
+        (is (= (get-in umm-json-coll-5138-3 [:meta :revision-date])
                (:modified opendata-coll-5138-3)))
         (is (= nil (:issued opendata-coll-5138-3))))
       (testing "references are correct"
@@ -833,7 +833,7 @@
   (testing "the organizations field in JSON response is correctly ordered by archive-center, distribution center, then the rest"
     (let [accepted-version (common-config/collection-umm-version)
           _ (side/eval-form `(common-config/set-collection-umm-version!
-                          umm-version/current-collection-version))
+                              umm-version/current-collection-version))
           distribution-org (dc/org :distribution-center "distribution-org")
           distribution-org-1 (dc/org :distribution-center "distribution-org-1")
           archive-org (dc/org :archive-center "archive-org")


### PR DESCRIPTION
![](https://media2.giphy.com/media/eQxrlxPiRd8kw/giphy-downsized.gif?cid=6104955e5bc64e635a39394973636616)
Refactor so that the Elasticsearch index field-names aren't exposed outside of the indexer and query-to-elastic namespaces.