### PR TITLE
CMR-5272: Updated granule elastic mapping to support granule UMM JSON search

### DIFF
--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -480,9 +480,11 @@
   {:_id  {:path "concept-id"}}
   (merge
     {:concept-id (m/stored m/string-field-mapping)
+     :revision-id (m/stored m/int-field-mapping)
 
      :native-id (m/doc-values m/string-field-mapping)
      :native-id.lowercase (m/doc-values m/string-field-mapping)
+     :native-id-stored (-> m/string-field-mapping m/stored m/doc-values)
 
      ;; This is used explicitly for sorting. The values take up less space in the
      ;; fielddata cache.
@@ -592,8 +594,9 @@
      :project-refs.lowercase-doc-values (m/doc-values m/string-field-mapping)
 
      :created-at (m/doc-values m/date-field-mapping)
-     :revision-date         m/date-field-mapping
-     :revision-date-doc-values           (m/doc-values m/date-field-mapping)
+     :revision-date m/date-field-mapping
+     :revision-date-doc-values (m/doc-values m/date-field-mapping)
+     :revision-date-stored-doc-values (-> m/date-field-mapping m/stored m/doc-values)
 
      :downloadable (m/stored m/bool-field-mapping)
      :browsable (m/stored m/bool-field-mapping)

--- a/system-int-test/resources/index_set_granule_mapping.clj
+++ b/system-int-test/resources/index_set_granule_mapping.clj
@@ -242,6 +242,16 @@
  :revision-date-doc-values {:format "yyyy-MM-dd'T'HH:mm:ssZ||yyyy-MM-dd'T'HH:mm:ss.SSSZ",
                             :doc_values true,
                             :type "date"},
+ :revision-id {:type "integer", :store "yes"},
+ :native-id-stored {:type "string",
+                    :index "not_analyzed",
+                    :store "yes",
+                    :doc_values true},
+ :revision-date-stored-doc-values {:type "date",
+                                   :format
+                                   "yyyy-MM-dd'T'HH:mm:ssZ||yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+                                   :store "yes",
+                                   :doc_values true}
  :access-value {:store "yes", :type "float"},
  :platform-sn.lowercase {:index "not_analyzed",
                          :type "string"},


### PR DESCRIPTION
This is the part 1 of supporting granule search in UMM JSON format. We separate the indexer change from the search-app change to allow clean backport of indexing changes to UAT and PROD to reindex all granules before we deploy the search changes that depend on the new granule elasticsearch fields.
![](https://media.giphy.com/media/13sc1Erq6rAoQU/giphy.gif)