### PR TITLE
CMR-6059: Fix intermittent test failure.

### DIFF
--- a/dev-system/src/cmr/dev_system/control.clj
+++ b/dev-system/src/cmr/dev_system/control.clj
@@ -125,6 +125,7 @@
 
     (POST "/clear-cache" []
       (debug "dev system /clear-cache")
+      (redis/reset)
       (doseq [[service-name clear-cache-fn] service-clear-cache-fns]
         (clear-cache-fn (app-context system service-name)))
       (debug "dev system /clear-cache complete")

--- a/redis-utils-lib/src/cmr/redis_utils/config.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/config.clj
@@ -24,6 +24,11 @@
   "The default value in seconds to use to expire keys. Default is 24 hours."
   {:default 86400 :type Long})
 
+(defconfig redis-max-scan-keys
+  "The maximum amount of keys to search for on each iteration of scan aswell as return
+  to user."
+  {:default 2000 :type Long})
+
 (defn redis-conn-opts
   "Redis connection options to be used with wcar."
   []

--- a/redis-utils-lib/src/cmr/redis_utils/redis.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis.clj
@@ -1,6 +1,7 @@
 (ns cmr.redis-utils.redis
   "Used to implement functions for calling Redis."
   (:require
+   [clojure.set :refer [union]]
    [cmr.common.log :refer [error]]
    [cmr.redis-utils.config :as config]
    [taoensso.carmine :as carmine :refer [wcar]]))
@@ -27,3 +28,22 @@
   "Evict all keys in redis. Primarily for dev-system use."
   []
   (wcar* (carmine/flushall)))
+
+(defn get-keys
+  "Scans the redis db for keys matching the match argument (use * to match all).
+  Will return up to the max-returned-keys keys. This config option is also used
+  as the page size to scan the redis db with. We use this method rather than the
+  KEYS redis command to avoid blocking other redis calls as KEYS can become an
+  expensive operation."
+  ([]
+   (get-keys "*"))
+  ([match]
+   (loop [cursor "0"
+          results #{}]
+     (let [[new-cursor new-results] (wcar* (carmine/scan cursor :match match :count (config/redis-max-scan-keys)))
+           merged-results (union results new-results)]
+       (if (or (= "0" (str new-cursor))
+               (>= (count merged-results) (config/redis-max-scan-keys)))
+         (vec (take (config/redis-max-scan-keys) merged-results))
+         (recur new-cursor
+                merged-results))))))

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -8,7 +8,7 @@
    [clojure.edn :as edn]
    [cmr.common.cache :as cache]
    [cmr.redis-utils.config :as config]
-   [cmr.redis-utils.redis :refer [wcar*]]
+   [cmr.redis-utils.redis :as redis :refer [wcar*]]
    [taoensso.carmine :as carmine]))
 
 (defn serialize
@@ -37,7 +37,7 @@
   cache/CmrCache
   (get-keys
     [this]
-    (map deserialize (wcar* (carmine/keys "*"))))
+    (map deserialize (redis/get-keys)))
 
   (get-value
     [this key]

--- a/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
+++ b/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
@@ -3,10 +3,11 @@
   (:require
    [clojure.test :refer :all]
    [cmr.common.cache :as cache]
+   [cmr.redis-utils.redis :as redis :refer [wcar*]]
    [cmr.redis-utils.redis-cache :as redis-cache]
    [cmr.redis-utils.test.test-util :as test-util]
    [cmr.redis-utils.config :as config]
-   [taoensso.carmine :as carmine :refer [wcar]]))
+   [taoensso.carmine :as carmine]))
 
 (use-fixtures :once test-util/embedded-redis-server-fixture)
 
@@ -16,7 +17,7 @@
       (cache/set-value rcache "test" "expire")
       (is (= "expire"
              (cache/get-value rcache "test")))
-      (is (> (wcar {} (carmine/ttl (redis-cache/serialize "test"))) 0)))))
+      (is (> (wcar* (carmine/ttl (redis-cache/serialize "test")) 0))))))
 
 (deftest test-redis-cache-with-persistance
   (testing "Redis cache with default timeout..."
@@ -24,4 +25,16 @@
       (cache/set-value rcache "test" "persist")
       (is (= "persist"
              (cache/get-value rcache "test")))
-      (is (= (wcar {} (carmine/ttl (redis-cache/serialize "test"))) -1)))))
+      (is (= -1
+             (wcar* (carmine/ttl (redis-cache/serialize "test"))))))))
+
+(deftest test-get-keys
+  (wcar* (carmine/set "get-keys-pattern#-test1" "test1"))
+  (wcar* (carmine/set "get-keys-pattern#-test2" "test2"))
+  (testing "Get keys less than max scan keys..."
+    (is (= 2 (count (redis/get-keys "get-keys-pattern#-*")))))
+  (testing "Get keys greater than max scan keys..."
+    (doseq [x (range (* 2 (config/redis-max-scan-keys)))]
+      (wcar* (carmine/set (str "get-keys-pattern-2#-" x) x)))
+    (is (= (config/redis-max-scan-keys)
+           (count (redis/get-keys "get-keys-pattern-2#-*"))))))

--- a/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/collection.clj
@@ -425,6 +425,7 @@
         user1-token (e/login (s/context) "user1")
         user2-token (e/login (s/context) "user2")]
 
+    (ingest/reindex-collection-permitted-groups (tc/echo-system-token))
     (index/wait-until-indexed)
 
     ;; A logged out token is normally not useful


### PR DESCRIPTION
Remove redis query with KEYS * in favor of SCAN.