### PR TITLE
CMR-5489: Fixed the service-bridge deployment introduced by CMR-5489

### DIFF
--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.3-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.4-SNAPSHOT"
   :description "A CMR services plugin that performs URL translations for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-ous-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -26,7 +26,7 @@
                  [com.stuartsierra/component "0.4.0"]
                  [environ "1.1.0"]
                  [gov.nasa.earthdata/cmr-authz "0.1.1"]
-                 [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]

--- a/cmr-exchange/ous-plugin/src/cmr/ous/config.clj
+++ b/cmr-exchange/ous-plugin/src/cmr/ous/config.clj
@@ -1,6 +1,7 @@
 (ns cmr.ous.config
   (:require
    [clojure.string :as string]
+   [cmr.exchange.common.config :as common-config]
    [cmr.exchange.common.file :as file]
    [cmr.exchange.common.util :as util]
    [cmr.metadata.proxy.config :as config]
@@ -19,4 +20,6 @@
 
 (defn data
   []
-  (util/deep-merge (base-data)))
+  (util/deep-merge (base-data)
+                   (common-config/props-data)
+                   (common-config/env-data)))

--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.5-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.6-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
   :license {:name "Apache License, Version 2.0"
@@ -26,15 +26,15 @@
                  [com.stuartsierra/component "0.4.0"]
                  [environ "1.1.0"]
                  [gov.nasa.earthdata/cmr-authz "0.1.1"]
-                 [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
                  [gov.nasa.earthdata/cmr-metadata-proxy "0.2.4-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.3-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.4-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-                 [gov.nasa.earthdata/cmr-sizing-plugin "0.2.9-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.0-SNAPSHOT"]
                  [http-kit "2.3.0"]
                  [markdown-clj "1.0.7"]
                  [metosin/reitit-core "0.2.13"]

--- a/cmr-exchange/service-bridge/src/cmr/opendap/config.clj
+++ b/cmr-exchange/service-bridge/src/cmr/opendap/config.clj
@@ -1,6 +1,7 @@
 (ns cmr.opendap.config
   (:require
    [clojure.string :as string]
+   [cmr.exchange.common.config :as common-config]
    [cmr.exchange.common.file :as file]
    [cmr.exchange.common.util :as util]
    [cmr.metadata.proxy.config :as config]
@@ -19,4 +20,6 @@
 
 (defn data
   []
-  (util/deep-merge (base-data)))
+  (util/deep-merge (base-data)
+                   (common-config/props-data)
+                   (common-config/env-data)))

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -15,18 +15,18 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.2.9-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.0-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :exclusions [gov.nasa.earthdata/cmr-http-kit]
   :dependencies [[gov.nasa.earthdata/cmr-authz "0.1.1"]
-                 [gov.nasa.earthdata/cmr-exchange-common "0.3.0-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-metadata-proxy "0.2.4-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.3-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.4-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [org.clojure/clojure "1.10.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}


### PR DESCRIPTION
1. The deployment to SIT failed because the code could not take the value from environment variable
CMR_SERVICE_BRIDGE_PORT, and was listening on the default port 3013.
2. When service-bridge was brought under cmr repo, metadata-proxy was at 0.2.1-SNAPSHOT.  This version removed the part that gets the env setting from the config.clj and moved it to exchange-common. Both this metadata-proxy version and the exchange-common version were not used by ous and service-bridge. They were still referencing the old clojars so it was deployed successfully.
3. CMR-5489 needed to create a new metadata-proxy snapshot to account for the new UMM-Var version, now both ous and service-bridge had to bump from metadata proxy snapshot of 0.2.0 to 0.2.2. 
Since 0.2.1 removed the env setting in the config.clj, I removed the part that's referencing it from the ous and service-bridge configs.
4. After looking at the code in the original repos, that part of the missing code is recovered.