### PR TITLE
CMR-5143: Add collection citations to data.gov.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -170,7 +170,8 @@
          collection-data-type :CollectionDataType summary :Abstract
          temporal-keywords :TemporalKeywords platforms :Platforms
          related-urls :RelatedUrls collection-temporal-extents :TemporalExtents
-         publication-references :PublicationReferences} collection
+         publication-references :PublicationReferences
+         collection-citations :CollectionCitations} collection
         parsed-version-id (collection-util/parse-version-id version-id)
         doi (get-in collection [:DOI :DOI])
         doi-lowercase (util/safe-lowercase doi)
@@ -186,6 +187,7 @@
         opendata-related-urls (map opendata/related-url->opendata-related-url related-urls)
         opendata-references (keep opendata/publication-reference->opendata-reference
                                   publication-references)
+        opendata-citations (keep opendata/collection-citation->opendata-citation collection-citations)
         personnel (opendata/opendata-email-contact collection)
         platforms (map util/map-keys->kebab-case platforms)
         kms-index (kf/get-kms-index context)
@@ -357,6 +359,7 @@
             :metadata-format (name (mt/format-key format))
             :related-urls (map json/generate-string opendata-related-urls)
             :publication-references opendata-references
+            :collection-citations  (map json/generate-string opendata-citations)
             :update-time update-time
             :insert-time insert-time
             :created-at created-at

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -56,3 +56,15 @@
   [publication-reference]
   (when-let [doi (-> publication-reference :DOI :DOI)]
     (doi->url doi)))
+
+(defn collection-citation->opendata-citation
+  "Returns subset of collection-citation needed for opendata response."
+  [collection-citation]
+  (let [citation-keys [:Creator
+                       :Editor
+                       :SeriesName
+                       :ReleasePlace
+                       :IssueIdentification
+                       :DataPresentationForm
+                       :OtherCitationDetails]]
+    (not-empty (select-keys collection-citation citation-keys))))

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -57,14 +57,17 @@
   (when-let [doi (-> publication-reference :DOI :DOI)]
     (doi->url doi)))
 
+(def citation-keys
+  "Subset of keys to retrieve from collection-citations."
+  [:Creator
+   :DataPresentationForm
+   :Editor
+   :IssueIdentification
+   :OtherCitationDetails
+   :ReleasePlace
+   :SeriesName])
+
 (defn collection-citation->opendata-citation
   "Returns subset of collection-citation needed for opendata response."
   [collection-citation]
-  (let [citation-keys [:Creator
-                       :Editor
-                       :SeriesName
-                       :ReleasePlace
-                       :IssueIdentification
-                       :DataPresentationForm
-                       :OtherCitationDetails]]
-    (not-empty (select-keys collection-citation citation-keys))))
+  (not-empty (select-keys collection-citation citation-keys)))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -413,6 +413,7 @@
           :science-keywords-flat (m/stored m/string-field-mapping)
           :related-urls (m/stored m/string-field-mapping)
           :publication-references (m/stored m/string-field-mapping)
+          :collection-citations (m/stored m/string-field-mapping)
           :contact-email (m/stored m/string-field-mapping)
           :personnel (m/stored m/string-field-mapping)
 

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -78,6 +78,7 @@
                          "project-sn"
                          "related-urls"
                          "publication-references"
+                         "collection-citations"
                          "start-date"
                          "end-date"
                          "revision-date"
@@ -126,6 +127,7 @@
           [opendata-format] :opendata-format
           related-urls :related-urls
           publication-references :publication-references
+          collection-citations :collection-citations
           [entry-title] :entry-title
           ords-info :ords-info
           ords :ords
@@ -138,6 +140,7 @@
           [archive-center] :archive-center} :fields} elastic-result
         personnel (json/decode personnel true)
         related-urls  (map #(json/decode % true) related-urls)
+        collection-citations (map #(json/decode % true) collection-citations)
         start-date (when start-date (string/replace (str start-date) #"\+0000" "Z"))
         end-date (when end-date (string/replace (str end-date) #"\+0000" "Z"))
         revision-date (when revision-date (string/replace (str revision-date) #"\+0000" "Z"))
@@ -154,6 +157,7 @@
             :concept-type :collection
             :related-urls related-urls
             :publication-references publication-references
+            :collection-citations collection-citations
             :project-sn project-sn
             :shapes (srl/ords-info->shapes ords-info ords)
             :personnel personnel
@@ -249,7 +253,7 @@
   (let [{:keys [id summary short-name project-sn update-time insert-time provider-id
                 science-keywords-flat entry-title opendata-format start-date end-date
                 related-urls publication-references personnel shapes archive-center
-                revision-date granule-start-date granule-end-date]} item
+                revision-date granule-start-date granule-end-date collection-citations]} item
         issued-time (get-issued-modified-time insert-time granule-start-date)
         ;; if issued-time is default date, set it to nil.
         issued-time (when-not (= issued-time (str umm-spec-date-util/parsed-default-date))
@@ -272,6 +276,13 @@
                            :distribution (not-empty (map related-url->distribution related-urls))
                            :landingPage (landing-page related-urls)
                            :language  [LANGUAGE_CODE]
+                           :creator (not-empty (keep :Creator collection-citations))
+                           :editor (not-empty (keep :Editor collection-citations))
+                           :series-name (not-empty (keep :SeriesName collection-citations))
+                           :release-place (not-empty (keep :ReleasePlace collection-citations))
+                           :issue-identification (not-empty (keep :IssueIdentification collection-citations))
+                           :data-presentation-form (not-empty (keep :DataPresentationForm collection-citations))
+                           :citation-details (not-empty (keep :OtherCitationDetails collection-citations))
                            :references (not-empty
                                         (map ru/related-url->encoded-url publication-references))
                            :issued (not-empty issued-time)})))

--- a/system-int-test/resources/opendata-testing-file.xml
+++ b/system-int-test/resources/opendata-testing-file.xml
@@ -8,13 +8,16 @@
     <Entry_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006 (AIRX3STD) at GES DISC</Entry_Title>
     <Dataset_Citation>
         <Dataset_Creator>AIRS Science Team/Joao Texeira</Dataset_Creator>
+        <Dataset_Editor>Test Editor</Dataset_Editor>
         <Dataset_Title>AIRS/Aqua L3 Daily Standard Physical Retrieval (AIRS+AMSU) 1 degree x 1 degree V006</Dataset_Title>
         <Dataset_Series_Name>AIRX3STD</Dataset_Series_Name>
         <Dataset_Release_Date>2013-03-12</Dataset_Release_Date>
         <Dataset_Release_Place>Greenbelt, MD, USA</Dataset_Release_Place>
         <Dataset_Publisher>Goddard Earth Sciences Data and Information Services Center (GES DISC)</Dataset_Publisher>
         <Version>006</Version>
+        <Issue_Identification>Test Issue Identification</Issue_Identification>
         <Data_Presentation_Form>Digital Science Data</Data_Presentation_Form>
+        <Other_Citation_Details>Test Citation Details</Other_Citation_Details>
         <Persistent_Identifier>
             <Type>DOI</Type>
             <Identifier>doi:10.5067/Aqua/AIRS/DATA301</Identifier>

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -692,11 +692,11 @@
 (deftest opendata-search-result
   (testing "Opendata search response"
     (let [concept (d/ingest-concept-with-metadata-file
-                   "cmr-5136-opendata-related-urls.xml"
+                   "opendata-testing-file.xml"
                    {:provider-id "PROV1"
                     :concept-type :collection
                     :format-key :dif10
-                    :native-id "cmr-5136-related-url-test"})
+                    :native-id "opendata-test"})
           concept-5138-1
                   (d/ingest-concept-with-metadata-file
                    "CMR-5138-DIF10-DataDates-Equal-NotProvided.xml"
@@ -730,6 +730,30 @@
           opendata-coll-5138-2 (first (get-in opendata-5138-2 [:results :dataset]))
           opendata-coll-5138-3 (first (get-in opendata-5138-3 [:results :dataset]))
           umm-json-coll-5138-3 (first (get-in umm-json-5138-3 [:results :items]))]
+      (testing "collection citation fields in opendata response."
+        (are3 [expected-result field-key opendata-test-collection]
+          (is (= expected-result (field-key opendata-test-collection)))
+
+          "Creator in response"
+          ["AIRS Science Team/Joao Texeira"] :creator opendata-coll
+
+          "Editor in response"
+          ["Test Editor"] :editor opendata-coll
+
+          "SeriesName in response"
+          ["AIRX3STD"] :series-name opendata-coll
+
+          "Release place in response"
+          ["Greenbelt, MD, USA"] :release-place opendata-coll
+
+          "IssueIdentification in response"
+          ["Test Issue Identification"] :issue-identification opendata-coll
+
+          "DataPresentationFrom in response"
+          ["Digital Science Data"] :data-presentation-form opendata-coll
+
+          "OtherCitationDetails in response"
+          ["Test Citation Details"] :citation-details opendata-coll))
       (testing "issued modified are correct for DataDates being Not provided."
         ;; The DataDates in this file = "Not provided", use the collection's Temporal_Coverage which is provided.
         (is (= "2002-08-31T00:00:00.000Z" (:issued opendata-coll-5138-1)))


### PR DESCRIPTION
Added the following fields from collection citations:
* Creator
* Editor
* SeriesName
* ReleasePlace
* IssueIdentification
* DataPresentationForm
* OtherCitationDetails
Omitted the following fields from collection citations:
* Version: Already described in entry title.
* OnlineResource: Landing page already grabbed from RelatedURLs.
* Publisher: Publisher already retrieved from provider-id and archive center.
* Title: Title already retrieve from EntryTitle.

Example of added fields:
![collection-citation-data gov](https://user-images.githubusercontent.com/11383467/47173676-aeacd300-d2dc-11e8-8656-fb38446bf0f2.png)