### PR TITLE
CMR-5374: Complete data.json response.

### DIFF
--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -236,20 +236,11 @@
      :headers {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)}
      :body results}))
 
-(def ^:private data-json-prod
-  "Public opendata collections in production for data.json response."
-  (let [query {:url "https://cmr.earthdata.nasa.gov/search/collections.opendata"
-               :method :get
-               :throw-exceptions false
-               :query-params {:page-size 20 :pretty true}} ;; Test just 20 datasets for now
-        response (client/request query)]
-    response))
-
-(defn- find-data-json-prod
-  "Retrieve collections as opendata from production."
+(defn- find-data-json
+  "Retrieve all public collections with gov.nasa.eosdis tag as opendata."
   [ctx]
-  {:status (:status data-json-prod)
-   :body (:body data-json-prod)})
+  {:status 200
+   :body (query-svc/get-data-json-collections ctx)})
 
 (defn- get-deleted-collections
   "Invokes query service to search for collections that are deleted and returns the response"
@@ -327,8 +318,8 @@
   "config-enabled route for data.json. Socrata does not support harvesting from
    data.json endpoints that do not explicitly end in /data.json. This is needed
    to harvest CMR opendata responses on data.nasa.gov."
-  (GET "/socrata_test/data.json"
+  (GET "/socrata/data.json"
     {ctx :request-context}
     (if (allow-data-json-flag)
-      (find-data-json-prod ctx)
+      (find-data-json ctx)
       (common-pages/not-found))))

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -329,6 +329,21 @@
          results (qe/execute-query context query)]
      (:items results))))
 
+(defn get-data-json-collections
+  [context]
+  (let [condition (common-params/parameter->condition context
+                                                      :collection
+                                                      :tag-key
+                                                      "gov.nasa.eosdis"
+                                                      {})
+        query (qm/query {:concept-type :collection
+                         :condition condition
+                         :page-size :unlimited
+                         :result-format :opendata
+                         :skip-acls? false})
+        results (qe/execute-query context query)]
+    (common-search/search-results->response context query results)))
+
 (defn get-provider-holdings
   "Executes elasticsearch search to get provider holdings"
   [context params]

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -167,6 +167,22 @@
       {:status status
        :body body})))
 
+(defn retrieve-data-json
+  "Returns the data.json response."
+  ([]
+   (retrieve-data-json {}))
+  ([options]
+   (let [url (url/data-json-url)
+         args (merge {:throw-exceptions false
+                      :connection-manager (s/conn-mgr)}
+                     options)
+         response (client/get url args)
+         {:keys [status body]} response]
+     (if (= 200 status)
+       {:status status
+        :results (json/decode body true)}
+       response))))
+
 (defn retrieve-concept
   "Returns the concept metadata through the search concept retrieval endpoint using the cmr
   concept-id and optionally revision-id."

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -298,7 +298,6 @@
   (format "http://localhost:%s/jobs/refresh-collection-metadata-cache"
           (transmit-config/search-port)))
 
-
 (defn search-health-url
   "URL to check search health."
   []
@@ -339,6 +338,11 @@
   "URL to get the humanizers report"
   []
   (format "http://localhost:%s/humanizers/report" (transmit-config/search-port)))
+
+(defn data-json-url
+  "URL to get data.json."
+  []
+  (format "http://localhost:%s/socrata/data.json" (transmit-config/search-port)))
 
 (defn search-root
   "Returns the search url root"

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -70,7 +70,6 @@
         private-collections-with-tag (create-collections 5)
         private-collections-without-tag (create-collections 4)]
     (tag-util/create-tag (config/echo-system-token) tag)
-    (index-util/wait-until-indexed)
 
     ;; Make collections public
     (make-collections-public public-collections-with-tag)

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -1,0 +1,92 @@
+(ns cmr.system-int-test.search.data-json-search-test
+  "This namespace contains tests for the data.json endpoint."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common-app.test.side-api :as side-api]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.search.api.concepts-search :as concepts-search]
+   [cmr.system-int-test.data2.core :as core]
+   [cmr.system-int-test.data2.umm-spec-collection :as umm-spec-collection]
+   [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.index-util :as index-util]
+   [cmr.system-int-test.utils.ingest-util :as ingest-util]
+   [cmr.system-int-test.utils.search-util :as search-util]
+   [cmr.system-int-test.utils.tag-util :as tag-util]
+   [cmr.transmit.config :as config]))
+
+(def ^:private coll-idx (atom 0))
+
+(defn- data-json-fixture
+  "Enable/Disable data.json endpoint, reset coll-idx for collection creation."
+  [f]
+  (let [saved-data-json-flag (concepts-search/allow-data-json-flag)]
+    (side-api/eval-form `(concepts-search/set-allow-data-json-flag! true))
+    (reset! coll-idx 0)
+    (f)
+    (side-api/eval-form `(concepts-search/set-allow-data-json-flag! ~saved-data-json-flag))))
+
+(use-fixtures :each (join-fixtures
+                      [(ingest-util/reset-fixture {"provguid1" "PROV1"}
+                                                  {:grant-all-search? false})
+                       tag-util/grant-all-tag-fixture
+                       data-json-fixture]))
+
+(defn- create-collections
+  "Create num-collections collections. Default provider is PROV1."
+  ([num-collections]
+   (create-collections num-collections "PROV1"))
+  ([num-collections provider]
+   (let [start-idx @coll-idx
+         end-idx (+ start-idx num-collections)]
+     (reset! coll-idx end-idx)
+     (doall
+      (for [idx (range start-idx end-idx)]
+        (core/ingest-umm-spec-collection
+         provider
+         (umm-spec-collection/collection idx {})))))))
+
+(defn- make-collections-public
+  "Take collection of umm-spec collections and make public. Default provider is PROV1."
+  ([collections]
+   (make-collections-public collections "PROV1"))
+  ([collections provider]
+   (->> (mapv :EntryTitle collections)
+        echo-util/coll-id
+        (echo-util/coll-catalog-item-id provider)
+        (echo-util/grant-guest (system/context)))))
+
+(defn- associate-collections
+  "Associate collections with tag."
+  [tag collections]
+  (tag-util/associate-by-concept-ids
+   (config/echo-system-token)
+   (:tag-key tag)
+   (map #(hash-map :concept-id (:concept-id %)) collections)))
+
+(deftest data-json-response
+  (let [tag (tag-util/make-tag {:tag-key "gov.nasa.eosdis"})
+        public-collections-with-tag (create-collections 5)
+        public-collections-without-tag (create-collections 5)
+        private-collections-with-tag (create-collections 5)
+        private-collections-without-tag (create-collections 5)]
+    (tag-util/create-tag (config/echo-system-token) tag)
+    (index-util/wait-until-indexed)
+
+    ;; Make collections public
+    (make-collections-public public-collections-with-tag)
+    (make-collections-public public-collections-without-tag)
+    (ingest-util/reindex-collection-permitted-groups (config/echo-system-token))
+    (index-util/wait-until-indexed)
+
+    ;; Associate collections with tag
+    (associate-collections tag public-collections-with-tag)
+    (associate-collections tag private-collections-with-tag)
+    (index-util/wait-until-indexed)
+
+    (testing "Only the public collections with the gov.nasa.eosdis tag are in the response"
+      (let [data-json (search-util/retrieve-data-json)
+            datasets (get-in data-json [:results :dataset])]
+        (is (= 200 (:status data-json)))
+        (is (= 5 (count datasets)))
+        (is (= (set (map :concept-id public-collections-with-tag))
+               (set (map :identifier datasets))))))))

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -66,7 +66,7 @@
 (deftest data-json-response
   (let [tag (tag-util/make-tag {:tag-key "gov.nasa.eosdis"})
         public-collections-with-tag (create-collections 5)
-        public-collections-without-tag (create-collections 5)
+        public-collections-without-tag (create-collections 10)
         private-collections-with-tag (create-collections 5)
         private-collections-without-tag (create-collections 5)]
     (tag-util/create-tag (config/echo-system-token) tag)
@@ -87,6 +87,6 @@
       (let [data-json (search-util/retrieve-data-json)
             datasets (get-in data-json [:results :dataset])]
         (is (= 200 (:status data-json)))
-        (is (= 5 (count datasets)))
+        (is (= (count public-collections-with-tag) (count datasets)))
         (is (= (set (map :concept-id public-collections-with-tag))
                (set (map :identifier datasets))))))))

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -65,10 +65,10 @@
 
 (deftest data-json-response
   (let [tag (tag-util/make-tag {:tag-key "gov.nasa.eosdis"})
-        public-collections-with-tag (create-collections 5)
-        public-collections-without-tag (create-collections 10)
+        public-collections-with-tag (create-collections 7)
+        public-collections-without-tag (create-collections 6)
         private-collections-with-tag (create-collections 5)
-        private-collections-without-tag (create-collections 5)]
+        private-collections-without-tag (create-collections 4)]
     (tag-util/create-tag (config/echo-system-token) tag)
     (index-util/wait-until-indexed)
 


### PR DESCRIPTION
* data.json endpoint at search/socrata/data.json.
* Move def to defn.
* Return all public collections with gov.nasa.eosdis tag.
* Use query functions instead of http calls.