### PR TITLE
CMR-5647: Search for email address at top level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here are the steps to do so:
 
 1. Ensure you have installed on your system the items listed above in the
    "Prerequisites" section.
-1. Download the Oracle JDBC JAR files into `./oracle-libs/support` by
+1. Download the Oracle JDBC JAR files into `./oracle-lib/support` by
    following instructions in `./oracle-lib/README.md`. (The CMR must have these
    libraries to build but it does not depend on Oracle DB when running
    locally. It uses a local in-memory database by default.) If you're reading this

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/opendata.clj
@@ -16,7 +16,7 @@
   contact info found in the ContactPersons, ContactGroups or DataCenters."
   [collection]
   (let [{:keys [ContactPersons ContactGroups DataCenters]} collection
-        contacts (concat ContactPersons ContactGroups (mapcat data-center/data-center-contacts DataCenters))
+        contacts (concat ContactPersons ContactGroups (mapcat data-center/data-center-contacts DataCenters) DataCenters)
         email-contact (some #(when (email-contact? %) %) contacts)]
     (when email-contact
       (let [email (some #(when (= "Email" (:Type %)) (:Value %))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -751,7 +751,15 @@
                                        :Description "Test access URL"
                                        :URLContentType "VisualizationURL"
                                        :Type "GET DATA"}]}
-          concept-umm (-> (umm-spec-collection/collection 1 related-urls)
+          data-centers {:DataCenters
+                        [(umm-spec-collection/data-center
+                          {:Roles ["ARCHIVER"]
+                           :ShortName "test-short-name"
+                           :ContactInformation {:ContactMechanisms
+                                                [{:Type "Email"
+                                                  :Value "test-address@example.com"}]}})]}
+          umm-attributes (merge related-urls data-centers)
+          concept-umm (-> (umm-spec-collection/collection 1 umm-attributes)
                           (umm-spec-collection/collection-concept :umm-json)
                           ingest/ingest-concept)
 
@@ -772,6 +780,9 @@
       (is (= 201 (:status concept-5138-1)))
       (is (= 201 (:status concept-5138-2)))
       (is (= 201 (:status concept-5138-3)))
+      (testing "Contact email in response when email is at top level DataCenter"
+        (is (= "mailto:test-address@example.com"
+               (get-in opendata-coll-umm [:contactPoint :hasEmail]))))
       (testing "distribution urls"
         (are3 [expected-distribution opendata-collection]
           (is (contains? (set (:distribution opendata-collection)) expected-distribution))


### PR DESCRIPTION
Contact email address can now be found when no contact person or contact group is provided but contact information exists at the top level of the data center. Example:
```
"DataCenters" : [ {
 "Roles" : [ "<role>" ],
 "ShortName" : "<shortname>",
 "ContactInformation" : {
 "ContactMechanisms" : [ {
 "Type" : "Email",
 "Value" : "<email-address>"
 } ],
...
```