### PR TITLE
CMR-5497: Change URS default relative-root-url to an empty string and refactor

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -28,83 +28,70 @@
 (defproject nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"
   :description "Implements the CMR access control application."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/access-control-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [commons-codec/commons-codec]
-    [commons-io]
-    [org.clojure/tools.reader]
-    [ring/ring-codec]]
-  :dependencies ~(concat '[
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [compojure "1.6.1"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-    project-dependencies)
-  :plugins [
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [commons-codec/commons-codec]
+               [commons-io]
+               [org.clojure/tools.reader]
+               [ring/ring-codec]]
+  :dependencies ~(concat '[[cheshire "5.8.1"]
+                           [clj-time "0.15.1"]
+                           [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                           [commons-codec/commons-codec "1.11"]
+                           [commons-io "2.6"]
+                           [compojure "1.6.1"]
+                           [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
+                           [org.clojure/clojure "1.10.0"]
+                           [org.clojure/tools.reader "1.3.2"]
+                           [ring/ring-codec "1.1.1"]
+                           [ring/ring-core "1.7.1"]
+                           [ring/ring-json "0.4.0"]]
+                  project-dependencies)
+  :plugins [[lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :test-paths ["test" "int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]
-        [ring-mock "0.1.5"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test" "int-test"]
-      :test-paths ["test" "int-test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    ;; This profile specifically here for generating documentation. It's faster
-    ;; than using the regular profile. An agent pool is being started when
-    ;; using the default profile which causes the wait of 60 seconds before
-    ;; allowing the JVM to shutdown since no call to shutdown-agents is made.
-    ;; Generate docs with: lein generate-static (the alias makes use of the
-    ;; static profile).
-    :static {}
-    :uberjar {
-      :main cmr.access-control.runner
-      :aot :all}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]
+                                  [ring-mock "0.1.5"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test" "int-test"]
+                   :test-paths ["test" "int-test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             ;; This profile specifically here for generating documentation. It's faster
+             ;; than using the regular profile. An agent pool is being started when
+             ;; using the default profile which causes the wait of 60 seconds before
+             ;; allowing the JVM to shutdown since no call to shutdown-agents is made.
+             ;; Generate docs with: lein generate-static (the alias makes use of the
+             ;; static profile).
+             :static {}
+             :uberjar {:main cmr.access-control.runner
+                       :aot :all}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"generate-static" ["with-profile" "static"
                                "run" "-m" "cmr.access-control.site.static" "all"]
             ;; Prints out documentation on configuration environment variables.

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -1,52 +1,40 @@
 (defproject nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"
   :description "Contains utilities for retreiving and working with ACLs."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/acl-lib"
-  :exclusions [
-    [commons-io]
-    [potemkin]]
-  :dependencies [
-    [commons-io "2.6"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [potemkin "0.4.5"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-io]
+               [potemkin]]
+  :dependencies [[commons-io "2.6"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [potemkin "0.4.5"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -1,81 +1,70 @@
 (defproject nasa-cmr/cmr-bootstrap-app "0.1.0-SNAPSHOT"
   :description "Bootstrap is a CMR application that can bootstrap the CMR with data from Catalog REST."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/bootstrap-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [commons-codec/commons-codec]
-    [commons-io]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/tools.reader]
-    [potemkin]
-    [ring/ring-codec]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-http "2.3.0"]
-    [clj-time "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [compojure "1.6.1"]
-    [nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [org.clojure/tools.reader "1.3.2"]
-    [potemkin "0.4.5"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [drift "1.5.3"]
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [commons-codec/commons-codec]
+               [commons-io]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/tools.reader]
+               [potemkin]
+               [ring/ring-codec]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-http "2.3.0"]
+                 [clj-time "0.15.1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [compojure "1.6.1"]
+                 [nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [potemkin "0.4.5"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[drift "1.5.3"]
+            [lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :uberjar {:main cmr.bootstrap.runner
-              :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :uberjar {:main cmr.bootstrap.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   ;; Database migrations run by executing "lein migrate"
   :aliases {"create-user" ["exec" "-p" "./support/create_user.clj"]
             "drop-user" ["exec" "-p" "./support/drop_user.clj"]

--- a/cmr-exchange/api-versioning/project.clj
+++ b/cmr-exchange/api-versioning/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,132 +18,109 @@
 (defproject gov.nasa.earthdata/cmr-api-versioning "0.1.0-SNAPSHOT"
   :description "A CMR utility library allowing services to provide versioned REST APIs"
   :url "https://github.com/cmr-exchange/cmr-api-versioning"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [clojusc/trifl "0.4.0"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.3-SNAPSHOT"]
-    [metosin/reitit-ring "0.2.4"]
-    [org.clojure/clojure "1.9.0"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[clojusc/trifl "0.4.0"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.1.3-SNAPSHOT"]
+                 [metosin/reitit-ring "0.2.4"]
+                 [org.clojure/clojure "1.9.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0-SNAPSHOT"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.ous.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.1"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0-SNAPSHOT"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.ous.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.1"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "version" ["do"
-      ["version"]
-      ["shell" "echo" "-n" "CMR OUS: "]
-      ["project-version"]]
-    "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
-    "uberjar" ["with-profile" "+system" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["clean"]
-      ["lint"]
-      ["ltest" ":all"]
-      ["ubercompile"]]
-    "build" ["do"
-      ["clean"]
-      ["lint"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":all"]
-      ["junit" ":all"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+system,+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "version" ["do"
+                       ["version"]
+                       ["shell" "echo" "-n" "CMR OUS: "]
+                       ["project-version"]]
+            "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
+            "uberjar" ["with-profile" "+system" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            "ltest" ["with-profile" "+test,+system" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["clean"]
+                          ["lint"]
+                          ["ltest" ":all"]
+                          ["ubercompile"]]
+            "build" ["do"
+                     ["clean"]
+                     ["lint"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":all"]
+                     ["junit" ":all"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+system,+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/authz/project.clj
+++ b/cmr-exchange/authz/project.clj
@@ -1,97 +1,83 @@
 (defproject gov.nasa.earthdata/cmr-authz "0.1.1"
   :description "An authorization utility library for CMR services"
   :url "https://github.com/cmr-exchange/authz"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
-    [http-kit "2.3.0"]
-    [metosin/reitit-ring "0.2.7"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/core.cache "0.7.1"]
-    [org.clojure/data.xml "0.2.0-alpha5"]
-    [tolitius/xml-in "0.1.0"]]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-kibit "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]]
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
+                 [http-kit "2.3.0"]
+                 [metosin/reitit-ring "0.2.7"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.cache "0.7.1"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [tolitius/xml-in "0.1.0"]]
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-kibit "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]]
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["ltest" ":unit"]
+                          ["ubercompile"]
+                          ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/cmr-client/project.clj
+++ b/cmr-exchange/cmr-client/project.clj
@@ -2,158 +2,131 @@
   :description "A Clojure(Script) Client for NASA's Common Metadata Repository"
   :url "https://github.com/cmr-exchange/cmr-client"
   :license {
-    :name "Apache License, Version 2.0"
-    :url "https://opensource.org/licenses/Apache-2.0"}
-  :exclusions [
-    org.clojure/clojure
-    potemkin]
-  :dependencies [
-    [clj-http "3.8.0"]
-    [cljs-http "0.1.44"]
-    [clojusc/ltest "0.3.0"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/clojurescript "1.10.217"]
-    [org.clojure/core.async "0.4.474"]
-    [org.clojure/data.json "0.2.6"]
-    [org.clojure/data.xml "0.2.0-alpha2"]
-    [potemkin "0.4.4"]]
+            :name "Apache License, Version 2.0"
+            :url "https://opensource.org/licenses/Apache-2.0"}
+  :exclusions [org.clojure/clojure
+               potemkin]
+  :dependencies [[clj-http "3.8.0"]
+                 [cljs-http "0.1.44"]
+                 [clojusc/ltest "0.3.0"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.217"]
+                 [org.clojure/core.async "0.4.474"]
+                 [org.clojure/data.json "0.2.6"]
+                 [org.clojure/data.xml "0.2.0-alpha2"]
+                 [potemkin "0.4.4"]]
   :source-paths ["src/clj" "src/cljc"]
-  :profiles {
-    :uberjar {
-      :aot :all}
-    :dev {
-      :dependencies [
-        [leiningen-core "2.8.1"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :plugins [
-        [lein-cljsbuild "1.1.7"]
-        [lein-figwheel "0.5.15"]
-        [lein-shell "0.5.0"]]
-      :resource-paths ["dev-resources" "test/data" "test/clj"]
-      :source-paths ["src/clj" "src/cljc" "test/clj" "dev-resources/src"]
-      :test-paths ["test/clj"]
-      :repl-options {
-        :init-ns cmr.client.dev}}
-    :test {
-      :resource-paths ["test/data"]
-      :source-paths ["test/clj"]
-      :test-paths ["test/clj"]
-      :test-selectors {
-        :default :unit
-        :unit :unit
-        :integration :integration
-        :system :system}
-      }
-    :lint {
-      :exclusions ^:replace [
-        org.clojure/clojure
-        org.clojure/tools.namespace]
-      :dependencies ^:replace [
-        [org.clojure/clojure "1.9.0"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :source-paths ^:replace ["src/clj" "src/cljc"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    :cljs {
-      :source-paths ^:replace ["src/cljs" "src/cljc"]}
-    :docs {
-      :dependencies [
-        [clojang/codox-theme "0.2.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.3"]
-        [lein-marginalia "0.9.1"]
-        [lein-simpleton "1.3.0"]]
-      :codox {
-        :project {
-          :name "CMR Client"
-          :description "A Clojure(Script)+JavaScript Client for NASA's Common Metadata Repository"}
-        :namespaces [#"^cmr\.client\..*"]
-        :metadata {
-          :doc/format :markdown
-          :doc "Documentation forthcoming"}
-        :themes [:clojang]
-        :doc-paths ["resources/docs"]
-        :output-path "docs/current"}}}
-  :cljsbuild {
-    :builds [
-      {:id "cmr-dev"
-       :source-paths ["src/cljs" "src/cljc"]
-       :figwheel true
-       :compiler {
-         :main "cmr.client"
-         :asset-path "js/out"
-         :output-to "resources/public/js/cmr_dev.js"
-         :output-dir "resources/public/js/out"}}
-      {:id "cmr-prod"
-       :source-paths ["src/cljs" "src/cljc"]
-       :compiler {
-         :main "cmr.client"
-         :static-fns true
-         :fn-invoke-direct true
-         :optimizations :simple
-         :output-to "resources/public/js/cmr_client.js"}}]}
-  :aliases {
-    "repl"
-      ["with-profile" "+dev" "repl"]
-    "build-cljs-dev"
-      ^{:doc "Build just the dev version of the ClojureScript code"}
-      ["cljsbuild" "once" "cmr-dev"]
-    "build-cljs-prod"
-      ^{:doc "Build just the prod version of the ClojureScript code"}
-      ["do"
-        ["shell" "rm" "-f" "resources/public/js/cmr_client.js"]
-        ["cljsbuild" "once" "cmr-prod"]]
-    "run-tests"
-      ^{:doc "Use the ltest runner for verbose, colourful test output"}
-      ["with-profile" "+test"
-       "run" "-m" "cmr.client.testing.runner"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps"
-      ^{:doc "Check to see if any dependencies are out of date or if jars are conflicting"}
-      ["do"
-        ["check-jars"]
-        ["check-vers"]]
-    "lint"
-      ^{:doc "Run linting tools against the source"}
-      ["with-profile" "+lint" "kibit"]
-    "docs"
-      ^{:doc "Generate API documentation"}
-      ["with-profile" "+docs" "do"
-        ["codox"]
-        ; ["marg" "--dir" "docs/current"
-        ;         "--file" "marginalia.html"
-        ;         "--name" "sockets"]
-        ;["shell" "cp" "resources/public/cdn.html" "docs"]
-        ]
-    "build"
-      ^{:doc "Perform the build tasks"}
-      ["with-profile" "+test" "do"
-        ;["check-deps"]
-        ["lint"]
-        ["test"]
-        ["compile"]
-        ["docs"]
-        ["uberjar"]
-        ["build-cljs-dev"]
-        ["build-cljs-prod"]]
-    "npm"
-      ^{:doc "Publish compiled JavaScript client"}
-      ["do"
-        ["shell" "rm" "-rf" "dist"]
-        ["shell" "mkdir" "dist"]
-        ["shell" "cp" "resources/public/js/cmr_client.js" "dist"]
-        ["shell" "npm" "publish" "--access" "public"]
-        ["shell" "rm" "-rf" "dist"]]
-    "publish"
-      ^{:doc "Publish to Clojars and npm"}
-      ["do"
-        ["deploy" "clojars"]
-        ["npm"]]})
+  :profiles {:uberjar {:aot :all}
+             :dev {:dependencies [[leiningen-core "2.8.1"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :plugins [[lein-cljsbuild "1.1.7"]
+                             [lein-figwheel "0.5.15"]
+                             [lein-shell "0.5.0"]]
+                   :resource-paths ["dev-resources" "test/data" "test/clj"]
+                   :source-paths ["src/clj" "src/cljc" "test/clj" "dev-resources/src"]
+                   :test-paths ["test/clj"]
+                   :repl-options {:init-ns cmr.client.dev}}
+             :test {:resource-paths ["test/data"]
+                    :source-paths ["test/clj"]
+                    :test-paths ["test/clj"]
+                    :test-selectors {:default :unit
+                                     :unit :unit
+                                     :integration :integration
+                                     :system :system}}
+             :lint {:exclusions ^:replace [org.clojure/clojure
+                                           org.clojure/tools.namespace]
+                    :dependencies ^:replace [[org.clojure/clojure "1.9.0"]
+                                             [org.clojure/tools.namespace "0.2.11"]]
+                    :source-paths ^:replace ["src/clj" "src/cljc"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             :cljs {:source-paths ^:replace ["src/cljs" "src/cljc"]}
+             :docs {:dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.3"]
+                              [lein-marginalia "0.9.1"]
+                              [lein-simpleton "1.3.0"]]
+                    :codox {:project {:name "CMR Client"
+                                      :description "A Clojure(Script)+JavaScript Client for NASA's Common Metadata Repository"}
+                            :namespaces [#"^cmr\.client\..*"]
+                            :metadata {:doc/format :markdown
+                                       :doc "Documentation forthcoming"}
+                            :themes [:clojang]
+                            :doc-paths ["resources/docs"]
+                            :output-path "docs/current"}}}
+  :cljsbuild {:builds [{:id "cmr-dev"
+                        :source-paths ["src/cljs" "src/cljc"]
+                        :figwheel true
+                        :compiler {:main "cmr.client"
+                                   :asset-path "js/out"
+                                   :output-to "resources/public/js/cmr_dev.js"
+                                   :output-dir "resources/public/js/out"}}
+                       {:id "cmr-prod"
+                        :source-paths ["src/cljs" "src/cljc"]
+                        :compiler {:main "cmr.client"
+                                   :static-fns true
+                                   :fn-invoke-direct true
+                                   :optimizations :simple
+                                   :output-to "resources/public/js/cmr_client.js"}}]}
+  :aliases {"repl"
+            ["with-profile" "+dev" "repl"]
+            "build-cljs-dev"
+            ^{:doc "Build just the dev version of the ClojureScript code"}
+            ["cljsbuild" "once" "cmr-dev"]
+            "build-cljs-prod"
+            ^{:doc "Build just the prod version of the ClojureScript code"}
+            ["do"
+              ["shell" "rm" "-f" "resources/public/js/cmr_client.js"]
+              ["cljsbuild" "once" "cmr-prod"]]
+            "run-tests"
+            ^{:doc "Use the ltest runner for verbose, colourful test output"}
+            ["with-profile" "+test"
+             "run" "-m" "cmr.client.testing.runner"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps"
+            ^{:doc "Check to see if any dependencies are out of date or if jars are conflicting"}
+            ["do"
+              ["check-jars"]
+              ["check-vers"]]
+            "lint"
+            ^{:doc "Run linting tools against the source"}
+            ["with-profile" "+lint" "kibit"]
+            "docs"
+            ^{:doc "Generate API documentation"}
+            ["with-profile" "+docs" "do"
+              ["codox"]]
+            ; ["marg" "--dir" "docs/current"
+            ;         "--file" "marginalia.html"
+            ;         "--name" "sockets"]
+            ;["shell" "cp" "resources/public/cdn.html" "docs"]
+
+            "build"
+            ^{:doc "Perform the build tasks"}
+            ["with-profile" "+test" "do"
+            ;["check-deps"]
+              ["lint"]
+              ["test"]
+              ["compile"]
+              ["docs"]
+              ["uberjar"]
+              ["build-cljs-dev"]
+              ["build-cljs-prod"]]
+            "npm"
+            ^{:doc "Publish compiled JavaScript client"}
+            ["do"
+              ["shell" "rm" "-rf" "dist"]
+              ["shell" "mkdir" "dist"]
+              ["shell" "cp" "resources/public/js/cmr_client.js" "dist"]
+              ["shell" "npm" "publish" "--access" "public"]
+              ["shell" "rm" "-rf" "dist"]]
+            "publish"
+            ^{:doc "Publish to Clojars and npm"}
+            ["do"
+              ["deploy" "clojars"]
+              ["npm"]]})

--- a/cmr-exchange/codox-theme/project.clj
+++ b/cmr-exchange/codox-theme/project.clj
@@ -1,8 +1,7 @@
 (defproject gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"
   :description "A Codox Theme for NASA EOSDIS Clojure Projects' Documentation"
   :url "https://github.com/cmr-exchange/codox-theme"
-  :license {
-    :name "Eclipse Public License 1.0"
-    :url "https://www.eclipse.org/legal/epl-v10.html"
-    :year 2018
-    :key "epl-1.0"})
+  :license {:name "Eclipse Public License 1.0"
+            :url "https://www.eclipse.org/legal/epl-v10.html"
+            :year 2018
+            :key "epl-1.0"})

--- a/cmr-exchange/dev-env-manager/project.clj
+++ b/cmr-exchange/dev-env-manager/project.clj
@@ -6,255 +6,209 @@
 (defproject gov.nasa.earthdata/cmr-dev-env-manager "0.0.4-SNAPSHOT"
   :description "An Alternate Development Environment Manager for the CMR"
   :url "https://github.com/cmr-exchange/dev-env-manager"
-  :license {
-    :name "Apache License 2.0"
-    :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :exclusions [
-    commons-codec
-    instaparse
-    org.apache.httpcomponents/httpclient
-    org.apache.maven.wagon/wagon-provider-api
-    org.clojure/clojure
-    org.clojure/tools.macro]
-  :dependencies [
-    [cheshire "5.8.0"]
-    [clj-http "3.7.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [commons-codec "1.11"]
-    [hawk "0.2.11"]
-    [instaparse "1.4.8"]
-    [leiningen-core "2.7.1" :exclusions [
-      commons-io
-      org.apache.httpcomponents/httpcore
-      org.slf4j/slf4j-nop]]
-    [org.apache.httpcomponents/httpclient "4.5.4"]
-    [org.apache.maven.wagon/wagon-provider-api "2.10"]
-    [org.clojure/clojure "1.8.0"]
-    [org.clojure/core.async "0.3.465" :exclusions [
-      org.clojure/tools.reader]]
-    [org.clojure/tools.macro "0.1.5"]]
+  :license {:name "Apache License 2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0"}
+  :exclusions [commons-codec
+               instaparse
+               org.apache.httpcomponents/httpclient
+               org.apache.maven.wagon/wagon-provider-api
+               org.clojure/clojure
+               org.clojure/tools.macro]
+  :dependencies [[cheshire "5.8.0"]
+                 [clj-http "3.7.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [commons-codec "1.11"]
+                 [hawk "0.2.11"]
+                 [instaparse "1.4.8"]
+                 [leiningen-core "2.7.1" :exclusions [commons-io
+                                                      org.apache.httpcomponents/httpcore
+                                                      org.slf4j/slf4j-nop]]
+                 [org.apache.httpcomponents/httpclient "4.5.4"]
+                 [org.apache.maven.wagon/wagon-provider-api "2.10"]
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.3.465" :exclusions [org.clojure/tools.reader]]
+                 [org.clojure/tools.macro "0.1.5"]]
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;;;   CMR D.E.M. specific configuration   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  :dem {
-    :logging {
-      :level :debug}
-    :elastic-search {
-      ;:image-id "docker.elastic.co/elasticsearch/elasticsearch:6.0.1"
-      :image-id "elasticsearch:1.6.2"
-      :ports ["127.0.0.1:9200:9200" "127.0.0.1:9300:9300"]
-      :env ["discovery.type=single-node"]
-      :container-id-file "/tmp/cmr-dem-elastic-container-id"}
-    :elastic-search-head {
-      :image-id "mobz/elasticsearch-head:1"
-      :ports ["127.0.0.1:9100:9100"]
-      :container-id-file "/tmp/cmr-dem-elastic-head-container-id"}
-    :enabled-services #{
-      ;; Support services
-      :elastic-search
-      ;:elastic-search-head
-      ;; CMR services
-      :cubby
-      :mock-echo}
-    :timer {
-      :delay 1000}}
+  :dem {:logging {:level :debug}
+        :elastic-search {
+                         ;:image-id "docker.elastic.co/elasticsearch/elasticsearch:6.0.1"
+                         :image-id "elasticsearch:1.6.2"
+                         :ports ["127.0.0.1:9200:9200" "127.0.0.1:9300:9300"]
+                         :env ["discovery.type=single-node"]
+                         :container-id-file "/tmp/cmr-dem-elastic-container-id"}
+        :elastic-search-head {:image-id "mobz/elasticsearch-head:1"
+                              :ports ["127.0.0.1:9100:9100"]
+                              :container-id-file "/tmp/cmr-dem-elastic-head-container-id"}
+        :enabled-services #{
+                            ;; Support services
+                            :elastic-search
+                            ;:elastic-search-head
+                            ;; CMR services
+                            :cubby
+                            :mock-echo}
+        :timer {:delay 1000}}
   :profiles {
-    ;; Tasks
-    :ubercompile {:aot :all}
-    ;; Environments
-    :dev {
-      :dependencies [
-        [clojusc/ltest "0.3.0-SNAPSHOT"]
-        [clojusc/trifl "0.3.0-SNAPSHOT"]
-        [clojusc/twig "0.3.2"]
-        [gov.nasa.earthdata/cmr-process-manager "0.1.0-SNAPSHOT"]
-        [me.raynes/conch "0.8.0"]
-        [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT" :exclusions [
-          com.dadrox/quiet-slf4j
-          com.google.code.findbugs/jsr305
-          gorilla-repl
-          org.slf4j/slf4j-nop]]
-        [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT" :exclusions [
-          commons-io]]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :source-paths [
-        "dev-resources/src"
-        "libs/common-lib/src"
-        "libs/transmit-lib/src"]
-      :repl-options {
-        :init-ns cmr.dev.env.manager.repl
-        :prompt #(str "\u001B[35m[\u001B[34m"
-                      %
-                      "\u001B[35m]\u001B[33m λ\u001B[m=> ")}}
-    :custom-repl {
-      :repl-options {
-        ;:welcome ~(print-welcome)
-        }}
-    :test {
-      :plugins [
-        [lein-ancient "0.6.14"]
-        [jonase/eastwood "0.2.5"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    :lint {
-      :source-paths ^:replace ["src"]}
-    :docs {
-      :dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.3"]
-        [lein-simpleton "1.3.0"]]
-      :codox {
-        :project {:name "CMR D.E.M."}
-        :themes [:clojang]
-        :output-path "docs/current"
-        :doc-paths ["resources/docs"]
-        :namespaces [#"^cmr\.dev\.env\.manager\.(?!test)"]
-        :metadata {:doc/format :markdown}}}
-    :instrumented {
-      :jvm-opts [
-        "-Dcom.sun.management.jmxremote"
-        "-Dcom.sun.management.jmxremote.ssl=false"
-        "-Dcom.sun.management.jmxremote.authenticate=false"
-        "-Dcom.sun.management.jmxremote.port=43210"]}
+              ;; Tasks
+             :ubercompile {:aot :all}
+             ;; Environments
+             :dev {:dependencies [[clojusc/ltest "0.3.0-SNAPSHOT"]
+                                  [clojusc/trifl "0.3.0-SNAPSHOT"]
+                                  [clojusc/twig "0.3.2"]
+                                  [gov.nasa.earthdata/cmr-process-manager "0.1.0-SNAPSHOT"]
+                                  [me.raynes/conch "0.8.0"]
+                                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT" :exclusions [com.dadrox/quiet-slf4j
+                                                                                         com.google.code.findbugs/jsr305
+                                                                                         gorilla-repl
+                                                                                         org.slf4j/slf4j-nop]]
+                                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT" :exclusions [commons-io]]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :source-paths ["dev-resources/src"
+                                  "libs/common-lib/src"
+                                  "libs/transmit-lib/src"]
+                   :repl-options {:init-ns cmr.dev.env.manager.repl
+                                  :prompt #(str "\u001B[35m[\u001B[34m"
+                                                %
+                                                "\u001B[35m]\u001B[33m λ\u001B[m=> ")}}
+             :custom-repl {:repl-options {}}
+             ;:welcome ~(print-welcome)
+             :test {:plugins [[lein-ancient "0.6.14"]
+                              [jonase/eastwood "0.2.5"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             :lint {:source-paths ^:replace ["src"]}
+             :docs {:dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.3"]
+                              [lein-simpleton "1.3.0"]]
+                    :codox {:project {:name "CMR D.E.M."}
+                            :themes [:clojang]
+                            :output-path "docs/current"
+                            :doc-paths ["resources/docs"]
+                            :namespaces [#"^cmr\.dev\.env\.manager\.(?!test)"]
+                            :metadata {:doc/format :markdown}}}
+             :instrumented {:jvm-opts ["-Dcom.sun.management.jmxremote"
+                                       "-Dcom.sun.management.jmxremote.ssl=false"
+                                       "-Dcom.sun.management.jmxremote.authenticate=false"
+                                       "-Dcom.sun.management.jmxremote.port=43210"]}
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;;;   Profiles for Managed Aapplications/Services   ;;;;;;;;;;;;;;;;;;;;;
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;; Note that CMR service port configuration is currently pulled in from
     ;; the `cmr.transmit.config` ns; see `cmr.dev.env.manager.config`.
-    :access-control {
-      :main cmr.access-control.runner
-      :source-paths [
-        "apps/access-control-app/src"
-        "apps/metadata-db-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/common-lib/src"
-        "libs/elastic-utils-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/transmit-lib/src"
-        "libs/umm-spec-lib/src"]}
-    :bootstrap {
-      :main cmr.bootstrap.runner
-      :source-paths [
-        "apps/access-control-app/src"
-        "apps/bootstrap-app/src"
-        "apps/indexer-app/src"
-        "apps/metadata-db-app/src"
-        "apps/virtual-product-app/src"
-        "libs/common-app-lib/src"
-        "libs/oracle-lib/src"
-        "libs/transmit-lib/src"]}
-    :cubby {
-      :dependencies [
-        [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-        [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-        [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-        [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-        [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]]
-      :main cmr.cubby.runner
-      :source-paths [
-        "apps/cubby-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/common-lib/src"
-        "libs/elastic-utils-lib/src"
-        "libs/transmit-lib/src"]}
-    :index-set {
-      :main cmr.index-set.runner
-      :source-paths [
-        "apps/index-set-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/elastic-utils-lib/src"]}
-    :indexer {
-      :main cmr.indexer.runner
-      :source-paths [
-        "apps/indexer-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/elastic-utils-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/transmit-lib/src"
-        "libs/umm-lib/src"
-        "libs/umm-spec-lib/src"]}
-    :ingest {
-      :main cmr.ingest.runner
-      :source-paths [
-        "apps/ingest-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/oracle-lib/src"
-        "libs/transmit-lib/src"
-        "libs/umm-lib/src"
-        "libs/umm-spec-lib/src"]}
-    :metadata-db {
-      :main cmr.metadata-db.runner
-      :source-paths [
-        "apps/metadata-db-app/src"
-        "libs/acl-lib/src"
-        "libs/common-app-lib/src"
-        "libs/common-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/oracle-lib/src"]}
-    :mock-echo {
-      :autoreload true
-      :main cmr.mock-echo.runner
-      :source-paths [
-        "apps/mock-echo-app/src"
-        "libs/common-app-lib/src"
-        "libs/common-lib/src"
-        "libs/transmit-lib/src"]}
-    :search {
-      :main cmr.search.runner
-      :source-paths [
-        "apps/search-app/src"
-        "libs/collection-renderer-lib/src"
-        "libs/common-app-lib/src"
-        "libs/elastic-utils-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/orbits-lib/src"
-        "libs/spatial-lib/src"
-        "libs/umm-lib/src"
-        "libs/umm-spec-lib/src"]}
-    :virtual-product {
-      :main cmr.virtual-product.runner
-      :source-paths [
-        "apps/virtual-product-app/src"
-        "libs/common-app-lib/src"
-        "libs/common-lib/src"
-        "libs/message-queue-lib/src"
-        "libs/transmit-lib/src"
-        "libs/umm-lib/src"]}}
+             :access-control {:main cmr.access-control.runner
+                              :source-paths ["apps/access-control-app/src"
+                                             "apps/metadata-db-app/src"
+                                             "libs/acl-lib/src"
+                                             "libs/common-app-lib/src"
+                                             "libs/common-lib/src"
+                                             "libs/elastic-utils-lib/src"
+                                             "libs/message-queue-lib/src"
+                                             "libs/transmit-lib/src"
+                                             "libs/umm-spec-lib/src"]}
+             :bootstrap {:main cmr.bootstrap.runner
+                         :source-paths ["apps/access-control-app/src"
+                                        "apps/bootstrap-app/src"
+                                        "apps/indexer-app/src"
+                                        "apps/metadata-db-app/src"
+                                        "apps/virtual-product-app/src"
+                                        "libs/common-app-lib/src"
+                                        "libs/oracle-lib/src"
+                                        "libs/transmit-lib/src"]}
+             :cubby {:dependencies [[nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                                    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                                    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                                    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                                    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]]
+                     :main cmr.cubby.runner
+                     :source-paths ["apps/cubby-app/src"
+                                    "libs/acl-lib/src"
+                                    "libs/common-app-lib/src"
+                                    "libs/common-lib/src"
+                                    "libs/elastic-utils-lib/src"
+                                    "libs/transmit-lib/src"]}
+             :index-set {:main cmr.index-set.runner
+                         :source-paths ["apps/index-set-app/src"
+                                        "libs/acl-lib/src"
+                                        "libs/common-app-lib/src"
+                                        "libs/elastic-utils-lib/src"]}
+             :indexer {:main cmr.indexer.runner
+                       :source-paths ["apps/indexer-app/src"
+                                      "libs/acl-lib/src"
+                                      "libs/common-app-lib/src"
+                                      "libs/elastic-utils-lib/src"
+                                      "libs/message-queue-lib/src"
+                                      "libs/transmit-lib/src"
+                                      "libs/umm-lib/src"
+                                      "libs/umm-spec-lib/src"]}
+             :ingest {:main cmr.ingest.runner
+                      :source-paths ["apps/ingest-app/src"
+                                     "libs/acl-lib/src"
+                                     "libs/common-app-lib/src"
+                                     "libs/message-queue-lib/src"
+                                     "libs/oracle-lib/src"
+                                     "libs/transmit-lib/src"
+                                     "libs/umm-lib/src"
+                                     "libs/umm-spec-lib/src"]}
+             :metadata-db {:main cmr.metadata-db.runner
+                           :source-paths ["apps/metadata-db-app/src"
+                                          "libs/acl-lib/src"
+                                          "libs/common-app-lib/src"
+                                          "libs/common-lib/src"
+                                          "libs/message-queue-lib/src"
+                                          "libs/oracle-lib/src"]}
+             :mock-echo {:autoreload true
+                         :main cmr.mock-echo.runner
+                         :source-paths ["apps/mock-echo-app/src"
+                                        "libs/common-app-lib/src"
+                                        "libs/common-lib/src"
+                                        "libs/transmit-lib/src"]}
+             :search {:main cmr.search.runner
+                      :source-paths ["apps/search-app/src"
+                                     "libs/collection-renderer-lib/src"
+                                     "libs/common-app-lib/src"
+                                     "libs/elastic-utils-lib/src"
+                                     "libs/message-queue-lib/src"
+                                     "libs/orbits-lib/src"
+                                     "libs/spatial-lib/src"
+                                     "libs/umm-lib/src"
+                                     "libs/umm-spec-lib/src"]}
+             :virtual-product {:main cmr.virtual-product.runner
+                               :source-paths ["apps/virtual-product-app/src"
+                                              "libs/common-app-lib/src"
+                                              "libs/common-lib/src"
+                                              "libs/message-queue-lib/src"
+                                              "libs/transmit-lib/src"
+                                              "libs/umm-lib/src"]}}
   :aliases {
-    ;; General aliases
-    "repl" ["trampoline" "repl"]
-    "unprotected-repl" ["repl"]
-    "ubercompile" ["with-profile" "+ubercompile" "do"
-      ["clean"]
-      ["compile"]
-      ["clean"]]
-    "check-deps" ["with-profile" "+test" "ancient" "check" ":all"]
-    "lint" ["with-profile" "+test,+lint" "kibit"]
-    "docs" ["with-profile" "+docs" "do"
-      ["clean"]
-      ["compile"]
-      ["codox"]
-      ["clean"]]
-    "build" ["with-profile" "+test" "do"
-      ["check-deps"]
-      ["lint"]
-      ["docs"]
-      ["ubercompile"]
-      ["clean"]
-      ["uberjar"]
-      ["clean"]
-      ["test"]]
-    ;; Profiling
-    "instrumented-repl" ["with-profile" "+instrumented" "repl"]
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    ;;;   Application Aliases   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    "cubby" ["trampoline" "with-profile" "+dev,+cubby" "run"]
-    "mock-echo" ["trampoline" "with-profile" "+dev,+mock-echo" "run"]})
+            ;; General aliases
+            "repl" ["trampoline" "repl"]
+            "unprotected-repl" ["repl"]
+            "ubercompile" ["with-profile" "+ubercompile" "do"
+                           ["clean"]
+                           ["compile"]
+                           ["clean"]]
+            "check-deps" ["with-profile" "+test" "ancient" "check" ":all"]
+            "lint" ["with-profile" "+test,+lint" "kibit"]
+            "docs" ["with-profile" "+docs" "do"
+                    ["clean"]
+                    ["compile"]
+                    ["codox"]
+                    ["clean"]]
+            "build" ["with-profile" "+test" "do"
+                     ["check-deps"]
+                     ["lint"]
+                     ["docs"]
+                     ["ubercompile"]
+                     ["clean"]
+                     ["uberjar"]
+                     ["clean"]
+                     ["test"]]
+            ;; Profiling
+            "instrumented-repl" ["with-profile" "+instrumented" "repl"]
+            ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+            ;;;   Application Aliases   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+            ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+            "cubby" ["trampoline" "with-profile" "+dev,+cubby" "run"]
+            "mock-echo" ["trampoline" "with-profile" "+dev,+mock-echo" "run"]})

--- a/cmr-exchange/edsc-stubs/project.clj
+++ b/cmr-exchange/edsc-stubs/project.clj
@@ -9,21 +9,16 @@
   :url "https://github.com/oubiwann/cmr-edsc-stubs"
   :license {:name "Apache License 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.0"]
-    [clj-time "0.14.0"]
-    [clojusc/trifl "0.1.0"]
-    [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-sample-data "0.2.0-SNAPSHOT"]
-    [org.clojure/clojure "1.8.0"]
-    [org.clojure/java.jdbc "0.7.1"]
-    [potemkin "0.4.4"]]
-  :profiles {
-    :uberjar {:aot :all}
-    :dev {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr-edsc-stubs.dev
-        :prompt ~get-prompt}}})
+  :dependencies [[cheshire "5.8.0"]
+                 [clj-time "0.14.0"]
+                 [clojusc/trifl "0.1.0"]
+                 [gov.nasa.earthdata/cmr-client "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sample-data "0.2.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/java.jdbc "0.7.1"]
+                 [potemkin "0.4.4"]]
+  :profiles {:uberjar {:aot :all}
+             :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr-edsc-stubs.dev
+                                  :prompt ~get-prompt}}})

--- a/cmr-exchange/exchange-common/project.clj
+++ b/cmr-exchange/exchange-common/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it.
     (catch Exception _ "")))
 
@@ -17,106 +17,88 @@
 (defproject gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"
   :description "Cross-project functionality, utilities, and general-use components"
   :url "https://github.com/cmr-exchange/cmr-exchange-common"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [clojusc/results "0.1.0"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [environ "1.1.0"]
-    [org.clojure/clojure "1.9.0"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[clojusc/results "0.1.0"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [environ "1.1.0"]
+                 [org.clojure/clojure "1.9.0"]]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    :dev {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]
-        [org.clojure/java.classpath "0.3.0"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.exchange.common.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.4"]
-        [lein-ancient "0.6.15"]
-        [lein-kibit "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]]
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             :dev {:dependencies [[clojusc/system-manager "0.3.0"]
+                                  [org.clojure/java.classpath "0.3.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [proto-repl "0.3.1"]]
+                   :plugins [[venantius/ultra "0.5.2"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.exchange.common.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.4"]
+                              [lein-ancient "0.6.15"]
+                              [lein-kibit "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]]
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Installing
-    "install" ["do"
-      ["clean"]
-      ["ubercompile"]
-      ["clean"]
-      ["install"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Installing
+            "install" ["do"
+                       ["clean"]
+                       ["ubercompile"]
+                       ["clean"]
+                       ["install"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/exchange-geo/project.clj
+++ b/cmr-exchange/exchange-geo/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,126 +18,105 @@
 (defproject gov.nasa.earthdata/cmr-exchange-geo "0.1.0"
   :description "A general geographic library that unifies separate libs under a common interface"
   :url "https://github.com/cmr-exchange/cmr-exchange-geo"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :exclusions [
-    [net.sf.geographiclib/GeographicLib-Java]]
-  :dependencies [
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.esri.geometry/esri-geometry-api "2.2.1"]
-    [com.vividsolutions/jts "1.13"]
-    [net.sf.geographiclib/GeographicLib-Java "1.49"]
-    [org.clojure/clojure "1.9.0"]
-    [org.geotools/gt-geometry "20.0"]
-    [org.geotools/gt-referencing "20.0"]]
-  :repositories [
-    ["osgeo" "https://download.osgeo.org/webdav/geotools"]]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :repl-options {
-        :init-ns cmr.exchange.geo.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]
-        [venantius/ultra "0.5.2"]]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :exclusions [[net.sf.geographiclib/GeographicLib-Java]]
+  :dependencies [[clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.esri.geometry/esri-geometry-api "2.2.1"]
+                 [com.vividsolutions/jts "1.13"]
+                 [net.sf.geographiclib/GeographicLib-Java "1.49"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.geotools/gt-geometry "20.0"]
+                 [org.geotools/gt-referencing "20.0"]]
+  :repositories [["osgeo" "https://download.osgeo.org/webdav/geotools"]]
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:repl-options {:init-ns cmr.exchange.geo.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]
+                              [venantius/ultra "0.5.2"]]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local" "repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+local,+security" "compile"]
-    "uberjar-aot" ["with-profile" "+ubercompile,+security" "uberjar"]
-    "check-vers" ["with-profile" "+lint,+security" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+local" "ltest"]
-    "junit" ["with-profile" "+test,+local" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["clean"]
-      ["lint"]
-      ["ltest" ":unit"]
-      ["ubercompile"]]
-    "build" ["do"
-      ["clean"]
-      ["lint"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["junit" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]
-    ;; Application
-    "run" ["with-profile" "+security" "run"]
-    "trampoline" ["with-profile" "+security" "trampoline"]
-    "start-service-bridge" ["trampoline" "run"]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local" "repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+local,+security" "compile"]
+            "uberjar-aot" ["with-profile" "+ubercompile,+security" "uberjar"]
+            "check-vers" ["with-profile" "+lint,+security" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+            ;["eastwood"]
+
+            "ltest" ["with-profile" "+test,+local" "ltest"]
+            "junit" ["with-profile" "+test,+local" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["clean"]
+                          ["lint"]
+                          ["ltest" ":unit"]
+                          ["ubercompile"]]
+            "build" ["do"
+                     ["clean"]
+                     ["lint"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["junit" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]
+            ;; Application
+            "run" ["with-profile" "+security" "run"]
+            "trampoline" ["with-profile" "+security" "trampoline"]
+            "start-service-bridge" ["trampoline" "run"]})

--- a/cmr-exchange/exchange-query/project.clj
+++ b/cmr-exchange/exchange-query/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it.
     (catch Exception _ "")))
 
@@ -17,124 +17,101 @@
 (defproject gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"
   :description "Cross-project query and parameter parsing and transformations"
   :url "https://github.com/cmr-exchange/cmr-exchange-query"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-    [org.clojure/clojure "1.9.0"]
-    [ring/ring-codec "1.1.1"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                 [org.clojure/clojure "1.9.0"]
+                 [ring/ring-codec "1.1.1"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.exchange.query.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :jvm-opts [
-        "-Dcmr.testing.config.data=testing-value"]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.exchange.query.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "ubercompile" ["with-profile" "+system,+local,+security,+ubercompile" "do"
-      ["clean"]
-      ["compile"]]
-    "uberjar" ["with-profile" "+system" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+system,+security" "jar"]
-    "build-uberjar" ["with-profile" "+system,+security" "uberjar"]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "ubercompile" ["with-profile" "+system,+local,+security,+ubercompile" "do"
+                           ["clean"]
+                           ["compile"]]
+            "uberjar" ["with-profile" "+system" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+
+            "ltest" ["with-profile" "+test,+system" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+system,+security" "jar"]
+            "build-uberjar" ["with-profile" "+system,+security" "uberjar"]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/graph/project.clj
+++ b/cmr-exchange/graph/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,132 +18,112 @@
 (defproject cmr-graph "0.1.0-SNAPSHOT"
   :description "A service and API for querying CMR metadata relationships"
   :url "https://github.com/cmr-exchange/cmr-graph"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.0"]
-    [clojurewerkz/elastisch "3.0.0"]
-    [clojurewerkz/neocons "3.2.0"]
-    [clojusc/system-manager "0.3.0-SNAPSHOT"]
-    [clojusc/trifl "0.3.0-SNAPSHOT"]
-    [clojusc/twig "0.3.2"]
-    [com.stuartsierra/component "0.3.2"]
-    [digest "1.4.6"]
-    [gov.nasa.earthdata/cmr-authz "0.1.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-process-manager "0.1.1-SNAPSHOT"]
-    [http-kit "2.2.0"]
-    [metosin/reitit-core "0.1.1-SNAPSHOT"]
-    [metosin/reitit-ring "0.1.1-SNAPSHOT"]
-    [metosin/ring-http-response "0.9.0"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/data.csv "0.1.4"]
-    [ring/ring-core "1.6.3"]
-    [ring/ring-codec "1.1.0"]
-    [ring/ring-defaults "0.3.1"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.0"]
+                 [clojurewerkz/elastisch "3.0.0"]
+                 [clojurewerkz/neocons "3.2.0"]
+                 [clojusc/system-manager "0.3.0-SNAPSHOT"]
+                 [clojusc/trifl "0.3.0-SNAPSHOT"]
+                 [clojusc/twig "0.3.2"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [digest "1.4.6"]
+                 [gov.nasa.earthdata/cmr-authz "0.1.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.1.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-process-manager "0.1.1-SNAPSHOT"]
+                 [http-kit "2.2.0"]
+                 [metosin/reitit-core "0.1.1-SNAPSHOT"]
+                 [metosin/reitit-ring "0.1.1-SNAPSHOT"]
+                 [metosin/ring-http-response "0.9.0"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/data.csv "0.1.4"]
+                 [ring/ring-core "1.6.3"]
+                 [ring/ring-codec "1.1.0"]
+                 [ring/ring-defaults "0.3.1"]]
   :main cmr.graph.core
-  :profiles {
-    :ubercompile {
-      :aot :all}
-    :dev {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.graph.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.0"]]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}
-    :docs {
-      :dependencies [
-        [clojang/codox-theme "0.2.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.3"]
-        [lein-marginalia "0.9.1"]]
-      :codox {
-        :project {
-          :name "CMR Graph"
-          :description "A service and API for querying CMR metadata relationships"}
-        :namespaces [#"^cmr\.graph\.(?!dev)"]
-        :metadata {
-          :doc/format :markdown
-          :doc "Documentation forthcoming"}
-        :themes [:clojang]
-        :doc-paths ["resources/docs"]
-        :output-path "docs/current"}}}
+  :profiles {:ubercompile {:aot :all}
+             :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [proto-repl "0.3.1"]]
+                   :plugins [[lein-shell "0.5.0"]
+                             [venantius/ultra "0.5.2"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.graph.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.0"]]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}
+             :docs {:dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.3"]
+                              [lein-marginalia "0.9.1"]]
+                    :codox {:project {:name "CMR Graph"
+                                      :description "A service and API for querying CMR metadata relationships"}
+                            :namespaces [#"^cmr\.graph\.(?!dev)"]
+                            :metadata {:doc/format :markdown
+                                       :doc "Documentation forthcoming"}
+                            :themes [:clojang]
+                            :doc-paths ["resources/docs"]
+                            :output-path "docs/current"}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test" "ltest"]
-    "junit" ["with-profile" "+test" "test2junit"]
-    ;; Documentation
-    "codox" ["with-profile" "+docs"
-      "codox"]
-    "marginalia" ["with-profile" "+docs"
-      "marg" "--dir" "docs/current"
-             "--file" "marginalia.html"
-             "--name" "Clojure Protocol Buffer Library"]
-    "docs" ["do"
-      ["codox"]
-      ["marginalia"]]
-    ;; Build tasks
-    "build" ["do"
-      ["ltest" ":unit"]
-      ["junit" ":unit"]
-      ["ubercompile"]
-      ["uberjar"]]
-    ;; Application
-    "start-cmr-graph"
-      ["trampoline" "run"]
-    ;; Docker Aliases
-    "docker-clean" [
-      "shell"
-      "docker" "system" "prune" "-f"]
-    "start-infra" [
-      "shell"
-      "docker-compose" "-f" "resources/docker/docker-compose.yml" "up"]
-    "stop-infra" [
-      "shell"
-      "docker-compose" "-f" "resources/docker/docker-compose.yml" "down"]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+
+            "ltest" ["with-profile" "+test" "ltest"]
+            "junit" ["with-profile" "+test" "test2junit"]
+            ;; Documentation
+            "codox" ["with-profile" "+docs"
+                     "codox"]
+            "marginalia" ["with-profile" "+docs"
+                          "marg" "--dir" "docs/current"
+                          "--file" "marginalia.html"
+                          "--name" "Clojure Protocol Buffer Library"]
+            "docs" ["do"
+                    ["codox"]
+                    ["marginalia"]]
+            ;; Build tasks
+            "build" ["do"
+                     ["ltest" ":unit"]
+                     ["junit" ":unit"]
+                     ["ubercompile"]
+                     ["uberjar"]]
+            ;; Application
+            "start-cmr-graph"
+            ["trampoline" "run"]
+            ;; Docker Aliases
+            "docker-clean" [
+                            "shell"
+                            "docker" "system" "prune" "-f"]
+            "start-infra" [
+                           "shell"
+                           "docker-compose" "-f" "resources/docker/docker-compose.yml" "up"]
+            "stop-infra" [
+                          "shell"
+                          "docker-compose" "-f" "resources/docker/docker-compose.yml" "down"]})

--- a/cmr-exchange/http-kit-support/project.clj
+++ b/cmr-exchange/http-kit-support/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it.
     (catch Exception _ "")))
 
@@ -18,122 +18,105 @@
   :description "Utilities, wrappers, middleware, and components for http-kit interop"
   :url "https://github.com/cmr-exchange/cmr-http-kit"
   :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-    [http-kit "2.3.0"]
-    [metosin/ring-http-response "0.9.1"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/data.xml "0.2.0-alpha5"]
-    [ring/ring-defaults "0.3.2"]
-    [selmer "1.12.5"]
-    [tolitius/xml-in "0.1.0"]]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        [commons-fileupload]]
-      :dependencies [
-        ;; The following pull required deps that have been either been
-        ;; explicitly or implicitly excluded above due to CVEs and need
-        ;; declare secure versions of the libs pulled in
-        [commons-fileupload "1.3.3"]
-        [commons-io "2.6"]]}
-    :dev {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]
-        [org.clojure/java.classpath "0.3.0"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.http.kit.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-kibit "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]]
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+            :name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
+                 [http-kit "2.3.0"]
+                 [metosin/ring-http-response "0.9.1"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [ring/ring-defaults "0.3.2"]
+                 [selmer "1.12.5"]
+                 [tolitius/xml-in "0.1.0"]]
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     [commons-fileupload]]
+                        :dependencies [
+                                       ;; The following pull required deps that have been either been
+                                       ;; explicitly or implicitly excluded above due to CVEs and need
+                                       ;; declare secure versions of the libs pulled in
+                                       [commons-fileupload "1.3.3"]
+                                       [commons-io "2.6"]]}
+             :dev {:dependencies [[clojusc/system-manager "0.3.0"]
+                                  [org.clojure/java.classpath "0.3.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [proto-repl "0.3.1"]]
+                   :plugins [[venantius/ultra "0.5.2"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.http.kit.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-kibit "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]]
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Installing
-    "install" ["do"
-      ["clean"]
-      ["ubercompile"]
-      ["clean"]
-      ["install"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["ltest" ":unit"]
+                          ["ubercompile"]
+                          ["build-uberjar"]]
+            ;; Installing
+            "install" ["do"
+                       ["clean"]
+                       ["ubercompile"]
+                       ["clean"]
+                       ["install"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/jar-plugin-lib/project.clj
+++ b/cmr-exchange/jar-plugin-lib/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,118 +18,97 @@
 (defproject gov.nasa.earthdata/cmr-jar-plugin "0.1.0"
   :description "A library for creating JAR-based plugins"
   :url "https://github.com/cmr-exchange/cmr-jar-plugin"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/java.classpath "0.3.0"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/java.classpath "0.3.0"]]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.plugin.jar.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.plugin.jar.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "version" ["do"
-      ["version"]
-      ["shell" "echo" "-n" "CMR-OPeNDAP: "]
-      ["project-version"]]
-    "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Lintint
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security,+system" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security,+system" "jar"]
-    "build-uberjar" ["with-profile" "+security,+system" "uberjar"]
-    "build-uberjar-aot" ["with-profile" "+security,+system,+ubercompile" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security,+system" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "version" ["do"
+                       ["version"]
+                       ["shell" "echo" "-n" "CMR-OPeNDAP: "]
+                       ["project-version"]]
+            "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Lintint
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+            ;["eastwood"]
+
+            ;; Security
+            "check-sec" ["with-profile" "+security,+system" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security,+system" "jar"]
+            "build-uberjar" ["with-profile" "+security,+system" "uberjar"]
+            "build-uberjar-aot" ["with-profile" "+security,+system,+ubercompile" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security,+system" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/metadata-proxy/project.clj
+++ b/cmr-exchange/metadata-proxy/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -20,195 +20,163 @@
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")
   :url "https://github.com/cmr-exchange/cmr-metadata-proxy"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [environ "1.1.0"]
-    [gov.nasa.earthdata/cmr-authz "0.1.1"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-query "0.2.0"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
-    [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-    [metosin/ring-http-response "0.9.1"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/core.async "0.4.490"]
-    [org.clojure/core.cache "0.7.1"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [environ "1.1.0"]
+                 [gov.nasa.earthdata/cmr-authz "0.1.1"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-query "0.2.0"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
+                 [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
+                 [metosin/ring-http-response "0.9.1"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.cache "0.7.1"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        [commons-fileupload]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]
-      :dependencies [
-        ;; The following pull required deps that have been either been
-        ;; explicitly or implicitly excluded above due to CVEs and need
-        ;; declare secure versions of the libs pulled in
-        [commons-fileupload "1.3.3"]
-        [commons-io "2.6"]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.metadata.proxy.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.4"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.7"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :jvm-opts [
-        "-Dcmr.testing.config.data=testing-value"]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}
-    :docs {
-      :dependencies [
-        [gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.5"]
-        [lein-simpleton "1.3.0"]]
-      :codox {
-        :project {:name "CMR Metadata-Proxy"}
-        :themes [:eosdis]
-        :html {
-          :transforms [[:head]
-                       [:append
-                         [:script {
-                           :src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
-                           :id "earthdata-tophat-script"
-                           :data-show-fbm "true"
-                           :data-show-status "true"
-                           :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
-                           :data-status-polling-interval "10"}]]
-                       [:body]
-                       [:prepend
-                         [:div {:id "earthdata-tophat2"
-                                :style "height: 32px;"}]]
-                       [:body]
-                       [:append
-                         [:script {
-                           :src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
-                           :type "text/javascript"}]]]}
-        :doc-paths ["resources/docs/markdown"]
-        :output-path "docs/current"
-        :namespaces [#"^cmr\..*(?!test).*"]
-        :metadata {:doc/format :markdown}}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     [commons-fileupload]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]
+                        :dependencies [;; The following pull required deps that have been either been
+                                       ;; explicitly or implicitly excluded above due to CVEs and need
+                                       ;; declare secure versions of the libs pulled in
+                                       [commons-fileupload "1.3.3"]
+                                       [commons-io "2.6"]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.metadata.proxy.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.4"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.7"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}
+             :docs {:dependencies [[gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.5"]
+                              [lein-simpleton "1.3.0"]]
+                    :codox {:project {:name "CMR Metadata-Proxy"}
+                            :themes [:eosdis]
+                            :html {:transforms [[:head]
+                                                [:append
+                                                  [:script {:src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
+                                                            :id "earthdata-tophat-script"
+                                                            :data-show-fbm "true"
+                                                            :data-show-status "true"
+                                                            :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
+                                                            :data-status-polling-interval "10"}]]
+                                                [:body]
+                                                [:prepend
+                                                  [:div {:id "earthdata-tophat2"
+                                                         :style "height: 32px;"}]]
+                                                [:body]
+                                                [:append
+                                                  [:script {:src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
+                                                            :type "text/javascript"}]]]}
+                            :doc-paths ["resources/docs/markdown"]
+                            :output-path "docs/current"
+                            :namespaces [#"^cmr\..*(?!test).*"]
+                            :metadata {:doc/format :markdown}}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "version" ["do"
-      ["version"]
-      ["shell" "echo" "-n" "CMR OUS: "]
-      ["project-version"]]
-    "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
-    "uberjar" ["with-profile" "+system" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Documentation and static content
-    "codox" ["with-profile" "+docs,+system" "codox"]
-    "marginalia" ["with-profile" "+docs,+system"
-      "marg" "--dir" "resources/public/docs/opendap/docs/current/marginalia"
-             "--file" "index.html"
-             "--name" "OPeNDAP/CMR Integration"]
-    "docs" ["do"
-      ["codox"]
-      ["marginalia"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["junit" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["ltest" ":unit"]
-      ["generate-static"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Installing
-    "install" ["do"
-      ["clean"]
-      ["ubercompile"]
-      ["clean"]
-      ["install"]]
-    ;; Publishing
-    "publish" ["with-profile" "+system,+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "version" ["do"
+                       ["version"]
+                       ["shell" "echo" "-n" "CMR OUS: "]
+                       ["project-version"]]
+            "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
+            "uberjar" ["with-profile" "+system" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+
+            "ltest" ["with-profile" "+test,+system" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Documentation and static content
+            "codox" ["with-profile" "+docs,+system" "codox"]
+            "marginalia" ["with-profile" "+docs,+system"
+                          "marg" "--dir" "resources/public/docs/opendap/docs/current/marginalia"
+                          "--file" "index.html"
+                          "--name" "OPeNDAP/CMR Integration"]
+            "docs" ["do"
+                    ["codox"]
+                    ["marginalia"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["junit" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["ltest" ":unit"]
+                          ["generate-static"]
+                          ["ubercompile"]
+                          ["build-uberjar"]]
+            ;; Installing
+            "install" ["do"
+                       ["clean"]
+                       ["ubercompile"]
+                       ["clean"]
+                       ["install"]]
+            ;; Publishing
+            "publish" ["with-profile" "+system,+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/mission-control/project.clj
+++ b/cmr-exchange/mission-control/project.clj
@@ -7,95 +7,80 @@
 (defproject gov.nasa.earthdata/cmr-mission-control "0.1.0"
   :description "An in-process messaging system for communication, coordination, and control between CMR components"
   :url "https://github.com/cmr-exchange/cmr-mission-control"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [clojusc/twig "0.4.0"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/core.async "0.4.474"]]
-  :profiles {
-    :ubercompile {
-      :aot :all}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    :dev {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]
-        [clojusc/trifl "0.4.2"]
-        [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :plugins [
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.mission-control.dev
-        :prompt ~get-prompt}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :plugins [
-        [lein-ltest "0.3.0"]]}}
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[clojusc/twig "0.4.0"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]]
+  :profiles {:ubercompile {:aot :all}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             :dev {:dependencies [[clojusc/system-manager "0.3.0"]
+                                  [clojusc/trifl "0.4.2"]
+                                  [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :plugins [[lein-shell "0.5.0"]
+                             [venantius/ultra "0.5.2"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.mission-control.dev
+                                  :prompt ~get-prompt}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:plugins [[lein-ltest "0.3.0"]]}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+            ;["eastwood"]
+
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["ltest" ":unit"]
+                          ["ubercompile"]
+                          ["build-uberjar"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/nlp/project.clj
+++ b/cmr-exchange/nlp/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it.
     (catch Exception _ "")))
 
@@ -17,153 +17,127 @@
 (defproject gov.nasa.earthdata/cmr-nlp "0.1.0-SNAPSHOT"
   :description "A service for converting natural language queries into CMR search parameters"
   :url "https://github.com/cmr-exchange/cmr-nlp"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [clojure-opennlp "0.5.0"]
-    [com.neovisionaries/nv-i18n "1.23"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-    [org.apache.commons/commons-csv "1.6"]
-    [org.clojure/clojure "1.10.0"]
-    [org.elasticsearch.client/elasticsearch-rest-high-level-client "6.5.3"]
-    [org.ocpsoft.prettytime/prettytime "4.0.2.Final"]
-    [org.ocpsoft.prettytime/prettytime-nlp "4.0.2.Final"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [clojure-opennlp "0.5.0"]
+                 [com.neovisionaries/nv-i18n "1.23"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
+                 [org.apache.commons/commons-csv "1.6"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.elasticsearch.client/elasticsearch-rest-high-level-client "6.5.3"]
+                 [org.ocpsoft.prettytime/prettytime "4.0.2.Final"]
+                 [org.ocpsoft.prettytime/prettytime-nlp "4.0.2.Final"]]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :resource-paths [
-        "data"]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.nlp.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.4"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.7"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}
-    :ingest {
-      :main cmr.nlp.elastic.ingest
-      :jvm-opts ^replace [
-        "-Dlogging.level=debug"
-        "-Dlogging.color=true"]}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:resource-paths ["data"]
+                     :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.nlp.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.4"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.7"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}
+             :ingest {:main cmr.nlp.elastic.ingest
+                      :jvm-opts ^replace ["-Dlogging.level=debug"
+                                          "-Dlogging.color=true"]}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "download-models" ["with-profile" "+local"
-      "shell" "resources/scripts/download-models"]
-    "download-geonames" ["with-profile" "+local"
-      "shell" "resources/scripts/download-geonames"]
-    "delete-models" ["with-profile" "+local"
-      "shell" "rm" "-rf" "data/models"]
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "ubercompile" ["with-profile" "+system,+local,+security,+ubercompile" "do"
-      ["clean"]
-      ["compile"]]
-    "uberjar" ["with-profile" "+system" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system,+local" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Docker Aliases
-    "docker-clean" ["with-profile" "+system,+local,+security" "do"
-      ["shell" "docker" "system" "prune" "-f"]]
-    "start-es" ["with-profile" "+system,+local,+security" "do"
-      ["shell" "docker-compose" "-f" "resources/elastic/docker-compose.yml" "up"]]
-    "stop-es" ["with-profile" "+system,+local,+security" "do"
-      ["shell" "docker-compose" "-f" "resources/elastic/docker-compose.yml" "down"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+system,+security" "do"
-      ["jar"]]
-    "build-uberjar" ["with-profile" "+system,+security" "do"
-      ["uberjar"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["download-models"]
-      ["ubercompile"]
-      ;; XXX This broke with the introduction of the Elasticsearch dep
-      ;;["check-sec"]
-      ["ltest" ":unit"]
-      ["build-uberjar"]]
-    ;; CLI
-    "ingest" ["with-profile" "+ingest,+local,+system" "do"
-      ["clean"]
-      ["trampoline" "run"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "download-models" ["with-profile" "+local"
+                               "shell" "resources/scripts/download-models"]
+            "download-geonames" ["with-profile" "+local"
+                                 "shell" "resources/scripts/download-geonames"]
+            "delete-models" ["with-profile" "+local"
+                             "shell" "rm" "-rf" "data/models"]
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "ubercompile" ["with-profile" "+system,+local,+security,+ubercompile" "do"
+                           ["clean"]
+                           ["compile"]]
+            "uberjar" ["with-profile" "+system" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            "ltest" ["with-profile" "+test,+system,+local" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Docker Aliases
+            "docker-clean" ["with-profile" "+system,+local,+security" "do"
+                            ["shell" "docker" "system" "prune" "-f"]]
+            "start-es" ["with-profile" "+system,+local,+security" "do"
+                        ["shell" "docker-compose" "-f" "resources/elastic/docker-compose.yml" "up"]]
+            "stop-es" ["with-profile" "+system,+local,+security" "do"
+                       ["shell" "docker-compose" "-f" "resources/elastic/docker-compose.yml" "down"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+system,+security" "do"
+                         ["jar"]]
+            "build-uberjar" ["with-profile" "+system,+security" "do"
+                             ["uberjar"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["download-models"]
+                     ["ubercompile"]
+                     ;; XXX This broke with the introduction of the Elasticsearch dep
+                     ;;["check-sec"]
+                     ["ltest" ":unit"]
+                     ["build-uberjar"]]
+            ;; CLI
+            "ingest" ["with-profile" "+ingest,+local,+system" "do"
+                      ["clean"]
+                      ["trampoline" "run"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,163 +18,139 @@
 (defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"
   :description "A CMR services plugin that performs URL translations for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-ous-plugin"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [environ "1.1.0"]
-    [gov.nasa.earthdata/cmr-authz "0.1.1"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-    [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-    [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-    [metosin/ring-http-response "0.9.1"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/core.async "0.4.490"]
-    [org.clojure/core.cache "0.7.1"]
-    [org.clojure/data.xml "0.2.0-alpha5"]
-    [org.clojure/java.classpath "0.3.0"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-defaults "0.3.2"]
-    [tolitius/xml-in "0.1.0"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [environ "1.1.0"]
+                 [gov.nasa.earthdata/cmr-authz "0.1.1"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                 [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
+                 [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+                 [metosin/ring-http-response "0.9.1"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.cache "0.7.1"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [org.clojure/java.classpath "0.3.0"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-defaults "0.3.2"]
+                 [tolitius/xml-in "0.1.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.ous.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]]
-      :jvm-opts [
-        "-Dcmr.testing.config.data=testing-value"]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.ous.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]]
+                    :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "version" ["do"
-      ["version"]
-      ["shell" "echo" "-n" "CMR OUS: "]
-      ["project-version"]]
-    "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
-    "uberjar" ["with-profile" "+system" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system" "ltest"]
-    "junit" ["with-profile" "+test,+system" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Documentation and static content
-    "codox" ["with-profile" "+docs,+system" "codox"]
-    "marginalia" ["with-profile" "+docs,+system"
-      "marg" "--dir" "resources/public/docs/opendap/docs/current/marginalia"
-             "--file" "index.html"
-             "--name" "OPeNDAP/CMR Integration"]
-    "docs" ["do"
-      ["codox"]
-      ["marginalia"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["clean"]
-      ["lint"]
-      ["ltest" ":unit"]
-      ["ubercompile"]]
-    "build" ["do"
-      ["clean"]
-      ["lint"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["junit" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Installing locally
-    "install" ["do"
-      ["clean"]
-      ["ubercompile"]
-      ["clean"]
-      ["install"]]
-    ;; Publishing
-    "publish" ["with-profile" "+system,+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "version" ["do"
+                       ["version"]
+                       ["shell" "echo" "-n" "CMR OUS: "]
+                       ["project-version"]]
+            "ubercompile" ["with-profile" "+system,+local,+ubercompile" "compile"]
+            "uberjar" ["with-profile" "+system" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+ubercompile" "uberjar"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+
+            "ltest" ["with-profile" "+test,+system" "ltest"]
+            "junit" ["with-profile" "+test,+system" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Documentation and static content
+            "codox" ["with-profile" "+docs,+system" "codox"]
+            "marginalia" ["with-profile" "+docs,+system"
+                          "marg" "--dir" "resources/public/docs/opendap/docs/current/marginalia"
+                          "--file" "index.html"
+                          "--name" "OPeNDAP/CMR Integration"]
+            "docs" ["do"
+                    ["codox"]
+                    ["marginalia"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["clean"]
+                          ["lint"]
+                          ["ltest" ":unit"]
+                          ["ubercompile"]]
+            "build" ["do"
+                     ["clean"]
+                     ["lint"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["junit" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            ;; Installing locally
+            "install" ["do"
+                       ["clean"]
+                       ["ubercompile"]
+                       ["clean"]
+                       ["install"]]
+            ;; Publishing
+            "publish" ["with-profile" "+system,+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/process-manager/project.clj
+++ b/cmr-exchange/process-manager/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it.
     (catch Exception _ "")))
 
@@ -17,147 +17,120 @@
 (defproject gov.nasa.earthdata/cmr-process-manager "0.1.1-SNAPSHOT"
   :description "Process management functionality for CMR services"
   :url "https://github.com/cmr-exchange/dev-env-manager"
-  :license {
-    :name "Apache License 2.0"
-    :url "https://www.apache.org/licenses/LICENSE-2.0"}
+  :license {:name "Apache License 2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :exclusions [org.clojure/clojure]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.0"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.3.2"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
-    [me.raynes/conch "0.8.0"]
-    [org.clojure/clojure "1.9.0"]
-    [org.clojure/core.async "0.4.474"]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.0"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
+                 [me.raynes/conch "0.8.0"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]]
   :profiles {
-    ;; Tasks
-    :ubercompile {
-      :aot :all}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    ;; Environments
-    :custom-repl {
-      :repl-options {
-        :prompt ~get-prompt
-        ;:welcome ~(print-welcome)
-        }}
-    :dev {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]
-        [clojusc/system-manager "0.3.0-SNAPSHOT"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :source-paths [
-        "dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.process.manager.repl
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.3"]
-        [lein-ancient "0.6.15"]
-        [lein-kibit "0.1.6"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]]
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}
-    :docs {
-      :dependencies [
-        [gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.5"]
-        [lein-simpleton "1.3.0"]]
-      :codox {
-        :project {:name "CMR Process Management"}
-        :themes [:eosdis]
-        :html {
-          :transforms [[:head]
-                       [:append
-                         [:script {
-                           :src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
-                           :id "earthdata-tophat-script"
-                           :data-show-fbm "true"
-                           :data-show-status "true"
-                           :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
-                           :data-status-polling-interval "10"}]]
-                       [:body]
-                       [:prepend
-                         [:div {:id "earthdata-tophat2"
-                                :style "height: 32px;"}]]
-                       [:body]
-                       [:append
-                         [:script {
-                           :src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
-                           :type "text/javascript"}]]]}
-        :doc-paths ["resources/docs/markdown"]
-        :output-path "docs/current"
-        :namespaces [#"^cmr\.process\.manager\.(?!test)"]
-        :metadata {:doc/format :markdown}}}}
+             ;; Tasks
+             :ubercompile {:aot :all}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             ;; Environments
+             :custom-repl {:repl-options {:prompt ~get-prompt}}
+             ;:welcome ~(print-welcome)
+             :dev {:dependencies [[clojusc/ltest "0.3.0"]
+                                  [clojusc/system-manager "0.3.0-SNAPSHOT"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.process.manager.repl
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.3"]
+                              [lein-ancient "0.6.15"]
+                              [lein-kibit "0.1.6"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]]
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}
+             :docs {:dependencies [[gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.5"]
+                              [lein-simpleton "1.3.0"]]
+                    :codox {:project {:name "CMR Process Management"}
+                            :themes [:eosdis]
+                            :html {:transforms [[:head]
+                                                [:append
+                                                  [:script {:src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
+                                                            :id "earthdata-tophat-script"
+                                                            :data-show-fbm "true"
+                                                            :data-show-status "true"
+                                                            :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
+                                                            :data-status-polling-interval "10"}]]
+                                                [:body]
+                                                [:prepend
+                                                  [:div {:id "earthdata-tophat2"
+                                                         :style "height: 32px;"}]]
+                                                [:body]
+                                                [:append
+                                                  [:script {:src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
+                                                            :type "text/javascript"}]]]}
+                            :doc-paths ["resources/docs/markdown"]
+                            :output-path "docs/current"
+                            :namespaces [#"^cmr\.process\.manager\.(?!test)"]
+                            :metadata {:doc/format :markdown}}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["with-profile" "+custom-repl" "do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "docs" ["with-profile" "+docs" "do"
-      ["clean"]
-      ["compile"]
-      ["codox"]
-      ["clean"]]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["docs"]
-      ["build"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["with-profile" "+custom-repl" "do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "docs" ["with-profile" "+docs" "do"
+                    ["clean"]
+                    ["compile"]
+                    ["codox"]
+                    ["clean"]]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["docs"]
+                          ["build"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/cmr-exchange/sample-data/project.clj
+++ b/cmr-exchange/sample-data/project.clj
@@ -7,44 +7,34 @@
 (defproject gov.nasa.earthdata/cmr-sample-data "0.2.0-SNAPSHOT"
   :description "Sample Data for the open source NASA Common Metadata Repository (CMR)"
   :url "https://github.com/oubiwann/cmr-sample-data"
-  :license {
-    :name "Apache License 2.0"
-    :url "https://www.apache.org/licenses/LICENSE-2.0"}
+  :license {:name "Apache License 2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :exclusions [org.clojure/clojure]
-  :dependencies [
-    [cheshire "5.8.0"]
-    [org.clojure/clojure "1.9.0"]]
-  :profiles {
-    :ubercompile {
-      :aot :all}
-    :dev {
-      :dependencies [
-        [clojusc/trifl "0.2.0"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :source-paths ["dev-resources/src"]
-      :repl-options {
-        :init-ns cmr.sample-data.dev
-        :prompt ~get-prompt}}
-    :test {
-      :plugins [
-        [lein-ancient "0.6.15"]
-        [jonase/eastwood "0.2.5"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}}
-  :aliases {
-    "ubercompile" ["with-profile" "+ubercompile" "compile"]
-    "check-deps" ["with-profile" "+test" "ancient" "check" ":all"]
-    "kibit" ["with-profile" "+test" "kibit"]
-    "eastwood" ["with-profile" "+test" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["with-profile" "+test" "do"
-      ["kibit"]
-      ["eastwood"]]
-    "build" ["with-profile" "+test" "do"
-      ["check-deps"]
-      ["lint"]
-      ["ubercompile"]
-      ["clean"]
-      ["uberjar"]
-      ["clean"]
-      ["test"]]})
+  :dependencies [[cheshire "5.8.0"]
+                 [org.clojure/clojure "1.9.0"]]
+  :profiles {:ubercompile {:aot :all}
+             :dev {:dependencies [[clojusc/trifl "0.2.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :source-paths ["dev-resources/src"]
+                   :repl-options {:init-ns cmr.sample-data.dev
+                                  :prompt ~get-prompt}}
+             :test {:plugins [[lein-ancient "0.6.15"]
+                              [jonase/eastwood "0.2.5"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}}
+  :aliases {"ubercompile" ["with-profile" "+ubercompile" "compile"]
+            "check-deps" ["with-profile" "+test" "ancient" "check" ":all"]
+            "kibit" ["with-profile" "+test" "kibit"]
+            "eastwood" ["with-profile" "+test" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["with-profile" "+test" "do"
+                    ["kibit"]
+                    ["eastwood"]]
+            "build" ["with-profile" "+test" "do"
+                     ["check-deps"]
+                     ["lint"]
+                     ["ubercompile"]
+                     ["clean"]
+                     ["uberjar"]
+                     ["clean"]
+                     ["test"]]})

--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,225 +18,189 @@
 (defproject gov.nasa.earthdata/cmr-service-bridge "1.6.1-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clojusc/trifl "0.4.2"]
-    [clojusc/twig "0.4.0"]
-    [com.stuartsierra/component "0.4.0"]
-    [environ "1.1.0"]
-    [gov.nasa.earthdata/cmr-authz "0.1.1"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-    [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-    [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-    [gov.nasa.earthdata/cmr-sizing-plugin "0.2.5-SNAPSHOT"]
-    [http-kit "2.3.0"]
-    [markdown-clj "1.0.6"]
-    [metosin/reitit-core "0.2.10"]
-    [metosin/reitit-ring "0.2.10"]
-    [metosin/ring-http-response "0.9.1"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/core.async "0.4.490"]
-    [org.clojure/core.cache "0.7.2"]
-    [org.clojure/data.xml "0.2.0-alpha5"]
-    [org.clojure/java.classpath "0.3.0"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-defaults "0.3.2"]
-    [selmer "1.12.5"]
-    [tolitius/xml-in "0.1.0"]]
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[cheshire "5.8.1"]
+                 [clojusc/trifl "0.4.2"]
+                 [clojusc/twig "0.4.0"]
+                 [com.stuartsierra/component "0.4.0"]
+                 [environ "1.1.0"]
+                 [gov.nasa.earthdata/cmr-authz "0.1.1"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.2.5-SNAPSHOT"]
+                 [http-kit "2.3.0"]
+                 [markdown-clj "1.0.6"]
+                 [metosin/reitit-core "0.2.10"]
+                 [metosin/reitit-ring "0.2.10"]
+                 [metosin/ring-http-response "0.9.1"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.cache "0.7.2"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [org.clojure/java.classpath "0.3.0"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-defaults "0.3.2"]
+                 [selmer "1.12.5"]
+                 [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :main cmr.opendap.core
   :aot [clojure.tools.logging.impl
         cmr.opendap.core]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]
-        ;; The following is excluded because it stomps on twig's logger
-        [org.slf4j/slf4j-simple]]}
-    :geo {
-      :dependencies [
-        [gov.nasa.earthdata/cmr-exchange-geo "0.1.0"]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.1"]]
-      :plugins [
-        [lein-project-version "0.1.0"]
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.opendap.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.4"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.7"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]
-        [test2junit "1.4.2"]
-        [venantius/ultra "0.5.2"]]
-      :jvm-opts [
-        "-Dcmr.testing.config.data=testing-value"]
-      :test2junit-output-dir "junit-test-results"
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}
-    :docs {
-      :dependencies [
-        [gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
-      :plugins [
-        [lein-codox "0.10.5"]
-        [lein-marginalia "0.9.1"]]
-      :source-paths ["resources/docs/src"]
-      :codox {
-        :project {
-          :name "CMR Service-Bridge"
-          :description "A CMR connector service that provides an inter-service API"}
-        :namespaces [#"^cmr\.opendap\.(?!dev)"]
-        :metadata {
-          :doc/format :markdown
-          :doc "Documentation forthcoming"}
-        :themes [:eosdis]
-        :html {
-          :transforms [[:head]
-                       [:append
-                         [:script {
-                           :src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
-                           :id "earthdata-tophat-script"
-                           :data-show-fbm "true"
-                           :data-show-status "true"
-                           :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
-                           :data-status-polling-interval "10"}]]
-                       [:body]
-                       [:prepend
-                         [:div {:id "earthdata-tophat2"
-                                :style "height: 32px;"}]]
-                       [:body]
-                       [:append
-                         [:script {
-                           :src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
-                           :type "text/javascript"}]]]}
-        :doc-paths ["resources/docs/markdown"]
-        :output-path "resources/public/docs/service-bridge/docs/current/reference"}}
-      :slate {
-        :plugins [[lein-shell "0.5.0"]]}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]
+                                     ;; The following is excluded because it stomps on twig's logger
+                                     [org.slf4j/slf4j-simple]]}
+             :geo {:dependencies [[gov.nasa.earthdata/cmr-exchange-geo "0.1.0"]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.1"]]
+                     :plugins [[lein-project-version "0.1.0"]
+                               [lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.opendap.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.4"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.7"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]
+                              [test2junit "1.4.2"]
+                              [venantius/ultra "0.5.2"]]
+                    :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
+                    :test2junit-output-dir "junit-test-results"
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}
+             :docs {:dependencies [[gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
+                    :plugins [[lein-codox "0.10.5"]
+                              [lein-marginalia "0.9.1"]]
+                    :source-paths ["resources/docs/src"]
+                    :codox {:project {:name "CMR Service-Bridge"
+                                      :description "A CMR connector service that provides an inter-service API"}
+                            :namespaces [#"^cmr\.opendap\.(?!dev)"]
+                            :metadata {:doc/format :markdown
+                                       :doc "Documentation forthcoming"}
+                            :themes [:eosdis]
+                            :html {:transforms [[:head]
+                                                [:append
+                                                  [:script {:src "https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
+                                                            :id "earthdata-tophat-script"
+                                                            :data-show-fbm "true"
+                                                            :data-show-status "true"
+                                                            :data-status-api-url "https://status.earthdata.nasa.gov/api/v1/notifications"
+                                                            :data-status-polling-interval "10"}]]
+                                                [:body]
+                                                [:prepend
+                                                  [:div {:id "earthdata-tophat2"
+                                                         :style "height: 32px;"}]]
+                                                [:body]
+                                                [:append
+                                                  [:script {:src "https://fbm.earthdata.nasa.gov/for/CMR/feedback.js"
+                                                            :type "text/javascript"}]]]}
+                            :doc-paths ["resources/docs/markdown"]
+                            :output-path "resources/public/docs/service-bridge/docs/current/reference"}}
+             :slate {:plugins [[lein-shell "0.5.0"]]}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system" "repl"]]
-    "repl-geo" ["do"
-      ["clean"]
-      ["with-profile" "+local,+system,+geo" "repl"]]
-    "version" ["do"
-      ["version"]
-      ["shell" "echo" "-n" "CMR Service-Bridge: "]
-      ["project-version"]]
-    "ubercompile" ["with-profile" "+system,+geo,+local,+security" "compile"]
-    "uberjar" ["with-profile" "+system,+geo" "uberjar"]
-    "uberjar-aot" ["with-profile" "+system,+geo,+ubercompile,+security" "uberjar"]
-    "check-vers" ["with-profile" "+lint,+system,+geo,+security" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "yagni" ["with-profile" "+lint" "yagni"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    "ltest" ["with-profile" "+test,+system,+local" "ltest"]
-    "junit" ["with-profile" "+test,+system,+local" "test2junit"]
-    "ltest-with-geo" ["with-profile" "+test,+system,+geo,+local" "ltest"]
-    "junit-with-geo" ["with-profile" "+test,+system,+geo,+local" "test2junit"]
-    ;; Security
-    "check-sec" ["with-profile" "+system,+geo,+local,+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Documentation and static content
-    "codox" ["with-profile" "+docs,+system,+geo" "codox"]
-    "marginalia" ["with-profile" "+docs,+system,+geo"
-      "marg" "--dir" "resources/public/docs/service-bridge/docs/current/marginalia"
-             "--file" "index.html"
-             "--name" "CMR integration with external services"]
-    "slate" ["with-profile" "+slate"
-      "shell" "resources/scripts/build-slate-docs"]
-    "docs" ["do"
-      ["codox"]
-      ["marginalia"]
-      ["slate"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["clean"]
-      ["lint"]
-      ["ltest" ":unit"]
-      ["ubercompile"]]
-    "build" ["do"
-      ["clean"]
-      ["lint"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["junit" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["build"]
-      ["docs"]]
-    ;; Publishing
-    "publish" ["with-profile" "+system,+security,+geo" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]
-    ;; Application
-    "run" ["with-profile" "+system,+security" "run"]
-    "trampoline" ["with-profile" "+system,+security" "trampoline"]
-    "start-service-bridge" ["trampoline" "run"]})
+            ;; Dev & Testing Aliases
+            "repl" ["do"
+                    ["clean"]
+                    ["with-profile" "+local,+system" "repl"]]
+            "repl-geo" ["do"
+                        ["clean"]
+                        ["with-profile" "+local,+system,+geo" "repl"]]
+            "version" ["do"
+                       ["version"]
+                       ["shell" "echo" "-n" "CMR Service-Bridge: "]
+                       ["project-version"]]
+            "ubercompile" ["with-profile" "+system,+geo,+local,+security" "compile"]
+            "uberjar" ["with-profile" "+system,+geo" "uberjar"]
+            "uberjar-aot" ["with-profile" "+system,+geo,+ubercompile,+security" "uberjar"]
+            "check-vers" ["with-profile" "+lint,+system,+geo,+security" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "yagni" ["with-profile" "+lint" "yagni"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+            "ltest" ["with-profile" "+test,+system,+local" "ltest"]
+            "junit" ["with-profile" "+test,+system,+local" "test2junit"]
+            "ltest-with-geo" ["with-profile" "+test,+system,+geo,+local" "ltest"]
+            "junit-with-geo" ["with-profile" "+test,+system,+geo,+local" "test2junit"]
+            ;; Security
+            "check-sec" ["with-profile" "+system,+geo,+local,+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Documentation and static content
+            "codox" ["with-profile" "+docs,+system,+geo" "codox"]
+            "marginalia" ["with-profile" "+docs,+system,+geo"
+                          "marg" "--dir" "resources/public/docs/service-bridge/docs/current/marginalia"
+                          "--file" "index.html"
+                          "--name" "CMR integration with external services"]
+            "slate" ["with-profile" "+slate"
+                     "shell" "resources/scripts/build-slate-docs"]
+            "docs" ["do"
+                    ["codox"]
+                    ["marginalia"]
+                    ["slate"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["clean"]
+                          ["lint"]
+                          ["ltest" ":unit"]
+                          ["ubercompile"]]
+            "build" ["do"
+                     ["clean"]
+                     ["lint"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["junit" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["build"]
+                          ["docs"]]
+            ;; Publishing
+            "publish" ["with-profile" "+system,+security,+geo" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]
+            ;; Application
+            "run" ["with-profile" "+system,+security" "run"]
+            "trampoline" ["with-profile" "+system,+security" "trampoline"]
+            "start-service-bridge" ["trampoline" "run"]})

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -2,9 +2,9 @@
   []
   (try
     (str
-      (slurp "resources/text/banner.txt")
+      (slurp "resources/text/banner.txt"))
       ;(slurp "resources/text/loading.txt")
-      )
+
     ;; If another project can't find the banner, just skip it;
     ;; this function is really only meant to be used by Dragon itself.
     (catch Exception _ "")))
@@ -18,129 +18,107 @@
 (defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.5-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
-  :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :exclusions [gov.nasa.earthdata/cmr-http-kit]
-  :dependencies [
-    [gov.nasa.earthdata/cmr-authz "0.1.1"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-    [org.clojure/clojure "1.10.0"]]
+  :dependencies [[gov.nasa.earthdata/cmr-authz "0.1.1"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
+                 [org.clojure/clojure "1.10.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
-  :profiles {
-    :ubercompile {
-      :aot :all
-      :source-paths ["test"]}
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}
-      :source-paths ^:replace ["src"]
-      :exclusions [
-        ;; The following are excluded due to their being flagged as a CVE
-        [com.google.protobuf/protobuf-java]
-        [com.google.javascript/closure-compiler-unshaded]]}
-    :system {
-      :dependencies [
-        [clojusc/system-manager "0.3.0"]]}
-    :local {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [proto-repl "0.3.3"]]
-      :plugins [
-        [lein-shell "0.5.0"]
-        [venantius/ultra "0.5.2"]]
-      :source-paths ["dev-resources/src"]
-      :jvm-opts [
-        "-Dlogging.color=true"]}
-    :dev {
-      :dependencies [
-        [clojusc/trifl "0.4.2"]
-        [clojusc/twig "0.4.0"]
-        [debugger "0.2.1"]]
-      :repl-options {
-        :init-ns cmr.sizing.dev
-        :prompt ~get-prompt
-        :init ~(println (get-banner))}}
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.3.4"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.1"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.7"]]}
-    :test {
-      :dependencies [
-        [clojusc/ltest "0.3.0"]]
-      :plugins [
-        [lein-ltest "0.3.0"]]
-      :test-selectors {
-        :unit #(not (or (:integration %) (:system %)))
-        :integration :integration
-        :system :system
-        :default (complement :system)}}}
+  :profiles {:ubercompile {:aot :all
+                           :source-paths ["test"]}
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}
+                        :source-paths ^:replace ["src"]
+                        :exclusions [
+                                     ;; The following are excluded due to their being flagged as a CVE
+                                     [com.google.protobuf/protobuf-java]
+                                     [com.google.javascript/closure-compiler-unshaded]]}
+             :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
+             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                    [proto-repl "0.3.3"]]
+                     :plugins [[lein-shell "0.5.0"]
+                               [venantius/ultra "0.5.2"]]
+                     :source-paths ["dev-resources/src"]
+                     :jvm-opts ["-Dlogging.color=true"]}
+             :dev {:dependencies [[clojusc/trifl "0.4.2"]
+                                  [clojusc/twig "0.4.0"]
+                                  [debugger "0.2.1"]]
+                   :repl-options {:init-ns cmr.sizing.dev
+                                  :prompt ~get-prompt
+                                  :init ~(println (get-banner))}}
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.3.4"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.1"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.7"]]}
+             :test {:dependencies [[clojusc/ltest "0.3.0"]]
+                    :plugins [[lein-ltest "0.3.0"]]
+                    :test-selectors {:unit #(not (or (:integration %) (:system %)))
+                                     :integration :integration
+                                     :system :system
+                                     :default (complement :system)}}}
   :aliases {
-    ;; Dev & Testing Aliases
-    "repl" ["with-profile" "+local,+system,+dev" "do"
-      ["clean"]
-      ["repl"]]
-    "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
-    "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
-    "check-jars" ["with-profile" "+lint" "do"
-      ["deps" ":tree"]
-      ["deps" ":plugin-tree"]]
-    "check-deps" ["do"
-      ["check-jars"]
-      ["check-vers"]]
-    "ltest" ["with-profile" "+test,+system,+security" "ltest"]
-    ;; Linting
-    "kibit" ["with-profile" "+lint" "kibit"]
-    "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "lint" ["do"
-      ["kibit"]
-      ;["eastwood"]
-      ]
-    ;; Security
-    "check-sec" ["with-profile" "+security" "do"
-      ["clean"]
-      ["dependency-check"]]
-    ;; Build tasks
-    "build-jar" ["with-profile" "+security" "jar"]
-    "build-uberjar" ["with-profile" "+security" "uberjar"]
-    "build-lite" ["do"
-      ["ltest" ":unit"]]
-    "build" ["do"
-      ["clean"]
-      ["check-vers"]
-      ["check-sec"]
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    "build-full" ["do"
-      ["ltest" ":unit"]
-      ["ubercompile"]
-      ["build-uberjar"]]
-    ;; Installing locally
-    "install" ["do"
-      ["clean"]
-      ["ubercompile"]
-      ["clean"]
-      ["install"]]
-    ;; Publishing
-    "publish" ["with-profile" "+security" "do"
-      ["clean"]
-      ["build-jar"]
-      ["deploy" "clojars"]]})
+            ;; Dev & Testing Aliases
+            "repl" ["with-profile" "+local,+system,+dev" "do"
+                    ["clean"]
+                    ["repl"]]
+            "ubercompile" ["with-profile" "+ubercompile,+security" "compile"]
+            "check-vers" ["with-profile" "+lint" "ancient" "check" ":all"]
+            "check-jars" ["with-profile" "+lint" "do"
+                          ["deps" ":tree"]
+                          ["deps" ":plugin-tree"]]
+            "check-deps" ["do"
+                          ["check-jars"]
+                          ["check-vers"]]
+            "ltest" ["with-profile" "+test,+system,+security" "ltest"]
+            ;; Linting
+            "kibit" ["with-profile" "+lint" "kibit"]
+            "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "lint" ["do"
+                    ["kibit"]]
+                    ;["eastwood"]
+
+            ;; Security
+            "check-sec" ["with-profile" "+security" "do"
+                         ["clean"]
+                         ["dependency-check"]]
+            ;; Build tasks
+            "build-jar" ["with-profile" "+security" "jar"]
+            "build-uberjar" ["with-profile" "+security" "uberjar"]
+            "build-lite" ["do"
+                          ["ltest" ":unit"]]
+            "build" ["do"
+                     ["clean"]
+                     ["check-vers"]
+                     ["check-sec"]
+                     ["ltest" ":unit"]
+                     ["ubercompile"]
+                     ["build-uberjar"]]
+            "build-full" ["do"
+                          ["ltest" ":unit"]
+                          ["ubercompile"]
+                          ["build-uberjar"]]
+            ;; Installing locally
+            "install" ["do"
+                       ["clean"]
+                       ["ubercompile"]
+                       ["clean"]
+                       ["install"]]
+            ;; Publishing
+            "publish" ["with-profile" "+security" "do"
+                       ["clean"]
+                       ["build-jar"]
+                       ["deploy" "clojars"]]})

--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -23,58 +23,46 @@
 (defproject nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"
   :description "Renders collections as HTML"
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/collection-renderer-lib"
-  :exclusions [
-    [commons-io]]
-  :dependencies [
-    [commons-io "2.6"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.jruby/jruby-complete ~jruby-version]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-io]]
+  :dependencies [[commons-io "2.6"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.jruby/jruby-complete ~jruby-version]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :resource-paths ["resources" ~gem-install-path]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"install-gems" ["shell"
                             "support/install_gems.sh"
                             ~jruby-version

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -1,60 +1,48 @@
 (defproject nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"
   :description "Library containing application services code common to multiple CMR applications."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-app-lib"
-  :exclusions [
-    [cheshire]
-    [clj-time]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [compojure "1.6.1"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.pegdown/pegdown "1.6.0"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]
-    [selmer "1.12.5"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [compojure "1.6.1"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.pegdown/pegdown "1.6.0"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]
+                 [selmer "1.12.5"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -1,102 +1,91 @@
 (defproject nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"
   :description "Provides common utility code for CMR projects."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-lib"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [commons-codec/commons-codec]
-    [instaparse]
-    [org.clojure/core.async]
-    [org.clojure/tools.reader]
-    [org.eclipse.jetty/jetty-http]
-    [org.eclipse.jetty/jetty-io]
-    [org.eclipse.jetty/jetty-util]
-    [ring/ring-core]]
-  :dependencies [
-    [camel-snake-kebab "0.4.0"]
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [clojail "1.0.6"]
-    [clojurewerkz/quartzite "2.1.0"]
-    [clojusc/ltest "0.3.0"]
-    [com.dadrox/quiet-slf4j "0.1"]
-    [com.gfredericks/test.chuck "0.2.9"]
-    [com.github.fge/json-schema-validator "2.2.6"]
-    [com.taoensso/timbre "4.10.0"]
-    [commons-codec/commons-codec "1.11"]
-    [compojure "1.6.1"]
-    [environ "1.1.0"]
-    [instaparse "1.4.10"]
-    [net.jpountz.lz4/lz4 "1.3.0"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/core.async "0.4.490"]
-    [org.clojure/core.cache "0.7.2"]
-    [org.clojure/data.codec "0.1.1"]
-    [org.clojure/data.xml "0.0.8"]
-    [org.clojure/test.check "0.9.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [org.clojure/tools.reader "1.3.2"]
-    [org.eclipse.jetty/jetty-http "9.4.14.v20181114"]
-    [org.eclipse.jetty/jetty-io "9.4.14.v20181114"]
-    [org.eclipse.jetty/jetty-servlets "9.4.14.v20181114"]
-    [org.eclipse.jetty/jetty-util "9.4.14.v20181114"]
-    [org.ow2.asm/asm "7.0"]
-    [potemkin "0.4.5"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-jetty-adapter "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [commons-codec/commons-codec]
+               [instaparse]
+               [org.clojure/core.async]
+               [org.clojure/tools.reader]
+               [org.eclipse.jetty/jetty-http]
+               [org.eclipse.jetty/jetty-io]
+               [org.eclipse.jetty/jetty-util]
+               [ring/ring-core]]
+  :dependencies [[camel-snake-kebab "0.4.0"]
+                 [cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [clojail "1.0.6"]
+                 [clojurewerkz/quartzite "2.1.0"]
+                 [clojusc/ltest "0.3.0"]
+                 [com.dadrox/quiet-slf4j "0.1"]
+                 [com.gfredericks/test.chuck "0.2.9"]
+                 [com.github.fge/json-schema-validator "2.2.6"]
+                 [com.taoensso/timbre "4.10.0"]
+                 [commons-codec/commons-codec "1.11"]
+                 [compojure "1.6.1"]
+                 [environ "1.1.0"]
+                 [instaparse "1.4.10"]
+                 [net.jpountz.lz4/lz4 "1.3.0"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.cache "0.7.2"]
+                 [org.clojure/data.codec "0.1.1"]
+                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/test.check "0.9.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [org.eclipse.jetty/jetty-http "9.4.14.v20181114"]
+                 [org.eclipse.jetty/jetty-io "9.4.14.v20181114"]
+                 [org.eclipse.jetty/jetty-servlets "9.4.14.v20181114"]
+                 [org.eclipse.jetty/jetty-util "9.4.14.v20181114"]
+                 [org.ow2.asm/asm "7.0"]
+                 [potemkin "0.4.5"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-jetty-adapter "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :global-vars {*warn-on-reflection* true}
   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [criterium "0.4.4"]
-        [proto-repl "0.3.1"]
-        [clj-http "2.3.0"]]
-      :jvm-opts ^:replace ["-server"]
-                           ;; XXX Note that profiling can be kept in a profile,
-                           ;;     with no need to comment/uncomment.
-                           ;; Uncomment this to enable assertions. Turn off during performance tests.
-                           ; "-ea"
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [criterium "0.4.4"]
+                                  [proto-repl "0.3.1"]
+                                  [clj-http "2.3.0"]]
+                   :jvm-opts ^:replace ["-server"]
+                             ;; XXX Note that profiling can be kept in a profile,
+                             ;;     with no need to comment/uncomment.
+                             ;; Uncomment this to enable assertions. Turn off during performance tests.
+                             ; "-ea"
 
-                           ;; Use the following to enable JMX profiling with visualvm
-                           ; "-Dcom.sun.management.jmxremote"
-                           ; "-Dcom.sun.management.jmxremote.ssl=false"
-                           ; "-Dcom.sun.management.jmxremote.authenticate=false"
-                           ; "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+                             ;; Use the following to enable JMX profiling with visualvm
+                             ; "-Dcom.sun.management.jmxremote"
+                             ; "-Dcom.sun.management.jmxremote.ssl=false"
+                             ; "-Dcom.sun.management.jmxremote.authenticate=false"
+                             ; "-Dcom.sun.management.jmxremote.port=1098"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/cubby-app/project.clj
+++ b/cubby-app/project.clj
@@ -1,70 +1,58 @@
 (defproject nasa-cmr/cmr-cubby-app "0.1.0-SNAPSHOT"
   :description "Provides a centralized caching service for the CMR. See README for details."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/cubby-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [org.clojure/tools.reader]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [compojure "1.6.1"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [org.clojure/tools.reader]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [compojure "1.6.1"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :test-paths ["int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test" "int-test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :uberjar {:main cmr.cubby.runner
-              :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test" "int-test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :uberjar {:main cmr.cubby.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -49,140 +49,125 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :exclusions [
-    [commons-codec/commons-codec]
-    [org.clojure/clojure]
-    [ring/ring-codec]]
-  :dependencies ~(concat '[
-    [commons-codec/commons-codec "1.11"]
-    [org.clojure/clojure "1.10.0"]
-    ;; Add groovy to support groovy scripting in elastic
-    [org.codehaus.groovy/groovy-all "2.4.0"]
-    [ring/ring-codec "1.1.1"]]
-    project-dependencies)
-  :plugins [
-    [lein-environ "1.1.0"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
-  :repl-options {
-    :init-ns user
-    :timeout 300000
-    :welcome (do
-              (println (slurp "resources/text/banner.txt"))
-              (println (slurp "resources/text/loading.txt")))}
+  :exclusions [[commons-codec/commons-codec]
+               [org.clojure/clojure]
+               [ring/ring-codec]]
+  :dependencies ~(concat '[[commons-codec/commons-codec "1.11"]
+                           [org.clojure/clojure "1.10.0"]
+                           ;; Add groovy to support groovy scripting in elastic
+                           [org.codehaus.groovy/groovy-all "2.4.0"]
+                           [ring/ring-codec "1.1.1"]]
+                  project-dependencies)
+  :plugins [[lein-environ "1.1.0"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
+  :repl-options {:init-ns user
+                 :timeout 300000
+                 :welcome (do
+                           (println (slurp "resources/text/banner.txt"))
+                           (println (slurp "resources/text/loading.txt")))}
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Dclojure.compiler.direct-linking=true"]
              ;; Uncomment to enable logging in jetty.
              ; "-Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog"
              ; "-Dorg.eclipse.jetty.LEVEL=INFO"
              ; "-Dorg.eclipse.jetty.websocket.LEVEL=INFO"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev-dependencies {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [criterium "0.4.4"]
-        [debugger "0.2.0"]
-        [drift "1.5.3"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]
-        [proto-repl-charts "0.3.2"]
-        [proto-repl-sayid "0.1.3"]
-        [ring-mock "0.1.5"]]
-      ;; XXX Note that profiling can be kept in a profile,
-      ;;     with no need to comment/uncomment.
-      ;; Use the following to enable JMX profiling with visualvm
-      ;:jvm-opts ^:replace ["-server"
-      ;                     "-Dcom.sun.management.jmxremote"
-      ;                     "-Dcom.sun.management.jmxremote.ssl=false"
-      ;                     "-Dcom.sun.management.jmxremote.authenticate=false"
-      ;                     "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev" "test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    ;; This is to separate the dependencies from the dev-config specified in profiles.clj
-    :dev [:dev-dependencies :dev-config]
-    ;; The following run-* profiles are used in conjunction with other lein
-    ;; profiles to set the default CMR run mode and may be used in the
-    ;; following manner:
-    ;;
-    ;;   $ lein with-profile +run-external repl
-    ;;
-    ;; which will use dev and the other default profiles in addition to
-    ;; run-external (or whichever run mode profile is given).
-    :run-in-memory {
-      :jvm-opts ["-Dcmr.runmode=in-memory"]}
-    :run-external {
-      :jvm-opts ["-Dcmr.runmode=external"]}
-    :uberjar {:main cmr.dev-system.runner
-              ;; See http://stephen.genoprime.com/2013/11/14/uberjar-with-titan-dependency.html
-              :uberjar-merge-with {#"org\.apache\.lucene\.codecs\.*" [slurp str spit]}
-              :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev-dependencies {:exclusions [[org.clojure/tools.nrepl]]
+                                :dependencies [[criterium "0.4.4"]
+                                               [debugger "0.2.0"]
+                                               [drift "1.5.3"]
+                                               [org.clojars.gjahad/debug-repl "0.3.3"]
+                                               [org.clojure/tools.namespace "0.2.11"]
+                                               [org.clojure/tools.nrepl "0.2.13"]
+                                               [pjstadig/humane-test-output "0.9.0"]
+                                               [proto-repl "0.3.1"]
+                                               [proto-repl-charts "0.3.2"]
+                                               [proto-repl-sayid "0.1.3"]
+                                               [ring-mock "0.1.5"]]
+                                ;; XXX Note that profiling can be kept in a profile,
+                                ;;     with no need to comment/uncomment.
+                                ;; Use the following to enable JMX profiling with visualvm
+                                ;:jvm-opts ^:replace ["-server"
+                                ;                     "-Dcom.sun.management.jmxremote"
+                                ;                     "-Dcom.sun.management.jmxremote.ssl=false"
+                                ;                     "-Dcom.sun.management.jmxremote.authenticate=false"
+                                ;                     "-Dcom.sun.management.jmxremote.port=1098"]
+                                :source-paths ["src" "dev" "test"]
+                                :injections [(require 'pjstadig.humane-test-output)
+                                             (pjstadig.humane-test-output/activate!)]}
+              ;; This is to separate the dependencies from the dev-config specified in profiles.clj
+             :dev [:dev-dependencies :dev-config]
+             ;; The following run-* profiles are used in conjunction with other lein
+             ;; profiles to set the default CMR run mode and may be used in the
+             ;; following manner:
+             ;;
+             ;;   $ lein with-profile +run-external repl
+             ;;
+             ;; which will use dev and the other default profiles in addition to
+             ;; run-external (or whichever run mode profile is given).
+             :run-in-memory {:jvm-opts ["-Dcmr.runmode=in-memory"]}
+             :run-external {:jvm-opts ["-Dcmr.runmode=external"]}
+             :uberjar {:main cmr.dev-system.runner
+             ;; See http://stephen.genoprime.com/2013/11/14/uberjar-with-titan-dependency.html
+                       :uberjar-merge-with {#"org\.apache\.lucene\.codecs\.*" [slurp str spit]}
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {
-    ;; Creates the checkouts directory to the local projects
-    "create-checkouts" ~create-checkouts-commands
-    ;; Alias to test2junit for consistency with lein-test-out
-    "test-out"
-      ["test2junit"]
-    ;; Installs the Elasticsearch Marvel plugin locally.
-    ;; Visit http://localhost:9210/_plugin/marvel/sense/index.html
-    "install-marvel"
-      ["shell" "cmr" "install" "local" "marvel"]
-    ;; Linting aliases
-    "kibit"
-      ["do"
-        ["shell" "echo" "== Kibit =="]
-        ["with-profile" "lint" "kibit"]]
-    "eastwood"
-      ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "bikeshed"
-      ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-    "yagni"
-      ["with-profile" "lint" "yagni"]
-    "check-deps"
-      ["with-profile" "lint" "ancient" ":all"]
-    "check-sec"
-      ["with-profile" "security" "dependency-check"]
-    "lint"
-      ["do"
-        ["check"] ["kibit"] ["eastwood"]]
-    ;; Placeholder for future docs and enabler of top-level alias
-    "generate-static"
-      ["with-profile" "static"
-       "shell" "echo"]
-    ;; Run a local copy of SQS/SNS
-    "start-sqs-sns"
-      ["shell" "cmr" "start" "local" "sqs-sns"]
-    "stop-sqs-sns"
-      ["shell" "cmr" "stop" "local" "sqs-sns"]
-    "restart-sqs-sns"
-      ["do"
-        ["stop-sqs-sns"]
-        ["start-sqs-sns"]]})
+            ;; Creates the checkouts directory to the local projects
+            "create-checkouts" ~create-checkouts-commands
+            ;; Alias to test2junit for consistency with lein-test-out
+            "test-out"
+            ["test2junit"]
+            ;; Installs the Elasticsearch Marvel plugin locally.
+            ;; Visit http://localhost:9210/_plugin/marvel/sense/index.html
+            "install-marvel"
+            ["shell" "cmr" "install" "local" "marvel"]
+            ;; Linting aliases
+            "kibit"
+            ["do"
+              ["shell" "echo" "== Kibit =="]
+              ["with-profile" "lint" "kibit"]]
+            "eastwood"
+            ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed"
+            ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
+            "yagni"
+            ["with-profile" "lint" "yagni"]
+            "check-deps"
+            ["with-profile" "lint" "ancient" ":all"]
+            "check-sec"
+            ["with-profile" "security" "dependency-check"]
+            "lint"
+            ["do"
+              ["check"] ["kibit"] ["eastwood"]]
+            ;; Placeholder for future docs and enabler of top-level alias
+            "generate-static"
+            ["with-profile" "static"
+             "shell" "echo"]
+            ;; Run a local copy of SQS/SNS
+            "start-sqs-sns"
+            ["shell" "cmr" "start" "local" "sqs-sns"]
+            "stop-sqs-sns"
+            ["shell" "cmr" "stop" "local" "sqs-sns"]
+            "restart-sqs-sns"
+            ["do"
+              ["stop-sqs-sns"]
+              ["start-sqs-sns"]]})

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -141,6 +141,7 @@
 
 (defmethod create-echo :in-memory
   [type]
+  (transmit-config/set-urs-relative-root-url! "/urs")
   (mock-echo-system/create-system))
 
 (defmethod create-echo :external

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -1,61 +1,49 @@
 (defproject nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"
   :description "A library containing utilities for dealing with Elasticsearch."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/elastic-utils-lib"
-  :exclusions [
-    [cheshire]
-    [commons-codec/commons-codec]
-    [commons-io]
-    [org.elasticsearch/elasticsearch]
-    [potemkin]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-http "2.3.0"]
-    [clojurewerkz/elastisch "2.2.2"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [log4j/log4j "1.2.17"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.elasticsearch/elasticsearch "1.6.2"]
-    [potemkin "0.4.5"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [commons-codec/commons-codec]
+               [commons-io]
+               [org.elasticsearch/elasticsearch]
+               [potemkin]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-http "2.3.0"]
+                 [clojurewerkz/elastisch "2.2.2"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [log4j/log4j "1.2.17"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.elasticsearch/elasticsearch "1.6.2"]
+                 [potemkin "0.4.5"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -16,49 +16,38 @@
 (defproject nasa-cmr/cmr-es-spatial-plugin "0.1.0-SNAPSHOT"
   :description "A Elastic Search plugin that enables spatial search entirely within elastic."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/es-spatial-plugin"
-  :exclusions [
-    [org.clojure/clojure]
-    [org.ow2.asm/asm]]
-  :dependencies [
-    [log4j/log4j "1.2.17"]
-    [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.logging "0.4.0"]
-    [org.elasticsearch/elasticsearch "1.6.2"]
-    [org.ow2.asm/asm "7.0"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[org.clojure/clojure]
+               [org.ow2.asm/asm]]
+  :dependencies [[log4j/log4j "1.2.17"]
+                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [org.elasticsearch/elasticsearch "1.6.2"]
+                 [org.ow2.asm/asm "7.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   ;; This is the minimum that must be AOT'd for running in an embeded elastic. AOT :all for installing
   ;; in an elastic vm.
-  :aot [
-    cmr.elasticsearch.plugins.spatial.script.core
-    cmr.elasticsearch.plugins.spatial.factory.core
-    cmr.elasticsearch.plugins.spatial.plugin]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [criterium "0.4.4"]
-        [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :global-vars {*warn-on-reflection* true
-                    *assert* false}
+  :aot [cmr.elasticsearch.plugins.spatial.script.core
+        cmr.elasticsearch.plugins.spatial.factory.core
+        cmr.elasticsearch.plugins.spatial.plugin]
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[criterium "0.4.4"]
+                                  [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :global-vars {*warn-on-reflection* true
+                                 *assert* false}
 
-      ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
-      ;; See https://github.com/technomancy/leiningen/wiki/Faster
-      :jvm-opts ^:replace ["-server"]
+                   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
+                   ;; See https://github.com/technomancy/leiningen/wiki/Faster
+                   :jvm-opts ^:replace ["-server"]
                              ;; important to allow logging to standard out
       ;                      "-Des.foreground=true"
       ;                      ;; Use the following to enable JMX profiling with visualvm
@@ -66,52 +55,46 @@
       ;                      "-Dcom.sun.management.jmxremote.ssl=false"
       ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
       ;                      "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev"]}
-    :uberjar {
-      :aot [
-        cmr.elasticsearch.plugins.spatial.script.core
-        cmr.elasticsearch.plugins.spatial.factory.core
-        cmr.elasticsearch.plugins.spatial.plugin
-        cmr.elasticsearch.plugins.spatial.script.helper
-        cmr.elasticsearch.plugins.spatial.factory.helper]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+                   :source-paths ["src" "dev"]}
+             :uberjar {:aot [cmr.elasticsearch.plugins.spatial.script.core
+                             cmr.elasticsearch.plugins.spatial.factory.core
+                             cmr.elasticsearch.plugins.spatial.plugin
+                             cmr.elasticsearch.plugins.spatial.script.helper
+                             cmr.elasticsearch.plugins.spatial.factory.helper]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Packages the spatial search plugin
             "package" ["do"
                        "clean,"
                        "uberjar,"
                        "shell" "zip" "-j" ~plugin-zip-name ~uberjar-name]
             ;; Packages and installs the plugin into the local elastic search vm
-            "install-local" [
-              "do"
-              "package,"
-              "shell"
-                "../../cmr-vms/elastic_local/install_plugin.sh"
-                ~plugin-zip-name
-                "spatialsearch-plugin,"
-              "clean"]
-            "install-workload" [
-              "do"
-              "package,"
-              "shell"
-                "install_plugin_into_workload.sh"
-                ~plugin-zip-name
-                "spatialsearch-plugin"]
+            "install-local" ["do"
+                             "package,"
+                             "shell"
+                             "../../cmr-vms/elastic_local/install_plugin.sh"
+                             ~plugin-zip-name
+                             "spatialsearch-plugin,"
+                             "clean"]
+            "install-workload" ["do"
+                                "package,"
+                                "shell"
+                                "install_plugin_into_workload.sh"
+                                ~plugin-zip-name
+                                "spatialsearch-plugin"]
             ;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/index-set-app/project.clj
+++ b/index-set-app/project.clj
@@ -2,80 +2,68 @@
   :description "index-set app is a microservice enabling CMR system create/maintain a logical set of indexes in Elasticsearch
                for indexing and searching for concepts."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/index-set-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [instaparse]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/core.async]
-    [org.clojure/tools.reader]
-    [potemkin]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [compojure "1.6.1"]
-    [instaparse "1.4.10"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/core.async "0.4.490"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [org.clojure/tools.reader "1.3.2"]
-    [potemkin "0.4.5"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [instaparse]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/core.async]
+               [org.clojure/tools.reader]
+               [potemkin]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [compojure "1.6.1"]
+                 [instaparse "1.4.10"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [potemkin "0.4.5"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :test-paths ["test" "int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [clj-http "2.3.0"]
-        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test" "int-test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :integration-test {:test-paths ["int-test"]
-                       :dependencies [[clj-http "2.3.0"]]}
-    :uberjar {
-      :main cmr.index-set.runner
-      :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[clj-http "2.3.0"]
+                                  [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test" "int-test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :integration-test {:test-paths ["int-test"]
+                                :dependencies [[clj-http "2.3.0"]]}
+             :uberjar {:main cmr.index-set.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -1,64 +1,51 @@
 (defproject nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"
   :description "This is the indexer application for the CMR. It is responsible for indexing modified data into Elasticsearch."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/indexer-app"
-  :exclusions [
-    [instaparse]]
-  :dependencies [
-    [compojure "1.6.1"]
-    [instaparse "1.4.10"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[instaparse]]
+  :dependencies [[compojure "1.6.1"]
+                 [instaparse "1.4.10"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :test-paths ["test" "int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :uberjar {
-      :main cmr.indexer.runner
-      :aot :all}
-    :integration-tests {
-      :test-paths ^:replace ["int-test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :uberjar {:main cmr.indexer.runner
+                       :aot :all}
+             :integration-tests {:test-paths ^:replace ["int-test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -1,86 +1,74 @@
 (defproject nasa-cmr/cmr-ingest-app "0.1.0-SNAPSHOT"
   :description "Ingest is an external facing CMR service facilitating providers to create and  update their concepts in CMR. Internally it delegates concept persistence operations to metadata db and indexer micro services."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/ingest-app"
-  :exclusions [
-    [commons-codec/commons-codec]
-    [commons-io]
-    [instaparse]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.slf4j/slf4j-api]
-    [ring/ring-codec]]
-  :dependencies [
-    [clj-http "2.3.0"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [compojure "1.6.1"]
-    [drift "1.5.3"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
-    [instaparse "1.4.10"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [net.sf.saxon/Saxon-HE "9.9.0-2"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [org.quartz-scheduler/quartz "2.3.0"]
-    [org.slf4j/slf4j-api "1.7.25"]
-    [potemkin "0.4.5"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [drift "1.5.3"]
-    [lein-exec "0.3.7"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-codec/commons-codec]
+               [commons-io]
+               [instaparse]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.slf4j/slf4j-api]
+               [ring/ring-codec]]
+  :dependencies [[clj-http "2.3.0"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [compojure "1.6.1"]
+                 [drift "1.5.3"]
+                 [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
+                 [instaparse "1.4.10"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [net.sf.saxon/Saxon-HE "9.9.0-2"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [org.quartz-scheduler/quartz "2.3.0"]
+                 [org.slf4j/slf4j-api "1.7.25"]
+                 [potemkin "0.4.5"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[drift "1.5.3"]
+            [lein-exec "0.3.7"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [ring-mock "0.1.5"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    ;; This profile specifically here for generating documentation. It's faster than using the regular
-    ;; profile. An agent pool is being started when using the default profile which causes the wait of
-    ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
-    ;; Generate docs with: lein generate-static
-    :static {}
-    :uberjar {
-      :main cmr.ingest.runner
-      :aot :all}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [lein-shell "0.5.0"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [ring-mock "0.1.5"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             ;; This profile specifically here for generating documentation. It's faster than using the regular
+             ;; profile. An agent pool is being started when using the default profile which causes the wait of
+             ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
+             ;; Generate docs with: lein generate-static
+             :static {}
+             :uberjar {:main cmr.ingest.runner
+                       :aot :all}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [lein-shell "0.5.0"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"generate-static" ["with-profile" "static"
                                "run" "-m" "cmr.ingest.site.static" "all"]
             ;; Database migrations run by executing "lein migrate"

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -1,103 +1,91 @@
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/message-queue-lib"
-  :exclusions [
-    [cheshire]
-    [clj-http]
-    [clj-time]
-    [commons-codec/commons-codec]
-    [commons-io]
-    [commons-logging]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/tools.reader]
-    [potemkin]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-http "2.3.0"]
-    [clj-time "0.15.1"]
-    [com.amazonaws/aws-java-sdk "1.11.479"]
-    [com.novemberain/langohr "5.0.0"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [commons-logging "1.2"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [potemkin "0.4.5"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-http]
+               [clj-time]
+               [commons-codec/commons-codec]
+               [commons-io]
+               [commons-logging]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/tools.reader]
+               [potemkin]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-http "2.3.0"]
+                 [clj-time "0.15.1"]
+                 [com.amazonaws/aws-java-sdk "1.11.479"]
+                 [com.novemberain/langohr "5.0.0"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [commons-logging "1.2"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [potemkin "0.4.5"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :aot [cmr.message-queue.test.ExitException]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {
-    ;; Alias to test2junit for consistency with lein-test-out
-    "test-out" ["test2junit"]
-    ;; Linting aliases
-    "kibit"
-      ["do"
-        ["shell" "echo" "== Kibit =="]
-        ["with-profile" "lint" "kibit"]]
-    "eastwood"
-      ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
-    "bikeshed"
-      ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-    "yagni"
-      ["with-profile" "lint" "yagni"]
-    "check-deps"
-      ["with-profile" "lint" "ancient" ":all"]
-    "check-sec"
-      ["with-profile" "security" "dependency-check"]
-    "lint"
-      ["do"
-        ["check"] ["kibit"] ["eastwood"]]
-    ;; Placeholder for future docs and enabler of top-level alias
-    "generate-static" ["with-profile" "static" "shell" "echo"]
-        ;; Run a local copy of SQS/SNS
-    "start-sqs-sns"
-      ["shell" "cmr" "start" "local" "sqs-sns"]
-    "stop-sqs-sns"
-      ["shell" "cmr" "stop" "local" "sqs-sns"]
-    "restart-sqs-sns"
-      ["do"
-        ["stop-sqs-sns"]
-        ["start-sqs-sns"]]})
+            ;; Alias to test2junit for consistency with lein-test-out
+            "test-out" ["test2junit"]
+            ;; Linting aliases
+            "kibit"
+            ["do"
+              ["shell" "echo" "== Kibit =="]
+              ["with-profile" "lint" "kibit"]]
+            "eastwood"
+            ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            "bikeshed"
+            ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
+            "yagni"
+            ["with-profile" "lint" "yagni"]
+            "check-deps"
+            ["with-profile" "lint" "ancient" ":all"]
+            "check-sec"
+            ["with-profile" "security" "dependency-check"]
+            "lint"
+            ["do"
+              ["check"] ["kibit"] ["eastwood"]]
+            ;; Placeholder for future docs and enabler of top-level alias
+            "generate-static" ["with-profile" "static" "shell" "echo"]
+            ;; Run a local copy of SQS/SNS
+            "start-sqs-sns"
+            ["shell" "cmr" "start" "local" "sqs-sns"]
+            "stop-sqs-sns"
+            ["shell" "cmr" "stop" "local" "sqs-sns"]
+            "restart-sqs-sns"
+            ["do"
+              ["stop-sqs-sns"]
+              ["start-sqs-sns"]]})

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -2,85 +2,73 @@
   :description "The metadata db is a micro-service that provides
                support for persisting metadata concepts."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/metadata-db-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [com.fasterxml.jackson.core/jackson-databind]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/tools.reader]
-    [org.slf4j/slf4j-api]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
-    [compojure "1.6.1"]
-    [drift "1.5.3"]
-    [inflections "0.13.0"]
-    [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [org.clojure/tools.reader "1.3.2"]
-    [org.quartz-scheduler/quartz "2.3.0"]
-    [org.slf4j/slf4j-api "1.7.25"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [drift "1.5.3"]
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [com.fasterxml.jackson.core/jackson-databind]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/tools.reader]
+               [org.slf4j/slf4j-api]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
+                 [compojure "1.6.1"]
+                 [drift "1.5.3"]
+                 [inflections "0.13.0"]
+                 [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [org.quartz-scheduler/quartz "2.3.0"]
+                 [org.slf4j/slf4j-api "1.7.25"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[drift "1.5.3"]
+            [lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :test-paths ["test" "int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [clj-http "2.3.0"]
-        [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test" "int-test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :integration-test {:test-paths ["int-test"]
-                       :dependencies [[clj-http "2.3.0"]]}
-    :uberjar {
-      :main cmr.metadata-db.runner
-      :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[clj-http "2.3.0"]
+                                  [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test" "int-test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :integration-test {:test-paths ["int-test"]
+                                :dependencies [[clj-http "2.3.0"]]}
+             :uberjar {:main cmr.metadata-db.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   ;; Database migrations run by executing "lein migrate"
   :aliases {"create-user" ["exec" "-p" "./support/create_user.clj"]
             "drop-user" ["exec" "-p" "./support/drop_user.clj"]

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -1,64 +1,51 @@
 (defproject nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"
   :description "Mocks out the ECHO REST API."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/mock-echo-app"
-  :exclusions [
-    [commons-io]
-    [instaparse]
-    [org.clojure/tools.reader]]
-  :dependencies [
-    [commons-io "2.6"]
-    [compojure "1.6.1"]
-    [instaparse "1.4.10"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-io]
+               [instaparse]
+               [org.clojure/tools.reader]]
+  :dependencies [[commons-io "2.6"]
+                 [compojure "1.6.1"]
+                 [instaparse "1.4.10"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :uberjar {
-      :main cmr.mock-echo.runner
-      :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :uberjar {:main cmr.mock-echo.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/mock-echo-app/src/cmr/mock_echo/api/routes.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/routes.clj
@@ -1,23 +1,24 @@
 (ns cmr.mock-echo.api.routes
   "Defines the HTTP URL routes for the application."
-  (:require [compojure.handler :as handler]
-            [compojure.route :as route]
-            [compojure.core :refer :all]
-            [ring.middleware.json :as ring-json]
-            [cheshire.core :as json]
-            [clojure.set :as set]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.api.errors :as errors]
-            [cmr.common.services.errors :as svc-errors]
-            [cmr.common.api.context :as context]
-            [cmr.mock-echo.api.tokens :as token-api]
-            [cmr.mock-echo.api.providers :as providers-api]
-            [cmr.mock-echo.api.acls :as acls-api]
-            [cmr.mock-echo.api.urs :as urs-api]
-            [cmr.mock-echo.data.token-db :as token-db]
-            [cmr.mock-echo.data.provider-db :as provider-db]
-            [cmr.mock-echo.data.acl-db :as acl-db]
-            [cmr.mock-echo.data.urs-db :as urs-db]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.set :as set]
+   [cmr.common.api.context :as context]
+   [cmr.common.api.errors :as errors]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.services.errors :as svc-errors]
+   [cmr.mock-echo.api.acls :as acls-api]
+   [cmr.mock-echo.api.providers :as providers-api]
+   [cmr.mock-echo.api.tokens :as token-api]
+   [cmr.mock-echo.api.urs :as urs-api]
+   [cmr.mock-echo.data.acl-db :as acl-db]
+   [cmr.mock-echo.data.provider-db :as provider-db]
+   [cmr.mock-echo.data.token-db :as token-db]
+   [cmr.mock-echo.data.urs-db :as urs-db]
+   [compojure.core :refer :all]
+   [compojure.handler :as handler]
+   [compojure.route :as route]
+   [ring.middleware.json :as ring-json]))
 
 (defn reset
   [context]
@@ -25,7 +26,6 @@
   (provider-db/reset context)
   (acl-db/reset context)
   (urs-db/reset context))
-
 
 (defn- build-routes [system]
   (routes

--- a/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
@@ -1,16 +1,19 @@
 (ns cmr.mock-echo.client.mock-urs-client
   "Contains functions for communicating with the mock urs api that aren't normal URS
   operations"
-  (:require [cmr.transmit.http-helper :as h]
-            [cmr.transmit.config :as config]
-            [cmr.transmit.connection :as conn]
-            [cmr.common.mime-types :as mt]
-            [cmr.common.services.errors :as errors]
-            [cheshire.core :as json]))
+  (:require
+   [cheshire.core :as json]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.services.errors :as errors]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]
+   [cmr.transmit.http-helper :as h]))
 
 (defn- create-users-url
+  "Call to create users in mock URS. Makes an assumption that the URS root context in the
+  connection is an empty string."
   [conn]
-  (format "%s/users" (conn/root-url conn)))
+  (format "%s/urs/users" (conn/root-url conn)))
 
 (defn create-users
   "Creates the users in mock urs given an array of maps with :username and :password"
@@ -26,7 +29,3 @@
       (errors/internal-error!
        (format "Unexpected status %d from response. body: %s"
                status (pr-str body))))))
-
-
-
-

--- a/mock-echo-app/src/cmr/mock_echo/system.clj
+++ b/mock-echo-app/src/cmr/mock_echo/system.clj
@@ -2,17 +2,18 @@
   "Defines functions for creating, starting, and stopping the application. Applications are
   represented as a map of components. Design based on
   http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts."
-  (:require [cmr.common.lifecycle :as lifecycle]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.mock-echo.api.routes :as routes]
-            [cmr.common.api.web-server :as web]
-            [cmr.mock-echo.data.token-db :as token-db]
-            [cmr.mock-echo.data.provider-db :as provider-db]
-            [cmr.mock-echo.data.acl-db :as acl-db]
-            [cmr.mock-echo.data.urs-db :as urs-db]
-            [cmr.transmit.config :as transmit-config]
-            [cmr.common.api.context :as context]
-            [cmr.common.system :as common-sys]))
+  (:require
+   [cmr.common.api.context :as context]
+   [cmr.common.api.web-server :as web]
+   [cmr.common.lifecycle :as lifecycle]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.system :as common-sys]
+   [cmr.mock-echo.api.routes :as routes]
+   [cmr.mock-echo.data.acl-db :as acl-db]
+   [cmr.mock-echo.data.provider-db :as provider-db]
+   [cmr.mock-echo.data.token-db :as token-db]
+   [cmr.mock-echo.data.urs-db :as urs-db]
+   [cmr.transmit.config :as transmit-config]))
 
 (def ^:private component-order
   "Defines the order to start the components."

--- a/oracle-lib/project.clj
+++ b/oracle-lib/project.clj
@@ -14,52 +14,41 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/oracle-lib"
   ;; Dynamically include extra repositories in the project definition if configured.
   :repositories [["releases" ~extra-repository]]
-  :dependencies [
-    [com.oracle/ojdbc6 "11.2.0.4"]
-    [com.oracle/ons "11.2.0.4"]
-    [com.oracle/ucp "11.2.0.4"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/java.jdbc "0.4.2"]
-    [sqlingvo "0.7.15"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :dependencies [[com.oracle/ojdbc6 "11.2.0.4"]
+                 [com.oracle/ons "11.2.0.4"]
+                 [com.oracle/ucp "11.2.0.4"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/java.jdbc "0.4.2"]
+                 [sqlingvo "0.7.15"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/orbits-lib/project.clj
+++ b/orbits-lib/project.clj
@@ -9,54 +9,43 @@
 
 (defproject nasa-cmr/cmr-orbits-lib "0.1.0-SNAPSHOT"
   :description "Contains Ruby code that allows performing orbit calculations for spatial search."
-  :dependencies [
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.jruby/jruby-complete ~jruby-version]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :dependencies [[nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.jruby/jruby-complete ~jruby-version]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :resource-paths ["resources"]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]
-      :resource-paths ["resources" "test_resources" ~dev-gem-install-path]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]
+                   :resource-paths ["resources" "test_resources" ~dev-gem-install-path]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"install-gems" ["shell"
                             "support/install_gems.sh"
                             ~jruby-version

--- a/project.clj
+++ b/project.clj
@@ -14,68 +14,63 @@
 ;; subdirectories, and then test-out in all project subdirectories.
 (defproject nasa-cmr/cmr "0.1.0-SNAPSHOT"
   :description "Top level project to support all CMR libraries and applications."
-  :plugins [
-    [lein-modules "0.3.11"]
-    [lein-shell "0.4.0"]]
-  :profiles {
-    :uberjar {
-      :modules {
-        :dirs ["access-control-app"
-               "cubby-app"
-               "bootstrap-app"
-               "index-set-app"
-               "indexer-app"
-               "ingest-app"
-               "metadata-db-app"
-               "search-app"
-               "virtual-product-app"
-               "es-spatial-plugin"]}}}
-  :aliases {
-    "kibit"
-      ["modules" "kibit"]
-    "eastwood"
-      ["modules" "eastwood"]
-    "lint"
-      ["modules" "lint"]
-    "check-deps"
-      ["modules" "check-deps"]
-    "check-sec"
-      ["modules" "check-sec"]
-    "deps-tree-conflicts"
-      ["modules" "deps" ":tree"]
-    "generate-static"
-      ["modules" "generate-static"]
-    ;; Run a local copy of SQS/SNS
-    "start-sqs-sns"
-      ["shell" "cmr" "start" "local" "sqs-sns"]
-    "stop-sqs-sns"
-      ["shell" "cmr" "stop" "local" "sqs-sns"]
-    "restart-sqs-sns"
-      ["do"
-        ["stop-sqs-sns"]
-        ["start-sqs-sns"]]
-    ;; Dev
-    "clean-all" ["modules" "do" "clean"]
-    "repl"
-      ["shell"
-       "echo" "You need to be in the `dev-system` directory for that."]
-    "test"
-      ["modules" "test-out"]
-    ;; Install tasks using up-stream .jar repos
-    "install-no-clean!"
-      ["modules" "do" "clean," "install,"]
-    "install!"
-      ["modules" "do" "clean," "install," "clean"]
-    "install-with-content-no-clean!"
-      ["modules" "do" "clean," "install," "generate-static,"]
-    "install-with-content!"
-      ["modules" "do" "clean," "install," "generate-static," "clean"]
-    ;; Install tasks using nexus .jar repos proxy
-    "internal-install-no-clean!"
-      ["modules" "with-profile" "+internal-repos" "do" "clean," "install,"]
-    "internal-install!"
-      ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "clean"]
-    "internal-install-with-content-no-clean!"
-      ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "generate-static,"]
-    "internal-install-with-content!"
-      ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "generate-static," "clean"]})
+  :plugins [[lein-modules "0.3.11"]
+            [lein-shell "0.4.0"]]
+  :profiles {:uberjar {:modules {:dirs ["access-control-app"
+                                        "cubby-app"
+                                        "bootstrap-app"
+                                        "index-set-app"
+                                        "indexer-app"
+                                        "ingest-app"
+                                        "metadata-db-app"
+                                        "search-app"
+                                        "virtual-product-app"
+                                        "es-spatial-plugin"]}}}
+  :aliases {"kibit"
+            ["modules" "kibit"]
+            "eastwood"
+            ["modules" "eastwood"]
+            "lint"
+            ["modules" "lint"]
+            "check-deps"
+            ["modules" "check-deps"]
+            "check-sec"
+            ["modules" "check-sec"]
+            "deps-tree-conflicts"
+            ["modules" "deps" ":tree"]
+            "generate-static"
+            ["modules" "generate-static"]
+            ;; Run a local copy of SQS/SNS
+            "start-sqs-sns"
+            ["shell" "cmr" "start" "local" "sqs-sns"]
+            "stop-sqs-sns"
+            ["shell" "cmr" "stop" "local" "sqs-sns"]
+            "restart-sqs-sns"
+            ["do"
+              ["stop-sqs-sns"]
+              ["start-sqs-sns"]]
+            ;; Dev
+            "clean-all" ["modules" "do" "clean"]
+            "repl"
+            ["shell"
+             "echo" "You need to be in the `dev-system` directory for that."]
+            "test"
+            ["modules" "test-out"]
+            ;; Install tasks using up-stream .jar repos
+            "install-no-clean!"
+            ["modules" "do" "clean," "install,"]
+            "install!"
+            ["modules" "do" "clean," "install," "clean"]
+            "install-with-content-no-clean!"
+            ["modules" "do" "clean," "install," "generate-static,"]
+            "install-with-content!"
+            ["modules" "do" "clean," "install," "generate-static," "clean"]
+            ;; Install tasks using nexus .jar repos proxy
+            "internal-install-no-clean!"
+            ["modules" "with-profile" "+internal-repos" "do" "clean," "install,"]
+            "internal-install!"
+            ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "clean"]
+            "internal-install-with-content-no-clean!"
+            ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "generate-static,"]
+            "internal-install-with-content!"
+            ["modules" "with-profile" "+internal-repos" "do" "clean," "install," "generate-static," "clean"]})

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -1,103 +1,90 @@
 (defproject nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"
   :description "Provides a public search API for concepts in the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [commons-codec/commons-codec]
-    [org.apache.httpcomponents/httpclient]
-    [org.clojure/clojure]
-    [org.clojure/tools.reader]
-    [ring/ring-codec]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-time "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [com.github.fge/json-schema-validator "2.2.6"]
-    [commons-codec/commons-codec "1.11"]
-    [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-orbits-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [net.sf.saxon/Saxon-HE "9.9.0-2"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/data.csv "0.1.4"]
-    [org.clojure/tools.reader "1.3.2"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]
-    [selmer "1.12.5"]
-    ;; Temporary inclusion of libraries needed for swagger UI until the dev portal is
-    ;; done.
-    [metosin/ring-swagger-ui "2.1.4-0"]
-    [metosin/ring-swagger "0.22.14"]
-    [prismatic/schema "1.1.9"]]
-  :plugins [
-    [lein-exec "0.3.7"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [commons-codec/commons-codec]
+               [org.apache.httpcomponents/httpclient]
+               [org.clojure/clojure]
+               [org.clojure/tools.reader]
+               [ring/ring-codec]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-time "0.15.1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                 [com.github.fge/json-schema-validator "2.2.6"]
+                 [commons-codec/commons-codec "1.11"]
+                 [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-collection-renderer-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-orbits-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [net.sf.saxon/Saxon-HE "9.9.0-2"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/data.csv "0.1.4"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]
+                 [selmer "1.12.5"]
+                 ;; Temporary inclusion of libraries needed for swagger UI until the dev portal is
+                 ;; done.
+                 [metosin/ring-swagger-ui "2.1.4-0"]
+                 [metosin/ring-swagger "0.22.14"]
+                 [prismatic/schema "1.1.9"]]
+  :plugins [[lein-exec "0.3.7"]
+            [test2junit "1.3.3"]]
   :repl-options {:init-ns user
                  :timeout 120000}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [criterium "0.4.4"]
-        [drift "1.5.3"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [ring-mock "0.1.5"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    ;; This profile specifically here for generating documentation. It's
-    ;; faster than using the regular profile. An agent pool is being started
-    ;; when using the default profile which causes the wait of 60 seconds
-    ;; before allowing the JVM to shutdown since no call to shutdown-agents is
-    ;; made. Generate docs with: lein generate-static (the alias makes use of the
-    ;; static profile).
-    :static {}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[criterium "0.4.4"]
+                                  [drift "1.5.3"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [ring-mock "0.1.5"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             ;; This profile specifically here for generating documentation. It's
+             ;; faster than using the regular profile. An agent pool is being started
+             ;; when using the default profile which causes the wait of 60 seconds
+             ;; before allowing the JVM to shutdown since no call to shutdown-agents is
+             ;; made. Generate docs with: lein generate-static (the alias makes use of the
+             ;; static profile).
+             :static {}
+             :uberjar {:main cmr.search.runner
+                       :aot :all}
 
-    :uberjar {:main cmr.search.runner
-              :aot :all}
-
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [lein-shell "0.5.0"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [lein-shell "0.5.0"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"generate-static" ["with-profile" "static"
                                "run" "-m" "cmr.search.site.static" "all"]
             ;; Prints out documentation on configuration environment variables.

--- a/search-relevancy-test/project.clj
+++ b/search-relevancy-test/project.clj
@@ -3,75 +3,64 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-relevancy-test"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [commons-codec/commons-codec]
-    [commons-fileupload]
-    [commons-io]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/tools.reader]
-    [potemkin]]
-  :dependencies [
-    [camel-snake-kebab "0.4.0"]
-    [cheshire "5.8.1"]
-    [clj-http "2.3.0"]
-    [clj-time "0.15.1"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-fileupload "1.3.3"]
-    [commons-io "2.6"]
-    [nasa-cmr/cmr-system-int-test "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [potemkin "0.4.5"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [commons-codec/commons-codec]
+               [commons-fileupload]
+               [commons-io]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/tools.reader]
+               [potemkin]]
+  :dependencies [[camel-snake-kebab "0.4.0"]
+                 [cheshire "5.8.1"]
+                 [clj-http "2.3.0"]
+                 [clj-time "0.15.1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-fileupload "1.3.3"]
+                 [commons-io "2.6"]
+                 [nasa-cmr/cmr-system-int-test "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [potemkin "0.4.5"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :main ^:skip-aot search-relevancy-test.runner
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev {
-    :dependencies [
-      [org.clojars.gjahad/debug-repl "0.3.3"]
-      [org.clojure/tools.namespace "0.2.11"]
-      [pjstadig/humane-test-output "0.9.0"]]
-    :injections [(require 'pjstadig.humane-test-output)
-                (pjstadig.humane-test-output/activate!)]
-    :jvm-opts ^:replace ["-server"
-                        "-XX:-OmitStackTraceInFastThrow"]
-    :source-paths ["src" "dev"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev {:dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [pjstadig/humane-test-output "0.9.0"]]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]
+                   :jvm-opts ^:replace ["-server"
+                                        "-XX:-OmitStackTraceInFastThrow"]
+                   :source-paths ["src" "dev"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/site-templates/project.clj
+++ b/site-templates/project.clj
@@ -2,23 +2,16 @@
   :description "Selmer templates for CMR documentation, directory pages, and various static web content"
   :url "https://github.com/nasa/Common-Metadata-Repository/site-templates"
   :license {
-    :name "Apache License, Version 2.0"
-    :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [
-    [org.clojure/clojure "1.10.0"]]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :test {
-      :plugins [
-        [lein-shell "0.5.0"]
-        [test2junit "1.4.0"]]}}
+            :name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :test {:plugins [[lein-shell "0.5.0"]
+                              [test2junit "1.4.0"]]}}
   :aliases {
-    ;; The following aliases are needed for the CMR build process.
-    "generate-static" ["with-profile" "+test" "shell" "echo" "NO OP"]
-    "check-sec" ["with-profile" "security" "dependency-check"]
-    "test-out" ["with-profile" "+test" "test2junit"]})
+            ;; The following aliases are needed for the CMR build process.
+            "generate-static" ["with-profile" "+test" "shell" "echo" "NO OP"]
+            "check-sec" ["with-profile" "security" "dependency-check"]
+            "test-out" ["with-profile" "+test" "test2junit"]})

--- a/spatial-lib/project.clj
+++ b/spatial-lib/project.clj
@@ -1,71 +1,59 @@
 (defproject nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"
   :description "A spatial library for the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/spatial-lib"
-  :exclusions [
-    [org.clojure/clojure]]
-  :dependencies [
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [net.jafama/jafama "2.3.1"]
-    [net.mikera/core.matrix "0.54.0"]
-    [net.mikera/vectorz-clj "0.28.0"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/math.combinatorics "0.1.4"]
-    [pjstadig/assertions "0.2.0"]
-    [primitive-math "0.1.4"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[org.clojure/clojure]]
+  :dependencies [[nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [net.jafama/jafama "2.3.1"]
+                 [net.mikera/core.matrix "0.54.0"]
+                 [net.mikera/vectorz-clj "0.28.0"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/math.combinatorics "0.1.4"]
+                 [pjstadig/assertions "0.2.0"]
+                 [primitive-math "0.1.4"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :global-vars {*warn-on-reflection* true}
   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [criterium "0.4.4"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]
-      :jvm-opts ^:replace ["-server"]
-                          ;; Uncomment this to enable assertions. Turn off during performance tests.
-                          ; "-ea"
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[criterium "0.4.4"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]
+                   :jvm-opts ^:replace ["-server"]
+                   ;; Uncomment this to enable assertions. Turn off during performance tests.
+                   ; "-ea"
 
-                          ;; Use the following to enable JMX profiling with visualvm
-                          ;  "-Dcom.sun.management.jmxremote"
-                          ;  "-Dcom.sun.management.jmxremote.ssl=false"
-                          ;  "-Dcom.sun.management.jmxremote.authenticate=false"
-                          ;  "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+                   ;; Use the following to enable JMX profiling with visualvm
+                   ;  "-Dcom.sun.management.jmxremote"
+                   ;  "-Dcom.sun.management.jmxremote.ssl=false"
+                   ;  "-Dcom.sun.management.jmxremote.authenticate=false"
+                   ;  "-Dcom.sun.management.jmxremote.port=1098"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -3,93 +3,81 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/system-int-test"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :exclusions [
-    [cheshire]
-    [clj-time]
-    [com.fasterxml.jackson.core/jackson-core]
-    [com.google.code.findbugs/jsr305]
-    [commons-codec/commons-codec]
-    [commons-io]
-    [org.apache.httpcomponents/httpclient]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/tools.logging]
-    [org.clojure/tools.reader]
-    [potemkin]
-    [ring/ring-codec]]
-  :dependencies [
-    [cheshire "5.8.1"]
-    [clj-http "2.3.0"]
-    [clj-time "0.15.1"]
-    [clj-xml-validation "1.0.2"]
-    [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-    [com.google.code.findbugs/jsr305 "3.0.2"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-bootstrap-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-ingest-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpclient "4.5.6"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.logging "0.4.0"]
-    [org.clojure/tools.reader "1.3.2"]
-    [potemkin "0.4.5"]
-    [prismatic/schema "1.1.9"]
-    [ring/ring-codec "1.1.1"]
-    [ring/ring-core "1.7.1"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[cheshire]
+               [clj-time]
+               [com.fasterxml.jackson.core/jackson-core]
+               [com.google.code.findbugs/jsr305]
+               [commons-codec/commons-codec]
+               [commons-io]
+               [org.apache.httpcomponents/httpclient]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/tools.logging]
+               [org.clojure/tools.reader]
+               [potemkin]
+               [ring/ring-codec]]
+  :dependencies [[cheshire "5.8.1"]
+                 [clj-http "2.3.0"]
+                 [clj-time "0.15.1"]
+                 [clj-xml-validation "1.0.2"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.8"]
+                 [com.google.code.findbugs/jsr305 "3.0.2"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-bootstrap-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-ingest-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpclient "4.5.6"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/tools.reader "1.3.2"]
+                 [potemkin "0.4.5"]
+                 [prismatic/schema "1.1.9"]
+                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-core "1.7.1"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"
-        :properties-file "resources/security/dependencycheck.properties"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]
-      :jvm-opts ^:replace ["-server"
-                           "-XX:-OmitStackTraceInFastThrow"]
-      :source-paths ["src" "dev"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"
+                                           :properties-file "resources/security/dependencycheck.properties"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]
+                   :jvm-opts ^:replace ["-server"
+                                        "-XX:-OmitStackTraceInFastThrow"]
+                   :source-paths ["src" "dev"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -1,11 +1,12 @@
 (ns cmr.system-int-test.utils.url-helper
   "helper to provide the urls to various service endpoints"
-  (:require [clojure.string :as str]
-            [cmr.common.config :as config]
-            [cmr.transmit.config :as transmit-config]
-            [cmr.elastic-utils.config :as es-config]
-            [ring.util.codec :as codec])
-  (:import java.net.URL))
+  (:require
+   [clojure.string :as str]
+   [cmr.common.config :as config]
+   [cmr.elastic-utils.config :as es-config]
+   [cmr.transmit.config :as transmit-config]
+   [ring.util.codec :as codec])
+  (:import (java.net URL)))
 
 (def search-public-protocol "http")
 (def search-public-host "localhost")

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -2,59 +2,47 @@
   :description "The Transmit Library is responsible for defining the common transmit
                 libraries that invoke services within the CMR projects."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/transmit-lib"
-    :exclusions [
-    [commons-codec/commons-codec]
-    [commons-io]
-    [org.apache.httpcomponents/httpcore]
-    [potemkin]]
-  :dependencies [
-    [clj-http "2.3.0"]
-    [commons-codec/commons-codec "1.11"]
-    [commons-io "2.6"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/data.csv "0.1.4"]
-    [potemkin "0.4.5"]
-    [prismatic/schema "1.1.9"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+    :exclusions [[commons-codec/commons-codec]
+                 [commons-io]
+                 [org.apache.httpcomponents/httpcore]
+                 [potemkin]]
+  :dependencies [[clj-http "2.3.0"]
+                 [commons-codec/commons-codec "1.11"]
+                 [commons-io "2.6"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/data.csv "0.1.4"]
+                 [potemkin "0.4.5"]
+                 [prismatic/schema "1.1.9"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test"]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test"]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -11,10 +11,11 @@
   with those that are defined here, but instances such as that are simply
   where there are values which are the same in both and not expected to change
   between public and private communications."
-  (:require [cmr.common.config :as cfg :refer [defconfig]]
-            [cmr.common.util :as util]
-            [cmr.transmit.connection :as conn]
-            [camel-snake-kebab.core :as csk]))
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.util :as util]
+   [cmr.transmit.connection :as conn]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants for help in testing.

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -87,7 +87,7 @@
 (def-app-conn-config metadata-db {:port 3001})
 ;; CMR open search is 3010
 (def-app-conn-config search {:port 3003})
-(def-app-conn-config urs {:port 3008, :relative-root-url "/urs"})
+(def-app-conn-config urs {:port 3008})
 (def-app-conn-config virtual-product {:port 3009})
 
 (defconfig urs-username

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -1,12 +1,13 @@
 (ns cmr.transmit.urs
-  (:require [cmr.transmit.connection :as conn]
-            [cmr.transmit.config :as config]
-            [ring.util.codec :as codec]
-            [cmr.common.mime-types :as mt]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.xml :as cx]
-            [clojure.data.xml :as x]
-            [cmr.transmit.http-helper :as h]))
+  (:require
+   [clojure.data.xml :as x]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.xml :as cx]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]
+   [cmr.transmit.http-helper :as h]
+   [ring.util.codec :as codec]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -109,8 +110,3 @@
  (login context "notexist" "foopass")
  (login context "notexist" "")
  (login context "notexist" nil))
-
-
-
-
-

--- a/umm-lib/project.clj
+++ b/umm-lib/project.clj
@@ -3,68 +3,56 @@
                model for Metadata Concepts in the CMR along with code to parse and generate the
                various dialects of each concept."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/umm-lib"
-  :exclusions [
-    [org.clojure/clojure]
-    [org.clojure/tools.reader]]
-  :dependencies [
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[org.clojure/clojure]
+               [org.clojure/tools.reader]]
+  :dependencies [[nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [criterium "0.4.4"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      :jvm-opts ^:replace ["-server"]
-                           ;; Uncomment this to enable assertions. Turn off during performance tests.
-                           ; "-ea"
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[criterium "0.4.4"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   :jvm-opts ^:replace ["-server"]
+                   ;; Uncomment this to enable assertions. Turn off during performance tests.
+                   ; "-ea"
 
-                           ;; Use the following to enable JMX profiling with visualvm
-                           ;; "-Dcom.sun.management.jmxremote"
-                           ;; "-Dcom.sun.management.jmxremote.ssl=false"
-                           ;; "-Dcom.sun.management.jmxremote.authenticate=false"
-                           ;; "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev" "test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+                   ;; Use the following to enable JMX profiling with visualvm
+                   ;; "-Dcom.sun.management.jmxremote"
+                   ;; "-Dcom.sun.management.jmxremote.ssl=false"
+                   ;; "-Dcom.sun.management.jmxremote.authenticate=false"
+                   ;; "-Dcom.sun.management.jmxremote.port=1098"]
+                   :source-paths ["src" "dev" "test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]
             ;; Linting aliases

--- a/umm-spec-lib/project.clj
+++ b/umm-spec-lib/project.clj
@@ -1,73 +1,61 @@
 (defproject nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"
   :description "Defines the Unified Metadata Model and mappings from various metadata standards into UMM."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/umm-spec-lib"
-  :exclusions [
-    [commons-io]
-    [org.apache.httpcomponents/httpcore]
-    [org.clojure/clojure]
-    [org.clojure/tools.reader]]
-  :dependencies [
-    [commons-io "2.6"]
-    [commons-validator/commons-validator "1.5.1"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [org.apache.httpcomponents/httpcore "4.4.10"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.reader "1.3.2"]]
-  :plugins [
-    [lein-exec "0.3.7"]
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-io]
+               [org.apache.httpcomponents/httpcore]
+               [org.clojure/clojure]
+               [org.clojure/tools.reader]]
+  :dependencies [[commons-io "2.6"]
+                 [commons-validator/commons-validator "1.5.1"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [org.apache.httpcomponents/httpcore "4.4.10"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.reader "1.3.2"]]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :exclusions [
-        [org.clojure/tools.nrepl]]
-      :dependencies [
-        [clj-http "2.3.0"]
-        [criterium "0.4.4"]
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [org.clojure/tools.nrepl "0.2.13"]
-        [pjstadig/humane-test-output "0.9.0"]
-        [proto-repl "0.3.1"]]
-      ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
-      ;; See https://github.com/technomancy/leiningen/wiki/Faster
-      :jvm-opts ^:replace ["-server"]
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:exclusions [[org.clojure/tools.nrepl]]
+                   :dependencies [[clj-http "2.3.0"]
+                                  [criterium "0.4.4"]
+                                  [org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [pjstadig/humane-test-output "0.9.0"]
+                                  [proto-repl "0.3.1"]]
+                   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
+                   ;; See https://github.com/technomancy/leiningen/wiki/Faster
+                   :jvm-opts ^:replace ["-server"]
       ;                      ;; Use the following to enable JMX profiling with visualvm
       ;                      "-Dcom.sun.management.jmxremote"
       ;                      "-Dcom.sun.management.jmxremote.ssl=false"
       ;                      "-Dcom.sun.management.jmxremote.authenticate=false"
       ;                      "-Dcom.sun.management.jmxremote.port=1098"]
-      :source-paths ["src" "dev" "test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+                   :source-paths ["src" "dev" "test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {"generate-umm-records" ["exec" "-ep" "(do (use 'cmr.umm-spec.record-generator) (generate-umm-records))"]
             ;; Alias to test2junit for consistency with lein-test-out
             "test-out" ["test2junit"]

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -1,63 +1,51 @@
 (defproject nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"
   :description "Adds virtual products to the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/virtual-product-app"
-  :exclusions [
-    [commons-logging]]
-  :dependencies [
-    [commons-logging "1.2"]
-    [compojure "1.6.1"]
-    [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
-    [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-    [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
-    [org.clojure/clojure "1.10.0"]
-    [org.clojure/tools.nrepl "0.2.13"]
-    [ring/ring-core "1.7.1"]
-    [ring/ring-json "0.4.0"]]
-  :plugins [
-    [lein-shell "0.5.0"]
-    [test2junit "1.3.3"]]
+  :exclusions [[commons-logging]]
+  :dependencies [[commons-logging "1.2"]
+                 [compojure "1.6.1"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
+                 [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-json "0.4.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :repl-options {:init-ns user}
   :test-paths ["test" "int-test"]
-  :profiles {
-    :security {
-      :plugins [
-        [com.livingsocial/lein-dependency-check "1.1.1"]]
-      :dependency-check {
-        :output-format [:all]
-        :suppression-file "resources/security/suppression.xml"}}
-    :dev {
-      :dependencies [
-        [org.clojars.gjahad/debug-repl "0.3.3"]
-        [org.clojure/tools.namespace "0.2.11"]
-        [pjstadig/humane-test-output "0.9.0"]]
-      :jvm-opts ^:replace ["-server"]
-      :source-paths ["src" "dev" "test" "int-test"]
-      :injections [(require 'pjstadig.humane-test-output)
-                   (pjstadig.humane-test-output/activate!)]}
-    :uberjar {
-      :main cmr.virtual-product.runner
-      :aot :all}
-    :static {}
-    ;; This profile is used for linting and static analysis. To run for this
-    ;; project, use `lein lint` from inside the project directory. To run for
-    ;; all projects at the same time, use the same command but from the top-
-    ;; level directory.
-    :lint {
-      :source-paths ^:replace ["src"]
-      :test-paths ^:replace []
-      :plugins [
-        [jonase/eastwood "0.2.5"]
-        [lein-ancient "0.6.15"]
-        [lein-bikeshed "0.5.0"]
-        [lein-kibit "0.1.6"]
-        [venantius/yagni "0.1.4"]]}
-    ;; The following profile is overriden on the build server or in the user's
-    ;; ~/.lein/profiles.clj file.
-    :internal-repos {}}
+  :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+                        :dependency-check {:output-format [:all]
+                                           :suppression-file "resources/security/suppression.xml"}}
+             :dev {:dependencies [[org.clojars.gjahad/debug-repl "0.3.3"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [pjstadig/humane-test-output "0.9.0"]]
+                   :jvm-opts ^:replace ["-server"]
+                   :source-paths ["src" "dev" "test" "int-test"]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]}
+             :uberjar {:main cmr.virtual-product.runner
+                       :aot :all}
+             :static {}
+             ;; This profile is used for linting and static analysis. To run for this
+             ;; project, use `lein lint` from inside the project directory. To run for
+             ;; all projects at the same time, use the same command but from the top-
+             ;; level directory.
+             :lint {:source-paths ^:replace ["src"]
+                    :test-paths ^:replace []
+                    :plugins [[jonase/eastwood "0.2.5"]
+                              [lein-ancient "0.6.15"]
+                              [lein-bikeshed "0.5.0"]
+                              [lein-kibit "0.1.6"]
+                              [venantius/yagni "0.1.4"]]}
+             ;; The following profile is overriden on the build server or in the user's
+             ;; ~/.lein/profiles.clj file.
+             :internal-repos {}}
   :aliases {;; Prints out documentation on configuration environment variables.
             "env-config-docs" ["exec" "-ep" "(do (use 'cmr.common.config) (print-all-configs-docs) (shutdown-agents))"]
             ;; Alias to test2junit for consistency with lein-test-out


### PR DESCRIPTION
The first commit has the change to change the default from "/urs" to "". The second commit is a refactor of the project.clj files to be indented as Clojure code.

![](https://media3.giphy.com/media/q7UMby9U8hW3C/giphy.gif?cid=6104955e5c59cbe96f3672665979d691)