### PR TITLE
CMR-5069-CMR-5070-CMR-5071

### DIFF
--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
@@ -94,7 +94,7 @@
           gran1 (concepts/create-and-save-concept :granule provider-id coll1 1 2)
           coll2 (concepts/create-and-save-concept :collection provider-id 2)
           gran3 (concepts/create-and-save-concept :granule provider-id coll2 2)
-          variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
+          variable (concepts/create-and-save-concept :variable provider-id 1)
           variable-association (concepts/create-and-save-concept :variable-association coll1 variable 1 1)
           service (concepts/create-and-save-concept :service provider-id 1)
           service-association (concepts/create-and-save-concept :service-association coll1 service 1 1)]
@@ -143,7 +143,7 @@
           gran1 (concepts/create-and-save-concept :granule provider-id coll1 1 2)
           coll2 (concepts/create-and-save-concept :collection provider-id 2)
           gran3 (concepts/create-and-save-concept :granule provider-id coll2 2)
-          variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
+          variable (concepts/create-and-save-concept :variable provider-id 1)
           variable-association (concepts/create-and-save-concept :variable-association coll1 variable 1 1)
           service (concepts/create-and-save-concept :service provider-id 1)
           service-association (concepts/create-and-save-concept :service-association coll1 service 1 1)]

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
@@ -24,9 +24,7 @@
                                                           :short-name "s2"}})
         associated-variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
         var-association1 (concepts/create-and-save-concept
-                          :variable-association coll1 associated-variable 1 3)
-        var-association2 (concepts/create-and-save-concept
-                          :variable-association coll2 associated-variable 2 2)]
+                          :variable-association coll1 associated-variable 1 3)]
     (testing "find latest revisions"
       (are3 [variable-associations params]
         (is (= (set variable-associations)
@@ -39,18 +37,18 @@
         {:associated-concept-id "C1200000000-REG_PROV"}
 
         "with metadata"
-        [var-association1 var-association2]
+        [var-association1]
         {}
 
         "exclude metadata"
-        [(dissoc var-association1 :metadata) (dissoc var-association2 :metadata)]
+        [(dissoc var-association1 :metadata)]
         {:exclude-metadata true}))
 
     (testing "find all revisions"
       (let [num-of-variable-associations (-> (util/find-concepts :variable-association {})
                                              :concepts
                                              count)]
-        (is (= 5 num-of-variable-associations))))))
+        (is (= 3 num-of-variable-associations))))))
 
 (deftest find-variable-associations-with-invalid-parameters
   (testing "extra parameters"

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -152,8 +152,8 @@
     (when (and variable-concept-id associated-concept-id)
       (let [;;get variable name for the variable-concept-id from cmr_variables.
             variable (->> @(:concepts-atom db)
-                            (filter #(= variable-concept-id (:concept-id %)))
-                            first)
+                          (filter #(= variable-concept-id (:concept-id %)))
+                          first)
             variable-name (get-in variable [:extra-fields :variable-name])
 
             ;;get all the variable associations with variable concept id being different from variable-concept-id
@@ -419,9 +419,9 @@
 
   (if-let [error (or (validate-concept-id-native-id-not-changing db provider concept)
                      (when (variable-association-concept? concept)
-                          (or (validate-same-provider-variable-association concept)
-                              (validate-collection-not-associated-with-another-variable-with-same-name db concept)
-                              (validate-variable-not-associated-with-another-collection db concept))))]
+                       (or (validate-same-provider-variable-association concept)
+                           (validate-collection-not-associated-with-another-variable-with-same-name db concept)
+                           (validate-variable-not-associated-with-another-collection db concept))))]
    ;; There was a concept id, native id mismatch with earlier concepts
    error
    ;; Concept id native id pair was valid

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -3,6 +3,7 @@
   (:require
    [clj-time.core :as t]
    [clj-time.format :as f]
+   [clojure.string :as string]
    [cmr.common.concepts :as cc]
    [cmr.common.date-time-parser :as p]
    [cmr.common.lifecycle :as lifecycle]
@@ -130,6 +131,111 @@
                               concept-id native-id existing-concept-id existing-native-id)
        :existing-concept-id existing-concept-id
        :existing-native-id existing-native-id})))
+
+(defn- concept-id-not-in-list?
+  "Check if the concept-id is not in the list of concept-ids."
+  [list concept-id]
+  (not (some #(= concept-id %) list)))
+
+(defn- concept-id-in-list?
+  "Check if the concept-id is in the list of concept-ids."
+  [list concept-id]
+  (some #(= concept-id %) list))
+
+(defn validate-collection-not-associated-with-another-variable-with-same-name
+  "Validates that collection in the concept is not associated with a different
+  variable, which has the same name as the variable in the concept.
+  Returns nil if valid and an error response if invalid."
+  [db concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [;;get variable name for the variable-concept-id from cmr_variables.
+            variable (->> @(:concepts-atom db)
+                            (filter #(= variable-concept-id (:concept-id %)))
+                            first)
+            variable-name (get-in variable [:extra-fields :variable-name])
+
+            ;;get all the variable associations with variable concept id being different from variable-concept-id
+            ;;and associated with the associated-concept-id, from cmr_variable_associations
+            v-associations (->> @(:concepts-atom db)
+                                (filter #(not= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                (filter #(= associated-concept-id (get-in % [:extra-fields :associated-concept-id]))))
+            v-concept-ids (map #(get-in % [:extra-fields :variable-concept-id]) v-associations)
+
+            ;;get all the deleted variable associations with variable concept id being different from variable-concept-id
+            ;;and associated with the associated-concept-id, from cmr_variable_association
+            deleted-v-associations (->> @(:concepts-atom db)
+                                        (filter #(not= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                        (filter #(= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                                        (filter #(= true (:deleted %))))
+            deleted-v-concept-ids (map #(get-in % [:extra-fields :variable-concept-id]) deleted-v-associations) 
+
+            ;;find the first v-concept-id in v-concept-ids that has variable name being variable-name.
+            ;;from cmr_variables table.
+            v-concept-id-same-name (->> @(:concepts-atom db)
+                                        (filter #(concept-id-in-list?
+                                                   v-concept-ids
+                                                   (:concept-id %)))
+                                        (filter #(concept-id-not-in-list?
+                                                   deleted-v-concept-ids
+                                                   (:concept-id %))) 
+                                        (filter #(= variable-name (get-in % [:extra-fields :variable-name])))
+                                        first
+                                        :concept-id)]
+        (when v-concept-id-same-name
+          {:error :collection-associated-with-variable-same-name
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because the collection is already associated with another variable [%s] with same name.")
+                                  variable-concept-id associated-concept-id v-concept-id-same-name)})))))
+
+(defn validate-variable-not-associated-with-another-collection
+  "Validates that variable in the concept is not associated with a different collection
+  from the collection in the concept.
+  Returns nil if valid and an error response if invalid."
+  [db concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [;;Get all the same variable and other collection associations that are deleted.
+            deleted-associations (->> @(:concepts-atom db)
+                                      (filter #(= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                      (filter #(not= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                                      (filter #(= true (:deleted %))))
+            ;;The variable can be associated with other collections if the associations are already deleted.
+            ;;so these associated concept ids are allowed.
+            allowed-associated-concept-ids (map #(get-in % [:extra-fields :associated-concept-id]) deleted-associations)
+
+            ;;Get all the same variable and other collection associations that are not deleted 
+            first-concept (->> @(:concepts-atom db)
+                               (filter #(= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                               (filter #(not= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                               (filter #(= false (:deleted %)))
+                               (filter #(concept-id-not-in-list?
+                                          allowed-associated-concept-ids
+                                          (get-in % [:extra-fields :associated-concept-id])))
+                               first)
+            associated_concept_id (get-in first-concept [:extra-fields :associated-concept-id])]
+        (when associated_concept_id
+          {:error :variable-associated-with-another-collection
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because the variable is already associated with another collection [%s].")
+                                  variable-concept-id associated-concept-id associated_concept_id)})))))
+
+(defn validate-same-provider-variable-association
+  "Validates that variable and the collection in the concept being saved are from the same provider.
+  Returns nil if valid and an error response if invalid."
+  [concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [v-provider-id (second (string/split variable-concept-id #"-"))
+            c-provider-id (second (string/split associated-concept-id #"-"))]
+        (when (not= v-provider-id c-provider-id)
+          {:error :variable-association-not-same-provider
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because they do not belong to the same provider.")
+                                  variable-concept-id associated-concept-id)})))))
 
 (defn- delete-time
   "Returns the parsed delete-time extra field of a concept."
@@ -300,11 +406,22 @@
            {:revision-id revision-id :transaction-id transaction-id}))
        @(:concepts-atom db)))
 
+(defn- variable-association-concept?
+  "Check if the concept is a variable association concept."
+  [concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (and variable-concept-id associated-concept-id)))
+
 (defn save-concept
   [db provider concept]
   {:pre [(:revision-id concept)]}
 
-  (if-let [error (validate-concept-id-native-id-not-changing db provider concept)]
+  (if-let [error (or (validate-concept-id-native-id-not-changing db provider concept)
+                     (when (variable-association-concept? concept)
+                          (or (validate-same-provider-variable-association concept)
+                              (validate-collection-not-associated-with-another-variable-with-same-name db concept)
+                              (validate-variable-not-associated-with-another-collection db concept))))]
    ;; There was a concept id, native id mismatch with earlier concepts
    error
    ;; Concept id native id pair was valid

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -274,6 +274,21 @@
                        native-id
                        concept-type
                        provider-id))
+
+    :variable-association-not-same-provider
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+    :collection-associated-with-variable-same-name
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+
+    :variable-associated-with-another-collection
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+
     ;; else
     (errors/internal-error! (:error-message result) (:throwable result))))
 

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -233,6 +233,13 @@
              (set (comparable-variable-associations expected-tas))]
             [status (set (comparable-variable-associations body))])))))
 
+(defn assert-variable-association-bad-request
+  "Assert the variable association response when status code is 200 is correct."
+  [err-msg response]
+  (let [{:keys [status body errors]} response]
+     (is (= 400 status))
+     (is (= errors err-msg))))
+
 (defn assert-variable-dissociation-response-ok?
   "Assert the variable association response when status code is 200 is correct."
   [coll-variable-associations response]

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
@@ -565,8 +565,7 @@
           variable3 (variables/ingest-variable variable3-concept)
           variable1-concept-id (:concept-id variable1)
           variable2-concept-id (:concept-id variable2)
-          variable1-assoc-colls [{:concept-id (:concept-id coll1)}
-                                 {:concept-id (:concept-id coll2)}]
+          variable1-assoc-colls [{:concept-id (:concept-id coll1)}]
           variable2-assoc-colls [{:concept-id (:concept-id coll3)
                                   :revision-id 1}]
           ;; Add the variable info to variable concepts for comparision with UMM JSON result
@@ -613,10 +612,10 @@
             (testing "delete collection affect the associated collections in search result"
               (let [coll1-concept (mdb/get-concept (:concept-id coll1))
                     _ (ingest/delete-concept coll1-concept)
-                    ;; Now variable1 is only associated to coll2, as coll1 is deleted
+                    ;; Now variable1 is not associated with any collection, as coll1 is deleted
                     expected-variable1 (assoc expected-variable1
                                               :associated-collections
-                                              [{:concept-id (:concept-id coll2)}])]
+                                              nil)]
                 (index/wait-until-indexed)
 
                 (du/assert-variable-umm-jsons-match


### PR DESCRIPTION
Implemented: 
CMR-5069: Multiple variables with the same name can't be associated with one collection.
CMR-5070: Each variable can only be associated with one collection.
CMR-5071: variable and collection can only be associated if they belong to the same provider.