### PR TITLE
CMR-5723: Add Access-Control-Expose-Headers to a few search routes

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -49,7 +49,7 @@
   "This CORS header is to define how long in seconds the response of the preflight request can be cached"
   "Access-Control-Max-Age")
 
-(defn search-response-headers
+(defn- search-response-headers
   "Generate headers for search response. CORS response headers can be tested through
   dev-system/resources/cors_headers_test.html"
   [content-type results]

--- a/common-app-lib/src/cmr/common_app/services/search.clj
+++ b/common-app-lib/src/cmr/common_app/services/search.clj
@@ -1,6 +1,6 @@
 (ns cmr.common-app.services.search
   "This contains common code for implementing search capabilities in a CMR application"
-  (:require 
+  (:require
    [cmr.common.util :as u]
    [cmr.common.cache.fallback-cache :as fallback-cache]
    [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
@@ -28,7 +28,7 @@
 
 (defn create-scroll-id-cache
   "Returns a single-threaded cache wrapping a fallback cache that uses a consistent cache backed by
-  cubby. This cache is used to store a map of cmr scroll-ids to ES scroll-ids in a consistent way 
+  cubby. This cache is used to store a map of cmr scroll-ids to ES scroll-ids in a consistent way
   acrosss all instances of search."
   []
   (stl-cache/create-single-thread-lookup-cache
@@ -64,7 +64,6 @@
                                       (search-results->response
                                        context query (assoc results :took query-execution-time)))]
     (info "query-execution-time:" query-execution-time "result-gen-time:" result-gen-time)
-
     {:results result-str
      :hits (:hits results)
      :result-format (:result-format query)

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -222,13 +222,15 @@
 (defn- find-tiles
   "Retrieves all the tiles which intersect the input geometry"
   [ctx params]
-  (core-api/search-response ctx {:results (query-svc/find-tiles-by-geometry ctx params)}))
+  (core-api/search-response ctx {:results (query-svc/find-tiles-by-geometry ctx params)
+                                 :result-format mt/json}))
 
 
 (defn- find-data-json
   "Retrieve all public collections with gov.nasa.eosdis tag as opendata."
   [ctx]
-  (core-api/search-response ctx {:results (query-svc/get-data-json-collections ctx)}))
+  (core-api/search-response ctx {:results (query-svc/get-data-json-collections ctx)
+                                 :result-format mt/json}))
 
 (defn- get-deleted-collections
   "Invokes query service to search for collections that are deleted and returns the response"

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -207,11 +207,8 @@
   (let [params (core-api/process-params :granule params path-w-extension headers mt/json)
         _ (info (format "Getting granule timeline from client %s with params %s."
                         (:client-id ctx) (pr-str params)))
-        search-params (lp/process-legacy-psa params)
-        results (query-svc/get-granule-timeline ctx search-params)]
-    {:status 200
-     :headers {common-routes/CORS_ORIGIN_HEADER "*"}
-     :body results}))
+        search-params (lp/process-legacy-psa params)]
+    (core-api/search-response ctx (query-svc/get-granule-timeline ctx search-params))))
 
 (defn- find-concepts-by-aql
   "Invokes query service to parse the AQL query, find results and returns the response"
@@ -225,16 +222,13 @@
 (defn- find-tiles
   "Retrieves all the tiles which intersect the input geometry"
   [ctx params]
-  (let [results (query-svc/find-tiles-by-geometry ctx params)]
-    {:status 200
-     :headers {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)}
-     :body results}))
+  (core-api/search-response ctx {:results (query-svc/find-tiles-by-geometry ctx params)}))
+
 
 (defn- find-data-json
   "Retrieve all public collections with gov.nasa.eosdis tag as opendata."
   [ctx]
-  {:status 200
-   :body (query-svc/get-data-json-collections ctx)})
+  (core-api/search-response ctx {:results (query-svc/get-data-json-collections ctx)}))
 
 (defn- get-deleted-collections
   "Invokes query service to search for collections that are deleted and returns the response"

--- a/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
@@ -3,18 +3,19 @@
   over granule start date and end dates. The aggregation results of start date and end dates are
   converted to a list of events of some number of granules starting and some number of granules
   ending. The events counts of granules are used to determine when intervals start and stop."
-  (:require [cmr.common-app.services.search.elastic-results-to-query-results :as elastic-results]
-            [cmr.common-app.services.search.elastic-search-index :as elastic-search-index]
-            [cmr.common-app.services.search.query-execution :as query-execution]
-            [cmr.common-app.services.search :as qs]
-            [cmr.common-app.services.search.query-to-elastic :as q2e]
-            [cmr.common.services.errors :as errors]
-            [cmr.search.models.query :as q]
-            [cmr.common-app.services.search.group-query-conditions :as gc]
-            [cheshire.core :as json]
-            [cmr.common-app.services.search.results-model :as r]
-            [clj-time.core :as t]
-            [clj-time.coerce :as c]))
+  (:require
+   [cheshire.core :as json]
+   [clj-time.coerce :as c]
+   [clj-time.core :as t]
+   [cmr.common-app.services.search :as qs]
+   [cmr.common-app.services.search.elastic-results-to-query-results :as elastic-results]
+   [cmr.common-app.services.search.elastic-search-index :as elastic-search-index]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.query-execution :as query-execution]
+   [cmr.common-app.services.search.query-to-elastic :as q2e]
+   [cmr.common-app.services.search.results-model :as r]
+   [cmr.common.services.errors :as errors]
+   [cmr.search.models.query :as q]))
 
 (defn- query-aggregations
   "Returns the elasticsearch aggregations to put in the query for finding granule timeline intervals."
@@ -225,25 +226,6 @@
     (r/map->Results {:items items
                      :result-format (:result-format query)})))
 
-(comment
-
-  (defn prettify-results
-    [{:keys [items]}]
-    (for [{:keys [concept-id intervals]} items]
-      {:concept-id concept-id
-       :intervals
-       (for [{:keys [start end num-grans]} intervals]
-         {:start (str start)
-          :end (str end)
-          :num-grans num-grans})}))
-
-  (prettify-results
-    (elastic-results/elastic-results->query-results
-      nil {:result-format :timeline
-           :interval :year} @last-elastic-results)))
-
-
-
 (defn interval->response-tuple
   "Converts an interval into the response tuple containing the start, end, and number of granules."
   [query {:keys [start end num-grans]}]
@@ -265,3 +247,20 @@
   (let [{:keys [items]} results
         response (map (partial collection-result->response-result query) items)]
     (json/generate-string response)))
+
+(comment
+
+  (defn prettify-results
+    [{:keys [items]}]
+    (for [{:keys [concept-id intervals]} items]
+      {:concept-id concept-id
+       :intervals
+       (for [{:keys [start end num-grans]} intervals]
+         {:start (str start)
+          :end (str end)
+          :num-grans num-grans})}))
+
+  (prettify-results
+    (elastic-results/elastic-results->query-results
+      nil {:result-format :timeline
+           :interval :year} @last-elastic-results)))

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -310,8 +310,10 @@
                    pv/validate-timeline-parameters
                    (p/timeline-parameters->query context)
                    (common-search/validate-query context))
-        results (qe/execute-query context query)]
-    (common-search/search-results->response context query results)))
+        [execution-time results] (u/time-execution
+                                  (common-search/search-results->response
+                                   context query (qe/execute-query context query)))]
+   {:results results :took execution-time}))
 
 (defn get-collections-by-providers
   "Returns all collections limited optionally by the given provider ids"
@@ -521,7 +523,7 @@
                             (pv/validate-tile-parameters)
                             (#(select-keys % [:bounding-box :point :line :polygon])))]
     (if (seq spatial-params)
-      (apply clojure.set/union
+      (apply set/union
              (for [[param-name values] spatial-params
                    value (if (sequential? values) values [values])]
                (shape-param->tile-set param-name value)))

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -313,7 +313,7 @@
         [execution-time results] (u/time-execution
                                   (common-search/search-results->response
                                    context query (qe/execute-query context query)))]
-   {:results results :took execution-time}))
+   {:results results :took execution-time :result-format mt/json}))
 
 (defn get-collections-by-providers
   "Returns all collections limited optionally by the given provider ids"

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -270,6 +270,7 @@
    (let [url-extension (get options :url-extension)
          snake-kebab? (get options :snake-kebab? true)
          headers (get options :headers {})
+         include-headers? (get options :include-headers)
          params (if snake-kebab?
                   (params->snake_case (util/map-keys csk/->snake_case_keyword params))
                   params)
@@ -292,8 +293,10 @@
                                     :body (codec/form-encode params)
                                     :connection-manager (s/conn-mgr)})))]
      (if (= 200 (:status response))
-       {:status (:status response)
-        :results (parse-timeline-response (:body response))}
+       (if include-headers?
+        (assoc response :results (parse-timeline-response (:body response)))
+        {:status (:status response)
+         :results (parse-timeline-response (:body response))})
        response))))
 
 (defn get-granule-timeline-with-post

--- a/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
@@ -272,4 +272,15 @@
              {:entry-title ["Dataset1" "Dataset2"]
               :start-date "1992-01-01T00:00:00Z"
               :end-date "2002-02-01T00:00:00Z"
-              :interval :month})))))
+              :interval :month}))
+      (testing "correct headers are returned"
+        (let [response (search/get-granule-timeline {:concept-id (:concept-id coll1)
+                                                     :start-date "2000-01-01T00:00:00Z"
+                                                     :end-date "2002-02-01T00:00:00Z"
+                                                     :interval :second}
+                                                    {:url-extension "json"
+                                                     :include-headers true})
+              headers (:headers response)]
+          (is (= "application/json;charset=utf-8" (get headers "Content-Type")))
+          (is (= "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id"
+                 (get headers "Access-Control-Expose-Headers"))))))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
@@ -1,32 +1,36 @@
 (ns cmr.system-int-test.search.granule-timeline-test
   "This tests the granule timeline feature of the search api."
   (:require
-    [cheshire.core :as json]
-    [clj-time.coerce :as c]
-    [clj-time.core :as t]
-    [clojure.string :as str]
-    [clojure.test :refer :all]
-    [cmr.common.concepts :as concepts]
-    [cmr.common.dev.util :as dev]
-    [cmr.system-int-test.data2.core :as d]
-    [cmr.system-int-test.data2.granule :as dg]
-    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
-    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
-    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-    [cmr.system-int-test.utils.index-util :as index]
-    [cmr.system-int-test.utils.ingest-util :as ingest]
-    [cmr.system-int-test.utils.search-util :as search]))
+   [cheshire.core :as json]
+   [clj-time.coerce :as c]
+   [clj-time.core :as t]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [cmr.common.concepts :as concepts]
+   [cmr.common.dev.util :as dev]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
 (defn make-gran
   ([coll n single-date-str]
-   (d/ingest "PROV1" (dg/granule-with-umm-spec-collection coll (:concept-id coll) {:granule-ur (str "gran" n)
-                                       :single-date-time single-date-str})))
+   (d/ingest "PROV1" (dg/granule-with-umm-spec-collection coll
+                                                          (:concept-id coll)
+                                                          {:granule-ur (str "gran" n)
+                                                           :single-date-time single-date-str})))
   ([coll n start-date-str end-date-str]
-   (d/ingest "PROV1" (dg/granule-with-umm-spec-collection coll (:concept-id coll) {:granule-ur (str "gran" n)
-                                                                                   :beginning-date-time start-date-str
-                                                                                   :ending-date-time end-date-str}))))
+   (d/ingest "PROV1" (dg/granule-with-umm-spec-collection coll
+                                                          (:concept-id coll)
+                                                          {:granule-ur (str "gran" n)
+                                                           :beginning-date-time start-date-str
+                                                           :ending-date-time end-date-str}))))
 
 (comment
   (do
@@ -34,18 +38,22 @@
     (ingest/create-provider {:provider-guid "provguid1" :provider-id "PROV1"})))
 
 (deftest timeline-test
-  (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "Dataset1"
-                                                                            :ShortName "S1"
-                                                                            :Version "V1"
-                                                                            :TemporalExtents
-                                                                             [(data-umm-cmn/temporal-extent
-                                                                                {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
-        coll2 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "Dataset2"
-                                                                            :ShortName "S2"
-                                                                            :Version "V2"
-                                                                            :TemporalExtents
-                                                                             [(data-umm-cmn/temporal-extent
-                                                                                {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
+  (let [coll1 (d/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection {:EntryTitle "Dataset1"
+                                       :ShortName "S1"
+                                       :Version "V1"
+                                       :TemporalExtents
+                                        [(data-umm-cmn/temporal-extent
+                                           {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
+        coll2 (d/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection {:EntryTitle "Dataset2"
+                                       :ShortName "S2"
+                                       :Version "V2"
+                                       :TemporalExtents
+                                        [(data-umm-cmn/temporal-extent
+                                           {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
         ;; Coll1 granules
         ;; Date range granules
         gran1 (make-gran coll1 1 "2000-02-01T00:00:00Z" "2000-05-01T00:00:00Z")
@@ -265,4 +273,3 @@
               :start-date "1992-01-01T00:00:00Z"
               :end-date "2002-02-01T00:00:00Z"
               :interval :month})))))
-


### PR DESCRIPTION
Headers now look like:
```
Date: Mon, 20 May 2019 13:22:49 GMT
Content-Type: application/json;charset=utf-8
Access-Control-Expose-Headers: CMR-Hits, CMR-Request-Id, CMR-Scroll-Id
Access-Control-Allow-Origin: *
CMR-Took: 9
CMR-Request-Id: d9b1a6ac-ffdf-409d-8191-bf23ad5a5a47
Vary: Accept-Encoding, User-Agent
Content-Length: 171
```