### PR TITLE
CMR-5137: Landing pages in opendata response use DOI if present

### DIFF
--- a/common-lib/src/cmr/common/doi.clj
+++ b/common-lib/src/cmr/common/doi.clj
@@ -1,0 +1,27 @@
+(ns cmr.common.doi
+  "Functions for handling DOIs within the CMR.")
+
+(def doi-base-url
+  "The base DOI URL."
+  "https://doi.org")
+
+(defn doi->url
+  "Converts a DOI into a URL if it is not already a URL."
+  [doi]
+  (if (re-matches #"http.*" doi)
+    doi
+    (format "%s/%s" doi-base-url doi)))
+
+(defn cmr-landing-page
+  "Given a CMR host and a concept ID, return the collection landing page for
+  the given id."
+  [cmr-base-url concept-id]
+  (format "%sconcepts/%s.html" cmr-base-url concept-id))
+
+(defn get-landing-page
+  "Returns the landing page for a collection. If the collection has a DOI use that, otherwise
+  use the CMR HTML page for the collection."
+  [cmr-base-url item]
+  (if-let [doi (:doi item)]
+    (doi->url doi)
+    (cmr-landing-page cmr-base-url (:concept-id item))))

--- a/common-lib/test/cmr/common/test/doi.clj
+++ b/common-lib/test/cmr/common/test/doi.clj
@@ -1,0 +1,48 @@
+(ns cmr.common.test.doi
+  "Unit test DOI functions."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.doi :as doi]))
+
+(def cmr-base-url "http://cmr.test.host/")
+
+(def coll-data-1
+  {:concept-id "C1200000003-PROV1"
+   :short-name "s3"
+   :entry-title "coll3"
+   :version-id "6"})
+
+(def coll-data-2
+  {:concept-id "C1200000003-PROV1"
+   :short-name "s3"
+   :entry-title "coll3"
+   :version-id "7"
+   :doi "doi6"})
+
+(def coll-data-3
+  {:concept-id "C1200000003-PROV1"
+   :short-name "s3"
+   :entry-title "coll3"
+   :version-id "8"
+   :doi "http://dx.doi.org/doi7"})
+
+(deftest doi->url-test
+  (testing "DOI is a URL already"
+    (is (= "http://dx.doi.org/doi7" (doi/doi->url (:doi coll-data-3)))))
+  (testing "DOI is not a URL"
+    (is (= "https://doi.org/doi6" (doi/doi->url (:doi coll-data-2))))))
+
+(deftest cmr-landing-page-test
+  (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
+         (doi/cmr-landing-page cmr-base-url "C1200000003-PROV1"))))
+
+(deftest get-landing-page-test
+  (testing "with no DOI data (cmr-only)"
+    (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
+           (doi/get-landing-page cmr-base-url coll-data-1))))
+  (testing "with DOI data and NO URL in the DOI"
+    (is (= "https://doi.org/doi6"
+           (doi/get-landing-page cmr-base-url coll-data-2))))
+  (testing "with DOI data and URL in the DOI"
+    (is (= "http://dx.doi.org/doi7"
+           (doi/get-landing-page cmr-base-url coll-data-3)))))

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -1,6 +1,7 @@
 (ns cmr.indexer.data.concepts.collection.opendata
   "Contains functions to convert collection into opendata related elasticsearch documents"
-  (require
+  (:require
+   [cmr.common.doi :as doi]
    [cmr.indexer.data.concepts.collection.data-center :as data-center]))
 
 (defn- email-contact?
@@ -39,20 +40,9 @@
      :mime-type MimeType
      :size size}))
 
-(def doi-base-url
-  "The base DOI URL."
-  "https://doi.org")
-
-(defn- doi->url
-  "Converts a DOI into a URL if it is not already a URL."
-  [doi]
-  (if (re-matches #"http.*" doi)
-    doi
-    (format "%s/%s" doi-base-url doi)))
-
 (defn publication-reference->opendata-reference
   "Returns an opendata reference for the given collection publication reference. Opendata only
   allows a string for a publication reference, so we'll use the DOI of the publication reference."
   [publication-reference]
   (when-let [doi (-> publication-reference :DOI :DOI)]
-    (doi->url doi)))
+    (doi/doi->url doi)))

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -39,31 +39,31 @@
 
 (defmethod q2e/concept-type->field-mappings :collection
   [_]
-  (let [default-mappings {:provider :provider-id
-                          :version :version-id
-                          :project :project-sn2
-                          :project-sn :project-sn2
-                          :project-h :project-sn.humanized2
-                          :updated-since :revision-date2
-                          :two-d-coordinate-system-name :two-d-coord-name
-                          :platform :platform-sn
-                          :platform-h :platform-sn.humanized2
+  (let [default-mappings {:author :authors
+                          :data-center-h :organization.humanized2
+                          :doi :doi-stored
+                          :granule-end-date :granule-end-date-stored
+                          :granule-start-date :granule-start-date-stored
                           :instrument :instrument-sn
                           :instrument-h :instrument-sn.humanized2
-                          :sensor :sensor-sn
-                          :data-center-h :organization.humanized2
-                          :processing-level-id-h :processing-level-id.humanized2
-                          :revision-date :revision-date2
-                          :variable-name :variable-names
-                          :variable-concept-id :variable-concept-ids
-                          :variable-native-id :variable-native-ids
                           :measurement :measurements
-                          :author :authors
-                          :doi :doi-stored
-                          :service-name :service-names
+                          :platform :platform-sn
+                          :platform-h :platform-sn.humanized2
+                          :processing-level-id-h :processing-level-id.humanized2
+                          :project :project-sn2
+                          :project-h :project-sn.humanized2
+                          :project-sn :project-sn2
+                          :provider :provider-id
+                          :revision-date :revision-date2
+                          :sensor :sensor-sn
                           :service-concept-id :service-concept-ids
-                          :granule-start-date :granule-start-date-stored
-                          :granule-end-date :granule-end-date-stored}]
+                          :service-name :service-names
+                          :two-d-coordinate-system-name :two-d-coord-name
+                          :updated-since :revision-date2
+                          :variable-concept-id :variable-concept-ids
+                          :variable-name :variable-names
+                          :variable-native-id :variable-native-ids
+                          :version :version-id}]
     (if (use-doc-values-fields)
       (merge default-mappings spatial-doc-values-field-mappings)
       default-mappings)))
@@ -114,26 +114,27 @@
 
 (defmethod q2e/elastic-field->query-field-mappings :collection
   [_]
-  {:project-sn2 :project-sn
-   :project-sn.humanized2 :project-h
-   :two-d-coord-name :two-d-coordinate-system-name
-   :platform-sn :platform
-   :platform-sn.humanized2 :platform-h
+  {:authors :author
+   :doi-stored :doi
+   :granule-end-date-stored :granule-end-date
+   :granule-start-date-stored :granule-start-date
    :instrument-sn :instrument
    :instrument-sn.humanized2 :instrument-h
-   :sensor-sn :sensor
-   :organization.humanized2 :data-center-h
-   :processing-level-id.humanized2 :processing-level-id-h
-   :revision-date2 :revision-date
-   :variable-names :variable-name
-   :variable-concept-ids :variable-concept-id
-   :variable-native-ids :variable-native-id
    :measurements :measurement
-   :authors :author
-   :service-names :service-name
+   :organization.humanized2 :data-center-h
+   :platform-sn :platform
+   :platform-sn.humanized2 :platform-h
+   :processing-level-id.humanized2 :processing-level-id-h
+   :project-sn.humanized2 :project-h
+   :project-sn2 :project-sn
+   :revision-date2 :revision-date
+   :sensor-sn :sensor
    :service-concept-ids :service-concept-id
-   :granule-start-date-stored :granule-start-date
-   :granule-end-date-stored :granule-end-date})
+   :service-names :service-name
+   :two-d-coord-name :two-d-coordinate-system-name
+   :variable-concept-ids :variable-concept-id
+   :variable-names :variable-name
+   :variable-native-ids :variable-native-id})
 
 (defmethod q2e/elastic-field->query-field-mappings :granule
   [_]

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -16,6 +16,7 @@
    [cmr.common-app.services.search.query-execution :as query-exec]
    [cmr.common-app.services.search.query-model :as query-model]
    [cmr.common-app.site.data :as common-data]
+   [cmr.common.doi :as doi]
    [cmr.common.log :refer :all]
    [cmr.common.mime-types :as mt]
    [cmr.common.util :refer [defn-timed]]
@@ -84,7 +85,7 @@
                                   :page-size :unlimited
                                   :result-format :query-specified
                                   :result-fields [:concept-id
-                                                  :doi-stored
+                                                  :doi
                                                   :entry-title
                                                   :short-name
                                                   :version-id]})
@@ -120,29 +121,11 @@
        (remove #(zero? (get % :collections-count 0)))
        (sort-by :id)))
 
-(defn has-doi?
-  "Determine whether a collection item has a DOI entry."
-  [item]
-  (some? (:doi-stored item)))
-
-(defn cmr-link
-  "Given a CMR host and a concept ID, return the collection landing page for
-  the given id."
-  [cmr-base-url concept-id]
-  (format "%sconcepts/%s.html" cmr-base-url concept-id))
-
-(defn make-href
-  "Create the `href` part of a landing page link."
-  [cmr-base-url item]
-  (if (has-doi? item)
-    (format "http://dx.doi.org/%s" (:doi-stored item))
-    (cmr-link cmr-base-url (:concept-id item))))
-
 (defn make-holding-data
   "Given a single item from a query's collections, update the item with data
   for linking to its landing page."
   [cmr-base-url item]
-  (assoc item :link-href (make-href cmr-base-url item)))
+  (assoc item :link-href (doi/get-landing-page cmr-base-url item)))
 
 (defn make-holdings-data
   "Given a collection from an elastic search query, generate landing page

--- a/search-app/test/cmr/search/test/site/data.clj
+++ b/search-app/test/cmr/search/test/site/data.clj
@@ -1,7 +1,8 @@
 (ns cmr.search.test.site.data
-  (:require [clojure.test :refer :all]
-            [cmr.search.site.data :as data]
-            [cmr.transmit.config :as config]))
+  (:require
+   [clojure.test :refer :all]
+   [cmr.search.site.data :as data]
+   [cmr.transmit.config :as config]))
 
 (def cmr-base-url "http://cmr.test.host/")
 
@@ -16,32 +17,7 @@
    :short-name "s3"
    :entry-title "coll3"
    :version-id "7"
-   :doi-stored "doi6"})
-
-(deftest cmr-link
-  (testing "generate a cmr landing page from a host and a concept id"
-    (let [cmr-host "cmr.sit.earthdata.nasa.gov"
-          concept-id "C1200196931-SCIOPS"]
-      (is (= "https://cmr.sit.earthdata.nasa.gov/concepts/C1200196931-SCIOPS.html"
-             (data/cmr-link cmr-host concept-id))))))
-
-(deftest has-doi?
-  (testing "check for doi in data that doesn't have one"
-    (is (not (data/has-doi? coll-data-1))))
-  (testing "check for doi in data that has one"
-    (is (data/has-doi? coll-data-2))))
-
-(deftest cmr-link
-  (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
-         (data/cmr-link cmr-base-url "C1200000003-PROV1"))))
-
-(deftest make-href
-  (testing "with no doi data (cmr-only)"
-    (is (= "http://cmr.test.host/concepts/C1200000003-PROV1.html"
-           (data/make-href cmr-base-url coll-data-1))))
-  (testing "with doi data"
-    (is (= "http://dx.doi.org/doi6"
-           (data/make-href cmr-base-url coll-data-2)))))
+   :doi "doi6"})
 
 (deftest make-holding-data
   (testing "with an entry title and short name"
@@ -53,7 +29,7 @@
       (is (= "6" (:version-id data)))))
   (testing "with an entry title, short name, and doi"
     (let [data (data/make-holding-data cmr-base-url coll-data-2)]
-      (is (= "http://dx.doi.org/doi6" (:link-href data)))
+      (is (= "https://doi.org/doi6" (:link-href data)))
       (is (= "s3" (:short-name data)))
       (is (= "7" (:version-id data))))))
 
@@ -65,6 +41,6 @@
            (get-in data [0 :link-href])))
     (is (= "s3" (get-in data [0 :short-name])))
     (is (= "6" (get-in data [0 :version-id])))
-    (is (= "http://dx.doi.org/doi6" (get-in data [1 :link-href])))
+    (is (= "https://doi.org/doi6" (get-in data [1 :link-href])))
     (is (= "s3" (get-in data [1 :short-name])))
     (is (= "7" (get-in data [1 :version-id])))))

--- a/system-int-test/resources/CMR-5138-DIF10-DataDates-Provided.xml
+++ b/system-int-test/resources/CMR-5138-DIF10-DataDates-Provided.xml
@@ -15,10 +15,6 @@
         <Dataset_Publisher>Goddard Earth Sciences Data and Information Services Center (GES DISC)</Dataset_Publisher>
         <Version>003</Version>
         <Data_Presentation_Form>Digital Science Data</Data_Presentation_Form>
-        <Persistent_Identifier>
-            <Type>DOI</Type>
-            <Identifier>10.5067/Aura/OMI/DATA2022</Identifier>
-        </Persistent_Identifier>
         <Online_Resource>https://disc.gsfc.nasa.gov/datacollection/OMSO2_003.html</Online_Resource>
     </Dataset_Citation>
     <Personnel>

--- a/system-int-test/src/cmr/system_int_test/data2/opendata.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/opendata.clj
@@ -124,7 +124,7 @@
                             :temporal (odrh/temporal start-date end-date)
                             :theme (conj project-sn "geospatial")
                             :distribution distribution
-                            :landingPage (odrh/landing-page related-urls)
+                            :landingPage (format "http://localhost:3003/concepts/%s.html" concept-id)
                             :language [odrh/LANGUAGE_CODE]
                             :references (not-empty
                                          (map ru/related-url->encoded-url publication-references))

--- a/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_directory_pages_test.clj
@@ -82,7 +82,7 @@
 (defn expected-provider3-level-links?
   [body]
   (string/includes? body "EOSDIS holdings for the PROV3 provider")
-  (let [url "http://dx.doi.org"]
+  (let [url "https://doi.org"]
     (and
       (string/includes? body (format "%s/%s" url "doi102"))
       (string/includes? body (format "%s/%s" url "doi103"))
@@ -169,27 +169,27 @@
                                      {:format :umm-json
                                       :accept-format :json})))
          someadmin-guest-colls (doall (for [n (range 120 123)]
-                                    (d/ingest-umm-spec-collection
-                                     "SOMEADMIN"
-                                     (assoc exp-conv/curr-ingest-ver-example-collection-record
-                                            :ShortName (str "s" n)
-                                            :EntryTitle (str "Collection Item " n)
-                                            :DOI (cm/map->DoiType
-                                                  {:DOI (str "doi" n)
-                                                   :Authority (str "auth" n)}))
-                                     {:format :umm-json
-                                      :accept-format :json})))
+                                       (d/ingest-umm-spec-collection
+                                        "SOMEADMIN"
+                                        (assoc exp-conv/curr-ingest-ver-example-collection-record
+                                               :ShortName (str "s" n)
+                                               :EntryTitle (str "Collection Item " n)
+                                               :DOI (cm/map->DoiType
+                                                     {:DOI (str "doi" n)
+                                                      :Authority (str "auth" n)}))
+                                        {:format :umm-json
+                                         :accept-format :json})))
          someadmin-invisible-colls (doall (for [n (range 130 133)]
-                                    (d/ingest-umm-spec-collection
-                                     "SOMEADMIN"
-                                     (assoc exp-conv/curr-ingest-ver-example-collection-record
-                                            :ShortName (str "s" n)
-                                            :EntryTitle (str "Collection Item " n)
-                                            :DOI (cm/map->DoiType
-                                                  {:DOI (str "doi" n)
-                                                   :Authority (str "auth" n)}))
-                                     {:format :umm-json
-                                      :accept-format :json})))]
+                                           (d/ingest-umm-spec-collection
+                                            "SOMEADMIN"
+                                            (assoc exp-conv/curr-ingest-ver-example-collection-record
+                                                   :ShortName (str "s" n)
+                                                   :EntryTitle (str "Collection Item " n)
+                                                   :DOI (cm/map->DoiType
+                                                         {:DOI (str "doi" n)
+                                                          :Authority (str "auth" n)}))
+                                            {:format :umm-json
+                                             :accept-format :json})))]
 
     (reset! test-collections
             {"PROV1" (sort (map :concept-id [c1-p1 c2-p1 c3-p1]))


### PR DESCRIPTION
![](https://media3.giphy.com/media/xT39CRup15MdJgjLy0/giphy-downsized.gif?cid=6104955e5bcddcf66c414b344da1296c)
Otherwise they use the collection HTML response for the landing page.