### PR TITLE
CMR-5832 CMR Search API Documentation Maximum URL Length does not provide reasonable guidance.

### DIFF
--- a/access-control-app/docs/acl-schema.md
+++ b/access-control-app/docs/acl-schema.md
@@ -187,3 +187,4 @@ This element must be one of the following enum values:
 * `DATA_QUALITY_SUMMARY_ASSIGNMENT`
 * `PROVIDER_CALENDAR_EVENT`
 * `DASHBOARD_DAAC_CURATOR`
+* `NON_NASA_DRAFT_USER`

--- a/access-control-app/docs/api.md
+++ b/access-control-app/docs/api.md
@@ -406,6 +406,8 @@ For system, provider, and single instance identities, the grantable permissions 
 | SYSTEM_OPTION_DEFINITION_DEPRECATION | create                       |
 | INGEST_MANAGEMENT_ACL                | read, update                 |
 | SYSTEM_CALENDAR_EVENT                | create, update, delete       |
+| DASHBOARD_ADMIN                      | create, read, update, delete |
+| DASHBOARD_ARC_CURATOR                | create, read, update, delete |
 
 #### Provider Identity
 | Target                          | Grantable Permissions        |
@@ -435,6 +437,8 @@ For system, provider, and single instance identities, the grantable permissions 
 | DATA_QUALITY_SUMMARY_DEFINITION | create, update, delete       |
 | DATA_QUALITY_SUMMARY_ASSIGNMENT | create, delete               |
 | PROVIDER_CALENDAR_EVENT         | create, update, delete       |
+| DASHBOARD_DAAC_CURATOR          | create, read, update, delete |
+| NON_NASA_DRAFT_USER             | create, read, update, delete |
 
 #### Single Instance Identity
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -184,7 +184,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
 
 #### <a name="maximum-url-length"></a> Maximum URL Length
 
-The Maximum URL Length supported by CMR is indirectly controlled by the Request Header Size setting in Jetty which is set to 1MB. This translates to roughly 500k characters. Clients using the Search API with query parameters should be careful not to exceed this limit or they will get an HTTP response of 413 FULL HEAD. If a client expects that the query url could be extra long so that it exceeds 500k characters, they should use the POST API for searching.
+The Maximum URL Length supported by CMR is indirectly controlled by the Request Header Size setting in Jetty which is set to 1MB. This translates to roughly 500k characters, however it is recommended that any GET request be limited to 6,000 characters, and in a web browser the recommended length is no longer than 2000 characters. Clients using the Search API with query parameters should be careful not to exceed this limit or they will get an HTTP response of 413 FULL HEAD. If a client expects that the query url could be extra long so that it exceeds 6k characters, they should use the POST API for searching.
 
 #### <a name="cors-header-support"></a> CORS Header support
 


### PR DESCRIPTION
In general, the max character limit restriction on URLs could be affected by the browser type and server config. We have done test on CMR endpoint before and the answer is ~6000 characters, but if you go through browsers, the general guideline is ~2000.
Our recommendation is for clients to use the POST endpoint when submitting queries with long query parameters