### PR TITLE
CMR-5497: Fix mock-echo URS endpoint so that calls to create users work if the URS_RELATIVE_ROOT_URL is empty or /urs

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -23,7 +23,6 @@
   [context provider-guid-id-map]
   (echo-client/create-providers context provider-guid-id-map))
 
-
 (defn get-or-create-group
   "Gets a group or creates it if it does not exist"
   ([context group-name]
@@ -34,7 +33,7 @@
                                {:raw? true :token token})
                             (get-in [:body :items])
                             (first))
-         ;;Return the existing group if it exists, otherwise create a new one
+         ;; Return the existing group if it exists, otherwise create a new one
          group (or existing-group (:body (ac/create-group context
                                           {:name group-name
                                            :description group-name}

--- a/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
@@ -7,13 +7,18 @@
    [cmr.common.services.errors :as errors]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]))
+   [cmr.transmit.http-helper :as h]
+   [clojure.string :as string]))
 
 (defn- create-users-url
-  "Call to create users in mock URS. Makes an assumption that the URS root context in the
-  connection is an empty string."
+  "Call to create users in mock URS. Depending on how tests are being run the context for URS URLs
+  might or might not have /urs as the relative root URL. We'll make sure we use the correct URL here
+  in all circumstances."
   [conn]
-  (format "%s/urs/users" (conn/root-url conn)))
+  (let [base-url (conn/root-url conn)]
+    (if (string/includes? base-url "urs")
+      (format "%s/users" base-url)
+      (format "%s/urs/users" base-url))))
 
 (defn create-users
   "Creates the users in mock urs given an array of maps with :username and :password"

--- a/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/mock_urs_client.clj
@@ -3,12 +3,12 @@
   operations"
   (:require
    [cheshire.core :as json]
+   [clojure.string :as string]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]
-   [clojure.string :as string]))
+   [cmr.transmit.http-helper :as h]))
 
 (defn- create-users-url
   "Call to create users in mock URS. Depending on how tests are being run the context for URS URLs


### PR DESCRIPTION
![](https://media1.giphy.com/media/GIEXgLDfghUSQ/giphy-tumblr.gif?cid=6104955e5c5da8ac316f4a363208051d)