### PR TITLE
CMR-5184-5185:  Added support for feature ids and crid ids.

### DIFF
--- a/umm-lib/src/cmr/umm/test/generators/granule.clj
+++ b/umm-lib/src/cmr/umm/test/generators/granule.clj
@@ -38,6 +38,8 @@
   (ext-gen/model-gen
     g/map->DataGranule
     (gen/hash-map :producer-gran-id (ext-gen/optional (ext-gen/string-ascii 1 10))
+                  :crid-ids (ext-gen/nil-if-empty (gen/vector (ext-gen/string-ascii 1 10)))
+                  :feature-ids (ext-gen/nil-if-empty (gen/vector (ext-gen/string-ascii 1 10)))
                   :day-night (gen/elements ["DAY" "NIGHT" "BOTH" "UNSPECIFIED"])
                   :production-date-time ext-gen/date-time
                   :size (ext-gen/choose-double 0 1024))))

--- a/umm-lib/src/cmr/umm/umm_granule.clj
+++ b/umm-lib/src/cmr/umm/umm_granule.clj
@@ -37,6 +37,12 @@
 
    ;; maps to Granule/DataGranule/SizeMBDataGranule
    size
+
+   ;; currently not mapped to any echo10/iso-smap granule schema.
+   crid-ids
+
+   ;; currently not mapped to any echo10/iso-smap granule schema.
+   feature-ids
    ])
 
 (defrecord GranuleTemporal

--- a/umm-lib/test/cmr/umm/test/echo10/granule.clj
+++ b/umm-lib/test/cmr/umm/test/echo10/granule.clj
@@ -38,7 +38,9 @@
     (let [xml (echo10/umm->echo10-xml granule)
           parsed (g/parse-granule xml)
           expected-parsed (umm->expected-parsed-echo10 granule)]
-      (= parsed expected-parsed))))
+      ;; Remove crid-ids and feature-ids because they are not supported in echo10 
+      (= (update-in parsed [:data-granule] dissoc :crid-ids :feature-ids)
+         (update-in expected-parsed [:data-granule] dissoc :crid-ids :feature-ids)))))
 
 (def all-fields-granule-xml
   "<Granule>

--- a/umm-lib/test/cmr/umm/test/iso_smap/granule.clj
+++ b/umm-lib/test/cmr/umm/test/iso_smap/granule.clj
@@ -93,7 +93,9 @@
     (let [xml (iso/umm->iso-smap-xml granule)
           parsed (g/parse-granule xml)
           expected-parsed (umm->expected-parsed-smap-iso granule)]
-      (= parsed expected-parsed))))
+      ;; Remove crid-ids and feature-ids because they are not supported in iso-smap.
+      (= (update-in parsed [:data-granule] dissoc :crid-ids :feature-ids)
+         (update-in expected-parsed [:data-granule] dissoc :crid-ids :feature-ids)))))
 
 (def sample-granule-xml
   (slurp (io/file (io/resource "data/iso_smap/sample_smap_iso_granule.xml"))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_g/expected_util.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_g/expected_util.clj
@@ -59,6 +59,8 @@
     :data-granule (umm-lib-g/map->DataGranule
                    {:day-night "UNSPECIFIED"
                     :producer-gran-id "SMAP_L3_SM_P_20150407_R13080_001.h5"
+                    :crid-ids ["CRIDValue"]
+                    :feature-ids ["FeatureIdValue1" "FeatureIdValue2"]
                     :production-date-time (dtp/parse-datetime "2018-07-19T12:01:01.000Z")
                     :size 23})
     :temporal (umm-lib-g/map->GranuleTemporal

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_g/granule.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_g/granule.clj
@@ -25,7 +25,15 @@
           actual (core/parse-metadata {} :granule :umm-json umm-g-metadata)
           expected (expected-util/umm->expected-parsed granule)
           actual (update-in actual [:spatial-coverage :geometries] set)
-          expected (update-in expected [:spatial-coverage :geometries] set)]
+          expected (update-in expected [:spatial-coverage :geometries] set)
+          ;; Need to remove the possible duplicate entries in crid-ids and feature-ids
+          ;; because Identifiers in UMM-G can't contain any duplicates.
+          expected (if (get-in expected [:data-granule :crid-ids]) 
+                     (update-in expected [:data-granule :crid-ids] distinct)
+                     expected)
+          expected (if (get-in expected [:data-granule :feature-ids])
+                     (update-in expected [:data-granule :feature-ids] distinct)
+                     expected)]
       (is (= expected actual)))))
 
 (def sample-umm-g-granule


### PR DESCRIPTION
The PR addressed:
1. Added support for grid-ids and feature-ids in old umm-g and new UMM-G v1.4 
2. Modified the generator code and the related tests so that the round trip of umm->UMM-G->umm
    tests could pass.

Note: Currently we don't support these fields in echo10 and iso_smap, so there is no need to parse them, yet. Also, the acceptance criteria says only to make the umm to UMM-G v1.4 round trip pass. So, this PR only covers that.  If we need to search for the granules using the crid-id and feature-id, I will have another PR to cover that.