### PR TITLE
CMR-5663: Only construct citation when needed.

### DIFF
--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -328,15 +328,19 @@
 
 (defn citation
   "Create the citation field for the opendata response. extra-fields contain
-   information outside of CollectionCitations to create the full citation field."
+  information outside of CollectionCitations to create the full citation field.
+  When OtherCitationDetails is the ONLY provided field then do not construct
+  the citation and assume that contains the full citation."
   ([collection-citation]
    (citation collection-citation {}))
   ([collection-citation extra-fields]
-   (when-let [citation-details (->> (merge collection-citation extra-fields)
-                                    evaluate-citation
-                                    (remove nil?)
-                                    not-empty)]
-     (str (string/join ". " citation-details) "."))))
+   (if (= [:other-citation-details] (keys collection-citation))
+     (:other-citation-details collection-citation)
+     (when-let [citation-details (->> (merge collection-citation extra-fields)
+                                      evaluate-citation
+                                      (remove nil?)
+                                      not-empty)]
+       (str (string/join ". " citation-details) ".")))))
 
 (defn- score-browse-image-related-url
   "Score the related-url based off number of browse-image fields."

--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
@@ -114,6 +114,12 @@
    (umm-cmn/map->RelatedUrlType (merge {:URL (d/unique-str "http://example.com/file")
                                         :Description (d/unique-str "description")}
                                        attribs))))
+
+(defn resource-citation
+  "Returns ResourceCitation"
+  [attribs]
+  (umm-cmn/map->ResourceCitationType attribs))
+
 (defn spatial
   [attributes]
   (let [{:keys [sc hsd vsds gsr orbit]} attributes]

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -758,16 +758,25 @@
                            :ContactInformation {:ContactMechanisms
                                                 [{:Type "Email"
                                                   :Value "test-address@example.com"}]}})]}
+          collection-citations {:CollectionCitations
+                                [(umm-spec-collection/resource-citation
+                                  {:OtherCitationDetails
+                                   "This citation only contains OtherCitationDetails."})]}
           umm-attributes (merge related-urls data-centers)
           concept-umm (-> (umm-spec-collection/collection 1 umm-attributes)
                           (umm-spec-collection/collection-concept :umm-json)
                           ingest/ingest-concept)
-
+          concept-citation (-> (umm-spec-collection/collection 2 collection-citations)
+                               (umm-spec-collection/collection-concept :umm-json)
+                               ingest/ingest-concept)
           _ (index/wait-until-indexed)
           opendata-5138-1 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-1)})
           opendata-5138-2 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-2)})
           opendata-5138-3 (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-5138-3)})
           opendata-umm (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-umm)})
+          opendata-citation (-> (search/find-concepts-opendata :collection {:concept_id (:concept-id concept-citation)})
+                                (get-in [:results :dataset])
+                                first)
           umm-json-5138-3 (search/find-concepts-umm-json :collection {:concept_id (:concept-id concept-5138-3)})
           opendata-coll-5138-1 (first (get-in opendata-5138-1 [:results :dataset]))
           opendata-coll-5138-2 (first (get-in opendata-5138-2 [:results :dataset]))
@@ -840,6 +849,9 @@
 
           "DataPresentationFrom in response"
           "Digital Science Data" :data-presentation-form opendata-coll-5138-1
+
+          "Only OtherCitationDetails is created for citation"
+          "This citation only contains OtherCitationDetails." :citation opendata-citation
 
           "Citation in response with missing version"
           (str "AIRS Science Team/Joao Texeira. 2013-03-12. AIRX3STD."


### PR DESCRIPTION
When OtherCitationDetails is the only key provided in the collection citation, assume that is the full citation.