### PR TITLE
CMR-5665: Remove the use of AverageSizeOfGranulesSampled in SES.

### DIFF
--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.10-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.11-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
   :license {:name "Apache License, Version 2.0"
@@ -34,7 +34,7 @@
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
                  [gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.2-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.3-SNAPSHOT"]
                  [http-kit "2.3.0"]
                  [markdown-clj "1.0.7"]
                  [metosin/reitit-core "0.3.1"]
@@ -48,7 +48,7 @@
                  [ring/ring-core "1.7.1"]
                  [ring/ring-codec "1.1.1"]
                  [ring/ring-defaults "0.3.2"]
-                 [selmer "1.12.11"]
+                 [selmer "1.12.12"]
                  [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"

--- a/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/native.clj
+++ b/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/native.clj
@@ -52,7 +52,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -64,7 +64,6 @@
                                 "?granules=%s"
                                 "&variable_aliases=%s"
                                 "&service_id=S1200341767-DEMO_PROV"
-                                "&format=native"
                                 "&total-granule-input-bytes=1000000")
                            (test-system/http-port)
                            collection-id
@@ -74,7 +73,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response))))) 

--- a/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/netcdf4.clj
+++ b/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/netcdf4.clj
@@ -41,7 +41,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -63,7 +63,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -85,7 +85,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -107,7 +107,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -129,7 +129,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))
@@ -150,8 +150,8 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 139324
-             :mb 0.13
+    (is (= [{:bytes 790000 
+             :mb 0.75
              :gb 0.0}]
            (util/parse-response response)))))
 
@@ -172,9 +172,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest mix-alias-var-size-test
@@ -195,9 +195,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest mix-one-alias-multi-var-with-duplicate-size-test
@@ -219,9 +219,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest mix-multi-alias-one-var-with-duplicate-size-test
@@ -243,9 +243,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest mix-multi-alias-multi-var-with-duplicate-size-test
@@ -268,9 +268,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest multi-alias-size-test
@@ -291,9 +291,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 438984930
-             :mb 418.65
-             :gb 0.41}]
+    (is (= [{:bytes 13225000 
+             :mb 12.61 
+             :gb 0.01}]
            (util/parse-response response)))))
 
 (deftest multi-alias-size-test-2
@@ -315,9 +315,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 1832215171 
-             :mb 1747.34 
-             :gb 1.71}]
+    (is (= [{:bytes 92225000 
+             :mb 87.95 
+             :gb 0.09}]
            (util/parse-response response)))))
 
 (deftest group-node-alias-size-test
@@ -337,9 +337,9 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 1832215171 
-             :mb 1747.34 
-             :gb 1.71}]
+    (is (= [{:bytes 92225000 
+             :mb 87.95 
+             :gb 0.09}]
            (util/parse-response response)))))
 
 (deftest multi-var-different-gran-size-test
@@ -359,8 +359,8 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 183178
-             :mb 0.17
+    (is (= [{:bytes 922000 
+             :mb 0.88
              :gb 0.0}]
            (util/parse-response response)))))
 
@@ -382,8 +382,8 @@
       (is (= 200 (:status response)))
       (is (= "cmr-service-bridge.v2.1; format=json"
              (get-in response [:headers :cmr-media-type])))
-      (is (= [{:bytes 69684
-               :mb 0.07
+      (is (= [{:bytes 790250 
+               :mb 0.75
                :gb 0.0}]
              (util/parse-response response)))))
 
@@ -406,7 +406,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 43855
-             :mb 0.04
+    (is (= [{:bytes 132000 
+             :mb 0.13
              :gb 0.0}]
            (util/parse-response response)))))

--- a/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/shapefile.clj
+++ b/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/sizing/shapefile.clj
@@ -52,7 +52,7 @@
     (is (= 200 (:status response)))
     (is (= "cmr-service-bridge.v2.1; format=json"
            (get-in response [:headers :cmr-media-type])))
-    (is (= [{:bytes 45 
+    (is (= [{:bytes 250 
              :mb 0.0
              :gb 0.0}]
            (util/parse-response response)))))

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.2-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.3-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {:name "Apache License, Version 2.0"

--- a/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
+++ b/cmr-exchange/ses-plugin/src/cmr/sizing/formats.clj
@@ -90,13 +90,6 @@
     (* total-dimensionality
        (max 2 (util/data-type->bytes data-type)))))
 
-(defn- get-avg-gran-size
-  "Gets SizeEstimation value for AverageSizeOfGranulesSampled and parses it to a number."
-  [variable]
-  (-> variable
-      (get-in [:umm :SizeEstimation :AverageSizeOfGranulesSampled])
-      read-number))
-
 (defn- get-rate
   "Gets the :Rate value for compression-format in avg-comp-info."
   [avg-comp-info compression-format]
@@ -264,19 +257,17 @@
    total-granule-input-bytes is a value given by the client in the size estimate request."
   [granule-count variables params compression-format]
   (reduce (fn [total-estimate variable]
-            (let [avg-gran-size (get-avg-gran-size variable)
-                  total-granule-input-bytes (read-string (:total-granule-input-bytes params))
+            (let [total-granule-input-bytes (read-string (:total-granule-input-bytes params))
                   avg-compression-rate (get-avg-compression-rate variable compression-format)]
               (log/info (format (str "request-id: %s variable-id: %s total-estimate: %s "
-                                     "avg-gran-size: %s total-granule-input-bytes: %s "
+                                     "total-granule-input-bytes: %s "
                                      "avg-compression-rate: %s")
                                 (:request-id params) (get-in variable [:meta :concept-id])
-                                total-estimate avg-gran-size total-granule-input-bytes
+                                total-estimate total-granule-input-bytes
                                 avg-compression-rate))
               (+ total-estimate
                  (* total-granule-input-bytes
-                    (or avg-compression-rate 0) 
-                    (/ (/ total-granule-input-bytes granule-count) avg-gran-size)))))
+                    (or avg-compression-rate 0)))))
           0
           variables))
 


### PR DESCRIPTION
Marty's study shows that a simple (total-bytes * avg-compression-rate) is more accurate than Bob's approach of using (total-bytes * arg-compression-rate * ((total-bytes/gran-count)/AverageSizeOfGrnaulesSamples))). 