### PR TITLE
CMR-5236: Change downloadURL criteria.

### DIFF
--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -219,7 +219,7 @@
   (let [{:keys [description url get-data-mime-type]} related-url
         get-data-mime-type (or (util/nil-if-value umm-spec-util/not-provided get-data-mime-type)
                                (ru/infer-url-mime-type url))
-        downloadable? (and (ru/downloadable-url? related-url) get-data-mime-type)
+        downloadable? (ru/downloadable-mime-type? get-data-mime-type)
         url-type (if downloadable? :downloadURL :accessURL)]
     (util/remove-nil-keys {url-type (ru/related-url->encoded-url url)
                            :mediaType (when downloadable? get-data-mime-type)

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -33,8 +33,7 @@
       {:downloadURL "http://example.com/mime-type"
        :mediaType "image/jpeg"}
       {:url "http://example.com/mime-type"
-       :get-data-mime-type "image/jpeg"
-       :type "GET DATA"}
+       :get-data-mime-type "image/jpeg"}
 
       "url is downloadable by guessing mime type"
       {:downloadURL "http://example.com/mime-type.jpeg"
@@ -48,8 +47,7 @@
        :description "test description."}
       {:url "http://example.com/mime-type.jpeg"
        :get-data-mime-type "Not provided"
-       :description "test description."
-       :type "GET DATA"}
+       :description "test description."}
 
       "url is not downloadable from un-guessable mime type and mime-type specified as Not provided"
       {:accessURL "http://example.com/un-guessable-mime-type"
@@ -59,16 +57,25 @@
        :description "test description."
        :get-data-mime-type "Not provided"}
 
-      "url type is not GET DATA so it is not downloadable"
-      {:accessURL "http://example.com/mime-type.jpeg"}
-      {:url "http://example.com/mime-type.jpeg"
-       :get-data-mime-type "image/jpeg"
+      "url is not downloadable based on text/html mimetype"
+      {:accessURL "http://example.com/mime-type.html"}
+      {:url "http://example.com/mime-type.html"
+       :get-data-mime-type "text/html"
        :type "GET RELATED VISUALIZATION"}
 
-      "url is GET DATA but missing mime type makes it not downloadable"
+      "url is not downloadable from missing mime type and undeterminable mime type"
       {:accessURL "http://example.com/missing-mime-type"}
       {:url "http://example.com/missing-mime-type"
-       :type "GET DATA"})))
+       :type "GET DATA"}
+
+      "url is not downloadable based on mimetype being guessed as text/html and text/* not downloadable"
+      {:accessURL "http://example.com/not-downloadable-html.html"}
+      {:url "http://example.com/not-downloadable-html.html"}
+
+      "url is downloadable based on mimetype being guessed for whitelisted mime type"
+      {:downloadURL "http://example.com/csv.csv"
+       :mediaType "text/csv"}
+      {:url "http://example.com/csv.csv"})))
 
 (deftest graphic-preview-type
   (testing "Not provided results in the field not being displayed"

--- a/umm-lib/src/cmr/umm/related_url_helper.clj
+++ b/umm-lib/src/cmr/umm/related_url_helper.clj
@@ -23,11 +23,23 @@
    "kmz" "application/vnd.google-earth.kmz"
    "dae" "image/vnd.collada+xml"})
 
+(def ^:private DOWNLOADABLE_MIME_TYPES
+  "White list of downloadable mime types"
+  #{"text/csv"})
+
 (defn infer-url-mime-type
   "Attempt to figure out mime type based off file extension."
   [url]
   (when url
     (mime-type/ext-mime-type url ADDITIONAL_MIME_TYPES)))
+
+(defn downloadable-mime-type?
+  "Mime type is downloadable if it is either in the list of approved
+   mime types or if it does not match text/*"
+  [mime-type]
+  (when mime-type
+    (or (contains? DOWNLOADABLE_MIME_TYPES mime-type)
+        (not (re-matches #"^(text\/).*" mime-type)))))
 
 (defn downloadable-url?
   "Returns true if the related-url is downloadable"

--- a/umm-lib/test/cmr/umm/test/related_url_helper.clj
+++ b/umm-lib/test/cmr/umm/test/related_url_helper.clj
@@ -24,6 +24,23 @@
       "test nil"
       nil nil)))
 
+(deftest downloadable-mime-type
+  (testing "Mime type is downloadable"
+    (are3 [downloadable? mime-type]
+      (is (= downloadable? (boolean (related-url-helper/downloadable-mime-type? mime-type))))
+
+      "text/* is not downloadable (exclude whitelist)"
+      false "text/html"
+
+      "whitelisted text/* is downloadable (text/csv)"
+      true "text/csv"
+
+      "anything other than text/* is downloadable"
+      true "application/json"
+
+      "nil is not downloadable"
+      false nil)))
+
 (deftest categorize-related-urls
   (testing "categorize related urls"
     (let [downloadable-url (umm-c/map->RelatedURL


### PR DESCRIPTION
* Change downloadURL criteria to now be based solely off the mime-type.
* Any mimetype other than text/*, with the exception of text/csv, is downloadable.
![download-more](https://user-images.githubusercontent.com/11383467/48086369-b3bdbd80-e1ca-11e8-8635-e289b189db53.png)
