### PR TITLE
CMR-5834: Limit ACL revisions to 10.

### DIFF
--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/cleanup_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/cleanup_test.clj
@@ -43,6 +43,33 @@
   [concept]
   (= 200 (:status (util/get-concept-by-id (:concept-id concept)))))
 
+(deftest old-acl-revisions-are-cleaned-up-1
+  (side/eval-form `(tk/set-time-override! (tk/now)))
+  (let [acl (concepts/create-and-save-concept :acl "CMR" 1 13)]
+
+    (is (all-revisions-exist? acl))
+
+    (is (= 204 (util/old-revision-concept-cleanup)))
+
+    ;; Any more than 10 of the oldest acl revisions should have been cleaned up
+    (is (revisions-removed? acl (range 1 4)))
+
+    ;; The latest 10 revisions should be kept
+    (is (revisions-exist? acl (range 4 14)))
+  (side/eval-form `(tk/clear-current-time!))))
+
+(deftest old-acl-revisions-are-cleaned-up-2
+  (side/eval-form `(tk/set-time-override! (tk/now)))
+  (let [acl (concepts/create-and-save-concept :acl "CMR" 1 10)]
+
+    (is (all-revisions-exist? acl))
+
+    (is (= 204 (util/old-revision-concept-cleanup)))
+
+    ;; All revisions should be kept since it's not more than 10.
+    (is (all-revisions-exist? acl))
+  (side/eval-form `(tk/clear-current-time!))))
+
 (deftest old-collection-revisions-are-cleaned-up
   (side/eval-form `(tk/set-time-override! (tk/now)))
   (let [coll1 (concepts/create-and-save-concept :collection "REG_PROV" 1 13)

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -50,7 +50,8 @@
 (def num-revisions-to-keep-per-concept-type
   "Number of revisions to keep by concept-type. If a concept instance has more than the number
   of revisions here the oldest ones will be deleted."
-  {:collection 10
+  {:acl 10
+   :collection 10
    :granule 1
    :tag 10
    :tag-association 10

--- a/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
@@ -12,7 +12,7 @@
 
 (def OLD_REVISIONS_CONCEPT_CLEANUP_INTERVAL
   "The number of seconds between jobs run to cleanup old revisions of granules and collections"
-  (* 3600 6))
+  (* 60 5))
 
 (defn expired-concept-cleanup
   [context]
@@ -28,6 +28,7 @@
 (defn old-revision-concept-cleanup
   [context]
   ;; cleanup CMR system concepts
+  (concept-service/delete-old-revisions context pv/cmr-provider :acl)
   (concept-service/delete-old-revisions context pv/cmr-provider :tag-association)
   (concept-service/delete-old-revisions context pv/cmr-provider :tag)
   (concept-service/delete-old-revisions context pv/cmr-provider :variable-association)

--- a/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
@@ -12,7 +12,7 @@
 
 (def OLD_REVISIONS_CONCEPT_CLEANUP_INTERVAL
   "The number of seconds between jobs run to cleanup old revisions of granules and collections"
-  (* 60 5))
+  (* 3600 6))
 
 (defn expired-concept-cleanup
   [context]


### PR DESCRIPTION
For testing:
Deployed to SIT.
Created an ACL with 20 revisions - ACL1200360718-CMR

Checked splunk:
2019-08-16 03:17:29.032 ip-10-5-33-36.ec2.internal [OldRevisionConceptCleanupJob] INFO [cmr.metadata-db.services.concept-service] - Starting deletion of old acls for provider CMR host =	 splunk_hec_serverssource =	 http:NGAP_Event_Collectorsourcetype =	 httpevent
  
Verified in SIT database that revisions 1 through 10 were removed and revisions 11 to 20 are remaining.