### PR TITLE
CMR-5433: As a SWOT user I want to search for granules based on the spatial extent string values of cycle, pass, and tile.

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/params.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/params.clj
@@ -100,6 +100,13 @@
   [_context concept-type param value options]
   (string-parameter->condition concept-type param value options))
 
+(defmethod parameter->condition :int
+  [_context concept-type param value options]
+  (if (sequential? value)
+    (gc/group-conds (group-operation param options)
+                    (map #(qm/numeric-value-condition param %) value))
+    (qm/numeric-value-condition param value)))
+
 ;; or-conds --> "not (CondA and CondB)" == "(not CondA) or (not CondB)"
 (defmethod parameter->condition :exclude
   [context concept-type param value options]

--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -13,6 +13,7 @@
    [cmr.indexer.data.concepts.attribute :as attrib]
    [cmr.indexer.data.concepts.orbit-calculated-spatial-domain :as ocsd]
    [cmr.indexer.data.concepts.spatial :as spatial]
+   [cmr.indexer.data.concepts.track :as track]
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.transmit.metadata-db :as mdb]
    [cmr.umm-spec.umm-spec-core :as umm-spec]
@@ -139,8 +140,10 @@
         browsable (not (empty? (ru/browse-urls related-urls)))
         update-time (get-in umm-granule [:data-provider-timestamps :update-time])
         update-time (index-util/date->elastic update-time)
+        track (get-in umm-granule [:spatial-coverage :track])
         {:keys [ShortName Version EntryTitle]} parent-collection
-        granule-spatial-representation (get-in parent-collection [:SpatialExtent :GranuleSpatialRepresentation])]
+        granule-spatial-representation (get-in parent-collection
+                                               [:SpatialExtent :GranuleSpatialRepresentation])]
     (merge {:concept-id concept-id
             :revision-id revision-id
             :concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))
@@ -231,7 +234,9 @@
             :start-coordinate-2-doc-values start-coordinate-2
             :end-coordinate-2-doc-values end-coordinate-2
             :atom-links atom-links
-            :orbit-calculated-spatial-domains-json ocsd-json}
+            :orbit-calculated-spatial-domains-json ocsd-json
+            :cycle (:cycle track)
+            :passes (track/passes->elastic-docs track)}
            (spatial->elastic parent-collection umm-granule))))
 
 (defmethod es/parsed-concept->elastic-doc :granule

--- a/indexer-app/src/cmr/indexer/data/concepts/track.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/track.clj
@@ -1,0 +1,25 @@
+(ns cmr.indexer.data.concepts.track
+  "Contains functions for converting track passes into elastic documents")
+
+(defn- tile->indexed-tiles
+  "Converts a pass track tile into tiles for indexing.
+  Track pass tile can be a Left, Right or Full tile, we index Full tile as both Left and
+  Right tiles, so we can find it by searching with either Left or Right tile.
+  e.g. 2F will be indexed as [2F 2L 2R]"
+  [tile]
+  (if-let [[_ tile-num] (re-matches #"(\d+)F" tile)]
+    [(str tile-num "F") (str tile-num "L") (str tile-num "R")]
+    [tile]))
+
+(defn- pass->elastic-doc
+  "Converts a track pass into the portion going in an elastic document"
+  [track-pass]
+  (let [{:keys [pass tiles]} track-pass]
+    {:pass pass
+     :tiles (mapcat tile->indexed-tiles tiles)}))
+
+(defn passes->elastic-docs
+  "Converts the track into elastic document of track passes"
+  [track]
+  (when-let [passes (:passes track)]
+    (map pass->elastic-doc passes)))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -211,8 +211,8 @@
 
 (defnestedmapping track-pass-mapping
   "Defines mappings for storing track pass."
-  {:pass m/int-field-mapping
-   :tiles m/string-field-mapping})
+  {:pass (m/doc-values m/int-field-mapping)
+   :tiles (m/doc-values m/string-field-mapping)})
 
 (defnestedmapping prioritized-humanizer-mapping
   "Defines a string value and priority for use in boosting facets."
@@ -619,7 +619,7 @@
      :start-coordinate-2-doc-values (m/doc-values m/double-field-mapping)
      :end-coordinate-2-doc-values (m/doc-values m/double-field-mapping)
 
-     :cycle m/int-field-mapping
+     :cycle (m/doc-values m/int-field-mapping)
      :passes track-pass-mapping
 
      ;; Used for orbit search

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -209,6 +209,11 @@
    :equator-crossing-longitude m/double-field-mapping
    :equator-crossing-date-time m/date-field-mapping})
 
+(defnestedmapping track-pass-mapping
+  "Defines mappings for storing track pass."
+  {:pass m/int-field-mapping
+   :tiles m/string-field-mapping})
+
 (defnestedmapping prioritized-humanizer-mapping
   "Defines a string value and priority for use in boosting facets."
   {:value m/string-field-mapping
@@ -614,6 +619,9 @@
      :start-coordinate-2-doc-values (m/doc-values m/double-field-mapping)
      :end-coordinate-2-doc-values (m/doc-values m/double-field-mapping)
 
+     :cycle m/int-field-mapping
+     :passes track-pass-mapping
+
      ;; Used for orbit search
      :orbit-asc-crossing-lon (m/stored m/double-field-mapping)
      :orbit-asc-crossing-lon-doc-values (-> m/double-field-mapping m/stored m/doc-values)
@@ -663,7 +671,7 @@
    :variable-name (-> m/string-field-mapping m/stored m/doc-values)
    :variable-name.lowercase (m/doc-values m/string-field-mapping)
    :alias (-> m/string-field-mapping m/stored m/doc-values)
-   :alias.lowercase (m/doc-values m/string-field-mapping) 
+   :alias.lowercase (m/doc-values m/string-field-mapping)
    :measurement (-> m/string-field-mapping m/stored m/doc-values)
    :measurement.lowercase (m/doc-values m/string-field-mapping)
    :keyword m/text-field-mapping

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -116,7 +116,9 @@
    :temporal-facet :temporal-facet
    :two-d-coordinate-system :two-d-coordinate-system
    :updated-since :updated-since
-   :version :collection-query})
+   :version :collection-query
+   :cycle :int
+   :passes :passes})
 
 (defmethod common-params/param-mappings :tag
   [_]

--- a/search-app/src/cmr/search/services/parameters/converters/pass.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/pass.clj
@@ -1,0 +1,21 @@
+(ns cmr.search.services.parameters.converters.pass
+  "Contains functions for converting passes query parameters to conditions"
+  (:require
+   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.params :as p]))
+
+;; Converts passes parameter and values into conditions
+(defmethod p/parameter->condition :passes
+  [context concept-type param value options]
+  (let [group-operation (p/group-operation param options :or)]
+
+    (if (map? (first (vals value)))
+      ;; If multiple passes are passed in like the following
+      ;;  -> passes[0][pass]=3&passes[1][pass]=4
+      ;; then this recurses back into this same function to handle each separately
+      (gc/group-conds
+       group-operation
+       (map #(p/parameter->condition context concept-type param % options) (vals value)))
+      ;; Creates the passes condition for a group of passes fields and values.
+      (nf/parse-nested-condition param value true false))))

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -53,7 +53,7 @@
     {:single-value #{:echo-compatible :include-facets}
      :multiple-value #{:granule-ur :short-name :instrument :collection-concept-id
                        :producer-granule-id :project :version :native-id :provider :entry-title
-                       :platform :sensor :feature-id :crid-id}
+                       :platform :sensor :feature-id :crid-id :cycle}
      :always-case-sensitive #{:echo-granule-id}
      :disallow-pattern #{:echo-granule-id}}))
 
@@ -173,6 +173,7 @@
    :attribute exclude-plus-or-option
    :temporal exclude-plus-and-or-option
    :created-at cpv/and-option
+   :passes cpv/and-option
    :revision-date cpv/and-option})
 
 (defmethod cpv/valid-parameter-options :tag

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -67,6 +67,7 @@
     cmr.search.services.parameters.converters.equator-crossing-longitude
     cmr.search.services.parameters.converters.humanizer
     cmr.search.services.parameters.converters.orbit-number
+    cmr.search.services.parameters.converters.pass
     cmr.search.services.parameters.converters.science-keyword
     cmr.search.services.parameters.converters.spatial
     cmr.search.services.parameters.converters.temporal

--- a/system-int-test/resources/index_set_granule_mapping.clj
+++ b/system-int-test/resources/index_set_granule_mapping.clj
@@ -258,4 +258,13 @@
  :project-refs.lowercase {:index "not_analyzed",
                           :type "string"},
  :end-lat {:store "yes", :type "double"},
- :lr-west-doc-values {:doc_values true, :type "float"}}
+ :lr-west-doc-values {:doc_values true, :type "float"}
+ :cycle {:type "integer"},
+ :passes
+ {:properties
+  {:pass {:type "integer"},
+   :tiles {:type "string", :index "not_analyzed"}},
+  :type "nested",
+  :_all {:enabled false},
+  :dynamic "strict",
+  :_source {:enabled false}}}

--- a/system-int-test/resources/index_set_granule_mapping.clj
+++ b/system-int-test/resources/index_set_granule_mapping.clj
@@ -259,11 +259,11 @@
                           :type "string"},
  :end-lat {:store "yes", :type "double"},
  :lr-west-doc-values {:doc_values true, :type "float"}
- :cycle {:type "integer"},
+ :cycle {:type "integer", :doc_values true},
  :passes
  {:properties
-  {:pass {:type "integer"},
-   :tiles {:type "string", :index "not_analyzed"}},
+  {:pass {:type "integer", :doc_values true},
+   :tiles {:type "string", :index "not_analyzed", :doc_values true}},
   :type "nested",
   :_all {:enabled false},
   :dynamic "strict",

--- a/system-int-test/src/cmr/system_int_test/data2/granule.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/granule.clj
@@ -147,8 +147,8 @@
   "Returns the umm-lib granule model Track from the given track param."
   [track]
   (when track
-    (g/map->Track
-     (let [{:keys [cycle passes]} track]
+    (let [{:keys [cycle passes]} track]
+      (g/map->Track
        {:cycle cycle
         :passes (map pass-param->TrackPass passes)}))))
 

--- a/system-int-test/src/cmr/system_int_test/data2/granule.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/granule.clj
@@ -138,10 +138,10 @@
 (defn- pass-param->TrackPass
   "Returns the umm-lib granule model TrackPass from the given pass param."
   [track-pass]
-  (g/map->TrackPass
-     (let [{:keys [pass tiles]} track-pass]
-       {:pass pass
-        :tiles tiles})))
+  (let [{:keys [pass tiles]} track-pass]
+    (g/map->TrackPass
+     {:pass pass
+      :tiles tiles})))
 
 (defn- track-param->Track
   "Returns the umm-lib granule model Track from the given track param."

--- a/system-int-test/src/cmr/system_int_test/data2/granule.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/granule.clj
@@ -1,18 +1,19 @@
 (ns cmr.system-int-test.data2.granule
   "Contains data generators for example based testing in system integration tests."
-  (:require [cmr.umm.umm-granule :as g]
-            [cmr.umm.umm-collection :as c]
-            [cmr.umm.granule.temporal :as gt]
-            [cmr.system-int-test.data2.core :as d]
-            [cmr.system-int-test.data2.collection :as dc]
-            [cmr.common.date-time-parser :as p]
-            [cmr.umm.umm-spatial :as umm-s]
-            [cmr.common.util :as util]
-            [cmr.umm.collection.entry-id :as eid]
-            [cmr.spatial.orbits.swath-geometry :as swath])
-  (:import [cmr.umm.umm_granule
-            Orbit
-            DataProviderTimestamps]))
+  (:require
+   [cmr.common.date-time-parser :as p]
+   [cmr.common.util :as util]
+   [cmr.spatial.mbr :as m]
+   [cmr.spatial.orbits.swath-geometry :as swath]
+   [cmr.system-int-test.data2.collection :as dc]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.umm.collection.entry-id :as eid]
+   [cmr.umm.granule.temporal :as gt]
+   [cmr.umm.umm-collection :as c]
+   [cmr.umm.umm-granule :as g]
+   [cmr.umm.umm-spatial :as umm-s])
+  (:import
+   [cmr.umm.umm_granule Orbit DataProviderTimestamps]))
 
 (defn related-url
   "Creates related url for online_only test"
@@ -133,6 +134,33 @@
 (defmethod spatial :geometry
   [& geometries]
   (g/map->SpatialCoverage {:geometries geometries}))
+
+(defn- pass-param->TrackPass
+  "Returns the umm-lib granule model TrackPass from the given pass param."
+  [track-pass]
+  (g/map->TrackPass
+     (let [{:keys [pass tiles]} track-pass]
+       {:pass pass
+        :tiles tiles})))
+
+(defn- track-param->Track
+  "Returns the umm-lib granule model Track from the given track param."
+  [track]
+  (when track
+    (g/map->Track
+     (let [{:keys [cycle passes]} track]
+       {:cycle cycle
+        :passes (map pass-param->TrackPass passes)}))))
+
+(defn spatial-with-track
+  "This is a helper function returns a spatial coverage of granule with track information.
+  This function is used only to construct various track for searching granules by track tests.
+  The given track is in the format of: e.g.
+  {:cycle 1
+   :passes [{:pass 3 :tiles [\"2F\" \"3R\"]}]}"
+  [track]
+  (g/map->SpatialCoverage {:geometries [(m/mbr -180 90 180 -90)]
+                           :track (track-param->Track track)}))
 
 (defn granule->orbit-shapes
   "This is a helper for creating the expected spatial for a granule that has orbit data that could be

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_by_track_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_by_track_test.clj
@@ -16,9 +16,10 @@
 (defn- ingest-granule-with-track
   "ingest a generated granule on the given provider, parent collection and track info"
   [provider-id coll track]
-  (d/ingest provider-id (dg/granule-with-umm-spec-collection
-                         coll (:concept-id coll)
-                         {:spatial-coverage (dg/spatial-with-track track)})
+  (d/ingest provider-id
+            (dg/granule-with-umm-spec-collection
+             coll (:concept-id coll)
+             {:spatial-coverage (dg/spatial-with-track track)})
             {:format :umm-json}))
 
 (deftest search-by-track

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_by_track_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_by_track_test.clj
@@ -1,0 +1,265 @@
+(ns cmr.system-int-test.search.granule-search-by-track-test
+  "Search CMR granules by track info, i.e. cycle, pass, tile."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.common.util :as util :refer [are3]]
+    [cmr.system-int-test.data2.core :as d]
+    [cmr.system-int-test.data2.granule :as dg]
+    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
+    [cmr.system-int-test.utils.index-util :as index]
+    [cmr.system-int-test.utils.ingest-util :as ingest]
+    [cmr.system-int-test.utils.search-util :as search]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}))
+
+(defn- ingest-granule-with-track
+  "ingest a generated granule on the given provider, parent collection and track info"
+  [provider-id coll track]
+  (d/ingest provider-id (dg/granule-with-umm-spec-collection
+                         coll (:concept-id coll)
+                         {:spatial-coverage (dg/spatial-with-track track)})
+            {:format :umm-json}))
+
+(deftest search-by-track
+  (let [coll1 (d/ingest-umm-spec-collection
+               "PROV1" (data-umm-c/collection
+                        {:SpatialExtent (data-umm-cmn/spatial {:gsr "GEODETIC"})
+                         :EntryTitle "E1"
+                         :ShortName "S1"}))
+        coll2 (d/ingest-umm-spec-collection
+               "PROV2" (data-umm-c/collection
+                        {:SpatialExtent (data-umm-cmn/spatial {:gsr "GEODETIC"})
+                         :EntryTitle "E2"
+                         :ShortName "S2"}))
+        coll1-concept-id (:concept-id coll1)
+        coll2-concept-id (:concept-id coll2)
+        gran1 (ingest-granule-with-track "PROV1" coll1
+                                         {:cycle 1
+                                          :passes [{:pass 1}]})
+        gran2 (ingest-granule-with-track "PROV1" coll1
+                                         {:cycle 2
+                                          :passes [{:pass 1}]})
+        gran3 (ingest-granule-with-track "PROV1" coll1
+                                         {:cycle 1
+                                          :passes [{:pass 2}]})
+        ;; granules for testing multiple passes and tiles
+        gran4 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 3
+                                          :passes [{:pass 1 :tiles ["1L"]}]})
+        gran5 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 3
+                                          :passes [{:pass 1 :tiles ["1R"]}
+                                                   {:pass 2 :tiles ["1L"]}]})
+        gran6 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 4
+                                          :passes [{:pass 1 :tiles ["1L"]}]})
+        ;; granules for testing Full track tiles and multiple tiles
+        gran7 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 3
+                                          :passes [{:pass 3 :tiles ["1L"]}
+                                                   {:pass 4 :tiles ["1L"]}]})
+        gran8 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 3
+                                          :passes [{:pass 3 :tiles ["1R"]}
+                                                   {:pass 4 :tiles ["2L"]}]})
+        gran9 (ingest-granule-with-track "PROV2" coll2
+                                         {:cycle 3
+                                          :passes [{:pass 3 :tiles ["1F"]}
+                                                   {:pass 4 :tiles ["2L"]}]})
+
+        gran10 (ingest-granule-with-track "PROV2" coll2
+                                          {:cycle 3
+                                           :passes [{:pass 3 :tiles ["5F" "6R"]}
+                                                    {:pass 4 :tiles ["5L" "6R"]}]})
+        gran11 (ingest-granule-with-track "PROV2" coll2
+                                          {:cycle 3
+                                           :passes [{:pass 3 :tiles ["5R" "6L"]}
+                                                    {:pass 4 :tiles ["5L" "6R" "8F"]}]})]
+    (index/wait-until-indexed)
+
+    (testing "search by cycles"
+      (are3 [items params]
+        (is (d/refs-match? items (search/find-refs :granule params)))
+
+        "search with single cycle"
+        [gran1 gran3] {:cycle 1}
+
+        "search with list of cycle with a single value"
+        [gran1 gran3] {:cycle [1]}
+
+        "search with multiple cycles"
+        [gran1 gran2 gran3] {:cycle [1 2]}
+
+        "search with cycle, no match"
+        [] {:cycle [12]}))
+
+    (testing "search by cycle and passes"
+      (are3 [items params options]
+        (is (d/refs-match? items (search/find-refs :granule (merge params options))))
+
+        "search with cycle and pass"
+        [gran1]
+        {:cycle 1
+         :passes {:0 {:pass 1}}}
+        {}
+
+        "search with cycle and multiple passes, default is OR"
+        [gran4 gran5]
+        {:cycle 3
+         :passes {:0 {:pass 1}
+                  :1 {:pass 2}}}
+        {}
+
+        "search with cycle and multiple passes, options AND"
+        [gran5]
+        {:cycle 3
+         :passes {:0 {:pass 1}
+                  :1 {:pass 2}}}
+        {"options[passes][AND]" "true"}
+
+        "search with cycle and multiple passes, options AND false"
+        [gran4 gran5]
+        {:cycle 3
+         :passes {:0 {:pass 1}
+                  :1 {:pass 2}}}
+        {"options[passes][AND]" "false"}))
+
+    (testing "search by cycle, passes and tiles"
+      (are3 [items params options]
+        (is (d/refs-match? items (search/find-refs :granule (merge params options))))
+
+        "search with cycle, pass and tile"
+        [gran4]
+        {:cycle 3
+         :passes {:0 {:pass 1
+                      :tiles "1L"}}}
+        {}
+
+        "search with cycle, multiple passes and tiles, default OR"
+        [gran4]
+        {:cycle 3
+         :passes {:0 {:pass 1
+                      :tiles "1L"}
+                  :1 {:pass 1
+                      :tiles "99R"}}}
+        {}
+
+        "search with cycle, multiple passes and tiles, options AND, not found"
+        []
+        {:cycle 3
+         :passes {:0 {:pass 1
+                      :tiles "1L"}
+                  :1 {:pass 1
+                      :tiles "99R"}}}
+        {"options[passes][AND]" "true"}
+
+        "search with cycle, multiple passes and tile (with Full track), search with half track"
+        [gran7 gran9]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles "1L"}}}
+        {}
+
+        "search with cycle, multiple passes and tile (with Full track), search with Full track"
+        [gran9]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles "1F"}}}
+        {}
+
+        "search with cycle, multiple passes and tile (with Full track), default OR"
+        [gran7 gran9]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles "1L"}
+                  :1 {:pass 4
+                      :tiles "1L"}}}
+        {}
+
+        "search with cycle, multiple passes and tile (with Full track), options AND"
+        [gran7]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles "1L"}
+                  :1 {:pass 4
+                      :tiles "1L"}}}
+        {"options[passes][AND]" "true"}
+
+        "search with cycle, multiple passes and multiple tiles, default OR"
+        [gran10 gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R" "6L"]}}}
+        {}
+
+        ;; This shows how to AND multiple tiles within a single pass together
+        "search with cycle, multiple passes and multiple tiles AND together"
+        [gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R"]}
+                  :1 {:pass 3
+                      :tiles ["6L"]}}}
+        {"options[passes][AND]" "true"}
+
+        "search with cycle, multiple passes and tiles with comma separated values"
+        [gran10 gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R,6L"]}}}
+        {}
+
+        ;; Note: option AND this way will not acutally ANDed the tiles,
+        ;; You will have to separate the tiles into separate passes then use option AND
+        ;; See tests with multiple tiles AND together for examples.
+        "search with cycle, multiple passes and tiles with comma separated values, options AND"
+        [gran10 gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R,6L"]}}}
+        {"options[passes][AND]" "true"}
+
+        "mixed tile formats"
+        [gran10 gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R"]}
+                  :1 {:pass 4
+                      :tiles ["4F,5L" "8F"]}
+                  :2 {:pass 4
+                      :tiles ["8R"]}}}
+        {}
+
+        "complicated example, default OR"
+        [gran10 gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R"]}
+                  :1 {:pass 4
+                      :tiles ["4F,5L" "8F"]}
+                  :2 {:pass 4
+                      :tiles ["8R"]}}}
+        {}
+
+        "complicated example, options AND"
+        [gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R"]}
+                  :1 {:pass 4
+                      :tiles ["4F,5L" "8F"]}
+                  :2 {:pass 4
+                      :tiles ["8R"]}}}
+        {"options[passes][AND]" "true"}
+
+        "complicated example, options AND, with simplified tiles value"
+        [gran11]
+        {:cycle 3
+         :passes {:0 {:pass 3
+                      :tiles ["5R"]}
+                  :1 {:pass 4
+                      :tiles ["5L"]}
+                  :2 {:pass 4
+                      :tiles ["8R"]}}}
+        {"options[passes][AND]" "true"}))))


### PR DESCRIPTION
This is the first cut of supporting granule search with track info. 

I filed CMR-5524 to add the various validation rules to make this feature complete. The search api doc will be updated once CMR-5524 is complete. This way we don't let people to try this before it is ready.

An example of searching granules with track info is:
curl -g  "http://localhost:3003/granules?cycle=3&passes[0][pass]=1&passes[0][tiles]=1L,2R"
