### PR TITLE
Cmr 5969 cmr 5970 cmr 5971 variable association restrictions

### DIFF
--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
@@ -94,7 +94,7 @@
           gran1 (concepts/create-and-save-concept :granule provider-id coll1 1 2)
           coll2 (concepts/create-and-save-concept :collection provider-id 2)
           gran3 (concepts/create-and-save-concept :granule provider-id coll2 2)
-          variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
+          variable (concepts/create-and-save-concept :variable provider-id 1)
           variable-association (concepts/create-and-save-concept :variable-association coll1 variable 1 1)
           service (concepts/create-and-save-concept :service provider-id 1)
           service-association (concepts/create-and-save-concept :service-association coll1 service 1 1)]
@@ -143,7 +143,7 @@
           gran1 (concepts/create-and-save-concept :granule provider-id coll1 1 2)
           coll2 (concepts/create-and-save-concept :collection provider-id 2)
           gran3 (concepts/create-and-save-concept :granule provider-id coll2 2)
-          variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
+          variable (concepts/create-and-save-concept :variable provider-id 1)
           variable-association (concepts/create-and-save-concept :variable-association coll1 variable 1 1)
           service (concepts/create-and-save-concept :service provider-id 1)
           service-association (concepts/create-and-save-concept :service-association coll1 service 1 1)]

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
@@ -24,9 +24,7 @@
                                                           :short-name "s2"}})
         associated-variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
         var-association1 (concepts/create-and-save-concept
-                          :variable-association coll1 associated-variable 1 3)
-        var-association2 (concepts/create-and-save-concept
-                          :variable-association coll2 associated-variable 2 2)]
+                          :variable-association coll1 associated-variable 1 3)]
     (testing "find latest revisions"
       (are3 [variable-associations params]
         (is (= (set variable-associations)
@@ -39,18 +37,18 @@
         {:associated-concept-id "C1200000000-REG_PROV"}
 
         "with metadata"
-        [var-association1 var-association2]
+        [var-association1]
         {}
 
         "exclude metadata"
-        [(dissoc var-association1 :metadata) (dissoc var-association2 :metadata)]
+        [(dissoc var-association1 :metadata)]
         {:exclude-metadata true}))
 
     (testing "find all revisions"
       (let [num-of-variable-associations (-> (util/find-concepts :variable-association {})
                                              :concepts
                                              count)]
-        (is (= 5 num-of-variable-associations))))))
+        (is (= 3 num-of-variable-associations))))))
 
 (deftest find-variable-associations-with-invalid-parameters
   (testing "extra parameters"

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -152,8 +152,8 @@
     (when (and variable-concept-id associated-concept-id)
       (let [;;get variable name for the variable-concept-id from cmr_variables.
             variable (->> @(:concepts-atom db)
-                            (filter #(= variable-concept-id (:concept-id %)))
-                            first)
+                          (filter #(= variable-concept-id (:concept-id %)))
+                          first)
             variable-name (get-in variable [:extra-fields :variable-name])
 
             ;;get all the variable associations with variable concept id being different from variable-concept-id
@@ -419,9 +419,9 @@
 
   (if-let [error (or (validate-concept-id-native-id-not-changing db provider concept)
                      (when (variable-association-concept? concept)
-                          (or (validate-same-provider-variable-association concept)
-                              (validate-collection-not-associated-with-another-variable-with-same-name db concept)
-                              (validate-variable-not-associated-with-another-collection db concept))))]
+                       (or (validate-same-provider-variable-association concept)
+                           (validate-collection-not-associated-with-another-variable-with-same-name db concept)
+                           (validate-variable-not-associated-with-another-collection db concept))))]
    ;; There was a concept id, native id mismatch with earlier concepts
    error
    ;; Concept id native id pair was valid

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -3,6 +3,7 @@
   (:require
    [clj-time.core :as t]
    [clj-time.format :as f]
+   [clojure.string :as string]
    [cmr.common.concepts :as cc]
    [cmr.common.date-time-parser :as p]
    [cmr.common.lifecycle :as lifecycle]
@@ -130,6 +131,111 @@
                               concept-id native-id existing-concept-id existing-native-id)
        :existing-concept-id existing-concept-id
        :existing-native-id existing-native-id})))
+
+(defn- concept-id-not-in-list?
+  "Check if the concept-id is not in the list of concept-ids."
+  [list concept-id]
+  (not (some #(= concept-id %) list)))
+
+(defn- concept-id-in-list?
+  "Check if the concept-id is in the list of concept-ids."
+  [list concept-id]
+  (some #(= concept-id %) list))
+
+(defn validate-collection-not-associated-with-another-variable-with-same-name
+  "Validates that collection in the concept is not associated with a different
+  variable, which has the same name as the variable in the concept.
+  Returns nil if valid and an error response if invalid."
+  [db concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [;;get variable name for the variable-concept-id from cmr_variables.
+            variable (->> @(:concepts-atom db)
+                            (filter #(= variable-concept-id (:concept-id %)))
+                            first)
+            variable-name (get-in variable [:extra-fields :variable-name])
+
+            ;;get all the variable associations with variable concept id being different from variable-concept-id
+            ;;and associated with the associated-concept-id, from cmr_variable_associations
+            v-associations (->> @(:concepts-atom db)
+                                (filter #(not= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                (filter #(= associated-concept-id (get-in % [:extra-fields :associated-concept-id]))))
+            v-concept-ids (map #(get-in % [:extra-fields :variable-concept-id]) v-associations)
+
+            ;;get all the deleted variable associations with variable concept id being different from variable-concept-id
+            ;;and associated with the associated-concept-id, from cmr_variable_association
+            deleted-v-associations (->> @(:concepts-atom db)
+                                        (filter #(not= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                        (filter #(= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                                        (filter #(= true (:deleted %))))
+            deleted-v-concept-ids (map #(get-in % [:extra-fields :variable-concept-id]) deleted-v-associations) 
+
+            ;;find the first v-concept-id in v-concept-ids that has variable name being variable-name.
+            ;;from cmr_variables table.
+            v-concept-id-same-name (->> @(:concepts-atom db)
+                                        (filter #(concept-id-in-list?
+                                                   v-concept-ids
+                                                   (:concept-id %)))
+                                        (filter #(concept-id-not-in-list?
+                                                   deleted-v-concept-ids
+                                                   (:concept-id %))) 
+                                        (filter #(= variable-name (get-in % [:extra-fields :variable-name])))
+                                        first
+                                        :concept-id)]
+        (when v-concept-id-same-name
+          {:error :collection-associated-with-variable-same-name
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because the collection is already associated with another variable [%s] with same name.")
+                                  variable-concept-id associated-concept-id v-concept-id-same-name)})))))
+
+(defn validate-variable-not-associated-with-another-collection
+  "Validates that variable in the concept is not associated with a different collection
+  from the collection in the concept.
+  Returns nil if valid and an error response if invalid."
+  [db concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [;;Get all the same variable and other collection associations that are deleted.
+            deleted-associations (->> @(:concepts-atom db)
+                                      (filter #(= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                                      (filter #(not= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                                      (filter #(= true (:deleted %))))
+            ;;The variable can be associated with other collections if the associations are already deleted.
+            ;;so these associated concept ids are allowed.
+            allowed-associated-concept-ids (map #(get-in % [:extra-fields :associated-concept-id]) deleted-associations)
+
+            ;;Get all the same variable and other collection associations that are not deleted 
+            first-concept (->> @(:concepts-atom db)
+                               (filter #(= variable-concept-id (get-in % [:extra-fields :variable-concept-id])))
+                               (filter #(not= associated-concept-id (get-in % [:extra-fields :associated-concept-id])))
+                               (filter #(= false (:deleted %)))
+                               (filter #(concept-id-not-in-list?
+                                          allowed-associated-concept-ids
+                                          (get-in % [:extra-fields :associated-concept-id])))
+                               first)
+            associated_concept_id (get-in first-concept [:extra-fields :associated-concept-id])]
+        (when associated_concept_id
+          {:error :variable-associated-with-another-collection
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because the variable is already associated with another collection [%s].")
+                                  variable-concept-id associated-concept-id associated_concept_id)})))))
+
+(defn validate-same-provider-variable-association
+  "Validates that variable and the collection in the concept being saved are from the same provider.
+  Returns nil if valid and an error response if invalid."
+  [concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (when (and variable-concept-id associated-concept-id)
+      (let [v-provider-id (second (string/split variable-concept-id #"-"))
+            c-provider-id (second (string/split associated-concept-id #"-"))]
+        (when (not= v-provider-id c-provider-id)
+          {:error :variable-association-not-same-provider
+           :error-message (format (str "Variable [%s] and collection [%s] can not be associated "
+                                       "because they do not belong to the same provider.")
+                                  variable-concept-id associated-concept-id)})))))
 
 (defn- delete-time
   "Returns the parsed delete-time extra field of a concept."
@@ -300,11 +406,22 @@
            {:revision-id revision-id :transaction-id transaction-id}))
        @(:concepts-atom db)))
 
+(defn- variable-association-concept?
+  "Check if the concept is a variable association concept."
+  [concept]
+  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
+        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
+    (and variable-concept-id associated-concept-id)))
+
 (defn save-concept
   [db provider concept]
   {:pre [(:revision-id concept)]}
 
-  (if-let [error (validate-concept-id-native-id-not-changing db provider concept)]
+  (if-let [error (or (validate-concept-id-native-id-not-changing db provider concept)
+                     (when (variable-association-concept? concept)
+                          (or (validate-same-provider-variable-association concept)
+                              (validate-collection-not-associated-with-another-variable-with-same-name db concept)
+                              (validate-variable-not-associated-with-another-collection db concept))))]
    ;; There was a concept id, native id mismatch with earlier concepts
    error
    ;; Concept id native id pair was valid

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -413,20 +413,13 @@
                         :transaction-id (long (:transaction_id result))})
           (su/query conn stmt)))))
 
-(defn- variable-association-concept?
-  "Check if the concept is a variable association concept."
-  [concept]
-  (let [variable-concept-id (get-in concept [:extra-fields :variable-concept-id])
-        associated-concept-id (get-in concept [:extra-fields :associated-concept-id])]
-    (and variable-concept-id associated-concept-id)))
-
 (defn save-concept
   [db provider concept]
   (try
     (j/with-db-transaction
      [conn db]
      (if-let [error (or (validate-concept-id-native-id-not-changing db provider concept)
-                        (when (variable-association-concept? concept)
+                        (when (= :variable-association (:concept-type concept))
                           (or (validate-same-provider-variable-association concept)
                               (validate-collection-not-associated-with-another-variable-with-same-name db concept)
                               (validate-variable-not-associated-with-another-collection db concept))))]

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -276,16 +276,16 @@
                        provider-id))
 
     :variable-association-not-same-provider
-    (cmsg/data-error :bad-request
+    (cmsg/data-error :can-not-associate
                      str
                      (:error-message result))
     :collection-associated-with-variable-same-name
-    (cmsg/data-error :bad-request
+    (cmsg/data-error :can-not-associate
                      str
                      (:error-message result))
 
     :variable-associated-with-another-collection
-    (cmsg/data-error :bad-request
+    (cmsg/data-error :can-not-associate
                      str
                      (:error-message result))
 

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -274,6 +274,21 @@
                        native-id
                        concept-type
                        provider-id))
+
+    :variable-association-not-same-provider
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+    :collection-associated-with-variable-same-name
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+
+    :variable-associated-with-another-collection
+    (cmsg/data-error :bad-request
+                     str
+                     (:error-message result))
+
     ;; else
     (errors/internal-error! (:error-message result) (:throwable result))))
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3513,10 +3513,18 @@ Access to variable and variable association is granted through the provider via 
 
 A variable identified by its concept id can be associated with collections through a list of collection concept revisions. The variable association request normally returns status code 200 with a response that consists of a list of individual variable association responses, one for each variable association attempted to create. Each individual variable association response has an `associated_item` field and either a `variable_association` field with the variable association concept id and revision id when the variable association succeeded or an `errors` field with detailed error message when the variable association failed. The `associated_item` field value has the collection concept id and the optional revision id that is used to identify the collection during variable association. Here is a sample variable association request and its response:
 
+Note: The following new features are added to support UVG:
+1. Each variable can only be associated with one collection.
+2. Each collection can only be associated with variables that don't share the same name.
+3. variable and collection can only be associated if they are from the same provider.
+
+Future work:
+1. Currently we are not addressing any existing data that don't satisfy the above new requirements. 
+2. We still require a list of collection concept revisions to be passed in, even though only one collection revision is allowed in the list. A ticket is filed to address these issues in the future if necessary.
+
 ```
 curl -XPOST -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR-ENDPOINT%/variables/V1200000008-PROV1/associations -d \
-'[{"concept_id": "C1200000005-PROV1"},
-  {"concept_id": "C1200000006-PROV1"}]'
+'[{"concept_id": "C1200000005-PROV1"}]'
 
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -3530,14 +3538,6 @@ Content-Length: 168
     },
     "associated_item":{
       "concept_id":"C1200000005-PROV1"
-    }
-  },
-  {
-    "errors":[
-      "Collection [C1200000006-PROV1] does not exist or is not visible."
-    ],
-    "associated_item":{
-      "concept_id":"C1200000006-PROV1"
     }
   }
 ]

--- a/search-app/src/cmr/search/services/association_service.clj
+++ b/search-app/src/cmr/search/services/association_service.clj
@@ -1,5 +1,4 @@
-ed:   variable_association_test.clj
-/co(ns cmr.search.services.association-service
+(ns cmr.search.services.association-service
   "Provides functions for associating and dissociating variables/services to collections.
   Tag association is keyed off tag-key rather than concept-id like variable/service association.
   So the code is slightly different and we have pushed off the potential refactoring until later."

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -233,6 +233,13 @@
              (set (comparable-variable-associations expected-tas))]
             [status (set (comparable-variable-associations body))])))))
 
+(defn assert-variable-association-bad-request
+  "Assert the variable association response when status code is 200 is correct."
+  [err-msg response]
+  (let [{:keys [status body errors]} response]
+     (is (= 400 status))
+     (is (= errors err-msg))))
+
 (defn assert-variable-dissociation-response-ok?
   "Assert the variable association response when status code is 200 is correct."
   [coll-variable-associations response]

--- a/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/collection_facets_v2_search_test.clj
@@ -106,8 +106,7 @@
     ;; create variable associations
     (au/associate-by-concept-ids token
                                  variable1-concept-id
-                                 [{:concept-id (:concept-id coll1)}
-                                  {:concept-id (:concept-id coll2)}])
+                                 [{:concept-id (:concept-id coll1)}])
     (au/associate-by-concept-ids token
                                  variable2-concept-id
                                  [{:concept-id (:concept-id coll2)}]))
@@ -690,12 +689,10 @@
     ;; SomeVariable is associated with coll4
     (au/associate-by-concept-ids token
                                  variable1-concept-id
-                                 [{:concept-id (:concept-id coll1)}
-                                  {:concept-id (:concept-id coll2)}])
+                                 [{:concept-id (:concept-id coll1)}])
     (au/associate-by-concept-ids token
                                  variable2-concept-id
-                                 [{:concept-id (:concept-id coll2)}
-                                  {:concept-id (:concept-id coll3)}])
+                                 [{:concept-id (:concept-id coll2)}])
     (au/associate-by-concept-ids token
                                  variable3-concept-id
                                  [{:concept-id (:concept-id coll4)}])
@@ -715,10 +712,10 @@
       (testing "search by variables param filters the other facets, but not variables facets"
         (let [facets-result (search-and-return-v2-facets
                              {:variables-h {:0 {:variable "Variable1"}}})]
-          (assert-facet-field facets-result "Measurements" "Measurement1" 2)
-          (assert-facet-field facets-result "Measurements" "Measurement2" 3)
+          (assert-facet-field facets-result "Measurements" "Measurement1" 1)
+          (assert-facet-field facets-result "Measurements" "Measurement2" 2)
           (assert-facet-field facets-result "Platforms" "P1" 1)
-          (assert-facet-field facets-result "Platforms" "P2" 1)
+          (assert-facet-field facets-result "Platforms" "P2" nil)
           (assert-facet-field-not-exist facets-result "Platforms" "P3")))
 
       (testing "search by both variables param and regular param"
@@ -737,7 +734,7 @@
                               :variables-h {:0 {:variable "Variable1"}}})]
           (assert-facet-field facets-result "Measurements" "Measurement1" 1)
           (assert-facet-field facets-result "Platforms" "P1" 1)
-          (assert-facet-field facets-result "Platforms" "P2" 1)
+          (assert-facet-field facets-result "Platforms" "P2" nil)
           (assert-facet-field-not-exist facets-result "Measurements" "Measurement2")
           (assert-facet-field-not-exist facets-result "Platforms" "P3")))
       (dev-sys-util/eval-in-dev-sys

--- a/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/facet_responses.clj
@@ -131,7 +131,7 @@
      [{:title "Measurement1",
        :type "filter",
        :applied false,
-       :count 2,
+       :count 1,
        :links
        {:apply
         "http://localhost:3003/collections.json?page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},
@@ -163,7 +163,7 @@
      [{:title "Popular",
        :type "filter",
        :applied false,
-       :count 2,
+       :count 1,
        :links
        {:apply
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&science_keywords_h%5B1%5D%5Btopic%5D=Popular&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -171,7 +171,7 @@
       {:title "Topic1",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1"},
@@ -180,7 +180,7 @@
        [{:title "Term1",
          :type "filter",
          :applied true,
-         :count 2,
+         :count 1,
          :links
          {:remove
           "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -189,7 +189,7 @@
          [{:title "Level1-1",
            :type "filter",
            :applied true,
-           :count 2,
+           :count 1,
            :links
            {:remove
             "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -198,7 +198,7 @@
            [{:title "Level1-2",
              :type "filter",
              :applied true,
-             :count 2,
+             :count 1,
              :links
              {:remove
               "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -207,7 +207,7 @@
              [{:title "Level1-3",
                :type "filter",
                :applied true,
-               :count 2,
+               :count 1,
                :links
                {:remove
                 "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -220,7 +220,7 @@
      [{:title "diadem-1D",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -228,7 +228,7 @@
       {:title "DMSP 5B/F3",
        :type "filter",
        :applied false,
-       :count 2,
+       :count 1,
        :links
        {:apply
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&platform_h%5B%5D=DMSP+5B%2FF3&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -241,7 +241,7 @@
      [{:title "ATM",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -249,7 +249,7 @@
       {:title "lVIs",
        :type "filter",
        :applied false,
-       :count 2,
+       :count 1,
        :links
        {:apply
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&instrument_h%5B%5D=lVIs&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -262,7 +262,7 @@
      [{:title "DOI/USGS/CMG/WHSC",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -275,7 +275,7 @@
      [{:title "proj1",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -283,7 +283,7 @@
       {:title "PROJ2",
        :type "filter",
        :applied false,
-       :count 2,
+       :count 1,
        :links
        {:apply
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&project_h%5B%5D=PROJ2&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -296,7 +296,7 @@
      [{:title "PL1",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&variables_h%5B0%5D%5Bvariable%5D=Variable1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -309,7 +309,7 @@
      [{:title "Measurement1",
        :type "filter",
        :applied true,
-       :count 2,
+       :count 1,
        :links
        {:remove
         "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -318,7 +318,7 @@
        [{:title "Variable1",
          :type "filter",
          :applied true,
-         :count 2,
+         :count 1,
          :links
          {:remove
           "http://localhost:3003/collections.json?data_center_h=DOI%2FUSGS%2FCMG%2FWHSC&science_keywords_h%5B0%5D%5Bvariable_level_3%5D=Level1-3&science_keywords_h%5B0%5D%5Bvariable_level_1%5D=Level1-1&science_keywords_h%5B0%5D%5Bterm%5D=Term1&project_h=proj1&instrument_h=ATM&page_size=0&science_keywords_h%5B0%5D%5Bvariable_level_2%5D=Level1-2&platform_h=DIADEM-1D&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1&science_keywords_h%5B0%5D%5Bcategory%5D=Earth+Science&processing_level_id_h=PL1&science_keywords_h%5B0%5D%5Btopic%5D=Topic1"},
@@ -932,7 +932,7 @@
              [{:title "Measurement1",
                :type "filter",
                :applied false,
-               :count 2,
+               :count 1,
                :links
                {:apply
                 "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},
@@ -1077,7 +1077,7 @@
              [{:title "Measurement1",
                :type "filter",
                :applied false,
-               :count 2,
+               :count 1,
                :links
                {:apply
                 "http://localhost:3003/collections.json?facets_size%5Bplatform%5D=1&platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},
@@ -1257,7 +1257,7 @@
              [{:title "Measurement1",
                :type "filter",
                :applied false,
-               :count 2,
+               :count 1,
                :links
                {:apply
                 "http://localhost:3003/collections.json?platform_h=diadem-1D&page_size=0&include_facets=v2&variables_h%5B0%5D%5Bmeasurement%5D=Measurement1"},

--- a/system-int-test/test/cmr/system_int_test/search/variable/collection_variable_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/collection_variable_search_test.clj
@@ -50,14 +50,12 @@
                                              :LongName "Measurement4"})]
 
     ;; create variable associations
-    ;; Variable1 is associated with coll1 and coll2
-    (au/associate-by-concept-ids token variable1-concept-id [{:concept-id (:concept-id coll1)}
-                                                             {:concept-id (:concept-id coll2)}])
-    ;; Variable2 is associated with coll2 and coll3
-    (au/associate-by-concept-ids token variable2-concept-id [{:concept-id (:concept-id coll2)}
-                                                             {:concept-id (:concept-id coll3)}])
-    ;; SomeVariable is associated with coll4
-    (au/associate-by-concept-ids token variable3-concept-id [{:concept-id (:concept-id coll4)}])
+    ;; Variable1 is associated with coll1
+    (au/associate-by-concept-ids token variable1-concept-id [{:concept-id (:concept-id coll1)}])
+    ;; Variable2 is associated with coll2
+    (au/associate-by-concept-ids token variable2-concept-id [{:concept-id (:concept-id coll2)}])
+    ;; SomeVariable is associated with coll3
+    (au/associate-by-concept-ids token variable3-concept-id [{:concept-id (:concept-id coll3)}])
     (index/wait-until-indexed)
 
     (testing "search collections by variables"
@@ -68,22 +66,22 @@
           (d/refs-match? items (search/find-refs :collection params)))
 
         "single variable search"
-        [coll1 coll2] "Variable1" {}
+        [coll1] "Variable1" {}
 
         "no matching variable"
         [] "Variable3" {}
 
         "multiple variables"
-        [coll1 coll2 coll3] ["Variable1" "Variable2"] {}
+        [coll1 coll2] ["Variable1" "Variable2"] {}
 
         "AND option false"
-        [coll1 coll2 coll3] ["Variable1" "Variable2"] {:and false}
+        [coll1 coll2] ["Variable1" "Variable2"] {:and false}
 
         "AND option true"
-        [coll2] ["Variable1" "Variable2"] {:and true}
+        [] ["Variable1" "Variable2"] {:and true}
 
         "pattern true"
-        [coll1 coll2 coll3] "Var*" {:pattern true}
+        [coll1 coll2] "Var*" {:pattern true}
 
         "pattern false"
         [] "Var*" {:pattern false}
@@ -92,7 +90,7 @@
         [] "Var*" {}
 
         "ignore-case true"
-        [coll1 coll2] "variable1" {:ignore-case true}
+        [coll1] "variable1" {:ignore-case true}
 
         "ignore-case false"
         [] "variable1" {:ignore-case false}))
@@ -105,7 +103,7 @@
           (d/refs-match? items (search/find-refs :collection params)))
 
         "single variable search"
-        [coll1 coll2] variable1-concept-id {}
+        [coll1] variable1-concept-id {}
 
         "variable concept id search is case sensitive"
         [] (string/lower-case variable1-concept-id) {}
@@ -114,13 +112,13 @@
         [] variable4-concept-id {}
 
         "multiple variables"
-        [coll1 coll2 coll3] [variable1-concept-id variable2-concept-id] {}
+        [coll1 coll2] [variable1-concept-id variable2-concept-id] {}
 
         "AND option false"
-        [coll1 coll2 coll3] [variable1-concept-id variable2-concept-id] {:and false}
+        [coll1 coll2] [variable1-concept-id variable2-concept-id] {:and false}
 
         "AND option true"
-        [coll2] [variable1-concept-id variable2-concept-id] {:and true}))
+        [] [variable1-concept-id variable2-concept-id] {:and true}))
 
     (testing "search collections by variable native-ids"
       (are3 [items variable options]
@@ -130,22 +128,22 @@
           (d/refs-match? items (search/find-refs :collection params)))
 
         "single variable search"
-        [coll1 coll2] "var1" {}
+        [coll1] "var1" {}
 
         "no matching variable"
         [] "var3" {}
 
         "multiple variables"
-        [coll1 coll2 coll3] ["var1" "var2"] {}
+        [coll1 coll2] ["var1" "var2"] {}
 
         "AND option false"
-        [coll1 coll2 coll3] ["var1" "var2"] {:and false}
+        [coll1 coll2] ["var1" "var2"] {:and false}
 
         "AND option true"
-        [coll2] ["var1" "var2"] {:and true}
+        [] ["var1" "var2"] {:and true}
 
         "pattern true"
-        [coll1 coll2 coll3] "var*" {:pattern true}
+        [coll1 coll2] "var*" {:pattern true}
 
         "pattern false"
         [] "var*" {:pattern false}
@@ -154,7 +152,7 @@
         [] "var*" {}
 
         "ignore-case true"
-        [coll1 coll2] "VAR1" {:ignore-case true}
+        [coll1] "VAR1" {:ignore-case true}
 
         "ignore-case false"
         [] "VAR1" {:ignore-case false}))
@@ -167,22 +165,22 @@
           (d/refs-match? items (search/find-refs :collection params)))
 
         "single measurement search"
-        [coll1 coll2] "Measurement1" {}
+        [coll1] "Measurement1" {}
 
         "no matching measurement"
         [] "Measurement3" {}
 
         "multiple measurements"
-        [coll1 coll2 coll3 coll4] ["Measurement1" "Measurement2"] {}
+        [coll1 coll2 coll3] ["Measurement1" "Measurement2"] {}
 
         "AND option false"
-        [coll1 coll2 coll3 coll4] ["Measurement1" "Measurement2"] {:and false}
+        [coll1 coll2 coll3] ["Measurement1" "Measurement2"] {:and false}
 
         "AND option true"
-        [coll2] ["Measurement1" "Measurement2"] {:and true}
+        [] ["Measurement1" "Measurement2"] {:and true}
 
         "pattern true"
-        [coll1 coll2 coll3 coll4] "M*" {:pattern true}
+        [coll1 coll2 coll3] "M*" {:pattern true}
 
         "pattern false"
         [] "M*" {:pattern false}
@@ -191,7 +189,7 @@
         [] "M*" {}
 
         "ignore-case true"
-        [coll1 coll2] "measurement1" {:ignore-case true}
+        [coll1] "measurement1" {:ignore-case true}
 
         "ignore-case false"
         [] "measurement1" {:ignore-case false}))
@@ -205,7 +203,7 @@
           (d/refs-match? items (search/find-refs :collection search-params)))
 
         "single measurement search"
-        [coll1 coll2]
+        [coll1]
         {:0 {:measurement "Measurement1"}}
         {}
 
@@ -215,25 +213,25 @@
         {}
 
         "multiple measurements"
-        [coll2]
+        []
         {:0 {:measurement "Measurement1"}
          :1 {:measurement "Measurement2"}}
         {}
 
         "multiple measurements option OR true"
-        [coll1 coll2 coll3 coll4]
+        [coll1 coll2 coll3]
         {:0 {:measurement "Measurement1"}
          :1 {:measurement "Measurement2"}}
         {:or true}
 
         "multiple measurements option OR false"
-        [coll2]
+        []
         {:0 {:measurement "Measurement1"}
          :1 {:measurement "Measurement2"}}
         {:or false}
 
         "single variable search"
-        [coll1 coll2]
+        [coll1]
         {:0 {:variable "Variable1"}}
         {}
 
@@ -243,29 +241,29 @@
         {}
 
         "multiple variables"
-        [coll2]
+        []
         {:0 {:variable "Variable1"}
          :1 {:variable "Variable2"}}
         {}
 
         "multiple variables option OR true"
-        [coll1 coll2 coll3]
+        [coll1 coll2]
         {:0 {:variable "Variable1"}
          :1 {:variable "Variable2"}}
         {:or true}
 
         "multiple variables option OR false"
-        [coll2]
+        []
         {:0 {:variable "Variable1"}
          :1 {:variable "Variable2"}}
         {:or false}
 
         "pattern true"
-        [coll1 coll2 coll3]
+        [coll1 coll2]
         {:0 {:variable "V*"}}
         {:pattern true}
 
-        "pattern true"
+        "pattern false"
         []
         {:0 {:variable "V*"}}
         {:pattern false}
@@ -276,7 +274,7 @@
         {}
 
         "ignore-case true"
-        [coll1 coll2]
+        [coll1]
         {:0 {:measurement "measurement1"}}
         {:ignore-case true}
 
@@ -286,18 +284,18 @@
         {:ignore-case false}
 
         "default ignore-case is true"
-        [coll1 coll2]
+        [coll1]
         {:0 {:measurement "measurement1"}}
         {}
 
         "not combined variable fields"
-        [coll2 coll3 coll4]
+        [coll2 coll3]
         {:0 {:variable "Variable2"}
          :1 {:measurement "Measurement2"}}
         {:or true}
 
         "combined variable fields"
-        [coll2 coll3]
+        [coll2]
         {:0 {:variable "Variable2"
              :measurement "Measurement2"}}
         {:or true}))))

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
@@ -52,21 +52,11 @@
 
     (testing "Associate variable with collections by concept-ids"
       (let [response (association-util/associate-by-concept-ids
-                      token concept-id [{:concept-id c1-p1}])
-            response1 (association-util/associate-by-concept-ids
-                      token concept-id [{:concept-id c3-p2}])
-            response2 (association-util/associate-by-concept-ids
-                      token concept-id [{:concept-id c2-p1}])]
+                      token concept-id [{:concept-id c1-p1}])]
         (vu/assert-variable-association-response-ok?
           {["C1200000013-PROV1"] {:concept-id "VA1200000026-CMR"
-                                 :revision-id 1}}
-          response)
-        (vu/assert-variable-association-bad-request
-          ["Variable [V1200000025-PROV1] and collection [C1200000019-PROV2] can not be associated because they do not belong to the same provider."]
-          response1)
-        (vu/assert-variable-association-bad-request
-          ["Variable [V1200000025-PROV1] and collection [C1200000014-PROV1] can not be associated because the variable is already associated with another collection [C1200000013-PROV1]."]
-          response2)))
+                                  :revision-id 1}}
+          response)))
 
     (testing "Associate to no collections"
       (let [response (association-util/associate-by-concept-ids token concept-id [])]
@@ -210,8 +200,9 @@
                       concept-id
                       (map #(hash-map :concept-id (:concept-id %)) all-prov1-colls))]
        (is (= 200 (:status response1)))
-       (is (= 400 (:status response2)))
-       (is (string/includes? (:errors response2) "can not be associated because the variable is already associated with another collection")))
+       (is (= 200 (:status response2)))
+       (is (string/includes? (some #(when (not= nil %) %) (map :errors (:body response2)))
+                             "can not be associated because the variable is already associated with another collection")))
 
     ;; Associate the variable with every prov2 collection is not allowed.
     ;; it can not be associated with any because they are from different provider.
@@ -219,8 +210,9 @@
                      prov3-token
                      concept-id
                      (map #(hash-map :concept-id (:concept-id %)) all-prov2-colls))]
-       (is (= 400 (:status response)))
-       (is (string/includes? (:errors response) "can not be associated because they do not belong to the same provider")))
+       (is (= 200 (:status response)))
+       (is (string/includes? (some #(when (not= nil %) %) (map :errors (:body response)))
+                             "can not be associated because they do not belong to the same provider")))
 
     ;; only one prov1 collection can be associated with the variable.
     (assert-variable-associated [c1-p1])
@@ -337,8 +329,9 @@
                         [{:concept-id (:concept-id coll2)
                           :revision-id (:revision-id coll2)}])]
         (is (= 200 (:status response1)))
-        (is (= 400 (:status response2)))
-        (is (string/includes? (:errors response2) "can not be associated because the variable is already associated with another collection")))
+        (is (= 200 (:status response2)))
+        (is (string/includes? (some #(when (not= nil %) %) (map :errors (:body response2)))
+                              "can not be associated because the variable is already associated with another collection")))
 
       (assert-variable-associated [coll1])
 

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
@@ -565,8 +565,7 @@
           variable3 (variables/ingest-variable variable3-concept)
           variable1-concept-id (:concept-id variable1)
           variable2-concept-id (:concept-id variable2)
-          variable1-assoc-colls [{:concept-id (:concept-id coll1)}
-                                 {:concept-id (:concept-id coll2)}]
+          variable1-assoc-colls [{:concept-id (:concept-id coll1)}]
           variable2-assoc-colls [{:concept-id (:concept-id coll3)
                                   :revision-id 1}]
           ;; Add the variable info to variable concepts for comparision with UMM JSON result
@@ -613,10 +612,10 @@
             (testing "delete collection affect the associated collections in search result"
               (let [coll1-concept (mdb/get-concept (:concept-id coll1))
                     _ (ingest/delete-concept coll1-concept)
-                    ;; Now variable1 is only associated to coll2, as coll1 is deleted
+                    ;; Now variable1 is not associated with any collection, as coll1 is deleted
                     expected-variable1 (assoc expected-variable1
                                               :associated-collections
-                                              [{:concept-id (:concept-id coll2)}])]
+                                              nil)]
                 (index/wait-until-indexed)
 
                 (du/assert-variable-umm-jsons-match


### PR DESCRIPTION
Implemented:
CMR-5969: Multiple variables with the same name can't be associated with one collection.
CMR-5970: Each variable can only be associated with one collection.
CMR-5971: variable and collection can only be associated if they belong to the same provider.