### PR TITLE
CMR-6016: Add timeout to Elasticsearch queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.lein-*
 profiles.clj
 browse-scaler/src/node_modules
+.classpath
+.project
+*.prefs
 
 ###############################
 ### Test Files

--- a/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
@@ -68,6 +68,7 @@
                  concept-type
                  (or (:result-fields query) (concept-type+result-format->fields concept-type query)))]
     {:version true
+     :timeout (es-config/elastic-query-timeout)
      :sort sort-params
      :size page-size
      :from offset

--- a/elastic-utils-lib/src/cmr/elastic_utils/config.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/config.clj
@@ -20,6 +20,10 @@
   "Timeout for ES scrolling"
   {:default "5m"})
 
+(defconfig elastic-query-timeout
+  "Timeout for ES queries"
+  {:default "170s"})
+
 (defconfig elastic-unknown-host-retries
   "Number of times to retry on ES unknown host error"
   {:default 3 :type Long})

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -14,6 +14,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Collection Result Feature Parameters](#collection-result-features)
     * [Headers](#headers)
     * [Extensions](#extensions)
+    * [Request Timeouts](#request-timeouts)
   * [Supported Result Formats](#supported-result-formats)
     * [ATOM](#atom)
     * [CSV](#csv)
@@ -289,6 +290,12 @@ Here is a list of supported extensions and their corresponding MimeTypes:
     * The UMM JSON extension returns concepts in the latest version of the UMM.
   * `umm_json_vX_Y` "application/vnd.nasa.cmr.umm_results+json; version=X.Y"
     * X and Y should be replaced with a major and minor number of the UMM version requested.
+
+#### <a name="request-timeouts"></a> Request Timeouts
+
+The CMR operating environment imposes a hard limit of 180 seconds on any request, after which a 504 error is
+returned. To avoid this, the CMR has an internal query timeout of 170 seconds - any query taking longer will time
+out and a subset of the total hit results will be returned instead of an error.
 
 ### <a name="supported-result-formats"></a> Supported Result Formats
 


### PR DESCRIPTION
This adds a timeout to the Elasticsearch queries to avoid 504 errors from CloudFront. This does not cause an error if the query times out - it simply returns whatever results are available when the timeout occurs.

Note that there are no additional (automated) tests for this as it is not possible to force a query timeout in Elasticsearch.