### PR TITLE
CMR-5423: remove data.json config option.

### DIFF
--- a/search-app/README.md
+++ b/search-app/README.md
@@ -11,6 +11,13 @@ generated into the static site by running the following:
 $ lein generate-static
 ```
 
+### Data.JSON
+
+Collections with gov.nasa.eosdis tag and returned as opendata to be harvested
+by data.nasa.gov can be retrieved with:
+
+    curl -i http://localhost:3003/socrata/data.json
+
 ## License
 
 Copyright © 2014-2017 NASA

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -5,7 +5,6 @@
    [clj-http.client :as client]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.services.search :as search]
-   [cmr.common-app.site.pages :as common-pages]
    [cmr.common.cache :as cache]
    [cmr.common.config :refer [defconfig]]
    [cmr.common.log :refer (debug info warn error)]

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -310,9 +310,10 @@
     (find-tiles ctx params)))
 
 (def data-json-routes
-  "config-enabled route for data.json. Socrata does not support harvesting from
+  "Route for data.json response. Socrata does not support harvesting from
    data.json endpoints that do not explicitly end in /data.json. This is needed
-   to harvest CMR opendata responses on data.nasa.gov."
+   to harvest CMR opendata responses on data.nasa.gov. This endpoint returns
+   collections with the gov.nasa.eosdis tag as opendata."
   (GET "/socrata/data.json"
     {ctx :request-context}
     (find-data-json ctx)))

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -30,11 +30,6 @@
    allow-all-granule-params-flag is set to false."
   {:default "Must be changed"})
 
-(defconfig allow-data-json-flag
-  "Flag to allow data.json route."
-  {:default false
-   :type Boolean})
-
 (def supported-provider-holdings-mime-types
   "The mime types supported by search."
   #{mt/any
@@ -320,6 +315,4 @@
    to harvest CMR opendata responses on data.nasa.gov."
   (GET "/socrata/data.json"
     {ctx :request-context}
-    (if (allow-data-json-flag)
-      (find-data-json ctx)
-      (common-pages/not-found))))
+    (find-data-json ctx)))

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -17,7 +17,7 @@
 (def ^:private coll-idx (atom 0))
 
 (defn- data-json-fixture
-  "Enable/Disable data.json endpoint, reset coll-idx for collection creation."
+  "Reset coll-idx for collection creation."
   [f]
   (reset! coll-idx 0)
   (f))

--- a/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/data_json_search_test.clj
@@ -19,11 +19,8 @@
 (defn- data-json-fixture
   "Enable/Disable data.json endpoint, reset coll-idx for collection creation."
   [f]
-  (let [saved-data-json-flag (concepts-search/allow-data-json-flag)]
-    (side-api/eval-form `(concepts-search/set-allow-data-json-flag! true))
-    (reset! coll-idx 0)
-    (f)
-    (side-api/eval-form `(concepts-search/set-allow-data-json-flag! ~saved-data-json-flag))))
+  (reset! coll-idx 0)
+  (f))
 
 (use-fixtures :each (join-fixtures
                       [(ingest-util/reset-fixture {"provguid1" "PROV1"}


### PR DESCRIPTION
no longer need data.json endpoint to be configurable. 