### PR TITLE
CMR-6049: Remove reference to preview gem version.

### DIFF
--- a/collection-renderer-lib/resources/collection_preview/bootstrap.rb
+++ b/collection-renderer-lib/resources/collection_preview/bootstrap.rb
@@ -16,14 +16,14 @@ require 'action_view'
 require 'action_dispatch'
 require 'rgeo'
 require 'geo_ruby'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/cmr_metadata_preview_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/options_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/data_contacts_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/citation_information_preview_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/additional_information_fields_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/related_urls_preview_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/overview_fields_helper'
-require 'gems/cmr_metadata_preview-0.1.0/app/helpers/cmr_metadata_preview/spatial_temporal_helper'
+require 'app/helpers/cmr_metadata_preview/cmr_metadata_preview_helper'
+require 'app/helpers/cmr_metadata_preview/options_helper'
+require 'app/helpers/cmr_metadata_preview/data_contacts_helper'
+require 'app/helpers/cmr_metadata_preview/citation_information_preview_helper'
+require 'app/helpers/cmr_metadata_preview/additional_information_fields_helper'
+require 'app/helpers/cmr_metadata_preview/related_urls_preview_helper'
+require 'app/helpers/cmr_metadata_preview/overview_fields_helper'
+require 'app/helpers/cmr_metadata_preview/spatial_temporal_helper'
 
 include ActionView::Helpers
 include ActionDispatch::Routing
@@ -48,7 +48,7 @@ def edit_collection_path(*args)
 end
 
 def resource_prefix
-  "gems/cmr_metadata_preview-0.1.0/app/views/"
+  "app/views/"
 end
 
 ####################################################################################################

--- a/collection-renderer-lib/src/cmr/collection_renderer/api/routes.clj
+++ b/collection-renderer-lib/src/cmr/collection_renderer/api/routes.clj
@@ -6,13 +6,9 @@
    [cmr.common.services.errors :as errors]
    [compojure.core :refer :all]))
 
-(def cmr-metadata-preview-gem
-  "Define the cmr_metadata_preview gem name. Update this when a new version of the gem is created."
-  "cmr_metadata_preview-0.1.0")
-
 (def assets-path
   "Defines path to cmr_metadata_preview gem assets"
-  (format "gems/%s/app/assets" cmr-metadata-preview-gem))
+  "app/assets")
 
 (defn- resource-or-not-found
   "Returns a URL to the resource on the classpath or throws a not found error"


### PR DESCRIPTION
Added gems/cmr_metadata_preview-<version> / to resource-paths to avoid needing to explicitly reference the version number. This makes updating the preview gem version easier.