### PR TITLE
The ISO 19115-2 MENDS metadata is not correctly generating the ShortName identifier section.

### DIFF
--- a/umm-spec-lib/resources/example-data/iso19115/artificial_test_data_2.xml
+++ b/umm-spec-lib/resources/example-data/iso19115/artificial_test_data_2.xml
@@ -212,9 +212,12 @@ Main NCEI website providing links to access data and data services.
                             <gmd:code>
                                 <gco:CharacterString>SPL1CS0</gco:CharacterString>
                             </gmd:code>
-                            <gmd:version>
-                                <gco:CharacterString>001</gco:CharacterString>
-                            </gmd:version>
+                            <gmd:codeSpace>
+                                <gco:CharacterString>gov.nasa.esdis.umm.shortname</gco:CharacterString>
+                            </gmd:codeSpace>
+                            <gmd:description>
+                                <gco:CharacterString>Short Name</gco:CharacterString>
+                            </gmd:description>
                         </gmd:MD_Identifier>
                     </gmd:identifier>
                 </gmd:CI_Citation>

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/iso19115_2.clj
@@ -296,7 +296,8 @@
             [:gmd:identifier
               [:gmd:MD_Identifier
                 [:gmd:code (char-string (:ShortName c))]
-                [:gmd:version (char-string (:Version c))]]]
+                [:gmd:codeSpace (char-string "gov.nasa.esdis.umm.shortname")]
+                [:gmd:description (char-string "Short Name")]]]
             (generate-doi c)
             (when-let [collection-data-type (:CollectionDataType c)]
               [:gmd:identifier


### PR DESCRIPTION
The ISO 19115-2 MENDS metadata is not correctly generating the ShortName identifier section.
The generated output generates the following:
{noformat}
                            <gmd:identifier>
                                <gmd:MD_Identifier>
                                    <gmd:code>
                                    <gco:CharacterString>AIRX3STD</gco:CharacterString>
                                    </gmd:code>
                                    <gmd:version>
                                    <gco:CharacterString>006</gco:CharacterString>
                                    </gmd:version>
                                </gmd:MD_Identifier>
                            </gmd:identifier>

{noformat}
But 
{noformat}
                                    <gmd:version>
                                    <gco:CharacterString>006</gco:CharacterString>
                                    </gmd:version>
{noformat}
is not valid ISO 19115-2. Instead this section should contain:
{noformat}
                                    <gmd:codeSpace>
                                    <gco:CharacterString>gov.nasa.esdis.umm.shortname</gco:CharacterString>
                                    </gmd:codeSpace>
                                    <gmd:description>
                                    <gco:CharacterString>Short Name</gco:CharacterString>
                                    </gmd:description>

{noformat}