### PR TITLE
CMT-5139: Add graphic to opendata response.

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -281,6 +281,12 @@
   [m filler]
   (w/postwalk-replace {nil filler} m))
 
+(defn nil-if-value
+  "Treat value as nil if matches key."
+  [key value]
+  (when-not (= key value)
+    value))
+
 (defn remove-empty-maps
   "Recursively removes maps with only nil values."
   [x]

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -32,17 +32,15 @@
   "Returns the opendata related url for the given collection related url"
   [related-url]
   (let [{:keys [Description Type Subtype URL]} related-url
-        Format (get-in related-url [:GetData :Format])
         get-data-mime-type (get-in related-url [:GetData :MimeType])
-        MimeType (get-in related-url [:GetService :MimeType])
+        get-service-mime-type (get-in related-url [:GetService :MimeType])
         size (get-in related-url [:GetData :Size])]
     {:type Type
      :sub-type Subtype
      :url URL
-     :format Format
      :get-data-mime-type get-data-mime-type
      :description Description
-     :mime-type MimeType
+     :get-service-mime-type get-service-mime-type
      :size size}))
 
 (defn publication-reference->opendata-reference

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -32,11 +32,15 @@
   "Returns the opendata related url for the given collection related url"
   [related-url]
   (let [{:keys [Description Type Subtype URL]} related-url
+        Format (get-in related-url [:GetData :Format])
+        get-data-mime-type (get-in related-url [:GetData :MimeType])
         MimeType (get-in related-url [:GetService :MimeType])
         size (get-in related-url [:GetData :Size])]
     {:type Type
      :sub-type Subtype
      :url URL
+     :format Format
+     :get-data-mime-type get-data-mime-type
      :description Description
      :mime-type MimeType
      :size size}))

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -331,6 +331,18 @@
                                     not-empty)]
      (str (string/join ". " citation-details) "."))))
 
+(defn- nil-if-not-provided
+  "nil if not provided."
+  [s]
+  (when-not (= umm-spec-util/not-provided s)
+    s))
+
+(defn graphic-preview-type
+  "Use format or mime type if provided."
+  [related-url]
+  (or (nil-if-not-provided (:format related-url))
+      (nil-if-not-provided (:get-data-mime-type related-url))))
+
 (defn- result->opendata
   "Converts a search result item to opendata."
   [context concept-type item]
@@ -343,7 +355,8 @@
         issued-time (when-not (= issued-time (str umm-spec-date-util/parsed-default-date))
                       issued-time)
         modified-time (get-issued-modified-time update-time granule-end-date)
-        collection-citation (first collection-citations)]
+        collection-citation (first collection-citations)
+        browse-image-related-url (first (ru/browse-urls related-urls))]
     ;; All fields are required unless otherwise noted
     (util/remove-nil-keys {:title (or entry-title umm-spec-util/not-provided)
                            :description (not-empty summary)
@@ -359,6 +372,9 @@
                            :temporal (temporal start-date end-date) ;; required if applicable
                            :theme (theme project-sn) ;; not required
                            :distribution (not-empty (map related-url->distribution related-urls))
+                           :graphic-preview-file (:url browse-image-related-url)
+                           :graphic-preview-description (:description browse-image-related-url)
+                           :graphic-preview-type (graphic-preview-type browse-image-related-url)
                            :landingPage (landing-page context item)
                            :language  [LANGUAGE_CODE]
                            :citation (citation collection-citation (select-keys item [:archive-center :doi :provider]))

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -2,16 +2,54 @@
   "This tests the opendata-results-handler namespace."
   (:require
    [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
    [cmr.search.results-handlers.opendata-results-handler :as opendata-results-handler]))
 
 (deftest graphic-preview-type
   (testing "Not provided results in the field not being displayed"
-    (is (nil? (opendata-results-handler/graphic-preview-type {:format "Not provided"})))
-    (is (nil? (opendata-results-handler/graphic-preview-type {:get-data-mime-type "Not provided"})))
-    (is (nil? (opendata-results-handler/graphic-preview-type {:format "Not provided"
-                                                              :get-data-mime-type "Not provided"}))))
+    (is (nil? (opendata-results-handler/graphic-preview-type {:get-data-mime-type "Not provided"}))))
   (testing "graphic-preview-type retrieval"
-    (is (= "image/gif" (opendata-results-handler/graphic-preview-type {:get-data-mime-type "image/gif"})))
-    (is (= "image/png" (opendata-results-handler/graphic-preview-type {:format "Not provided"
-                                                                       :get-data-mime-type "image/png"})))
-    (is (= "png" (opendata-results-handler/graphic-preview-type {:format "png"})))))
+    (is (= "image/gif" (opendata-results-handler/graphic-preview-type {:get-data-mime-type "image/gif"})))))
+
+(deftest get-best-browse-image
+ (let [all-browse-fields {:url "http://example.com"
+                          :get-data-mime-type "image/gif"
+                          :description "a test description-0"
+                          :type "GET RELATED VISUALIZATION"
+                          :size 0}
+       only-description {:description "a test description-1"
+                         :type "GET RELATED VISUALIZATION"}
+       only-not-provided-mime-type {:get-data-mime-type "Not provided"
+                                    :type "GET RELATED VISUALIZATION"}
+       only-mime-type {:get-data-mime-type "image/gif"
+                       :type "GET RELATED VISUALIZATION"}
+       no-browse-fields {:size 0
+                         :type "GET RELATED VISUALIZATION"
+                         :get-service-mime-type "image/png"}
+       not-a-browse-image {:type "GET DATA"
+                           :size 0
+                           :get-service-mime-type "image/png"
+                           :description "a test description-3"
+                           :get-data-mime-type "image/png"
+                           :url "http://example.com/not-a-browse-image"}]
+   (testing "Browse image related url with most fields is chosen"
+     (are3 [expected-url related-urls]
+       (is (= expected-url (opendata-results-handler/get-best-browse-image-related-url related-urls)))
+
+       "Related url with only mime type. One containing Not provided, one containing the actual mime-type"
+       only-mime-type [only-mime-type only-not-provided-mime-type]
+
+       "Browse with all fields"
+       all-browse-fields [only-description all-browse-fields only-mime-type]
+
+       "Browse image with only one field chosen over a non-browse image with all the fields."
+       only-mime-type [not-a-browse-image only-mime-type only-not-provided-mime-type]
+
+       "nil is returneded for no browse images found"
+       nil [not-a-browse-image]
+
+       "empty urls"
+       nil []
+
+       "nil urls"
+       nil nil))))

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -1,0 +1,17 @@
+(ns cmr.search.test.results-handlers.opendata-results-handler
+  "This tests the opendata-results-handler namespace."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.search.results-handlers.opendata-results-handler :as opendata-results-handler]))
+
+(deftest graphic-preview-type
+  (testing "Not provided results in the field not being displayed"
+    (is (nil? (opendata-results-handler/graphic-preview-type {:format "Not provided"})))
+    (is (nil? (opendata-results-handler/graphic-preview-type {:get-data-mime-type "Not provided"})))
+    (is (nil? (opendata-results-handler/graphic-preview-type {:format "Not provided"
+                                                              :get-data-mime-type "Not provided"}))))
+  (testing "graphic-preview-type retrieval"
+    (is (= "image/gif" (opendata-results-handler/graphic-preview-type {:get-data-mime-type "image/gif"})))
+    (is (= "image/png" (opendata-results-handler/graphic-preview-type {:format "Not provided"
+                                                                       :get-data-mime-type "image/png"})))
+    (is (= "png" (opendata-results-handler/graphic-preview-type {:format "png"})))))

--- a/system-int-test/src/cmr/system_int_test/data2/opendata.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/opendata.clj
@@ -107,7 +107,7 @@
         personnel (person-with-email personnel)
         contact-point (contact-point personnel)
         collection-citation (first collection-citations)
-        browse-image-related-url (first (ru/browse-urls related-urls))
+        browse-image-related-url (odrh/get-best-browse-image-related-url related-urls)
         archive-center (:org-name (first (filter #(= :archive-center (:type %)) organizations)))]
     (util/remove-nil-keys {:title entry-title
                            :description summary

--- a/system-int-test/src/cmr/system_int_test/data2/opendata.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/opendata.clj
@@ -107,6 +107,7 @@
         personnel (person-with-email personnel)
         contact-point (contact-point personnel)
         collection-citation (first collection-citations)
+        browse-image-related-url (first (ru/browse-urls related-urls))
         archive-center (:org-name (first (filter #(= :archive-center (:type %)) organizations)))]
     (util/remove-nil-keys {:title entry-title
                            :description summary
@@ -125,6 +126,9 @@
                            :temporal (odrh/temporal start-date end-date)
                            :theme (conj project-sn "geospatial")
                            :distribution distribution
+                           :graphic-preview-file (:url browse-image-related-url)
+                           :graphic-preview-description (:description browse-image-related-url)
+                           :graphic-preview-type (odrh/graphic-preview-type browse-image-related-url)
                            :landingPage (format "http://localhost:3003/concepts/%s.html" concept-id)
                            :language [odrh/LANGUAGE_CODE]
                            :citation (odrh/citation collection-citation {:provider provider-id

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -729,9 +729,15 @@
       (is (= 201 (:status concept-5138-1)))
       (is (= 201 (:status concept-5138-2)))
       (is (= 201 (:status concept-5138-3)))
-      (testing "collection citation fields in opendata response."
+      (testing "Opendata fields in response."
         (are3 [expected-result field-key opendata-test-collection]
           (is (= expected-result (field-key opendata-test-collection)))
+
+          "graphic-preview-file in response"
+          "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png" :graphic-preview-file opendata-coll-5138-1
+
+          "graphic-preview-description in response"
+          "Sample data of the \"AIRS/Aqua Level 3 daily standard physical retrieval product (Without HSB)\"." :graphic-preview-description opendata-coll-5138-1
 
           "Creator in response"
           "AIRS Science Team/Joao Texeira" :creator opendata-coll-5138-1


### PR DESCRIPTION
* Get browse images from RelatedUrls.
* Add graphic-preview-file from browse image URL.
* Add graphic-preview-description from browse image description.
* Add graphic-preview-type from either the RelatedUrl/GetData/Format or RelatedUrl/GetData/MimeType.

On data.gov the Additional Metadata will now display the fields as:
![graphic_meta](https://user-images.githubusercontent.com/11383467/47394068-90394400-d6ef-11e8-91d4-c9488212ce94.png)

The image will show as such:
![graphic_image](https://user-images.githubusercontent.com/11383467/47394076-962f2500-d6ef-11e8-947e-99b157f7d0cd.png)