### PR TITLE
CMR-5743: Fixed the relative path for css files.

### DIFF
--- a/collection-renderer-lib/resources/collection_preview/collection_preview.erb
+++ b/collection-renderer-lib/resources/collection_preview/collection_preview.erb
@@ -21,8 +21,8 @@ metadata =  JSON.parse(umm_json)
   <%= csrf_meta_tag %>
   <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
-  <link href="https://cmr.earthdata.nasa.gov:443/search/site/css/eui.css" rel="stylesheet" />
-  <link href="https://cmr.earthdata.nasa.gov:443/search/site/css/cmr.css" rel="stylesheet" />
+  <link href="<%=search_public_root_url%>site/css/eui.css" rel="stylesheet" />
+  <link href="<%=search_public_root_url%>site/css/cmr.css" rel="stylesheet" />
 
   <%= stylesheet_link_tag relative_root_url + "/stylesheets/application", media: 'all' %>
   <%= javascript_include_tag relative_root_url + "/javascripts/application" %>

--- a/collection-renderer-lib/resources/collection_preview/collection_preview.erb
+++ b/collection-renderer-lib/resources/collection_preview/collection_preview.erb
@@ -21,8 +21,8 @@ metadata =  JSON.parse(umm_json)
   <%= csrf_meta_tag %>
   <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,300" rel="stylesheet" type="text/css">
-  <link href="../../../site/css/eui.css" rel="stylesheet" /> 
-  <link href="../../../site/css/cmr.css" rel="stylesheet" /> 
+  <link href="https://cmr.earthdata.nasa.gov:443/search/site/css/eui.css" rel="stylesheet" />
+  <link href="https://cmr.earthdata.nasa.gov:443/search/site/css/cmr.css" rel="stylesheet" />
 
   <%= stylesheet_link_tag relative_root_url + "/stylesheets/application", media: 'all' %>
   <%= javascript_include_tag relative_root_url + "/javascripts/application" %>

--- a/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
+++ b/collection-renderer-lib/src/cmr/collection_renderer/services/collection_renderer.clj
@@ -4,6 +4,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.lifecycle :as l]
    [cmr.common.log :refer [info]]
    [cmr.common-app.services.search :as search]
@@ -11,7 +12,7 @@
    [cmr.umm-spec.migration.version.core :as vm]
    [cmr.umm-spec.umm-json :as umm-json]
    [cmr.umm-spec.versioning :as umm-version]
-   [cmr.common.config :as cfg :refer [defconfig]])
+   [cmr.transmit.config :as config])
   (:import
    (java.io ByteArrayInputStream)
    (javax.script ScriptEngine ScriptEngineManager Invocable)))
@@ -148,4 +149,5 @@
                  "relative_root_url" (context->relative-root-url context)
                  "edsc_url" (search-edsc-url)
                  "concept_id" concept-id
-                 "additional_information" additional-information}))))
+                 "additional_information" additional-information
+                 "search_public_root_url" (config/application-public-root-url :search)}))))


### PR DESCRIPTION
On Chrome it complained about http(instead of https) access to the css files because it's using relative paths. Changed them to absolute paths. 