### PR TITLE
CMR-4460: Bootstrap returns a 404 - Not Found for unknown routes.

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -93,7 +93,8 @@
           (drift/run (conj migrate-args "-c" "config.migrate-config/app-migrate-config")))
         {:status 204})
       ;; Add routes for checking health of the application
-      (common-health/health-api-routes hs/health))))
+      (common-health/health-api-routes hs/health))
+    (route/not-found "Not Found")))
 
 (defn make-api [system]
   (-> (build-routes system)

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -75,16 +75,16 @@
 (defn- bulk-index-by-url
   "Calls bootstrap app on the given bulk index url"
   ([bulk-index-url headers]
-    (let [response (client/request
-                    {:method :post
-                     :headers headers
-                     :url bulk-index-url
-                     :content-type :json
-                     :accept :json
-                     :throw-exceptions false
-                     :connection-manager (s/conn-mgr)})
-          body (json/decode (:body response) true)]
-      (assoc body :status (:status response)))))
+   (let [response (client/request
+                   {:method :post
+                    :headers headers
+                    :url bulk-index-url
+                    :content-type :json
+                    :accept :json
+                    :throw-exceptions false
+                    :connection-manager (s/conn-mgr)})
+         body (json/decode (:body response) true)]
+     (assoc body :status (:status response)))))
 
 (defn bulk-index-variables
   "Call the bootstrap app to bulk index variables (either all of them, or just the

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/concepts_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/concepts_test.clj
@@ -22,7 +22,7 @@
                                             {:grant-all-ingest? true
                                              :grant-all-search? true
                                              :grant-all-access-control? false})
-                     tags/grant-all-tag-fixture]))
+                      tags/grant-all-tag-fixture]))
 
 (defn- normalize-search-result-item
   "Returns a map with just concept-id and revision-id for the given item."

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/tag_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/tag_test.clj
@@ -19,7 +19,7 @@
                                             {:grant-all-ingest? true
                                              :grant-all-search? true
                                              :grant-all-access-control? false})
-                     tags/grant-all-tag-fixture]))
+                      tags/grant-all-tag-fixture]))
 
 ;; This test is to verify that bulk index works with tombstoned tag associations
 (deftest bulk-index-collections-with-tag-association-test

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/validation_test.clj
@@ -10,6 +10,8 @@
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.url-helper :as url]
+   [clj-http.client :as client]
    [cmr.transmit.config :as transmit-config]
    [cmr.umm.echo10.echo10-core :as echo10]))
 
@@ -100,3 +102,14 @@
              [400 [err-msg1]] [(:status fail-stat1) (:errors fail-stat1)]
              [400 [err-msg2]] [(:status fail-stat2) (:errors fail-stat2)]
              [400 [err-msg1]] [(:status fail-stat3) (:errors fail-stat3)])))))
+
+(deftest invalid-route-test
+  (s/only-with-real-database
+   (testing "Invalid route returns a 404"
+    (let [response (client/request
+                    {:method :post
+                     :url (url/bootstrap-url "bad-route")
+                     :accept :json
+                     :throw-exceptions false
+                     :connection-manager (s/conn-mgr)})]
+      (is (= 404 (:status response)))))))


### PR DESCRIPTION
  ![](https://media1.giphy.com/media/9J7tdYltWyXIY/giphy-downsized.gif?cid=6104955e5c463a6f7672456d2e68e105)
