### PR TITLE
CMR-5695: Recreate SNS and SQS clients when they encounter an error

### DIFF
--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -135,11 +135,11 @@
 (when (string? (dev-config/dev-system-queue-type))
   (dev-config/set-dev-system-queue-type!
     (keyword (dev-config/dev-system-queue-type))))
-
 ;; If the ENV var for the dev queue type was set to use AWS, let's make the
 ;; `set-aws` call.
-(when (= :aws (dev-config/dev-system-queue-type))
-  (set-aws true))
+(if (= :aws (dev-config/dev-system-queue-type))
+  (set-aws true)
+  (set-aws false))
 
 (defn set-logging-level!
   "Sets the logging level to the given setting. Puts the level in refresh-persistent-settings

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -178,8 +178,7 @@
 (defmethod create-queue-broker :aws
   [type]
   (-> (external-queue-config [])
-      sqs/create-queue-broker
-      wrapper/create-queue-broker-wrapper))
+      sqs/create-queue-broker))
 
 (defn create-metadata-db-app
   "Create an instance of the metadata-db application."

--- a/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
@@ -124,6 +124,15 @@
     ;; clear all channels
     (drain-channels (vals queues-to-channels)))
 
+  (reconnect
+    [this]
+    (try
+      (lifecycle/stop this nil)
+      (catch Exception e
+        (warn e "Failed to properly stop in call to reconnect.")))
+    (lifecycle/start this nil)
+    this)
+
   (health
     [this]
     {:ok? true}))

--- a/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
@@ -29,6 +29,11 @@
     [this]
     "Reset the broker, deleting any queues and any queued messages")
 
+  (reconnect
+    [this]
+    "Reinitiates the connection to the underlying exchanges. Used when there appears to
+    be a systemic problem reaching the exchanges.")
+
   (health
     [this]
     "Checks to see if the queue is up and functioning properly. Returns a map with the

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -169,7 +169,7 @@
 
 
 (defn set-aws-client-attr!
-  "Conditionally configure the AWS client instance with by calling the given
+  "Conditionally configure the AWS client instance by calling the given
   method with the given args."
   [client-obj method args]
   (when-not (nil? (first args))

--- a/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/sqs.clj
@@ -472,6 +472,13 @@
         (.purgeQueue sqs-client q-purge-req)
         (.purgeQueue sqs-client dlq-purge-req))))
 
+  (reconnect
+    [this]
+    (warn "Recreating SNS client.")
+    (let [sns-client (create-aws-client :sns)]
+      (reset! sns-client-atom sns-client)
+      this))
+
   (health
     [this]
     ;; try to get a list of queues for the first topic (exchange) to test the connection to SNS/SQS

--- a/message-queue-lib/src/cmr/message_queue/services/queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/services/queue.clj
@@ -32,6 +32,8 @@
                 (error e)
                 false))
     (warn "Attempt to queue messaged failed. Retrying: " msg)
+    ;; May be a systemic problem causing the timeout. Reinitialize the queue-broker connection.
+    (queue-protocol/reconnect queue-broker)
     (Thread/sleep (config/messaging-retry-delay))
     (recur queue-broker exchange-name msg)))
 

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -81,7 +81,8 @@
 (defn- current-messages
   "Return a list of the current messages."
   [broker-wrapper]
-  (for [[_ queue-history] (deref (:message-queue-history-atom broker-wrapper))
+  (for [[_ queue-history] (when (:message-queue-history-atom broker-wrapper)
+                            (deref (:message-queue-history-atom broker-wrapper)))
         msg (:messages (last queue-history))]
     msg))
 

--- a/message-queue-lib/test/cmr/message_queue/test/queue/sqs.clj
+++ b/message-queue-lib/test/cmr/message_queue/test/queue/sqs.clj
@@ -163,7 +163,7 @@
                      (assoc :sqs-client client))]
       ;; Start a worker thread so we can test its error handling
       (#'sqs/create-async-handler
-       broker (testing-queue-name) identity)
+       broker (testing-queue-name) identity false)
       ;; Wait for the readMessage calls to complete
       (wait-for-reads receive-fn-index 2)
       ;; Verify the worker thread made it past the first exception to call receiveMessage


### PR DESCRIPTION
This PR makes changes our SNS and SQS client connections to be atoms so that if they encounter an unrecoverable error, we will recreate the client and all future requests will use the new client.

I made some changes to our dev-system setup so that testing with :aws as the :messaging component will work. I reproduced the same problem we saw in operations and verified that the connection was recreated successfully and all subsequent ingests worked correctly (messages made it to the SNS exchange and were picked up and indexed successfully).

The way I reproduced the problem was running the following in the REPL:
```(-> user/system :apps :metadata-db :queue-broker :sns-client-atom deref .shutdown)```

I'm also going to run a workload run before merging this PR in.