### PR TITLE
CMR-5489: Fixed SES compression rate retrieval for Var1.4

### DIFF
--- a/cmr-exchange/metadata-proxy/project.clj
+++ b/cmr-exchange/metadata-proxy/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.1-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.2-SNAPSHOT"
   :description ~(str "A library that provides convenience functions for "
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")
@@ -24,8 +24,8 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[cheshire "5.8.1"]
                  [clojusc/trifl "0.4.2"]
-                 [clojusc/twig "0.4.0"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [clojusc/twig "0.4.1"]
+                 [com.stuartsierra/component "0.4.0"]
                  [environ "1.1.0"]
                  [gov.nasa.earthdata/cmr-authz "0.1.1"]
                  [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
@@ -35,14 +35,14 @@
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.490"]
-                 [org.clojure/core.cache "0.7.1"]]
+                 [org.clojure/core.cache "0.7.2"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
   :profiles {:ubercompile {:aot :all
                            :source-paths ["test"]}
-             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]
                         :dependency-check {:output-format [:all]
                                            :suppression-file "resources/security/suppression.xml"}
                         :source-paths ^:replace ["src"]
@@ -55,7 +55,7 @@
                         :dependencies [;; The following pull required deps that have been either been
                                        ;; explicitly or implicitly excluded above due to CVEs and need
                                        ;; declare secure versions of the libs pulled in
-                                       [commons-fileupload "1.3.3"]
+                                       [commons-fileupload "1.4"]
                                        [commons-io "2.6"]]}
              :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
              :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
@@ -71,7 +71,7 @@
                                   :init ~(println (get-banner))}}
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.3.4"]
+                    :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
                               [lein-kibit "0.1.6"]

--- a/cmr-exchange/metadata-proxy/src/cmr/metadata/proxy/concepts/variable.clj
+++ b/cmr-exchange/metadata-proxy/src/cmr/metadata/proxy/concepts/variable.clj
@@ -16,7 +16,7 @@
 ;; XXX We can pull this from configuration once async-get-metadata function
 ;;     signatures get updated to accept the system data structure as an arg.
 (def variables-api-path "/variables")
-(def pinned-variable-schema-version "1.3")
+(def pinned-variable-schema-version "1.4")
 (def results-content-type "application/vnd.nasa.cmr.umm_results+json")
 (def charset "charset=utf-8")
 (def accept-format "%s; version=%s; %s")

--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -15,28 +15,28 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.1-SNAPSHOT"
   :description "A CMR services plugin that performs URL translations for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-ous-plugin"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[cheshire "5.8.1"]
                  [clojusc/trifl "0.4.2"]
-                 [clojusc/twig "0.4.0"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [clojusc/twig "0.4.1"]
+                 [com.stuartsierra/component "0.4.0"]
                  [environ "1.1.0"]
                  [gov.nasa.earthdata/cmr-authz "0.1.1"]
                  [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.490"]
-                 [org.clojure/core.cache "0.7.1"]
+                 [org.clojure/core.cache "0.7.2"]
                  [org.clojure/data.xml "0.2.0-alpha5"]
                  [org.clojure/java.classpath "0.3.0"]
                  [ring/ring-core "1.7.1"]
@@ -47,7 +47,7 @@
   :aot [clojure.tools.logging.impl]
   :profiles {:ubercompile {:aot :all
                            :source-paths ["test"]}
-             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]
                         :dependency-check {:output-format [:all]
                                            :suppression-file "resources/security/suppression.xml"}
                         :source-paths ^:replace ["src"]
@@ -71,11 +71,11 @@
                                   :init ~(println (get-banner))}}
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.3.3"]
+                    :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
                               [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.6"]]}
+                              [venantius/yagni "0.1.7"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]

--- a/cmr-exchange/ous-plugin/src/cmr/ous/config.clj
+++ b/cmr-exchange/ous-plugin/src/cmr/ous/config.clj
@@ -19,6 +19,4 @@
 
 (defn data
   []
-  (util/deep-merge (base-data)
-                   (config/props-data)
-                   (config/env-data)))
+  (util/deep-merge (base-data)))

--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -15,14 +15,14 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.1-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.2-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[cheshire "5.8.1"]
                  [clojusc/trifl "0.4.2"]
-                 [clojusc/twig "0.4.0"]
+                 [clojusc/twig "0.4.1"]
                  [com.stuartsierra/component "0.4.0"]
                  [environ "1.1.0"]
                  [gov.nasa.earthdata/cmr-authz "0.1.1"]
@@ -30,15 +30,15 @@
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-                 [gov.nasa.earthdata/cmr-sizing-plugin "0.2.5-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.2.6-SNAPSHOT"]
                  [http-kit "2.3.0"]
-                 [markdown-clj "1.0.6"]
-                 [metosin/reitit-core "0.2.10"]
-                 [metosin/reitit-ring "0.2.10"]
+                 [markdown-clj "1.0.7"]
+                 [metosin/reitit-core "0.2.13"]
+                 [metosin/reitit-ring "0.2.13"]
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
@@ -48,7 +48,7 @@
                  [ring/ring-core "1.7.1"]
                  [ring/ring-codec "1.1.1"]
                  [ring/ring-defaults "0.3.2"]
-                 [selmer "1.12.5"]
+                 [selmer "1.12.6"]
                  [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
@@ -58,7 +58,7 @@
         cmr.opendap.core]
   :profiles {:ubercompile {:aot :all
                            :source-paths ["test"]}
-             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]
                         :dependency-check {:output-format [:all]
                                            :suppression-file "resources/security/suppression.xml"}
                         :source-paths ^:replace ["src"]
@@ -83,7 +83,7 @@
                                   :init ~(println (get-banner))}}
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.3.4"]
+                    :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
                               [lein-kibit "0.1.6"]

--- a/cmr-exchange/service-bridge/src/cmr/opendap/config.clj
+++ b/cmr-exchange/service-bridge/src/cmr/opendap/config.clj
@@ -19,6 +19,4 @@
 
 (defn data
   []
-  (util/deep-merge (base-data)
-                   (config/props-data)
-                   (config/env-data)))
+  (util/deep-merge (base-data)))

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.5-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.6-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -25,8 +25,8 @@
                  [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.2-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [org.clojure/clojure "1.10.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}
@@ -36,7 +36,7 @@
   :aot [clojure.tools.logging.impl]
   :profiles {:ubercompile {:aot :all
                            :source-paths ["test"]}
-             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.1"]]
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]
                         :dependency-check {:output-format [:all]
                                            :suppression-file "resources/security/suppression.xml"}
                         :source-paths ^:replace ["src"]
@@ -52,14 +52,14 @@
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[clojusc/trifl "0.4.2"]
-                                  [clojusc/twig "0.4.0"]
+                                  [clojusc/twig "0.4.1"]
                                   [debugger "0.2.1"]]
                    :repl-options {:init-ns cmr.sizing.dev
                                   :prompt ~get-prompt
                                   :init ~(println (get-banner))}}
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.3.4"]
+                    :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
                               [lein-kibit "0.1.6"]

--- a/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
+++ b/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
@@ -44,11 +44,18 @@
       (get-in [:umm :SizeEstimation :AverageSizeOfGranulesSampled])
       read-number))
 
+(defn- get-netcdf4-rate
+  "Gets the :Rate value for :NetCDF-4 format in avg-comp-info."
+  [avg-comp-info]
+  (some #(when (= "NetCDF-4" (:Format %)) (:Rate %)) avg-comp-info))  
+
 (defn- get-avg-compression-rate-netcdf4
-  "Gets SizeEstimation value for AvgCompressionRateNetCDF4 and parses it to a number."
+  "Gets :Rate value for NetCDF-4 format in :SizeEstimation of variable 
+  and parses it to a number."
   [variable]
   (-> variable
-      (get-in [:umm :SizeEstimation :AvgCompressionRateNetCDF4])
+      (get-in [:umm :SizeEstimation :AverageCompressionInformation])
+      get-netcdf4-rate
       read-number))
 
 (defn- get-avg-digit-number

--- a/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
+++ b/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
@@ -7,6 +7,9 @@
 ;;; Note that all internal operations for estimating size are performed
 ;;; assuming bytes as the units.
 
+(def NetCDF-4
+  "NetCDF-4")
+
 (defn- read-number
   "If value is string, read-string.  Otherwise ignore."
   [value]
@@ -47,7 +50,7 @@
 (defn- get-netcdf4-rate
   "Gets the :Rate value for :NetCDF-4 format in avg-comp-info."
   [avg-comp-info]
-  (some #(when (= "NetCDF-4" (:Format %)) (:Rate %)) avg-comp-info))  
+  (some #(when (= NetCDF-4 (:Format %)) (:Rate %)) avg-comp-info))  
 
 (defn- get-avg-compression-rate-netcdf4
   "Gets :Rate value for NetCDF-4 format in :SizeEstimation of variable 


### PR DESCRIPTION
This ticket only addresses the existing compression formats: ASCII and NetCDF-4.  Since we don't use compression rate for ASCII estimate anymore, it only affects NetCDF-4.