### PR TITLE
CMR-5797 Add "Non-NASA" user all for draft MMT

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
@@ -1282,32 +1282,32 @@
                                    (:concept_id acl)
                                    {:token token})))
 
-    (is (= {"NON_NASA_DRAFT_USER" ["read" "create" "update" "delete"]}
-           (json/parse-string
-             (access-control/get-permissions
-              (test-util/conn-context)
-              {:user_id "user1"
-               :provider "PROV1"
-               :target "NON_NASA_DRAFT_USER"}
-              {:token token}))))
+    (testing "MMT DRAFT NON NASA USERS Acl permissions"
+      (are3 [perms params]
+        (is (= {"NON_NASA_DRAFT_USER" perms}
+               (json/parse-string
+                 (access-control/get-permissions
+                  (test-util/conn-context)
+                  params
+                  {:token token}))))
 
-    (is (= {"NON_NASA_DRAFT_USER" ["read" "create" "update" "delete"]}
-           (json/parse-string
-             (access-control/get-permissions
-              (test-util/conn-context)
-              {:user_type "guest"
-               :provider "PROV1"
-               :target "NON_NASA_DRAFT_USER"}
-              {:token token}))))
+        "user1 permissions"
+        ["read" "create" "update" "delete"]
+        {:user_id "user1"
+         :provider "PROV1"
+         :target "NON_NASA_DRAFT_USER"}
 
-    (is (= {"NON_NASA_DRAFT_USER" ["read" "update"]}
-           (json/parse-string
-             (access-control/get-permissions
-              (test-util/conn-context)
-              {:user_id "user2"
-               :provider "PROV1"
-               :target "NON_NASA_DRAFT_USER"}
-              {:token token}))))))
+        "guest permissions"
+        ["read"]
+        {:user_type "guest"
+         :provider "PROV1"
+         :target "NON_NASA_DRAFT_USER"}
+
+        "user2 permissions"
+        ["read" "update"]
+        {:user_id "user2"
+         :provider "PROV1"
+         :target "NON_NASA_DRAFT_USER"}))))
 
 (deftest CMR-5128-mmt-dashboard-acl-test
   (let [token (echo-util/login (test-util/conn-context) "admin")

--- a/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
@@ -40,7 +40,7 @@
                              "\"PROVIDER_ORDER_CLOSURE\" \"PROVIDER_ORDER_TRACKING_ID\" \"PROVIDER_INFORMATION\" "
                              "\"PROVIDER_CONTEXT\" \"AUTHENTICATOR_DEFINITION\" \"PROVIDER_POLICIES\" \"USER\" "
                              "\"GROUP\" \"DASHBOARD_DAAC_CURATOR\" \"PROVIDER_OBJECT_ACL\" \"CATALOG_ITEM_ACL\" \"INGEST_MANAGEMENT_ACL\" "
-                             "\"DATA_QUALITY_SUMMARY_DEFINITION\" \"DATA_QUALITY_SUMMARY_ASSIGNMENT\" \"PROVIDER_CALENDAR_EVENT\"]")]
+                             "\"DATA_QUALITY_SUMMARY_DEFINITION\" \"DATA_QUALITY_SUMMARY_ASSIGNMENT\" \"PROVIDER_CALENDAR_EVENT\" \"NON_NASA_DRAFT_USER\"]")]
     (are [params errors]
       (= {:status 400 :body {:errors errors} :content-type :json}
          (ac/get-permissions (u/conn-context) params {:raw? true}))

--- a/access-control-app/src/cmr/access_control/data/acl_schema.clj
+++ b/access-control-app/src/cmr/access_control/data/acl_schema.clj
@@ -73,7 +73,8 @@
    ingest-management-acl-target
    "DATA_QUALITY_SUMMARY_DEFINITION"
    "DATA_QUALITY_SUMMARY_ASSIGNMENT"
-   "PROVIDER_CALENDAR_EVENT"])
+   "PROVIDER_CALENDAR_EVENT"
+   "NON_NASA_DRAFT_USER"])
 
 (def valid-permissions
   "A collection of valid permissions for group permissions"

--- a/access-control-app/src/cmr/access_control/services/acl_validation.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_validation.clj
@@ -41,9 +41,10 @@
                               "CATALOG_ITEM_ACL"                [c r u d]
                               "INGEST_MANAGEMENT_ACL"           [r u]
                               "DATA_QUALITY_SUMMARY_DEFINITION" [c u d]
-                              "DASHBOARD_DAAC_CURATOR_ROLE"     [c r u d]
+                              "DASHBOARD_DAAC_CURATOR"          [c r u d]
                               "DATA_QUALITY_SUMMARY_ASSIGNMENT" [c d]
-                              "PROVIDER_CALENDAR_EVENT"         [c u d]}
+                              "PROVIDER_CALENDAR_EVENT"         [c u d]
+                              "NON_NASA_DRAFT_USER"             [c r u d]}
    :system-identity          {"SYSTEM_AUDIT_REPORT"             [r]
                               "METRIC_DATA_POINT_SAMPLE"        [r]
                               "SYSTEM_INITIALIZER"              [c]


### PR DESCRIPTION
Adds a new target to provider object acls to allow mmt to manage non nasa draft mmt users.