### PR TITLE
Cmr 6016 add timed out header

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -55,7 +55,6 @@
   "Generate headers for search response. CORS response headers can be tested through
   dev-system/resources/cors_headers_test.html"
   [content-type results]
-  (println (str "RESULTS: " results))
   (merge {CONTENT_TYPE_HEADER (mt/with-utf-8 content-type)
           CORS_CUSTOM_EXPOSED_HEADER "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id, CMR-Timed-Out"
           CORS_ORIGIN_HEADER "*"}

--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -24,6 +24,8 @@
 
 (def HITS_HEADER "CMR-Hits")
 
+(def TIMED_OUT_HEADER "CMR-Timed-Out")
+
 (def TOOK_HEADER "CMR-Took")
 
 (def SCROLL_ID_HEADER "CMR-Scroll-Id")
@@ -53,9 +55,11 @@
   "Generate headers for search response. CORS response headers can be tested through
   dev-system/resources/cors_headers_test.html"
   [content-type results]
+  (println (str "RESULTS: " results))
   (merge {CONTENT_TYPE_HEADER (mt/with-utf-8 content-type)
-          CORS_CUSTOM_EXPOSED_HEADER "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id"
+          CORS_CUSTOM_EXPOSED_HEADER "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id, CMR-Timed-Out"
           CORS_ORIGIN_HEADER "*"}
+         (when (:timed-out results) {TIMED_OUT_HEADER "true"})
          (when (:hits results) {HITS_HEADER (str (:hits results))})
          (when (:took results) {TOOK_HEADER (str (:took results))})
          (when (:scroll-id results) {SCROLL_ID_HEADER (str (:scroll-id results))})))

--- a/common-app-lib/src/cmr/common_app/services/search.clj
+++ b/common-app-lib/src/cmr/common_app/services/search.clj
@@ -66,5 +66,6 @@
     (info "query-execution-time:" query-execution-time "result-gen-time:" result-gen-time)
     {:results result-str
      :hits (:hits results)
+     :timed-out (:timed-out results)
      :result-format (:result-format query)
      :scroll-id (:scroll-id results)}))

--- a/common-app-lib/src/cmr/common_app/services/search/elastic_results_to_query_results.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/elastic_results_to_query_results.clj
@@ -37,15 +37,17 @@
   "Default function for converting elastic-results to query-results"
   [context query elastic-results]
   (let [hits (get-in elastic-results [:hits :total])
+        timed-out (:timed_out elastic-results)
         scroll-id (:_scroll_id elastic-results)
         elastic-matches (get-in elastic-results [:hits :hits])
         items (mapv #(elastic-result->query-result-item context query %) elastic-matches)]
     (results/map->Results
-     {:aggregations (:aggregations elastic-results)
-      :hits hits 
-      :items items 
-      :result-format (:result-format query)
-      :scroll-id scroll-id})))
+      {:aggregations (:aggregations elastic-results)
+        :hits hits 
+        :timed-out timed-out
+        :items items 
+        :result-format (:result-format query)
+        :scroll-id scroll-id})))
 
 (defmethod elastic-results->query-results :default
   [context query elastic-results]

--- a/common-app-lib/src/cmr/common_app/services/search/results_model.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/results_model.clj
@@ -24,6 +24,9 @@
    ;; The number of milliseconds the search took
    took
 
+   ;; Whether or not the Elasticsearch query timed out
+   timed-out 
+
    ;; The result format requested by the user.
    result-format
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -295,7 +295,8 @@ Here is a list of supported extensions and their corresponding MimeTypes:
 
 The CMR operating environment imposes a hard limit of 180 seconds on any request, after which a 504 error is
 returned. To avoid this, the CMR has an internal query timeout of 170 seconds - any query taking longer will time
-out and a subset of the total hit results will be returned instead of an error.
+out and a subset of the total hit results will be returned instead of an error. The response for queries that time 
+out will include the `CMR-Time-Out` header set to `true`.
 
 ### <a name="supported-result-formats"></a> Supported Result Formats
 

--- a/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
@@ -270,6 +270,7 @@
                 (map collection-elastic-result->query-result-item elastic-matches))]
     (r/map->Results {:hits hits
                      :items items
+                     :timed-out (:timed_out elastic-results)
                      :result-format (:result-format query)
                      :scroll-id scroll-id})))
 

--- a/search-app/src/cmr/search/results_handlers/kml_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/kml_results_handler.clj
@@ -67,11 +67,12 @@
 (defn- elastic-results->query-results
   [context query elastic-results]
   (let [hits (get-in elastic-results [:hits :total])
+        timed-out (:timed_out elastic-results)
         elastic-matches (get-in elastic-results [:hits :hits])
         items (if (= :granule (:concept-type query))
                 (granule-elastic-results->query-result-items context query elastic-matches)
                 (map collection-elastic-result->query-result-item elastic-matches))]
-    (r/map->Results {:hits hits :items items :result-format (:result-format query)})))
+    (r/map->Results {:hits hits :timed-out timed-out :items items :result-format (:result-format query)})))
 
 (doseq [concept-type [:granule :collection]]
   (defmethod elastic-results/elastic-results->query-results [concept-type :kml]

--- a/search-app/src/cmr/search/results_handlers/metadata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/metadata_results_handler.clj
@@ -67,6 +67,7 @@
   (let [{:keys [concept-type result-format result-features]} query
         hits (get-in elastic-results [:hits :total])
         scroll-id (:_scroll_id elastic-results)
+        timed-out (:timed_out elastic-results)
         elastic-matches (get-in elastic-results [:hits :hits])
         result-items (mapv #(elastic-result->query-result-item concept-type %) elastic-matches)
         tuples (mapv #(vector (:concept-id %) (:revision-id %)) result-items)
@@ -83,6 +84,7 @@
     (debug "Transformer metadata request time was" req-time "ms.")
     (results/map->Results {:hits hits
                            :items items
+                           :timed-out timed-out
                            :result-format result-format
                            :scroll-id scroll-id})))
 

--- a/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
@@ -224,6 +224,7 @@
         items (map (partial collection-bucket->intervals (:interval query) start-date end-date)
                    (get-in elastic-results [:aggregations :by-collection :buckets]))]
     (r/map->Results {:items items
+                     :timed-out (:timed_out elastic-results)
                      :result-format (:result-format query)})))
 
 (defn interval->response-tuple

--- a/search-app/src/cmr/search/results_handlers/umm_json_results_helper.clj
+++ b/search-app/src/cmr/search/results_handlers/umm_json_results_helper.clj
@@ -79,6 +79,7 @@
   [context concept-type query elastic-results]
   (let [{:keys [result-format]} query
         hits (get-in elastic-results [:hits :total])
+        timed-out (:timed_out elastic-results)
         scroll-id (:_scroll_id elastic-results)
         elastic-matches (get-in elastic-results [:hits :hits])
         ;; Get concept metadata in specified UMM format and version
@@ -94,6 +95,7 @@
                     elastic-matches
                     concepts)]
     (results/map->Results {:hits hits
+                           :timed-out timed-out
                            :items items
                            :result-format result-format
                            :scroll-id scroll-id})))

--- a/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_timeline_test.clj
@@ -282,5 +282,5 @@
                                                      :include-headers true})
               headers (:headers response)]
           (is (= "application/json;charset=utf-8" (get headers "Content-Type")))
-          (is (= "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id"
+          (is (= "CMR-Hits, CMR-Request-Id, CMR-Scroll-Id, CMR-Timed-Out"
                  (get headers "Access-Control-Expose-Headers"))))))))


### PR DESCRIPTION
Adds a CMR-Timed-Out header to indicate an Elasticsearch query timeout occurred.