### PR TITLE
CMR-5747: Fixed ignore_conflict parameter.

### DIFF
--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -47,7 +47,7 @@
       ;; Index a concept
       (POST "/" {body :body context :request-context params :params headers :headers}
         (let [{:keys [concept-id revision-id]} (walk/keywordize-keys body)
-              options {:ignore_conflict? (ignore-conflict? params)}]
+              options {:ignore-conflict? (ignore-conflict? params)}]
           ;; indexing all revisions index, does nothing for concept types that do not support all revisions index
           (index-svc/index-concept-by-concept-id-revision-id
             context concept-id revision-id (assoc options :all-revisions-index? true))

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -70,6 +70,41 @@
                     :throw-exceptions false})]
     (is (= 200 (:status response)) (:body response))))
 
+(defn reindex-concept-ignore-conflict-default
+  "Re-index concept"
+  [concept-id revision-id]
+  (let [response (client/post (url/indexer-url)
+                   {:connection-manager (s/conn-mgr)
+                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
+                             "content-type" "application/json"}
+                    :throw-exceptions false
+                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")})]
+    (is (= 201 (:status response)) (:body response))))
+
+(defn reindex-concept-ignore-conflict-true
+  "Re-index concept"
+  [concept-id revision-id]
+  (let [response (client/post (url/indexer-url)
+                   {:connection-manager (s/conn-mgr)
+                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
+                              "content-type" "application/json"}
+                    :throw-exceptions false
+                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")
+                    :query-params {:ignore_conflict "not-false"}})]
+    (is (= 201 (:status response)) (:body response))))
+
+(defn reindex-concept-ignore-conflict-false
+  "Re-index concept"
+  [concept-id revision-id]
+  (let [response (client/post (url/indexer-url)
+                   {:connection-manager (s/conn-mgr)
+                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
+                              "content-type" "application/json"}
+                    :throw-exceptions false
+                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")
+                    :query-params {:ignore_conflict "false"}})]
+    (is (= 409 (:status response)) (:body response))))
+
 (defn doc-present?
   "If doc is present return true, otherwise return false"
   [index-name type-name doc-id]

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -71,7 +71,7 @@
     (is (= 200 (:status response)) (:body response))))
 
 (defn reindex-concept-ignore-conflict-default
-  "Re-index concept"
+  "Re-index concept without passing in ignore_conflict param should default to conflict being ignored."
   [concept-id revision-id]
   (let [response (client/post (url/indexer-url)
                    {:connection-manager (s/conn-mgr)
@@ -82,7 +82,7 @@
     (is (= 201 (:status response)) (:body response))))
 
 (defn reindex-concept-ignore-conflict-true
-  "Re-index concept"
+  "Re-index concept with ignore_conflict param set to anything but false should result in conflict being ignored."
   [concept-id revision-id]
   (let [response (client/post (url/indexer-url)
                    {:connection-manager (s/conn-mgr)
@@ -94,7 +94,7 @@
     (is (= 201 (:status response)) (:body response))))
 
 (defn reindex-concept-ignore-conflict-false
-  "Re-index concept"
+  "Re-index concept with ignore_conflict set to false should result in conflict NOT being ignored."
   [concept-id revision-id]
   (let [response (client/post (url/indexer-url)
                    {:connection-manager (s/conn-mgr)

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -70,40 +70,22 @@
                     :throw-exceptions false})]
     (is (= 200 (:status response)) (:body response))))
 
-(defn reindex-concept-ignore-conflict-default
-  "Re-index concept without passing in ignore_conflict param should default to conflict being ignored."
-  [concept-id revision-id]
-  (let [response (client/post (url/indexer-url)
-                   {:connection-manager (s/conn-mgr)
-                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
-                             "content-type" "application/json"}
-                    :throw-exceptions false
-                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")})]
-    (is (= 201 (:status response)) (:body response))))
-
-(defn reindex-concept-ignore-conflict-true
-  "Re-index concept with ignore_conflict param set to anything but false should result in conflict being ignored."
-  [concept-id revision-id]
-  (let [response (client/post (url/indexer-url)
-                   {:connection-manager (s/conn-mgr)
-                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
-                              "content-type" "application/json"}
-                    :throw-exceptions false
-                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")
-                    :query-params {:ignore_conflict "not-false"}})]
-    (is (= 201 (:status response)) (:body response))))
-
-(defn reindex-concept-ignore-conflict-false
-  "Re-index concept with ignore_conflict set to false should result in conflict NOT being ignored."
-  [concept-id revision-id]
-  (let [response (client/post (url/indexer-url)
-                   {:connection-manager (s/conn-mgr)
-                    :headers {transmit-config/token-header (transmit-config/echo-system-token)
-                              "content-type" "application/json"}
-                    :throw-exceptions false
-                    :body (str "{\"concept-id\": " "\"" concept-id "\", " "\"revision-id\": " "\"" revision-id "\"" "}")
-                    :query-params {:ignore_conflict "false"}})]
-    (is (= 409 (:status response)) (:body response))))
+(defn reindex-concept-with-ignore-conflict-param
+  "Re-index concept with ignore_conflict param."
+  ([concept-id revision-id]
+   (reindex-concept-with-ignore-conflict-param concept-id revision-id nil))
+  ([concept-id revision-id ignore_conflict]
+   (let [query-params (if ignore_conflict
+                        {:ignore_conflict ignore_conflict}
+                        {})
+         response (client/post (url/indexer-url)
+                    {:connection-manager (s/conn-mgr)
+                     :headers {transmit-config/token-header (transmit-config/echo-system-token)
+                               "content-type" "application/json"}
+                     :throw-exceptions false
+                     :body (json/generate-string {:concept-id concept-id :revision-id revision-id})
+                     :query-params query-params})]
+     response)))
 
 (defn doc-present?
   "If doc is present return true, otherwise return false"

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -565,3 +565,8 @@
   "URL to search or update acls"
   []
   (format "http://localhost:%s/acls" (transmit-config/access-control-port)))
+
+(defn indexer-url
+  "URL to index a concept"
+  []
+  (format "http://localhost:%s" (transmit-config/indexer-port)))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -71,10 +71,12 @@
       (is (= 1 revision-id1))
       (is (= 2 revision-id2))
       (is (= concept-id1 concept-id2))
-      (index/reindex-concept-ignore-conflict-default concept-id1 revision-id1)
-      (index/reindex-concept-ignore-conflict-true concept-id1 revision-id1)
-      (index/reindex-concept-ignore-conflict-false concept-id1 revision-id1)
-      )))
+      (let [response1 (index/reindex-concept-with-ignore-conflict-param concept-id1 revision-id1)
+            response2 (index/reindex-concept-with-ignore-conflict-param concept-id1 revision-id1 "not-false")
+            response3 (index/reindex-concept-with-ignore-conflict-param concept-id1 revision-id1 "false")]
+        (is (= 201 (:status response1)) (:body response1))
+        (is (= 201 (:status response2)) (:body response2))
+        (is (= 409 (:status response3)) (:body response3))))))
 
 ;; Verify that user-id is saved from User-Id or token header
 (deftest collection-ingest-user-id-test

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -55,6 +55,27 @@
       (is (= 5 revision-id))
       (is (mdb/concept-exists-in-mdb? concept-id 5)))))
 
+;; Verify a concept can be ingested twice to get two revisions and ignore_conflict can impact the reindex status. 
+(deftest collection-ingest-test
+  (testing "ingest of a new concept twice to get two revisions, and reindex revision 1, with ignore_conflict on and off."
+    (let [concept (data-umm-c/collection-concept {})
+          ingested-concept1 (ingest/ingest-concept concept)
+          ingested-concept2 (ingest/ingest-concept concept)
+          concept-id1 (:concept-id ingested-concept1)
+          concept-id2 (:concept-id ingested-concept2)
+          revision-id1 (:revision-id ingested-concept1)
+          revision-id2 (:revision-id ingested-concept2)]
+      (index/wait-until-indexed)
+      (is (mdb/concept-exists-in-mdb? concept-id1 revision-id1))
+      (is (mdb/concept-exists-in-mdb? concept-id2 revision-id2))
+      (is (= 1 revision-id1))
+      (is (= 2 revision-id2))
+      (is (= concept-id1 concept-id2))
+      (index/reindex-concept-ignore-conflict-default concept-id1 revision-id1)
+      (index/reindex-concept-ignore-conflict-true concept-id1 revision-id1)
+      (index/reindex-concept-ignore-conflict-false concept-id1 revision-id1)
+      )))
+
 ;; Verify that user-id is saved from User-Id or token header
 (deftest collection-ingest-user-id-test
   (testing "ingest of new concept"


### PR DESCRIPTION
This has been tested in SIT. Basically what gets selected in index-svc/index-concept-by-concept-id-revision-id is :ignore-conflict. 