### PR TITLE
CMR-5272: Added support to search granules in UMM JSON format.

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -281,7 +281,7 @@ Here is a list of supported extensions and their corresponding MimeTypes:
   * `native`    "application/metadata+xml" (Returns search results in their individual native formats)
   * `umm-json`   "application/vnd.nasa.cmr.legacy_umm_results+json" (only supported for collections)
     * The UMM JSON format was originally used for an alpha version of UMM JSON search results. Currently it still returns data in that style to avoid breaking clients dependent on it. This will be changed in a future version to return the latest version of the UMM.
-  * `umm_json`   "application/vnd.nasa.cmr.umm_results+json" (only supported for collections)
+  * `umm_json`   "application/vnd.nasa.cmr.umm_results+json" (supported for collections, granules, variables and services)
     * The UMM JSON extension returns concepts in the latest version of the UMM.
   * `umm_json_vX_Y` "application/vnd.nasa.cmr.umm_results+json; version=X.Y"
     * X and Y should be replaced with a major and minor number of the UMM version requested.
@@ -815,7 +815,7 @@ __Example__
 
 #### <a name="umm-json"></a> UMM JSON
 
-The UMM JSON response contains meta-metadata of the collection and the UMM fields. The UMM JSON format is only applicable to collection, variable and service searches. The UMM-JSON response is helpful if you wish to get the native-id of a collection after ingesting it. The version of the UMM returned will be the version requested or the latest most version. Clients are recommended to always specify a version to avoid breaking changes in UMM.
+The UMM JSON response contains meta-metadata of the collection and the UMM fields. The UMM JSON format is applicable to collection, granule, variable and service searches. The UMM-JSON response is helpful if you wish to get the native-id of a concept after ingesting it. The version of the UMM returned will be the version requested or the latest version. Clients are recommended to always specify a version to avoid breaking changes in UMM.
 
 This format can be retrieved in a variety of methods:
 

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -28,6 +28,7 @@
    [cmr.search.results-handlers.atom-json-results-handler]
    [cmr.search.results-handlers.atom-results-handler]
    [cmr.search.results-handlers.csv-results-handler]
+   [cmr.search.results-handlers.granules-umm-json-results-handler]
    [cmr.search.results-handlers.kml-results-handler]
    [cmr.search.results-handlers.metadata-results-handler]
    [cmr.search.results-handlers.opendata-results-handler]

--- a/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
+++ b/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
@@ -349,7 +349,7 @@
              "order-concepts:" t6)
       ordered-concepts)
 
-    ;; Granule queries won't use the cache
+    ;; Concepts other than collection (e.g. granule, variable, service) won't use the cache
     (fetch-metadata context concept-tuples target-format)))
 
 (defn get-latest-formatted-concepts

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -84,7 +84,9 @@
   (let [default-mappings {:granule-ur.lowercase :granule-ur.lowercase2
                           :producer-gran-id.lowercase :producer-gran-id.lowercase2
                           :provider :provider-id
-                          :updated-since :revision-date
+                          :native-id :native-id-stored
+                          :revision-date :revision-date-stored-doc-values
+                          :updated-since :revision-date-stored-doc-values
                           :producer-granule-id :producer-gran-id
                           :platform :platform-sn
                           :instrument :instrument-sn
@@ -93,8 +95,9 @@
     (if (use-doc-values-fields)
       (merge default-mappings
              {:provider :provider-id-doc-values
-              :updated-since :revision-date-doc-values}
-             query-field->granule-doc-values-fields-map)
+              :updated-since :revision-date-stored-doc-values}
+             query-field->granule-doc-values-fields-map
+             {:revision-date :revision-date-stored-doc-values})
       default-mappings)))
 
 (defmethod q2e/concept-type->field-mappings :tag
@@ -141,7 +144,9 @@
   (merge {:platform-sn :platform
           :instrument-sn :instrument
           :sensor-sn :sensor
-          :project-refs :project}
+          :project-refs :project
+          :native-id-stored :native-id
+          :revision-date-stored-doc-values :revision-date}
          (set/map-invert query-field->granule-doc-values-fields-map)))
 
 (defmethod q2e/elastic-field->query-field-mappings :tag
@@ -339,7 +344,7 @@
                                :project :project-refs.lowercase-doc-values
                                :start-date :start-date-doc-values
                                :end-date :end-date-doc-values
-                               :revision-date :revision-date-doc-values
+                               :revision-date :revision-date-stored-doc-values
                                :entry-title :entry-title.lowercase-doc-values
                                :short-name :short-name.lowercase-doc-values
                                :version :version-id.lowercase-doc-values

--- a/search-app/src/cmr/search/results_handlers/granules_umm_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/granules_umm_json_results_handler.clj
@@ -1,0 +1,57 @@
+(ns cmr.search.results-handlers.granules-umm-json-results-handler
+  "Handles granule umm-json results format and related functions"
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as string]
+   [cmr.common-app.services.search :as qs]
+   [cmr.common-app.services.search.elastic-results-to-query-results :as elastic-results]
+   [cmr.common-app.services.search.elastic-search-index :as elastic-search-index]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.util :as util]
+   [cmr.search.results-handlers.umm-json-results-helper :as results-helper]))
+
+(def granule-meta-fields
+  "Defines the fields in elastic search we retrieve to populate the meta fields
+  in granule UMM JSON response."
+  ["concept-id"
+   "revision-id"
+   "native-id"
+   "provider-id"
+   "metadata-format"
+   "revision-date"])
+
+(defn granule-elastic-result->meta
+  "Takes an elasticsearch result and returns a map of the meta fields in granule UMM JSON response."
+  [elastic-result]
+  (let [{[concept-id] :concept-id
+         [revision-id] :revision-id
+         [native-id] :native-id
+         [provider-id] :provider-id
+         [metadata-format] :metadata-format
+         [revision-date] :revision-date} (:fields elastic-result)
+        revision-date (when revision-date (string/replace (str revision-date) #"\+0000" "Z"))]
+    (util/remove-nil-keys
+     {:concept-type :granule
+      :concept-id concept-id
+      :revision-id revision-id
+      :native-id native-id
+      :provider-id provider-id
+      :format (mt/format->mime-type (keyword metadata-format))
+      :revision-date revision-date})))
+
+(defmethod elastic-search-index/concept-type+result-format->fields [:granule :umm-json-results]
+  [concept-type query]
+  granule-meta-fields)
+
+(defmethod results-helper/elastic-result+metadata->umm-json-item :granule
+  [concept-type elastic-result metadata]
+  {:meta (granule-elastic-result->meta elastic-result)
+   :umm (json/decode metadata)})
+
+(defmethod elastic-results/elastic-results->query-results [:granule :umm-json-results]
+  [context query elastic-results]
+  (results-helper/query-elastic-results->query-results context :granule query elastic-results))
+
+(defmethod qs/search-results->response [:granule :umm-json-results]
+  [context query results]
+  (json/generate-string (select-keys results [:hits :took :items])))

--- a/search-app/src/cmr/search/results_handlers/variables_umm_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/variables_umm_json_results_handler.clj
@@ -9,11 +9,6 @@
    [cmr.common.util :as util]
    [cmr.search.results-handlers.umm-json-results-helper :as results-helper]))
 
-(defn- variable-elastic-result->meta
-  "Returns a map of the meta fields for the given variable elastic result."
-  [elastic-result]
-  (results-helper/elastic-result->meta :variable elastic-result))
-
 (defmethod elastic-search-index/concept-type+result-format->fields [:variable :umm-json-results]
   [concept-type query]
   (concat

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -170,7 +170,7 @@
   query."
   {:concept-id :collection-concept-id
    :has-granules-created-at :created-at
-   :has-granules-revised-at :revision-date-doc-values})
+   :has-granules-revised-at :revision-date-stored-doc-values})
 
 (defmulti tag-param->condition
   "Convert tag param and value into query condition"

--- a/search-app/src/cmr/search/validators/validation.clj
+++ b/search-app/src/cmr/search/validators/validation.clj
@@ -30,7 +30,9 @@
 
 (defmethod cqv/supported-result-formats :granule
   [_]
-  #{:xml, :json, :echo10, :atom, :iso19115, :csv, :kml, :native :timeline})
+  (into #{:xml, :json, :echo10, :atom, :iso19115, :csv, :kml, :native :timeline
+          :umm-json :umm-json-results}
+        (umm-versioned-result-formats :granule)))
 
 (defmethod cqv/supported-result-formats :variable
   [_]

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
@@ -1,5 +1,5 @@
 (ns cmr.system-int-test.search.granule-search-format-test
-  "Integration tests for searching granules in csv format"
+  "Integration tests for searching granules in various formats"
   (:require
    [clj-http.client :as client]
    [clojure.string :as string]

--- a/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
@@ -1,0 +1,74 @@
+(ns cmr.system-int-test.search.granule-umm-json-search-test
+  "Integration tests for searching granules in UMM JSON format"
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.mime-types :as mt]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.umm-json :as du]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.umm.umm-granule :as umm-g]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(defn- ingest-granule-concept
+  "Returns granule concept in the given parent collection, entry title, granule ur
+  and metadata format. Metadata format is in keyword form, e.g. :echo10, :iso-smap, :umm-json."
+  [collection entry-title granule-ur metadata-format]
+  (let [granule (dg/granule-with-umm-spec-collection
+                 collection
+                 (:concept-id collection)
+                 {:granule-ur granule-ur
+                  :collection-ref (umm-g/map->CollectionRef {:entry-title entry-title})})
+        gran-concept (d/item->concept granule metadata-format)
+        umm-g-gran (d/item->concept granule :umm-json)
+        {:keys [concept-id revision-id status] :as response} (ingest/ingest-concept gran-concept)]
+    (if (#{200 201} status)
+      (merge umm-g-gran response {:format metadata-format})
+      response)))
+
+(defn assert-umm-json-found
+  ([granules version]
+   (assert-umm-json-found granules version nil))
+  ([granules version params]
+   (let [params (merge {:concept-id (map :concept-id granules)} params)
+         options {:accept (mt/with-version mt/umm-json-results version)}
+         response (search/find-concepts-umm-json :granule params options)]
+     (du/assert-granule-umm-jsons-match version granules response))))
+
+(deftest search-granule-in-umm-json-test
+  (let [coll1-entry-title "coll1"
+        collection (d/ingest-umm-spec-collection
+                    "PROV1"
+                    (data-umm-c/collection {:EntryTitle coll1-entry-title}))
+        gran-to-be-deleted (d/ingest "PROV1"
+                                     (dg/granule-with-umm-spec-collection
+                                      collection (:concept-id collection)))
+        echo10-gran (ingest-granule-concept collection coll1-entry-title "echo10-gran" :echo10)
+        smap-gran (ingest-granule-concept collection coll1-entry-title "iso-smap-gran" :iso-smap)
+        umm-g-gran (ingest-granule-concept collection coll1-entry-title "umm-g-gran" :umm-json)]
+    ;; delete a granule and verify that the deleted granule is not found
+    (ingest/delete-concept (d/item->concept gran-to-be-deleted :echo10))
+    (index/wait-until-indexed)
+    (testing "search granules in UMM JSON format"
+      (assert-umm-json-found [echo10-gran smap-gran umm-g-gran] "1.4" {:provider "PROV1"}))
+
+    (testing "search granules with invalid UMM JSON version"
+      (let [expected-errors [(str "The mime type [application/vnd.nasa.cmr.umm_results+json] "
+                                  "with version [1.0] is not supported for granules.")]]
+
+        (testing "invalid UMM JSON version via suffix"
+          (let [{:keys [status errors]} (search/find-concepts-umm-json
+                                         :granule {} {:url-extension "umm_json_v1_0"})]
+            (is (= [400 expected-errors]
+                   [status errors]))))
+
+        (testing "invalid UMM JSON version via accept header"
+          (let [{:keys [status errors]} (search/find-concepts-umm-json
+                                         :granule {}
+                                         {:accept (mt/with-version mt/umm-json "1.0")})]
+            (is (= [400 expected-errors]
+                   [status errors]))))))))

--- a/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
@@ -173,12 +173,6 @@
         {:all-revisions true}))))
 
 (deftest search-umm-json-error-cases
-  (testing "granule umm-json search is not supported"
-    (is (= {:status 400
-            :errors [(format "The mime type [%s] with version [%s] is not supported for granules."
-                             (mt/format->mime-type :umm-json-results)
-                             umm-version/current-granule-version)]}
-           (select-keys (search/find-concepts-umm-json :granule {}) [:status :errors]))))
   (testing "Searching with invalid UMM JSON extension"
     (is (= {:status 400
             ;; XML is returned here because we don't specify an accept header and the URL extension is unknown.

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.4/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.4/umm-g-search-results-json-schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-g-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["granule"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+    },
+    "ConceptIdType": {
+      "description": "The concept id of a concept.",
+      "type": "string",
+      "minLength": 4,
+      "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+    }
+  },
+  "title": "UMM JSON Granule Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -25,6 +25,10 @@
   "Defines the name of the search result schema."
   "umm-search-results-json-schema.json")
 
+(def granule-search-result-schema-name
+  "Defines the name of the granule search result schema."
+  "umm-g-search-results-json-schema.json")
+
 (def variable-search-result-schema-name
   "Defines the name of the variable search result schema."
   "umm-var-search-results-json-schema.json")
@@ -255,6 +259,12 @@
   [json-str umm-version]
   (validate-umm-json-search-result
    json-str :collection search-result-schema-name umm-version))
+
+(defn validate-granule-umm-json-search-result
+  "Validates the granule UMM JSON search result and returns a list of errors if invalid."
+  [json-str umm-version]
+  (validate-umm-json-search-result
+   json-str :granule granule-search-result-schema-name umm-version))
 
 (defn validate-variable-umm-json-search-result
   "Validates the variable UMM JSON search result and returns a list of errors if invalid."


### PR DESCRIPTION
This is the second part of CMR-5272 to add in the search support to return granule search in UMM JSON format. e.g. 
```
{
  "hits" : 2,
  "took" : 58,
  "items" : [ {
    "meta" : {
      "concept-type" : "granule",
      "concept-id" : "G1200000007-PROV1",
      "revision-id" : 1,
      "native-id" : "echo1o-granule",
      "provider-id" : "PROV1",
      "format" : "application/echo10+xml",
      "revision-date" : "2018-11-09T03:48:38Z"
    },
    "umm" : {
      "TemporalExtent" : {
        "RangeDateTime" : {
          "BeginningDateTime" : "2013-08-09T00:00:00.000Z",
          "EndingDateTime" : "2013-08-09T00:00:00.000Z"
        }
      },
      "GranuleUR" : "8046d7eb-0ce7-48f5-921a-a1600f41c5b2",
      .......
    }
  }
  .......]
}
```