### PR TITLE
MMT-1908: Update preview gem to handle metadata which has data centers with no short name.

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -14,7 +14,7 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-      "d81ad5ef55c"))
+      "03072e2c727"))
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
Updating preview gem commit reference