### PR TITLE
CMR-6020: Added retries to execute ES query on UnknownHostException

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
@@ -113,10 +113,11 @@
       (errors/throw-service-error :service-unavailable "Exhausted retries to execute ES query"))
     (catch UnknownHostException e
       (info (format
-             (str "Excute ES query failed due to UnknownHostException. Retry in half a second."
+             (str "Execute ES query failed due to UnknownHostException. Retry in %.3f seconds."
                   " Will retry up to %d times.")
+             (/ (es-config/elastic-unknown-host-retry-interval-ms) 1000.0)
              max-retries))
-      (Thread/sleep 500)
+      (Thread/sleep (es-config/elastic-unknown-host-retry-interval-ms))
       (do-send-with-retry context index-info query (- max-retries 1)))))
 
 (defn- do-send

--- a/elastic-utils-lib/src/cmr/elastic_utils/config.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/config.clj
@@ -1,6 +1,6 @@
 (ns cmr.elastic-utils.config
   "Contains configuration functions for communicating with elastic search"
-  (:require 
+  (:require
    [clojure.data.codec.base64 :as b64]
    [cmr.common.config :as config :refer [defconfig]]))
 
@@ -16,9 +16,13 @@
     "Token used for basic auth authentication with elastic."
     {:default (str "Basic " (b64/encode (.getBytes "echo-elasticsearch")))})
 
-(defconfig elastic-scroll-timeout 
+(defconfig elastic-scroll-timeout
   "Timeout for ES scrolling"
   {:default "5m"})
+
+(defconfig elastic-unknown-host-retries
+  "Number of times to retry on ES unknown host error"
+  {:default 3 :type Long})
 
 (defconfig elastic-scroll-search-type
   "Search type to use with scrolling - either 'scan' or 'query_then_fetch'"
@@ -34,4 +38,3 @@
    ;; to retry again
    :retry-handler nil
    :admin-token (elastic-admin-token)})
-  

--- a/elastic-utils-lib/src/cmr/elastic_utils/config.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/config.clj
@@ -24,6 +24,10 @@
   "Number of times to retry on ES unknown host error"
   {:default 3 :type Long})
 
+(defconfig elastic-unknown-host-retry-interval-ms
+  "Number of milliseconds to retry an ES unknown host error"
+  {:default 500 :type Long})
+
 (defconfig elastic-scroll-search-type
   "Search type to use with scrolling - either 'scan' or 'query_then_fetch'"
   {:default "query_then_fetch"})


### PR DESCRIPTION
James and I add this retry to resolve the 503 error related to search encounters UnknownHostException when talking to ES cluster via DNS name. We are planning to backport this fix to PROD.