### PR TITLE
Adding debug to see which collecion/revision are being reindexed.

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -123,11 +123,11 @@
   ([context concept-batches]
    (bulk-index context concept-batches nil))
   ([context concept-batches options]
+   (doseq [batch concept-batches]
+     (doseq [concept batch]
+       (let [cptinfo (str (:concept-id concept) "/" (:revision-id concept))]
+              (info "Reindexing concept-id/revision-id: " cptinfo))))
    (reduce (fn [num-indexed batch]
-             (map (fn [concept] 
-                    (let [cptinfo (str (:concept-id concept) "/" (:revision-id concept))]
-                      (info "Reindexing concept-id/revision-id: " cptinfo)))
-                  batch) 
              (let [batch (prepare-batch context batch options)]
                (es/bulk-index-documents context batch options)
                (+ num-indexed (count batch))))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -124,6 +124,10 @@
    (bulk-index context concept-batches nil))
   ([context concept-batches options]
    (reduce (fn [num-indexed batch]
+             (map (fn [concept] 
+                    (let [cptinfo (str (:concept-id concept) "/" (:revision-id concept))]
+                      (info "Reindexing concept-id/revision-id: " cptinfo)))
+                  batch) 
              (let [batch (prepare-batch context batch options)]
                (es/bulk-index-documents context batch options)
                (+ num-indexed (count batch))))


### PR DESCRIPTION
1. Check to see if the collection/revisions are fetched from metadata_db correctly.
2. If so, and the bulk_index in the indexer doesn't return error, then that means the bulk reindexing is not working correctly. 