### PR TITLE
CMR-5144 As a user browsing data.gov, I want the relevant Google Scholar link to appear on the page, so I can easily reference these listings.

### DIFF
--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -356,9 +356,10 @@
   See https://project-open-data.cio.gov/v1.1/schema/#dataset-distribution-fields."
   [doi]
   (when doi
-    {:accessURL (str "https://scholar.google.com/scholar?q=" (or (second
-                                                                  (re-find #"^doi:(.*)$" doi))
-                                                                 doi))
+    {:accessURL (ru/related-url->encoded-url
+                 (str "https://scholar.google.com/scholar?q=" (or (second
+                                                                   (re-find #"^doi:(.*)$" doi))
+                                                                  doi)))
      :title "Google Scholar search results",
      :description "Search results for publications that cite this dataset by its DOI."}))
 

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -63,7 +63,7 @@
       "Related URLs present with doi in doi: format"
       [{:accessURL "https://foo.bar/baz"
         :description "test description"}
-       {:accessURL "https://scholar.google.com/scholar?q=10.0000/Test/TEST/DATA301"
+       {:accessURL "https://scholar.google.com/scholar?q=10.0000%2FTest%2FTEST%2FDATA301"
         :title "Google Scholar search results",
         :description "Search results for publications that cite this dataset by its DOI."}]
       [{:description "test description"
@@ -73,7 +73,7 @@
       "Related URLs present with doi not in doi: format"
       [{:accessURL "https://foo.bar/baz"
         :description "test description"}
-       {:accessURL "https://scholar.google.com/scholar?q=This is a test string"
+       {:accessURL "https://scholar.google.com/scholar?q=This+is+a+test+string"
         :title "Google Scholar search results",
         :description "Search results for publications that cite this dataset by its DOI."}]
       [{:description "test description"
@@ -88,14 +88,14 @@
       nil
 
       "Related URLs nil with doi in doi: format"
-      [{:accessURL "https://scholar.google.com/scholar?q=10.0000/Test/TEST/DATA301"
+      [{:accessURL "https://scholar.google.com/scholar?q=10.0000%2FTest%2FTEST%2FDATA301"
         :title "Google Scholar search results",
         :description "Search results for publications that cite this dataset by its DOI."}]
       nil
       "doi:10.0000/Test/TEST/DATA301"
 
       "Related URLs nil with doi not in doi: format"
-      [{:accessURL "https://scholar.google.com/scholar?q=This is a test string",
+      [{:accessURL "https://scholar.google.com/scholar?q=This+is+a+test+string"
         :title "Google Scholar search results",
         :description "Search results for publications that cite this dataset by its DOI."}]
       nil

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -53,3 +53,55 @@
 
        "nil urls"
        nil nil))))
+
+(deftest distribution-test
+  (let [make-distributions #'opendata-results-handler/make-distributions]
+    (are3 [expected related-urls doi]
+      (is (= (set expected)
+             (set (make-distributions related-urls doi))))
+
+      "Related URLs present with doi in doi: format"
+      [{:accessURL "https://foo.bar/baz"
+        :description "test description"}
+       {:accessURL "https://scholar.google.com/scholar?q=10.0000/Test/TEST/DATA301"
+        :title "Google Scholar search results",
+        :description "Search results for publications that cite this dataset by its DOI."}]
+      [{:description "test description"
+        :url "https://foo.bar/baz"}]
+      "doi:10.0000/Test/TEST/DATA301"
+
+      "Related URLs present with doi not in doi: format"
+      [{:accessURL "https://foo.bar/baz"
+        :description "test description"}
+       {:accessURL "https://scholar.google.com/scholar?q=This is a test string"
+        :title "Google Scholar search results",
+        :description "Search results for publications that cite this dataset by its DOI."}]
+      [{:description "test description"
+        :url "https://foo.bar/baz"}]
+      "This is a test string"
+
+      "Related URLs present with doi nil"
+      [{:accessURL "https://foo.bar/baz"
+        :description "test description"}]
+      [{:description "test description"
+        :url "https://foo.bar/baz"}]
+      nil
+
+      "Related URLs nil with doi in doi: format"
+      [{:accessURL "https://scholar.google.com/scholar?q=10.0000/Test/TEST/DATA301"
+        :title "Google Scholar search results",
+        :description "Search results for publications that cite this dataset by its DOI."}]
+      nil
+      "doi:10.0000/Test/TEST/DATA301"
+
+      "Related URLs nil with doi not in doi: format"
+      [{:accessURL "https://scholar.google.com/scholar?q=This is a test string",
+        :title "Google Scholar search results",
+        :description "Search results for publications that cite this dataset by its DOI."}]
+      nil
+      "This is a test string"
+
+      "Related URLs nil with doi nil"
+      nil
+      nil
+      nil)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -605,7 +605,7 @@
         revision-date-coll5 (-> umm-json-coll5
                                 (get-in [:results :items])
                                 first
-                                 (get-in [:meta :revision-date]))
+                                (get-in [:meta :revision-date]))
         ;; iso-smap LongName and CollectionCitation/Title have the same mapping.
         ;; Need to add it to coll4 collection-citations to be exposed to citation creation.
         coll4-opendata (assoc coll4 :collection-citations [{:title (get-in coll4 [:product :long-name])}])
@@ -810,14 +810,15 @@
         (is (= #{"https://doi.org/10.1117/1.JRS.8.084994" "https://doi.org/10.5194/acp-14-399-2014"}
                (set references))))
       (testing "correct distribution field"
-        (is (= 13 (count distribution)))
+        (is (= 14 (count distribution)))
         (testing "every distribution has an access URL."
           (is (every? #(some? (:accessURL %)) distribution)))
         (testing "every distribution has a description."
           (is (every? #(not (string/blank? (:description %))) distribution)))
         (testing "distribution URLs are correctly URL encoded."
           (is (= (set (map url-util/url->comparable-url
-                           ["https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png"
+                           ["https://scholar.google.com/scholar?q=10.5067/Aqua/AIRS/DATA301"
+                            "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png"
                             "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/"
                             "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html"
                             "https://disc.gsfc.nasa.gov/SSW/#keywords=AIRX3STD%20006"

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -817,7 +817,7 @@
           (is (every? #(not (string/blank? (:description %))) distribution)))
         (testing "distribution URLs are correctly URL encoded."
           (is (= (set (map url-util/url->comparable-url
-                           ["https://scholar.google.com/scholar?q=10.5067/Aqua/AIRS/DATA301"
+                           ["https://scholar.google.com/scholar?q=10.5067%2FAqua%2FAIRS%2FDATA301"
                             "https://docserver.gesdisc.eosdis.nasa.gov/public/project/Images/AIRX3STD_006.png"
                             "https://acdisc.gesdisc.eosdis.nasa.gov/data/Aqua_AIRS_Level3/AIRX3STD.006/"
                             "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level3/AIRX3STD.006/contents.html"


### PR DESCRIPTION
This PR constructs a distribution for a google scholar search url, and adds it to the distribution field in the opendata result.