### PR TITLE
CMR-5387: Fixed common-lib xslt translation to explicitly use Saxon lib.

### DIFF
--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -28,6 +28,7 @@
     [environ "1.1.0"]
     [instaparse "1.4.10"]
     [net.jpountz.lz4/lz4 "1.3.0"]
+    [net.sf.saxon/Saxon-HE "9.9.0-2"]
     [org.clojure/clojure "1.10.0"]
     [org.clojure/core.async "0.4.490"]
     [org.clojure/core.cache "0.7.2"]

--- a/common-lib/src/cmr/common/xml/xslt.clj
+++ b/common-lib/src/cmr/common/xml/xslt.clj
@@ -8,7 +8,8 @@
            [javax.xml.transform
             TransformerFactory
             Templates
-            URIResolver]))
+            URIResolver]
+           net.sf.saxon.TransformerFactoryImpl))
 
 (defn- create-uri-resolver
   "Creates an instance of the URIResolver interface that will direct all paths within the xslt
@@ -24,7 +25,7 @@
   [f]
   (with-open [r (io/reader f)]
     (let [xsl-resource (StreamSource. r)
-          factory (TransformerFactory/newInstance)]
+          factory (TransformerFactoryImpl.)]
       (.setURIResolver factory (create-uri-resolver))
       (.newTemplates factory xsl-resource))))
 

--- a/common-lib/src/cmr/common/xml/xslt.clj
+++ b/common-lib/src/cmr/common/xml/xslt.clj
@@ -1,15 +1,12 @@
 (ns cmr.common.xml.xslt
   "Provides functions for invoking xsl on metadata."
-  (:require [clojure.java.io :as io])
-  (:import java.io.StringReader
-           java.io.StringWriter
-           javax.xml.transform.stream.StreamSource
-           javax.xml.transform.stream.StreamResult
-           [javax.xml.transform
-            TransformerFactory
-            Templates
-            URIResolver]
-           net.sf.saxon.TransformerFactoryImpl))
+  (:require
+   [clojure.java.io :as io])
+  (:import
+   (java.io StringReader StringWriter)
+   (javax.xml.transform TransformerFactory Templates URIResolver)
+   (javax.xml.transform.stream StreamSource StreamResult)
+   (net.sf.saxon TransformerFactoryImpl)))
 
 (defn- create-uri-resolver
   "Creates an instance of the URIResolver interface that will direct all paths within the xslt


### PR DESCRIPTION
This is to guarantee that xslt 2.0 processor is used for xslt translation.