### PR TITLE
CMR-5336,CMR-5314,CMR-5326,CMR-5328,CMR-5329,CMR-5330: Fix vulnerabil…

### DIFF
--- a/acl-lib/resources/security/suppression.xml
+++ b/acl-lib/resources/security/suppression.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+</suppressions>

--- a/elastic-utils-lib/resources/security/suppression.xml
+++ b/elastic-utils-lib/resources/security/suppression.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+</suppressions>

--- a/spatial-lib/resources/security/suppression.xml
+++ b/spatial-lib/resources/security/suppression.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+
+  <!-- Suppressing git vulnerabilities -->
+  <suppress>
+     <notes><![CDATA[
+     file name: mathz-0.3.0.jar
+     ]]></notes>
+     <gav regex="true">^net\.mikera:mathz:.*$</gav>
+     <cpe>cpe:/a:git_project:git</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: mathz-0.3.0.jar
+    ]]></notes>
+    <gav regex="true">^net\.mikera:mathz:.*$</gav>
+    <cpe>cpe:/a:git:git</cpe>
+  </suppress>
+</suppressions>

--- a/transmit-lib/resources/security/suppression.xml
+++ b/transmit-lib/resources/security/suppression.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+</suppressions>

--- a/umm-lib/resources/security/suppression.xml
+++ b/umm-lib/resources/security/suppression.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+
+  <!-- Suppressing git vulnerabilities -->
+  <suppress>
+     <notes><![CDATA[
+     file name: mathz-0.3.0.jar
+     ]]></notes>
+     <gav regex="true">^net\.mikera:mathz:.*$</gav>
+     <cpe>cpe:/a:git_project:git</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: mathz-0.3.0.jar
+    ]]></notes>
+    <gav regex="true">^net\.mikera:mathz:.*$</gav>
+    <cpe>cpe:/a:git:git</cpe>
+  </suppress>
+
+  <!-- Elasticsearch version < 1.6.1 suppressions:
+
+  The following suppressions all indicate vulnerabitlies in
+  elasticsearch before version 1.6.1. The version being used is 1.6.2
+  so they are false positives -->
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2014-3120</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2014-6439</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-1427</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-3337</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-5531</cve>
+  </suppress>
+
+  <!-- mintToken vulnerability. False positive, cmr does not do this. -->
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-common-app-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-common-app-lib:.*$</gav>
+    <cve>CVE-2018-13661</cve>
+  </suppress>
+</suppressions>

--- a/umm-spec-lib/resources/security/suppression.xml
+++ b/umm-spec-lib/resources/security/suppression.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--For non-false positives suppress with <suppress until="YYYY-MM-DD">...-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: clansi-1.0.0.jar
+    ]]></notes>
+    <gav regex="true">^clansi:clansi:.*$</gav>
+    <cpe>cpe:/a:style_it_project:style_it</cpe>
+  </suppress>
+
+  <!-- Suppressing git vulnerabilities -->
+  <suppress>
+     <notes><![CDATA[
+     file name: mathz-0.3.0.jar
+     ]]></notes>
+     <gav regex="true">^net\.mikera:mathz:.*$</gav>
+     <cpe>cpe:/a:git_project:git</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: mathz-0.3.0.jar
+    ]]></notes>
+    <gav regex="true">^net\.mikera:mathz:.*$</gav>
+    <cpe>cpe:/a:git:git</cpe>
+  </suppress>
+
+  <!-- Elasticsearch version < 1.6.1 suppressions:
+
+  The following suppressions all indicate vulnerabitlies in
+  elasticsearch before version 1.6.1. The version being used is 1.6.2
+  so they are false positives -->
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2014-3120</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2014-6439</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-1427</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-3337</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-elastic-utils-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-elastic-utils-lib:.*$</gav>
+    <cve>CVE-2015-5531</cve>
+  </suppress>
+
+  <!-- mintToken vulnerability. False positive, cmr does not do this. -->
+  <suppress>
+    <notes><![CDATA[
+    file name: cmr-common-app-lib-0.1.0-SNAPSHOT.jar
+    ]]></notes>
+    <gav regex="true">^nasa-cmr:cmr-common-app-lib:.*$</gav>
+    <cve>CVE-2018-13661</cve>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
…ities.

The vulnerabilities found for these projects are the following:

clojusc/ltest - Only affects tests.
cmr-elastic-utils-lib - Elastic vulnerabilities for versions < 1.6.2
cmr-common-app-lib - mintToken vulnerability does not affect the CMR
net.mikera/vectorz-clj - git vulnerabilities seem irrelevant. Here are the vulnerabilities initially found: https://nvd.nist.gov/view/vuln/search-results?adv_search=true&cves=on&cpe_version=cpe%3A%2Fa%3Agit%3Agit