### PR TITLE
Mask tokens in error messages

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_acl_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_acl_test.clj
@@ -61,7 +61,7 @@
     (let [group (u/make-group)
           response (u/create-group "nonexist-token" group {:allow-failure? true})]
       (is (= {:status 401
-              :errors ["Token [nonexist-token] does not exist"]}
+              :errors ["Token does not exist"]}
              response)))))
 
 (deftest create-provider-group-test

--- a/common-lib/src/cmr/common/api/errors.clj
+++ b/common-lib/src/cmr/common/api/errors.clj
@@ -27,7 +27,7 @@
              CORS_ORIGIN_HEADER "*"}
    :body {:errors ["An Internal Error has occurred."]}})
 
-(defn- mask-token-error
+(defn mask-token-error
  [error-string]
  (if (re-matches #".*Token .* does not exist.*" error-string)
   "Token does not exist"

--- a/common-lib/src/cmr/common/api/errors.clj
+++ b/common-lib/src/cmr/common/api/errors.clj
@@ -27,6 +27,12 @@
              CORS_ORIGIN_HEADER "*"}
    :body {:errors ["An Internal Error has occurred."]}})
 
+(defn- mask-token-error
+ [error-string]
+ (if (re-matches #".*Token .* does not exist.*" error-string)
+  "Token does not exist"
+  error-string))
+
 (defn- keyword-path->string-path
   "Converts a set of keyword field paths into the string equivalent field paths
   to return to the user."
@@ -51,7 +57,7 @@
 
 (defmethod error->json-element String
   [error]
-  error)
+  (mask-token-error error))
 
 (defmethod error->json-element cmr.common.services.errors.PathErrors
   [error]
@@ -67,7 +73,7 @@
 
 (defmethod error->xml-element String
   [error]
-  (x/element :error {} error))
+  (x/element :error {} (mask-token-error error)))
 
 (defmethod error->xml-element cmr.common.services.errors.PathErrors
   [error]

--- a/common-lib/test/cmr/common/test/api/errors.clj
+++ b/common-lib/test/cmr/common/test/api/errors.clj
@@ -1,9 +1,6 @@
-(ns cmr.common.test.api.web-server
-  "This tests capabilities of the web server component."
+(ns cmr.common.test.api.errors
+  "This tests capabilities of the API error utilities."
   (:require
-   [clj-http.client :as h]
-   [clojure.java.io :as io]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [cmr.common.api.errors :as errors]))
 

--- a/common-lib/test/cmr/common/test/api/errors.clj
+++ b/common-lib/test/cmr/common/test/api/errors.clj
@@ -9,4 +9,4 @@
 
 (deftest test-error-masked
   (let [error-message "Token 123 does not exist"]
-  (is (= "Token does not exist" (errors/mask-token-error error-message)))))
+    (is (= "Token does not exist" (errors/mask-token-error error-message)))))

--- a/common-lib/test/cmr/common/test/api/errors.clj
+++ b/common-lib/test/cmr/common/test/api/errors.clj
@@ -1,0 +1,12 @@
+(ns cmr.common.test.api.web-server
+  "This tests capabilities of the web server component."
+  (:require
+   [clj-http.client :as h]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [cmr.common.api.errors :as errors]))
+
+(deftest test-error-masked
+  (let [error-message "Token 123 does not exist"]
+  (is (= "Token does not exist" (errors/mask-token-error error-message)))))

--- a/system-int-test/src/cmr/system_int_test/utils/site_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/site_util.clj
@@ -44,7 +44,7 @@
                         url-path
                         (add-token-header "ABC" {:throw-exceptions? false}))]
           (is (= 401 (:status response)))
-          (is (= ["Token ABC does not exist"]
+          (is (= ["Token does not exist"]
                  (search/safe-parse-error-xml (:body response))))))
       (testing "regular user token"
         (let [response (get-search-response

--- a/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
@@ -34,7 +34,7 @@
   (ingest/create-provider {:provider-guid "PROV3" :provider-id "PROV3"}))
 
 (deftest invalid-security-token-test
-  (is (= {:errors ["Token [ABC123] does not exist"], :status 401}
+  (is (= {:errors ["Token does not exist"], :status 401}
          (search/find-refs :collection {:token "ABC123"}))))
 
 (deftest expired-security-token-test
@@ -429,7 +429,7 @@
 
     ;; A logged out token is normally not useful
     (e/logout (s/context) user2-token)
-    (is (= {:errors ["Token [ABC-2] does not exist"], :status 401}
+    (is (= {:errors ["Token does not exist"], :status 401}
            (search/find-refs :collection {:token user2-token})))
 
     ;; Use user1-token so it will be cached

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -76,7 +76,7 @@
 
   (testing "Create with unknown token"
     (is (= {:status 401
-            :errors ["Token [ABC] does not exist"]}
+            :errors ["Token does not exist"]}
            (humanizer-util/update-community-usage-metrics "ABC" sample-usage-csv))))
 
   (testing "Create without permission"

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
@@ -36,7 +36,7 @@
 
   (testing "Create with unknown token"
     (is (= {:status 401
-            :errors ["Token [ABC] does not exist"]}
+            :errors ["Token does not exist"]}
            (humanizer-util/update-humanizers "ABC" (humanizer-util/make-humanizers)))))
 
   (testing "Create without permission"

--- a/system-int-test/test/cmr/system_int_test/search/tagging/tag_crud_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tagging/tag_crud_test.clj
@@ -30,7 +30,7 @@
 
   (testing "Create with unknown token"
     (is (= {:status 401
-            :errors ["Token [ABC] does not exist"]}
+            :errors ["Token does not exist"]}
            (tags/create-tag "ABC" (tags/make-tag)))))
 
   (let [valid-user-token (echo-util/login (system/context) "user1")

--- a/transmit-lib/src/cmr/transmit/echo/rest.clj
+++ b/transmit-lib/src/cmr/transmit/echo/rest.clj
@@ -70,12 +70,13 @@
                   (json/decode body true))]
      [status parsed body])))
 
-
 (defn unexpected-status-error!
   [status body]
   (errors/internal-error!
-    (format "Unexpected status %d from response. body: %s"
-            status (pr-str body))))
+    ; Don't print potentially sensitive information.
+    (if (re-matches #".*Token .* does not exist.*" body)
+     (format "Unexpected status %d from response. body: %s" status "Token does not exist")
+     (format "Unexpected status %d from response. body: %s" status (pr-str body)))))
 
 (defn- get-rest-health
   "Returns the echo-rest health by calling its availability api"

--- a/transmit-lib/test/cmr/transmit/test/echo/rest.clj
+++ b/transmit-lib/test/cmr/transmit/test/echo/rest.clj
@@ -5,10 +5,9 @@
 
 (deftest test-error-masked
   (let [error-message "Unexpected error message: Token 123 does not exist."
-        status 500]
+        status 500
+        replacement-message "Token does not exist"]
     (is (thrown-with-msg?
         java.lang.Exception
-        ;; Fixme - (format "%d %s" status message) was getting the error:
-        ;; java.lang.ClassCastException: java.lang.String cannot be cast to java.util.regex.Pattern
-        #"Unexpected status 500 from response. body: Token does not exist"
+        (re-pattern (format "Unexpected status %d from response. body: %s" status replacement-message))
         (rest/unexpected-status-error! status error-message)))))

--- a/transmit-lib/test/cmr/transmit/test/echo/rest.clj
+++ b/transmit-lib/test/cmr/transmit/test/echo/rest.clj
@@ -1,0 +1,10 @@
+(ns cmr.transmit.test.echo.rest
+  "Tests for cmr.transmit.echo.rest namespace"
+  (:require [clojure.test :refer :all]
+            [cmr.transmit.echo.rest :as rest]))
+
+(deftest test-error-masked
+  (let [error-message "Unexpected error message: Token 123 does not exist."
+       status 500]
+    (is (= (format "Unexpected status %d from response. body: %s" status "Token does not exist")
+           (rest/unexpected-status-error! status error-message)))))

--- a/transmit-lib/test/cmr/transmit/test/echo/rest.clj
+++ b/transmit-lib/test/cmr/transmit/test/echo/rest.clj
@@ -5,6 +5,10 @@
 
 (deftest test-error-masked
   (let [error-message "Unexpected error message: Token 123 does not exist."
-       status 500]
-    (is (= (format "Unexpected status %d from response. body: %s" status "Token does not exist")
-           (rest/unexpected-status-error! status error-message)))))
+        status 500]
+    (is (thrown-with-msg?
+        java.lang.Exception
+        ;; Fixme - (format "%d %s" status message) was getting the error:
+        ;; java.lang.ClassCastException: java.lang.String cannot be cast to java.util.regex.Pattern
+        #"Unexpected status 500 from response. body: Token does not exist"
+        (rest/unexpected-status-error! status error-message)))))


### PR DESCRIPTION
Proposed changes:
* Mask token in error messages in transmit echo rest
* Mask token in common API errors module

TODOs:
- [ ] A few more unit tests
- [ ] Passing unit tests