### PR TITLE
Cmr 5873 browse scaler throws 502

### DIFF
--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -68,7 +68,7 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   // If given an image url, fetch the image and resize. If no image
   // exists, return the not found response
   const imageUrl = await getImageUrlFromConcept(conceptId, conceptType);
-  console.log (`BEFORE SLURPING`)
+  console.log (`BEFORE SLURPING`);
   const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
   console.log (`AFTER SLURPING ${imageBuffer}`);
 

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -71,6 +71,7 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
 
   if (imageUrl === null || imageBuffer === null || imageBuffer === undefined) {
+    console.log (`IMAGENOTRETURNED`);
     const imgNotFound = await notFound();
     return buildResponse(imgNotFound);
   }

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -3,8 +3,8 @@ const { getCollectionLevelBrowseImage, getGranuleLevelBrowseImage } = require('.
 const { cacheImage, getImageFromCache } = require('./cache');
 const { withTimeout, slurpImageIntoBuffer } = require('./util');
 
-const timeoutInterval = 1000;
-
+const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 1000;
+console.log(`TIMEOUT INTERVAL IS: ${timeoutInterval}`);
 /**
  * buildResponse: assembles response body to avoid code duplication
  * @param {Buffer<Image>} image
@@ -67,30 +67,18 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
 
   // If given an image url, fetch the image and resize. If no image
   // exists, return the not found response
-  console.log ("BEFORE GETING IMAGEURL"); 
   const imageUrl = await withTimeout(timeoutInterval, getImageUrlFromConcept(conceptId, conceptType));
-
   if (imageUrl === null) {
-    console.log ("IMAGE URL NOT RETURNED");
+    console.log("IMAGE URL IS NOT RETURNED.");
     const imgNotFound = await notFound();
-    console.log ("AFTER notFound when IMAGE URL NOT RETURNED");
     return buildResponse(imgNotFound);
   }
 
-  console.log ("BEFORE SLURPING");
   const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
-
   if (imageBuffer === null || imageBuffer === undefined) {
-    console.log ("IMAGE NOT RETURNED");
+    console.log("IMAGE IS NOT RETURNED."); 
     const imgNotFound = await notFound();
-    console.log ("AFTER notFound when IMAGE NOT RETURNED");
-
-    if (imgNotFound === null) {
-      console.log ("IMAGE imgNotFound NOT RETURNED");
-      return null; 
-    }
-    console.log ("IMAGE imgNotFound RETURNED");
-    return buildResponse(imgNotFound); 
+    return buildResponse(imgNotFound);
   }
 
   const thumbnail = await resizeImage(imageBuffer, height, width);

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -68,10 +68,12 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   // If given an image url, fetch the image and resize. If no image
   // exists, return the not found response
   const imageUrl = await getImageUrlFromConcept(conceptId, conceptType);
+  console.log (`BEFORE SLURPING`)
   const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
+  console.log (`AFTER SLURPING ${imageBuffer}`);
 
   if (imageUrl === null || imageBuffer === null || imageBuffer === undefined) {
-    console.log (`IMAGENOTRETURNED`);
+    console.log (`IMAGE NOT RETURNED`);
     const imgNotFound = await notFound();
     return buildResponse(imgNotFound);
   }

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -67,13 +67,20 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
 
   // If given an image url, fetch the image and resize. If no image
   // exists, return the not found response
-  const imageUrl = await getImageUrlFromConcept(conceptId, conceptType);
-  console.log (`BEFORE SLURPING`);
-  const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
-  console.log (`AFTER SLURPING ${imageBuffer}`);
+  console.log ("BEFORE GETING IMAGEURL"); 
+  const imageUrl = await withTimeout(timeoutInterval, getImageUrlFromConcept(conceptId, conceptType));
 
-  if (imageUrl === null || imageBuffer === null || imageBuffer === undefined) {
-    console.log (`IMAGE NOT RETURNED`);
+  if (imageUrl === null) {
+    console.log ("IMAGE URL NOT RETURNED");
+    const imgNotFound = await notFound();
+    return buildResponse(imgNotFound);
+  }
+
+  console.log ("BEFORE SLURPING");
+  const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
+
+  if (imageBuffer === null || imageBuffer === undefined) {
+    console.log ("IMAGE NOT RETURNED");
     const imgNotFound = await notFound();
     return buildResponse(imgNotFound);
   }

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -73,7 +73,7 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   if (imageUrl === null) {
     console.log ("IMAGE URL NOT RETURNED");
     const imgNotFound = await notFound();
-    console.log ("AFTER notFound");
+    console.log ("AFTER notFound when IMAGE URL NOT RETURNED");
     return buildResponse(imgNotFound);
   }
 
@@ -82,8 +82,8 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
 
   if (imageBuffer === null || imageBuffer === undefined) {
     console.log ("IMAGE NOT RETURNED");
-    const imgNotFound = await withTimeout(timeoutInterval, notFound());
-    console.log ("AFTER notFound");
+    const imgNotFound = await notFound();
+    console.log ("AFTER notFound when IMAGE NOT RETURNED");
 
     if (imgNotFound === null) {
       console.log ("IMAGE imgNotFound NOT RETURNED");

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -3,7 +3,7 @@ const { getCollectionLevelBrowseImage, getGranuleLevelBrowseImage } = require('.
 const { cacheImage, getImageFromCache } = require('./cache');
 const { withTimeout, slurpImageIntoBuffer } = require('./util');
 
-const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 2000;
+const timeoutInterval = 1000;
 
 /**
  * buildResponse: assembles response body to avoid code duplication

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -73,6 +73,7 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   if (imageUrl === null) {
     console.log ("IMAGE URL NOT RETURNED");
     const imgNotFound = await notFound();
+    console.log ("AFTER notFound");
     return buildResponse(imgNotFound);
   }
 
@@ -82,6 +83,7 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   if (imageBuffer === null || imageBuffer === undefined) {
     console.log ("IMAGE NOT RETURNED");
     const imgNotFound = await withTimeout(timeoutInterval, notFound());
+    console.log ("AFTER notFound");
 
     if (imgNotFound === null) {
       console.log ("IMAGE imgNotFound NOT RETURNED");

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -81,8 +81,14 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
 
   if (imageBuffer === null || imageBuffer === undefined) {
     console.log ("IMAGE NOT RETURNED");
-    const imgNotFound = await notFound();
-    return buildResponse(imgNotFound);
+    const imgNotFound = await withTimeout(timeoutInterval, notFound());
+
+    if (imgNotFound === null) {
+      console.log ("IMAGE imgNotFound NOT RETURNED");
+      return null; 
+    }
+    console.log ("IMAGE imgNotFound RETURNED");
+    return buildResponse(imgNotFound); 
   }
 
   const thumbnail = await resizeImage(imageBuffer, height, width);

--- a/browse-scaler/src/index.js
+++ b/browse-scaler/src/index.js
@@ -4,7 +4,7 @@ const { cacheImage, getImageFromCache } = require('./cache');
 const { withTimeout, slurpImageIntoBuffer } = require('./util');
 
 const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 1000;
-console.log(`TIMEOUT INTERVAL IS: ${timeoutInterval}`);
+console.log(`Timeout interval is: ${timeoutInterval}`);
 /**
  * buildResponse: assembles response body to avoid code duplication
  * @param {Buffer<Image>} image
@@ -69,14 +69,14 @@ const resizeImageFromConceptId = async (conceptType, conceptId, height, width) =
   // exists, return the not found response
   const imageUrl = await withTimeout(timeoutInterval, getImageUrlFromConcept(conceptId, conceptType));
   if (imageUrl === null) {
-    console.log("IMAGE URL IS NOT RETURNED.");
+    console.log(`No image url returned for: ${conceptId}`);
     const imgNotFound = await notFound();
     return buildResponse(imgNotFound);
   }
 
   const imageBuffer = await withTimeout(timeoutInterval, slurpImageIntoBuffer(imageUrl));
   if (imageBuffer === null || imageBuffer === undefined) {
-    console.log("IMAGE IS NOT RETURNED."); 
+    console.log(`No image returned for: ${conceptId}`);
     const imgNotFound = await notFound();
     return buildResponse(imgNotFound);
   }

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -1,5 +1,7 @@
 const sharp = require('sharp');
 
+const { withTimeout } = require('util');
+const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 2000;
 /**
  * resizeImage: Resize a given image to a given height and width
  * @param {Buffer<Image>} image An image binary contained in a buffer
@@ -36,14 +38,7 @@ exports.resizeImage = async (image, height, width) => {
  */
 exports.notFound = async () => {
   console.log("BEFORE sharp"); 
-  try {
-  const notFound = await sharp('image-unavailable.svg')
-    .toFormat('png')
-    .toBuffer();
-  } catch (err) {
-    console.log(`Could not pull image-unavailable.svg file: ${err}`);
-    return null;
-  }
+  const notFound = await withTimeout(timeoutInterval, sharp('image-unavailable.svg').toFormat('png').toBuffer());
   console.log(`image not found. got file ${notFound}`);
   return notFound;
 };

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -1,6 +1,6 @@
 const sharp = require('sharp');
 
-const { withTimeout } = require('util');
+const { withTimeout } = require('./util');
 const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 2000;
 /**
  * resizeImage: Resize a given image to a given height and width

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -35,6 +35,7 @@ exports.resizeImage = async (image, height, width) => {
  * @return {Buffer<Image>} This is what you show the user when an image cannot be found or resized
  */
 exports.notFound = async () => {
+  console.log("BEFORE sharp"); 
   const notFound = await sharp('image-unavailable.svg')
     .toFormat('png')
     .toBuffer();

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -36,9 +36,14 @@ exports.resizeImage = async (image, height, width) => {
  */
 exports.notFound = async () => {
   console.log("BEFORE sharp"); 
+  try {
   const notFound = await sharp('image-unavailable.svg')
     .toFormat('png')
     .toBuffer();
+  } catch (err) {
+    console.log(`Could not pull image-unavailable.svg file: ${err}`);
+    return null;
+  }
   console.log(`image not found. got file ${notFound}`);
   return notFound;
 };

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -35,10 +35,9 @@ exports.resizeImage = async (image, height, width) => {
  * @return {Buffer<Image>} This is what you show the user when an image cannot be found or resized
  */
 exports.notFound = async () => {
-  console.log("BEFORE sharp"); 
   const notFound = await sharp('image-unavailable.svg')
-     .toFormat('png')
-     .toBuffer();
+    .toFormat('png')
+    .toBuffer();
   console.log(`image not found. got file ${notFound}`);
   return notFound;
 };

--- a/browse-scaler/src/resize.js
+++ b/browse-scaler/src/resize.js
@@ -1,7 +1,5 @@
 const sharp = require('sharp');
 
-const { withTimeout } = require('./util');
-const timeoutInterval = process.env.EXTERNAL_REQUEST_TIMEOUT || 2000;
 /**
  * resizeImage: Resize a given image to a given height and width
  * @param {Buffer<Image>} image An image binary contained in a buffer
@@ -38,7 +36,9 @@ exports.resizeImage = async (image, height, width) => {
  */
 exports.notFound = async () => {
   console.log("BEFORE sharp"); 
-  const notFound = await withTimeout(timeoutInterval, sharp('image-unavailable.svg').toFormat('png').toBuffer());
+  const notFound = await sharp('image-unavailable.svg')
+     .toFormat('png')
+     .toBuffer();
   console.log(`image not found. got file ${notFound}`);
   return notFound;
 };

--- a/browse-scaler/src/util.js
+++ b/browse-scaler/src/util.js
@@ -10,7 +10,7 @@ exports.withTimeout = (millis, promise) => {
   // create two promises: one that does the actual work,
   // and one that will reject them after a given number of milliseconds
   const timeout = new Promise((resolve, reject) => setTimeout(() => reject(null), millis));
-  return Promise.race([promise, timeout]).then(value => value);
+  return Promise.race([promise, timeout]).then(value => value, value => null);
 };
 
 /**


### PR DESCRIPTION
The issue was we set request timeout to be 3 seconds. When the image was not found, the time it took to get to that point was already very close to 3 seconds(through withTimeout function). so it didn't have enough time to complete notFound function before the request timed out, which threw 502.

1. Shortened the default timeoutInterval to be 1000, instead of 2000ms. 
2. Added withTimeout to getImageUrlFromConcept, just in case it takes too long.
3. Modified withTimeout function to handle the case when the promise is rejected.

