### PR TITLE
CMR-5359: Make number of Jetty threads configurable and default to 1024.

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -19,14 +19,15 @@
   ring jetty adapter default of 8."
   8)
 
-(def MAX_THREADS
+(defconfig MAX_THREADS
   "The maximum number of threads for Jetty to use to process requests. This was originally set to
   the ring jetty adapter default of 50.
 
   VERY IMPORTANT NOTE: The value set here must correspond to the number of persistent HTTP
   connections we use in the transmit library. Do not change this or refactor this code without
   making sure that the transmit library uses the same amount."
-  50)
+  {:default 1024
+   :type Long})
 
 (def MIN_GZIP_SIZE
   "The size that will be used to determine if responses should be GZIP'd. See the following Stack
@@ -185,7 +186,7 @@
                              {:port port
                               :join? false
                               :min-threads MIN_THREADS
-                              :max-threads MAX_THREADS
+                              :max-threads (MAX_THREADS)
                               :configurator (fn [^Server jetty]
                                               (doseq [^Connector connector (.getConnectors jetty)]
                                                 (let [^HttpConnectionFactory http-conn-factory

--- a/elastic-utils-lib/src/cmr/elastic_utils/connect.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/connect.clj
@@ -21,11 +21,11 @@
         http-options {:conn-mgr (conn-mgr/make-reusable-conn-manager
                                   {;; Maximum number of threads that will be used for connecting.
                                    ;; Very important that this matches the maximum number of threads that will be running
-                                   :threads web-server/MAX_THREADS
+                                   :threads (web-server/MAX_THREADS)
                                    ;; Maximum number of simultaneous connections per host
                                    ;; There's usually one elasticsearch hostname and we always connect
                                    ;; to the same host so it makes sense to make this larger.
-                                   :default-per-route web-server/MAX_THREADS
+                                   :default-per-route (web-server/MAX_THREADS)
                                    ;; This is the length of time in _seconds_ that a connection will
                                    ;; be left open for reuse. The default is 5 seconds which is way
                                    ;; too short.

--- a/transmit-lib/src/cmr/transmit/connection.clj
+++ b/transmit-lib/src/cmr/transmit/connection.clj
@@ -16,9 +16,9 @@
          :conn-mgr (conn-mgr/make-reusable-conn-manager
                      {;; Maximum number of threads that will be used for connecting.
                       ;; Very important that this matches the maximum number of threads that will be running
-                      :threads web-server/MAX_THREADS
+                      :threads (web-server/MAX_THREADS)
                       ;; Maximum number of simultaneous connections per host
-                      :default-per-route web-server/MAX_THREADS
+                      :default-per-route (web-server/MAX_THREADS)
                       ;; This is the length of time in _seconds_ that a connection will
                       ;; be left open for reuse. The default is 5 seconds which is way
                       ;; too short.


### PR DESCRIPTION
More threads
![](https://media3.giphy.com/media/YP9WadrYt8dz2/giphy-downsized.gif?cid=6104955e5c13ba7c526d707a6b64ad27)
