### PR TITLE
CMR-5378: Add the release version to the footer for the CMR core landing pages.

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -43,7 +43,7 @@
     [commons-codec/commons-codec "1.11"]
     [commons-io "2.6"]
     [compojure "1.6.1"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
     [org.clojure/clojure "1.10.0"]
     [org.clojure/tools.reader "1.3.2"]
     [ring/ring-codec "1.1.1"]

--- a/access-control-app/src/cmr/access_control/site/data.clj
+++ b/access-control-app/src/cmr/access_control/site/data.clj
@@ -10,16 +10,19 @@
   from outside this context; the data functions defined herein are specifically
   for use in page templates, structured explicitly for their needs."
   (:require
+   [cmr.common-app.config :as common-config]
    [cmr.common-app.site.data :as common-data]))
 
 (defn base-page
   "Data that all app pages have in common."
   [context]
-  (assoc (common-data/base-page context) :app-title "Access Control"))
+  (assoc (common-data/base-page context) :app-title "Access Control"
+                                         :release-version (str "v " (common-config/release-version))))
 
 (defn base-static
   "Data that all static pages have in common.
 
   Note that static pages don't have any context."
   []
-  (assoc (common-data/base-static) :app-title "Access Control"))
+  (assoc (common-data/base-static) :app-title "Access Control"
+                                   :release-version (str "v " (common-config/release-version))))

--- a/common-app-lib/resources/public/site/css/eui.css
+++ b/common-app-lib/resources/public/site/css/eui.css
@@ -160,24 +160,24 @@ table.image-grid p {
 }
 
 .eui-masthead-logo.eui-application-logo a:link {
-  padding: 13px 0 10px 120px; 
+  padding: 13px 0 10px 140px; 
   background-image: url(../images/cmr-logo-white.png);
   width: inherit;
 }
 
 .eui-masthead-logo.eui-application-logo a:hover {
-  padding: 13px 0 10px 120px; 
+  padding: 13px 0 10px 140px; 
   background-image: url(../images/cmr-logo-white.png);
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 1.3 / 1), only screen and (min-resolution: 125dpi), only screen and (min-resolution: 1.3dppx) {
   .eui-masthead-logo.eui-application-logo a:link {
-    padding: 13px 0 10px 120px;
+    padding: 13px 0 10px 140px;
     background-image: url(../images/cmr-logo-white_2x.png);
   }
 
   .eui-masthead-logo.eui-application-logo a:hover {
-    padding: 13px 0 10px 120px;
+    padding: 13px 0 10px 140px;
     background-image: url(../images/cmr-logo-white_2x.png);
   }
 }

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -20,4 +20,4 @@
 
 (defconfig release-version
   "Contains the release version of CMR."
-  {:default "1.1.1-r1.1.1"})
+  {:default "dev"})

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -17,3 +17,7 @@
   "Flag for whether or not launchpad token is enforeced."
   {:default false
    :type Boolean})
+
+(defconfig release-version
+  "Contains the release version of CMR."
+  {:default "1.1.1-r1.1.1"})

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -15,7 +15,7 @@
     [commons-io "2.6"]
     [compojure "1.6.1"]
     [drift "1.5.3"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
     [instaparse "1.4.10"]
     [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]

--- a/ingest-app/src/cmr/ingest/site/data.clj
+++ b/ingest-app/src/cmr/ingest/site/data.clj
@@ -10,6 +10,7 @@
   this context; the data functions defined herein are specifically for use in
   page templates, structured explicitly for their needs."
   (:require
+   [cmr.common-app.config :as common-config]
    [cmr.common-app.site.data :as common-data]))
 
 (def data-partners-guide
@@ -23,7 +24,7 @@
   [context]
   (merge (common-data/base-page context)
          data-partners-guide
-         {:app-title "Ingest"}))
+         {:app-title "Ingest" :release-version (str "v " (common-config/release-version))}))
 
 (defn base-static
   "Data that all static pages have in common.
@@ -32,4 +33,4 @@
   []
   (merge (common-data/base-static)
          data-partners-guide
-         {:app-title "Ingest"}))
+         {:app-title "Ingest" :release-version (str "v " (common-config/release-version))}))

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -16,7 +16,7 @@
     [com.fasterxml.jackson.core/jackson-core "2.9.8"]
     [com.github.fge/json-schema-validator "2.2.6"]
     [commons-codec/commons-codec "1.11"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
     [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
     [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -12,6 +12,7 @@
   (:require
    [clj-time.core :as clj-time]
    [clojure.string :as string]
+   [cmr.common-app.config :as common-config]
    [cmr.common-app.services.search.group-query-conditions :as gc]
    [cmr.common-app.services.search.query-execution :as query-exec]
    [cmr.common-app.services.search.query-model :as query-model]
@@ -149,11 +150,13 @@
 
 (defmethod base-page :cli
   [context]
-  (assoc (common-data/base-static) :app-title "Search"))
+  (assoc (common-data/base-static) :app-title "Search" 
+                                   :release-version (str "v " (common-config/release-version))))
 
 (defmethod base-page :default
   [context]
-  (assoc (common-data/base-page context) :app-title "Search"))
+  (assoc (common-data/base-page context) :app-title "Search" 
+                                         :release-version (str "v " (common-config/release-version))))
 
 (defn get-directory-links
   "Provide the list of links that will be rendered on the top-level directory

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -101,15 +101,6 @@
            (:body response)
            "site/docs/search/site")))))
 
-(deftest dynamic-release-version
-  (side-api/eval-form `(common-config/set-release-version! "1.0"))
-  (let [response (site (request :get (str base-url "/site/docs/search")))]
-    (testing "release version is changed to 1.0."
-      (is (string/includes?
-           (:body response)
-           "v 1.0"))))
-  (side-api/eval-form `(common-config/set-release-version! "dev")))
-
 (deftest search-url-reorg-redirects
   (let [response (site (request :get (str base-url "/site/docs/search/api")))]
     (testing "clean docs URL for api docs performs redirect"

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -1,8 +1,11 @@
 (ns cmr.search.test.site.routes
-  (:require [clojure.string :as string]
-            [clojure.test :refer :all]
-            [cmr.search.site.routes :as r]
-            [ring.mock.request :refer [request]]))
+  (:require 
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.common-app.config :as common-config]
+   [cmr.common-app.test.side-api :as side-api]
+   [cmr.search.site.routes :as r]
+   [ring.mock.request :refer [request]]))
 
 (def ^:private scheme "https")
 (def ^:private host "cmr.example.com")
@@ -90,10 +93,21 @@
            "Documentation for Search"))
       (is (string/includes?
            (:body response)
+           "v dev"))
+      (is (string/includes?
+           (:body response)
            "site/docs/search/api"))
       (is (string/includes?
            (:body response)
            "site/docs/search/site")))))
+
+(deftest dynamic-release-version
+  (let [_ (side-api/eval-form `(common-config/set-release-version! "1.0"))
+        response (site (request :get (str base-url "/site/docs/search")))]
+    (testing "release version is changed to 1.0."
+      (is (string/includes?
+           (:body response)
+           "v 1.0")))))
 
 (deftest search-url-reorg-redirects
   (let [response (site (request :get (str base-url "/site/docs/search/api")))]

--- a/search-app/test/cmr/search/test/site/routes.clj
+++ b/search-app/test/cmr/search/test/site/routes.clj
@@ -102,12 +102,13 @@
            "site/docs/search/site")))))
 
 (deftest dynamic-release-version
-  (let [_ (side-api/eval-form `(common-config/set-release-version! "1.0"))
-        response (site (request :get (str base-url "/site/docs/search")))]
+  (side-api/eval-form `(common-config/set-release-version! "1.0"))
+  (let [response (site (request :get (str base-url "/site/docs/search")))]
     (testing "release version is changed to 1.0."
       (is (string/includes?
            (:body response)
-           "v 1.0")))))
+           "v 1.0"))))
+  (side-api/eval-form `(common-config/set-release-version! "dev")))
 
 (deftest search-url-reorg-redirects
   (let [response (site (request :get (str base-url "/site/docs/search/api")))]

--- a/site-templates/project.clj
+++ b/site-templates/project.clj
@@ -1,4 +1,4 @@
-(defproject gov.nasa.earthdata/cmr-site-templates "0.1.0-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"
   :description "Selmer templates for CMR documentation, directory pages, and various static web content"
   :url "https://github.com/nasa/Common-Metadata-Repository/site-templates"
   :license {

--- a/site-templates/resources/templates/base.html
+++ b/site-templates/resources/templates/base.html
@@ -28,6 +28,7 @@
       <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
       <li><a href="http://www.usa.gov/">USA.gov</a></li>
       <li><a href="javascript:feedback.showForm();">Feedback</a></li>
+      <li style="float: right;"><span class="version badge eui-badge--md">{{ release-version }}</span></li>
   </ul>
 </nav>
 {% endblock %}


### PR DESCRIPTION
At deployment environment variable CMR_RELEASE_VERSION is set to the release version.  This is done through bamboo adding this env variable to .env, which is sourced when CMR starts up.