### PR TITLE
CMR-5526: Changed the page_size to 2000.

### DIFF
--- a/cmr-exchange/metadata-proxy/project.clj
+++ b/cmr-exchange/metadata-proxy/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.5-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"
   :description ~(str "A library that provides convenience functions for "
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")
@@ -33,7 +33,7 @@
                  [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
                  [metosin/ring-http-response "0.9.1"]
-                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
                  [org.clojure/core.cache "0.7.2"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
@@ -62,7 +62,7 @@
                                     [proto-repl "0.3.1"]]
                      :plugins [[lein-project-version "0.1.0"]
                                [lein-shell "0.5.0"]
-                               [venantius/ultra "0.5.4"]]
+                               [venantius/ultra "0.6.0"]]
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[debugger "0.2.1"]]
@@ -73,7 +73,7 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.1"]
+                              [lein-bikeshed "0.5.2"]
                               [lein-kibit "0.1.6"]
                               [venantius/yagni "0.1.7"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]

--- a/cmr-exchange/metadata-proxy/src/cmr/metadata/proxy/concepts/variable.clj
+++ b/cmr-exchange/metadata-proxy/src/cmr/metadata/proxy/concepts/variable.clj
@@ -26,12 +26,11 @@
                            charset))
 (def id-search-constraint "concept_id[]")
 (def alias-search-constraint "alias[]")
-
+(def max-page-size 2000)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Support/Utility Functions   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -47,7 +46,7 @@
     "&"
     (conj
       (map #(str (codec/url-encode search-constraint) "=" %) variable-info)
-      (str "page_size=" (count variable-info))
+      (str "page_size=" max-page-size)
       (str (codec/url-encode "options[alias][pattern]") "=true"))))
 
 (defn async-get-metadata

--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.5-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"
   :description "A CMR services plugin that performs URL translations for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-ous-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -30,11 +30,11 @@
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.5-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [metosin/ring-http-response "0.9.1"]
-                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
                  [org.clojure/core.cache "0.7.2"]
                  [org.clojure/data.xml "0.2.0-alpha5"]
@@ -62,7 +62,7 @@
                                     [proto-repl "0.3.1"]]
                      :plugins [[lein-project-version "0.1.0"]
                                [lein-shell "0.5.0"]
-                               [venantius/ultra "0.5.4"]]
+                               [venantius/ultra "0.6.0"]]
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[debugger "0.2.1"]]
@@ -73,7 +73,7 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.1"]
+                              [lein-bikeshed "0.5.2"]
                               [lein-kibit "0.1.6"]
                               [venantius/yagni "0.1.7"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]

--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.8-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.10-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
   :license {:name "Apache License, Version 2.0"
@@ -30,15 +30,15 @@
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.5-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.5-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.1-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.2-SNAPSHOT"]
                  [http-kit "2.3.0"]
                  [markdown-clj "1.0.7"]
-                 [metosin/reitit-core "0.2.13"]
-                 [metosin/reitit-ring "0.2.13"]
+                 [metosin/reitit-core "0.3.1"]
+                 [metosin/reitit-ring "0.3.1"]
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
@@ -48,7 +48,7 @@
                  [ring/ring-core "1.7.1"]
                  [ring/ring-codec "1.1.1"]
                  [ring/ring-defaults "0.3.2"]
-                 [selmer "1.12.9"]
+                 [selmer "1.12.11"]
                  [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
@@ -74,7 +74,7 @@
                                     [proto-repl "0.3.1"]]
                      :plugins [[lein-project-version "0.1.0"]
                                [lein-shell "0.5.0"]
-                               [venantius/ultra "0.5.4"]]
+                               [venantius/ultra "0.6.0"]]
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[debugger "0.2.1"]]
@@ -85,13 +85,13 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.1"]
+                              [lein-bikeshed "0.5.2"]
                               [lein-kibit "0.1.6"]
                               [venantius/yagni "0.1.7"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]
-                              [venantius/ultra "0.5.4"]]
+                              [venantius/ultra "0.6.0"]]
                     :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
                     :test2junit-output-dir "junit-test-results"
                     :test-selectors {:unit #(not (or (:integration %) (:system %)))

--- a/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/netcdf4.clj
+++ b/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/netcdf4.clj
@@ -20,9 +20,9 @@
 (def variable2-id "V1200301323-HMR_TME")
 (def variable3-id "V1200297236-HMR_TME")
 (def variable-alias "/Data_5HZ/Geolocation/d_lat")
+(def variable2-alias "/Data_5HZ/Geolocation/test")
 (def variable3-alias "/Data_5HZ/Geolocation/d_lon")
-(def group-node-alias1 "/Data_5HZ/Geolocation")
-(def group-node-alias2 "/Data_5HZ/Geolocation/")
+(def group-node-alias "/Data_5HZ/Geolocation")
 (def options (request/add-token-header {} (util/get-sit-token)))
 
 (deftest one-var-size-test
@@ -296,29 +296,31 @@
              :gb 0.41}]
            (util/parse-response response)))))
 
-(deftest group-node-alias-size-test-1
+(deftest multi-alias-size-test-2
   (let [response @(httpc/get
                    (format (str "http://localhost:%s"
                                 "/service-bridge/size-estimate/collection/%s"
                                 "?granules=%s"
-                                "&variable_aliases=%s"
+                                "&variable_aliases=%s,%s,%s"
                                 "&format=nc4"
                                 "&service_id=S1200341768-DEMO_PROV"
                                 "&total-granule-input-bytes=100000000")
                            (test-system/http-port)
                            collection-id
                            granule-id
-                           group-node-alias1)
+                           variable-alias
+                           variable2-alias
+                           variable3-alias)
                    options)]
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 1832215171 
+             :mb 1747.34 
+             :gb 1.71}]
            (util/parse-response response)))))
 
-(deftest group-node-alias-size-test-2
+(deftest group-node-alias-size-test
   (let [response @(httpc/get
                    (format (str "http://localhost:%s"
                                 "/service-bridge/size-estimate/collection/%s"
@@ -330,14 +332,14 @@
                            (test-system/http-port)
                            collection-id
                            granule-id
-                           group-node-alias2)
+                           group-node-alias)
                    options)]
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 1832215171 
+             :mb 1747.34 
+             :gb 1.71}]
            (util/parse-response response)))))
 
 (deftest multi-var-different-gran-size-test

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.1-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.2-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -25,8 +25,8 @@
                  [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.5-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.5-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [org.clojure/clojure "1.10.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}
@@ -48,7 +48,7 @@
              :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
                                     [proto-repl "0.3.3"]]
                      :plugins [[lein-shell "0.5.0"]
-                               [venantius/ultra "0.5.4"]]
+                               [venantius/ultra "0.6.0"]]
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[clojusc/trifl "0.4.2"]
@@ -61,7 +61,7 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.1"]
+                              [lein-bikeshed "0.5.2"]
                               [lein-kibit "0.1.6"]
                               [venantius/yagni "0.1.7"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]


### PR DESCRIPTION
This is to account for:
1. Fix the group node wildcard case, where (count [/a/b/* /a/b]) is obviously not right for the page_size.
2. For normal variable concept-id case, where page_size = (count variable-info) is correct, but it can't be more than 2000. 

Tried to implement scrolling in the event when the returning number of variables > 2000, but the response in the code doesn't return any header info where CMR-Scroll-Id can be used for subsequent calls. I think some changes need to be made in the http code but it doesn't look intuitive to me.  Since the existing code before this ticket used (count variable-info) for page_size, where it didn't take into account of 2000+ case either. So, it's an existing bug. I think perhaps I could just file a new ticket to fix it using scrolling, although it's unlikely that we will have more than 2000 variables per collection for subsetting. 