### PR TITLE
CMR-5726: Removed the trailing .html from the granule's urls.

### DIFF
--- a/cmr-exchange/metadata-proxy/project.clj
+++ b/cmr-exchange/metadata-proxy/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.7-SNAPSHOT"
   :description ~(str "A library that provides convenience functions for "
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")
@@ -86,7 +86,7 @@
                                      :system :system
                                      :default (complement :system)}}
              :docs {:dependencies [[gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
-                    :plugins [[lein-codox "0.10.6"]
+                    :plugins [[lein-codox "0.10.7"]
                               [lein-simpleton "1.3.0"]]
                     :codox {:project {:name "CMR Metadata-Proxy"}
                             :themes [:eosdis]

--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-ous-plugin "0.3.7-SNAPSHOT"
   :description "A CMR services plugin that performs URL translations for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-ous-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -30,7 +30,7 @@
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.7-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [metosin/ring-http-response "0.9.1"]
@@ -40,7 +40,7 @@
                  [org.clojure/data.xml "0.2.0-alpha5"]
                  [org.clojure/java.classpath "0.3.0"]
                  [ring/ring-core "1.7.1"]
-                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-codec "1.1.2"]
                  [ring/ring-defaults "0.3.2"]
                  [tolitius/xml-in "0.1.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}

--- a/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
+++ b/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
@@ -86,13 +86,20 @@
   (let [pattern (re-pattern (format "(.*)(%s)(.*)" (:match tag-data)))]
     (string/replace data-url pattern (str "$1" (:replace tag-data) "$3"))))
 
+(defn remove-trailing-html
+  "Takes a url and remove the .html in the end."
+  [url]
+  (log/trace "Attempting trailing .html removal from url...")
+  (when url
+    (string/replace url #"\.html$" "")))
+
 (defn granule-link->opendap-url
   "Converts a granule-link to an OPeNDAP URL."
   [granule-link tag-data]
-  (let [data-url (-> granule-link :datafile-link :href)
+  (let [data-url (-> granule-link :datafile-link :href remove-trailing-html)
         data-url-replaced-by-tags (when tag-data
                                     (process-tag-datafile-replacement data-url tag-data))
-        opendap-url (-> granule-link :opendap-link :href)]
+        opendap-url (-> granule-link :opendap-link :href remove-trailing-html)]
     (log/trace "Data file:" granule-link)
     (log/trace "Tag data:" tag-data)
     (log/trace "Data URL replaced by tags:" data-url-replaced-by-tags)

--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.11-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-service-bridge "1.6.12-SNAPSHOT"
   :description "A CMR connector service that provides an inter-service API"
   :url "https://github.com/cmr-exchange/cmr-service-bridge"
   :license {:name "Apache License, Version 2.0"
@@ -30,15 +30,15 @@
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-jar-plugin "0.1.0"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.7-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.7-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
-                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.3-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-sizing-plugin "0.3.4-SNAPSHOT"]
                  [http-kit "2.3.0"]
-                 [markdown-clj "1.0.7"]
-                 [metosin/reitit-core "0.3.1"]
-                 [metosin/reitit-ring "0.3.1"]
+                 [markdown-clj "1.10.0"]
+                 [metosin/reitit-core "0.3.7"]
+                 [metosin/reitit-ring "0.3.7"]
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.4.490"]
@@ -46,7 +46,7 @@
                  [org.clojure/data.xml "0.2.0-alpha5"]
                  [org.clojure/java.classpath "0.3.0"]
                  [ring/ring-core "1.7.1"]
-                 [ring/ring-codec "1.1.1"]
+                 [ring/ring-codec "1.1.2"]
                  [ring/ring-defaults "0.3.2"]
                  [selmer "1.12.12"]
                  [tolitius/xml-in "0.1.0"]]
@@ -99,7 +99,7 @@
                                      :system :system
                                      :default (complement :system)}}
              :docs {:dependencies [[gov.nasa.earthdata/codox-theme "1.0.0-SNAPSHOT"]]
-                    :plugins [[lein-codox "0.10.6"]
+                    :plugins [[lein-codox "0.10.7"]
                               [lein-marginalia "0.9.1"]]
                     :source-paths ["resources/docs/src"]
                     :codox {:project {:name "CMR Service-Bridge"

--- a/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/ous/core.clj
+++ b/cmr-exchange/service-bridge/test/cmr/opendap/tests/system/app/ous/core.clj
@@ -54,6 +54,26 @@
     (is (= ["https://opendap.cr.usgs.gov/opendap/hyrax/DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf.nc"]
            (util/parse-response response)))))
 
+(deftest no-tag-replacement-uses-opendap-url-with-html
+  (let [collection-id "C1200354716-DEMO_PROV"
+        granule-id "G1200354717-DEMO_PROV"
+        options (-> {}
+                    (request/add-token-header (util/get-sit-token))
+                    (util/override-api-version-header "v2.1"))
+        response @(httpc/get
+                   (format (str "http://localhost:%s"
+                                "/service-bridge/ous/collection/%s"
+                                "?granules=%s")
+                           (test-system/http-port)
+                           collection-id
+                           granule-id)
+                   options)]
+    (is (= 200 (:status response)))
+    (is (= "cmr-service-bridge.v2.1; format=json"
+           (get-in response [:headers :cmr-media-type])))
+    (is (= ["https://podaac-opendap.jpl.nasa.gov/opendap/allData/ghrsst/data/GDS2/L3U/GMI/REMSS/v8.2a/2018/331/20181127000000-REMSS-L3U_GHRSST-SSTsubskin-GMI-f35_20181127v8.2-v02.0-fv01.0.nc.nc"]
+           (util/parse-response response)))))
+
 (deftest no-tag-replacement-and-no-opendap-url
   (let [collection-id "C1200237759-DEMO_PROV"
         granule-id "G1200237760-DEMO_PROV"

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.3-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-sizing-plugin "0.3.4-SNAPSHOT"
   :description "A size estimation service for subsetted GIS data"
   :url "https://github.com/cmr-exchange/cmr-sizing-plugin"
   :license {:name "Apache License, Version 2.0"
@@ -25,8 +25,8 @@
                  [gov.nasa.earthdata/cmr-exchange-common "0.3.1-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-exchange-query "0.3.2-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-http-kit "0.2.0-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.6-SNAPSHOT"]
-                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.6-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-metadata-proxy "0.2.7-SNAPSHOT"]
+                 [gov.nasa.earthdata/cmr-ous-plugin "0.3.7-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.0"]
                  [org.clojure/clojure "1.10.0"]]
   :manifest {"CMR-Plugin" "service-bridge-app"}


### PR DESCRIPTION
It might be desirable to allow multiple tag replacements. I will create another ticket if the team thinks we should do it.