### PR TITLE
CMR-5236: Opendata downloadURL vs accessURL.

### DIFF
--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -219,8 +219,9 @@
   (let [{:keys [description url get-data-mime-type]} related-url
         get-data-mime-type (or (util/nil-if-value umm-spec-util/not-provided get-data-mime-type)
                                (ru/infer-url-mime-type url))
-        downloadable? (and (ru/downloadable-url? related-url) get-data-mime-type)]
-    (util/remove-nil-keys {(if downloadable? :downloadURL :accessURL) (ru/related-url->encoded-url url)
+        downloadable? (and (ru/downloadable-url? related-url) get-data-mime-type)
+        url-type (if downloadable? :downloadURL :accessURL)]
+    (util/remove-nil-keys {url-type (ru/related-url->encoded-url url)
                            :mediaType (when downloadable? get-data-mime-type)
                            :description description})))
 

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -216,8 +216,12 @@
   "Returns a distribution open data field for the provided related URL.
   See https://project-open-data.cio.gov/v1.1/schema/#dataset-distribution-fields."
   [related-url]
-  (let [{:keys [description url]} related-url]
-    (util/remove-nil-keys {:accessURL (ru/related-url->encoded-url url)
+  (let [{:keys [description url get-data-mime-type]} related-url
+        get-data-mime-type (or (util/nil-if-value umm-spec-util/not-provided get-data-mime-type)
+                               (ru/infer-url-mime-type url))
+        downloadable? (and (ru/downloadable-url? related-url) get-data-mime-type)]
+    (util/remove-nil-keys {(if downloadable? :downloadURL :accessURL) (ru/related-url->encoded-url url)
+                           :mediaType (when downloadable? get-data-mime-type)
                            :description description})))
 
 (defn landing-page

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -723,6 +723,21 @@
                                        :GetData {:MimeType "image/png"
                                                  :Format "png"
                                                  :Size 10.0
+                                                 :Unit "KB"}}
+                                      {:Description "Download url description"
+                                       :URL "http://example.com/download.png"
+                                       :URLContentType "DistributionURL"
+                                       :Type "GET DATA"
+                                       :GetData {:Format "png"
+                                                 :MimeType "image/png"
+                                                 :Size 10.0
+                                                 :Unit "KB"}}
+                                      {:Description "no mime type specified"
+                                       :URL "http://example2.com/download.json"
+                                       :URLContentType "DistributionURL"
+                                       :Type "GET DATA"
+                                       :GetData {:Format "png"
+                                                 :Size 10.0
                                                  :Unit "KB"}}]}
           concept-umm (-> (umm-spec-collection/collection 1 related-urls)
                           (umm-spec-collection/collection-concept :umm-json)
@@ -745,6 +760,23 @@
       (is (= 201 (:status concept-5138-1)))
       (is (= 201 (:status concept-5138-2)))
       (is (= 201 (:status concept-5138-3)))
+      (testing "accessURL and downloadURL in response"
+        (are3 [expected-distribution opendata-collection]
+          (is (contains? (set (:distribution opendata-collection)) expected-distribution))
+
+          "accessURL in distribution"
+          {:accessURL "http://example.com/browse-image"
+           :description "A test related url description."} opendata-coll-umm
+
+          "downloadURL in distribution"
+          {:downloadURL "http://example.com/download.png"
+           :description "Download url description"
+           :mediaType "image/png"} opendata-coll-umm
+
+          "downloadURL in distribution with no specified mime type"
+          {:downloadURL "http://example2.com/download.json"
+           :description "no mime type specified"
+           :mediaType "application/json"} opendata-coll-umm))
       (testing "Opendata fields in response."
         (are3 [expected-result field-key opendata-test-collection]
           (is (= expected-result (field-key opendata-test-collection)))

--- a/umm-lib/src/cmr/umm/related_url_helper.clj
+++ b/umm-lib/src/cmr/umm/related_url_helper.clj
@@ -2,13 +2,32 @@
   "Contains functions for categorizing UMM related urls."
   (:require
    [clojure.string :as string]
-   [ring.util.codec :as codec]))
+   [ring.util.codec :as codec]
+   [ring.util.mime-type :as mime-type]))
 
 (def DOCUMENTATION_MIME_TYPES
   "Mime Types that indicate the RelatedURL is of documentation type"
   ["text/rtf" "text/richtext" "text/plain" "text/html" "text/example" "text/enriched"
    "text/directory" "text/csv" "text/css" "text/calendar" "application/http" "application/msword"
    "application/rtf" "application/wordperfect5.1"])
+
+(def ^:private ADDITIONAL_MIME_TYPES
+  "Mime types outside the scope of ring/mime-types defaults."
+  {"nc" "application/x-netcdf"
+   "gml" "application/gml+xml"
+   "kml" "application/vnd.google-earth.kml+xml"
+   "hdf" "application/x-hdf"
+   "he5" "application/xhdf5"
+   "hdf5" "application/xhdf5"
+   "h5" "application/xhdf5"
+   "kmz" "application/vnd.google-earth.kmz"
+   "dae" "image/vnd.collada+xml"})
+
+(defn infer-url-mime-type
+  "Attempt to figure out mime type based off file extension."
+  [url]
+  (when url
+    (mime-type/ext-mime-type url ADDITIONAL_MIME_TYPES)))
 
 (defn downloadable-url?
   "Returns true if the related-url is downloadable"

--- a/umm-lib/test/cmr/umm/test/related_url_helper.clj
+++ b/umm-lib/test/cmr/umm/test/related_url_helper.clj
@@ -7,6 +7,23 @@
    [cmr.umm.related-url-helper :as related-url-helper]
    [cmr.umm.umm-collection :as umm-c]))
 
+(deftest guess-url-mime-type
+  (testing "guess mime type based on url"
+    (are3 [expected-mime-type url]
+      (is (= expected-mime-type (related-url-helper/infer-url-mime-type url)))
+
+      "test mime type in default list is properly guessed"
+      "image/jpeg" "http://example.com/test/mime/type.jpeg"
+
+      "test mime type not in default list is properly guessed"
+      "application/x-netcdf" "http://example.com/test/mime/type.nc"
+
+      "Test mime type not found returns nil"
+      nil "http://example.com/test/mime/type.fake_mime_type"
+
+      "test nil"
+      nil nil)))
+
 (deftest categorize-related-urls
   (testing "categorize related urls"
     (let [downloadable-url (umm-c/map->RelatedURL


### PR DESCRIPTION
* Decide whether to use accessURL or downloadURL for distributions.
* Infer mime type based off file extension if one is not provided.
* Determine if URL is downloadable based off the type being "GET DATA" and the ability to figure out the mime type.