### PR TITLE
Use proper config namespace for ingest migrations

### DIFF
--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -34,7 +34,7 @@
          (conj
           migrate-args
           "-c"
-          "config.migrate-config/app-migrate-config")))
+          "config.ingest-migrate-config/app-migrate-config")))
       {:status 204}))
 
 (def job-management-routes


### PR DESCRIPTION
Missed this change on the last PR