### PR TITLE
CMR 4645 can not search for 2000 granules

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/validators/max_number_of_conditions.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/validators/max_number_of_conditions.clj
@@ -6,7 +6,7 @@
 
 (defconfig max-number-of-conditions
   "The configured maximum number of conditions in a query"
-  {:default 2050
+  {:default 4100 
    :type Long})
 
 (defprotocol ConditionCounter

--- a/system-int-test/test/cmr/system_int_test/search/collection_identifier_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_identifier_search_test.clj
@@ -637,11 +637,11 @@
       (is (= {:hits 0 :refs []}
              (select-keys response [:hits :refs])))))
   (testing "Query with too many conditions"
-    (is (= {:errors ["The number of conditions in the query [3000] exceeded the maximum allowed for a query [2050]. Reduce the number of conditions in your query."]
+    (is (= {:errors ["The number of conditions in the query [6000] exceeded the maximum allowed for a query [4100]. Reduce the number of conditions in your query."]
             :status 400}
            (search/find-refs
             :collection
-            {:science-keywords (into {} (for [n (range 1000)]
+            {:science-keywords (into {} (for [n (range 2000)]
                                           [(keyword (str n))
                                            {:category n
                                             :topic n

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_readable_granule_name_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_readable_granule_name_test.clj
@@ -57,6 +57,25 @@
      (search/find-refs :granule {:readable-granule-name ["*1" "*2"]
                                  "options[readable-granule-name][pattern]" true}))))
 
+(deftest search-with-2000-granule-id
+  (testing "Verify the number of conditions is twice as many as the number of granules"
+    (is (= {:errors ["The number of conditions in the query [4102] exceeded the maximum allowed for a query [4100]. Reduce the number of conditions in your query."]
+            :status 400}
+           (search/find-refs
+            :granule
+            {:readable-granule-name (for [n (range 2051)]
+                                      (str "gran-" n))
+             "options[readable-granule-name][pattern]" true}
+            {:method :post}))))
+  (testing "2000 granule-id search is supported."
+    (is (= nil 
+           (:errors (search/find-refs
+                      :granule
+                      {:readable-granule-name (for [n (range 2000)]
+                                                (str "gran-" n))
+                       "options[readable-granule-name][pattern]" true}
+                      {:method :post}))))))
+
 (deftest search-by-producer-granule-id
   (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 1 {}))
         coll2 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 2 {}))


### PR DESCRIPTION
The query condition limit was added in CMR-3069 to fix the 500 error, it's supposed to also support 2000 granule-id search.
We set the limit to 2050 thinking it's more than enough to support that, but forgot we query two fields for each granule-id.
in order to support that, we need to bump the limit up to more than 4001.. 