### PR TITLE
Cmr 6132 1

### DIFF
--- a/access-control-app/src/cmr/db.clj
+++ b/access-control-app/src/cmr/db.clj
@@ -1,16 +1,29 @@
 (ns cmr.db
   "Entry point for the db (elasticsearch) related operations. Defines a main method that accepts arguments."
-  (:require [cmr.common.log :refer (debug info warn error)]
-            [cmr.access-control.data.access-control-index :as ac-index]
-            [cmr.common-app.services.search.elastic-search-index :as search-index]
-            [cmr.elastic-utils.config :as es-config]
-            [cmr.common.lifecycle :as l])
+  (:require
+   [cmr.access-control.data.access-control-index :as ac-index]
+   [cmr.common-app.config :as common-config]
+   [cmr.common-app.services.search.elastic-search-index :as search-index]
+   [cmr.common.lifecycle :as l]
+   [cmr.common.log :refer (debug info warn error)]
+   [cmr.elastic-utils.config :as es-config])
   (:gen-class))
+
+(defn- migrate-es
+  "Create indexes and update mappings for the given ES config"
+  [config]
+  (let [elastic-store (l/start (search-index/create-elastic-search-index config) nil)]
+    (ac-index/create-index-or-update-mappings elastic-store)))
 
 (defn migrate
   []
-  (let [elastic-store (l/start (search-index/create-elastic-search-index) nil)]
-    (ac-index/create-index-or-update-mappings elastic-store)))
+  (when (= :both (common-config/index-es-engine-key))
+    (migrate-es (es-config/elastic-config))
+    (migrate-es (es-config/new-elastic-config)))
+  (when (= :old (common-config/index-es-engine-key))
+    (migrate-es (es-config/elastic-config)))
+  (when (= :new (common-config/index-es-engine-key))
+    (migrate-es (es-config/new-elastic-config))))
 
 (defn -main
   "Execute the given database operation specified by input arguments."

--- a/bootstrap-app/src/cmr/bootstrap/data/rebalance_util.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/rebalance_util.clj
@@ -5,6 +5,7 @@
    [clojurewerkz.elastisch.rest.document :as esd]
    [cmr.bootstrap.embedded-system-helper :as helper]
    [cmr.common-app.config :as common-config]
+   [cmr.common-app.services.search.elastic-search-index :as esi]
    [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.data.elasticsearch :as indexer-es]
    [cmr.indexer.data.index-set :as index-set]
@@ -23,8 +24,7 @@
 (defn- granule-count-for-collection
   "Gets the granule count for the collection in the elastic index."
   [indexer-context index-name concept-id]
-  (let [conn (indexer-es/context->conn
-              (assoc indexer-context :search-engine (common-config/search-es-engine-key)))
+  (let [conn (esi/context->search-conn indexer-context)
         query (es-query-for-collection-concept-id concept-id)]
     (:count (es-helper/count-query conn index-name granule-mapping-type-name query))))
 

--- a/bootstrap-app/src/cmr/bootstrap/data/rebalance_util.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/rebalance_util.clj
@@ -4,6 +4,8 @@
    [clojurewerkz.elastisch.query :as q]
    [clojurewerkz.elastisch.rest.document :as esd]
    [cmr.bootstrap.embedded-system-helper :as helper]
+   [cmr.common-app.config :as common-config]
+   [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.data.elasticsearch :as indexer-es]
    [cmr.indexer.data.index-set :as index-set]
    [cmr.metadata-db.services.concept-service :as cs]))
@@ -21,9 +23,10 @@
 (defn- granule-count-for-collection
   "Gets the granule count for the collection in the elastic index."
   [indexer-context index-name concept-id]
-  (let [conn (indexer-es/context->conn indexer-context)
+  (let [conn (indexer-es/context->conn
+              (assoc indexer-context :search-engine (common-config/search-es-engine-key)))
         query (es-query-for-collection-concept-id concept-id)]
-    (:count (esd/count conn index-name granule-mapping-type-name query))))
+    (:count (es-helper/count-query conn index-name granule-mapping-type-name query))))
 
 (defn rebalancing-collection-counts
   "Returns the counts of a rebalancing collection from metadata db, the small collections index,

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -23,7 +23,7 @@
   {:default "dev"})
 
 (defconfig index-es-engine
-  "Name of the ES engine used for indexing, possible values are: old, new."
+  "Name of the ES engine used for indexing, possible values are: old, new, both."
   {:default "old"})
 
 (defconfig search-es-engine

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -21,3 +21,21 @@
 (defconfig release-version
   "Contains the release version of CMR."
   {:default "dev"})
+
+(defconfig index-es-engine
+  "Name of the ES engine used for indexing, possible values are: old, new."
+  {:default "old"})
+
+(defconfig search-es-engine
+  "Name of the ES engine used for searching, possible values are: old, new."
+  {:default "old"})
+
+(defn index-es-engine-key
+  "Returns the configured CMR_INDEX_ES_ENGINE value in keyword"
+  []
+  (keyword (index-es-engine)))
+
+(defn search-es-engine-key
+  "Returns the configured CMR_SEARCH_ES_ENGINE value in keyword"
+  []
+  (keyword (search-es-engine)))

--- a/elastic-utils-lib/src/cmr/elastic_utils/config.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/config.clj
@@ -12,6 +12,14 @@
   "Port elastic is listening on."
   {:default 9210 :type Long})
 
+(defconfig new-elastic-host
+  "Elastic host or VIP for new ES."
+  {:default "localhost"})
+
+(defconfig new-elastic-port
+  "Port for new ES is listening on."
+  {:default 9209 :type Long})
+
 (defconfig elastic-admin-token
     "Token used for basic auth authentication with elastic."
     {:default (str "Basic " (b64/encode (.getBytes "echo-elasticsearch")))})
@@ -41,6 +49,17 @@
   []
   {:host (elastic-host)
    :port (elastic-port)
+   ;; This can be set to specify an Apached HTTP retry handler function to use. The arguments of the
+   ;; function is that as specified in clj-http's documentation. It returns true or false of whether
+   ;; to retry again
+   :retry-handler nil
+   :admin-token (elastic-admin-token)})
+
+(defn new-elastic-config
+  "Returns the elastic config for new ES as a map"
+  []
+  {:host (new-elastic-host)
+   :port (new-elastic-port)
    ;; This can be set to specify an Apached HTTP retry handler function to use. The arguments of the
    ;; function is that as specified in clj-http's documentation. It returns true or false of whether
    ;; to retry again

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
@@ -1,0 +1,54 @@
+(ns cmr.elastic-utils.es-helper
+  "Defines helper functions for invoking ES"
+  (:require
+   [cmr.common-app.config :as common-config]
+   [clojurewerkz.elastisch.rest.document :as doc]
+   [clojurewerkz.elastisch.rest.index :as esi]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.services.errors :as errors]
+   [cmr.elastic-utils.connect :as esc]))
+
+(defmulti search
+  "Performs a search query across one or more indexes and one or more mapping types
+   based on search-es-engine type."
+  (fn [conn index mapping-type & args]
+    (common-config/search-es-engine-key)))
+
+(defmethod search :old
+  [conn index mapping-type & args]
+  (apply doc/search conn index mapping-type args))
+
+(defmethod search :new
+  [conn index mapping-type & args]
+  ;; TODO: add implementation
+  )
+
+(defmulti count-query
+  "Performs a count query over one or more indexes and types
+   based on search-es-engine type."
+  (fn [conn index mapping-type query]
+    (common-config/search-es-engine-key)))
+
+(defmethod count-query :old
+  [conn index mapping-type query]
+  (doc/count conn index mapping-type query))
+
+(defmethod count-query :new
+  [conn index mapping-type query]
+  ;; TODO: add implementation
+  )
+
+(defmulti scroll
+  "Performs a count query over one or more indexes and types
+   based on search-es-engine type."
+  (fn [conn scroll-id opts]
+    (common-config/search-es-engine-key)))
+
+(defmethod scroll :old
+  [conn scroll-id opts]
+  (doc/scroll conn scroll-id opts))
+
+(defmethod scroll :new
+  [conn scroll-id opts]
+  ;; TODO: add implementation
+  )

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
@@ -1,0 +1,34 @@
+(ns cmr.elastic-utils.es-index-helper
+  "Defines helper functions for invoking ES index"
+  (:require
+   [cmr.common-app.config :as common-config]
+   [clojurewerkz.elastisch.rest.index :as esi]))
+
+(defmulti exists?
+  "Used to check if the index (indices) exists or not."
+  (fn [conn index-name]
+    (common-config/index-es-engine-key)))
+
+(defn- old-exists?
+  [conn index-name]
+  (esi/exists? conn index-name))
+
+(defn- new-exists?
+  [conn index-name]
+  ;; TODO: add implementation
+  )
+
+(defmethod exists? :old
+  [conn index-name]
+  (old-exists? conn index-name))
+
+(defmethod exists? :new
+  [conn index-name]
+  (new-exists? conn index-name))
+
+(defmethod exists? :both
+  [conn index-name]
+  (let [{old-conn :old
+         new-conn :new} conn]
+    (and (old-exists? conn index-name)
+         (new-exists? conn index-name))))

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
@@ -32,3 +32,98 @@
          new-conn :new} conn]
     (and (old-exists? conn index-name)
          (new-exists? conn index-name))))
+
+(defmulti update-mapping
+  "Register or modify specific mapping definition for a specific type."
+  (fn [conn index-name-or-names type-name opts]
+    (common-config/index-es-engine-key)))
+
+(defmethod update-mapping :old
+  [conn index-name-or-names type-name opts]
+  (esi/update-mapping conn index-name-or-names type-name opts))
+
+(defmethod update-mapping :new
+  [conn index-name-or-names type-name opts]
+  ;; TODO: add implementation
+  )
+
+(defmethod update-mapping :both
+  [conn index-name-or-names type-name opts]
+  ;; TODO: add implementation
+  )
+
+(defmulti create
+  "Create an index"
+  (fn [conn index-name opts]
+    (common-config/index-es-engine-key)))
+
+(defmethod create :old
+  [conn index-name opts]
+  (esi/create conn index-name opts))
+
+(defmethod create :new
+  [conn index-name opts]
+  ;; TODO: add implementation
+  )
+
+(defmethod create :both
+  [conn index-name opts]
+  ;; TODO: add implementation
+  )
+
+(defmulti refresh
+  "refresh an index"
+  (fn [conn index-name]
+    (common-config/index-es-engine-key)))
+
+(defmethod refresh :old
+  [conn index-name]
+  (esi/refresh conn index-name))
+
+(defmethod refresh :new
+  [conn index-name]
+  ;; TODO: add implementation
+  )
+
+(defmethod refresh :both
+  [conn index-name]
+  ;; TODO: add implementation
+  )
+
+(defmulti delete
+  "delete an index"
+  (fn [conn index-name]
+    (common-config/index-es-engine-key)))
+
+(defmethod delete :old
+  [conn index-name]
+  (esi/delete conn index-name))
+
+(defmethod delete :new
+  [conn index-name]
+  ;; TODO: add implementation
+  )
+
+(defmethod delete :both
+  [conn index-name]
+  ;; TODO: add implementation
+  )
+
+(defmulti update-aliases
+  "update index aliases"
+  (fn [conn actions]
+    (common-config/index-es-engine-key)))
+
+(defmethod update-aliases :old
+  [conn actions]
+  (esi/update-aliases conn actions))
+
+(defmethod update-aliases :new
+  [conn actions]
+  ;; TODO: add implementation
+  )
+
+(defmethod update-aliases :both
+  [conn actions]
+  ;; TODO: add implementation
+  )

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -4,6 +4,7 @@
    [clj-time.format :as f]
    [clojurewerkz.elastisch.rest.document :as doc]
    [clojurewerkz.elastisch.rest.index :as esi]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.elastic-utils.connect :as esc]))
@@ -120,7 +121,7 @@
   * elastic-store - A component containing an elastic connection under the :conn key"
   [index-name index-settings type-name mappings elastic-store]
   (let [conn (:conn elastic-store)]
-    (if (esi/exists? conn index-name)
+    (if (esi-helper/exists? conn index-name)
       (do
         (info (format "Updating %s mappings and settings" index-name))
         (let [response (esi/update-mapping conn index-name type-name :mapping mappings :ignore_conflicts false)]
@@ -148,7 +149,7 @@
   "Development time helper function to delete an index and recreate it to empty all data."
   [index-name index-settings type-name mappings elastic-store]
   (let [conn (:conn elastic-store)]
-    (when (esi/exists? conn index-name)
+    (when (esi-helper/exists? conn index-name)
       (info "Deleting the cubby index")
       (esi/delete conn index-name))
     (create-index-or-update-mappings index-name index-settings type-name mappings elastic-store)))

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -3,7 +3,6 @@
   (:require
    [clj-time.format :as f]
    [clojurewerkz.elastisch.rest.document :as doc]
-   [clojurewerkz.elastisch.rest.index :as esi]
    [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
@@ -124,15 +123,15 @@
     (if (esi-helper/exists? conn index-name)
       (do
         (info (format "Updating %s mappings and settings" index-name))
-        (let [response (esi/update-mapping conn index-name type-name :mapping mappings :ignore_conflicts false)]
+        (let [response (esi-helper/update-mapping conn index-name type-name {:mapping mappings :ignore_conflicts false})]
           (when-not (= {:acknowledged true} response)
             (errors/internal-error!
              (str "Unexpected response when updating elastic mappings: " (pr-str response))))))
       (do
         (info (format "Creating %s index" index-name))
-        (esi/create conn index-name :settings {:index index-settings} :mappings mappings)
+        (esi-helper/create conn index-name {:settings {:index index-settings} :mappings mappings})
         (esc/wait-for-healthy-elastic elastic-store)))
-    (esi/refresh conn index-name)))
+    (esi-helper/refresh conn index-name)))
 
 (defmacro try-elastic-operation
   "Handles any Elasticsearch exceptions from the body and converts them to internal errors. We do this
@@ -151,7 +150,7 @@
   (let [conn (:conn elastic-store)]
     (when (esi-helper/exists? conn index-name)
       (info "Deleting the cubby index")
-      (esi/delete conn index-name))
+      (esi-helper/delete conn index-name))
     (create-index-or-update-mappings index-name index-settings type-name mappings elastic-store)))
 
 (defn save-elastic-doc
@@ -213,4 +212,4 @@
 (defn create-index-alias
   "Creates the alias for the index."
   [conn index alias]
-  (esi/update-aliases conn [{:add {:index index :alias alias}}]))
+  (esi-helper/update-aliases conn [{:add {:index index :alias alias}}]))

--- a/indexer-app/int-test/cmr/indexer/test/services/index_fields.clj
+++ b/indexer-app/int-test/cmr/indexer/test/services/index_fields.clj
@@ -6,12 +6,11 @@
    [clojure.string :as string]
    [clojure.test :refer :all]
    [clojurewerkz.elastisch.rest :as esr]
-   [clojurewerkz.elastisch.rest.document :as doc]
-   [clojurewerkz.elastisch.rest.index :as esi]
    [cmr.common.cache :as cache]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.test.test-util :as tu]
    [cmr.elastic-utils.embedded-elastic-server :as elastic-server]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.data.index-set :as idx-set]))
 
@@ -114,11 +113,12 @@
   "Fixture that creates an index and drops it."
   [f]
   (let [conn (get-in @context [:system :db :conn])]
-    (esi/create conn "tests" :settings idx-set/collection-setting-v2 :mappings idx-set/collection-mapping)
+    (esi-helper/create
+     conn "tests" {:settings idx-set/collection-setting-v2 :mappings idx-set/collection-mapping})
     (try
       (f)
       (finally
-        (esi/delete conn "tests")))))
+        (esi-helper/delete conn "tests")))))
 
 ;; Run once for the whole test suite
 (use-fixtures

--- a/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
+++ b/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
-   [clojurewerkz.elastisch.rest.index :as esi]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.indexer.services.index-set-service :as svc]
    [cmr.indexer.test.utility :as util]))
 
@@ -25,7 +25,7 @@
           index-set-id (get-in index-set [:index-set :id])
           index-names (svc/get-index-names index-set)]
       (for [idx-name index-names]
-        (is (esi/exists? @util/elastic-connection idx-name)))))
+        (is (esi-helper/exists? @util/elastic-connection idx-name)))))
   (testing "index-set doc existence"
     (let [index-set util/sample-index-set
           index-set-id (get-in index-set [:index-set :id])
@@ -58,7 +58,7 @@
           expected-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
           {:keys [status]} (util/create-index-set index-set)]
       (is (= 201 status))
-      (is (esi/exists? @util/elastic-connection expected-idx-name))))
+      (is (esi-helper/exists? @util/elastic-connection expected-idx-name))))
   (testing "delete index-set"
     (let [index-set util/sample-index-set
           index-set-id (get-in index-set [:index-set :id])
@@ -66,7 +66,7 @@
           expected-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
           {:keys [status]} (util/delete-index-set index-set-id)]
       (is (= 204 status))
-      (is (not (esi/exists? @util/elastic-connection expected-idx-name))))))
+      (is (not (esi-helper/exists? @util/elastic-connection expected-idx-name))))))
 
 ;; Verify get index-sets fetches all index-sets in elastic.
 ;; Create 2 index-sets with different ids but with same number of concepts and indices associated
@@ -86,7 +86,7 @@
           body (-> (util/get-index-sets) :response :body)
           actual-es-indices (util/list-es-indices body)]
       (for [es-idx-name actual-es-indices]
-        (is (esi/exists? @util/elastic-connection es-idx-name)))
+        (is (esi-helper/exists? @util/elastic-connection es-idx-name)))
       (is (= expected-idx-cnt (count actual-es-indices))))))
 
 
@@ -114,7 +114,7 @@
      (doseq [collection expected-coll-indexes
              :let [collection-index-part (-> collection (str/replace "-" "_") str/lower-case)
                    elastic-index-name (str util/sample-index-set-id "_" collection-index-part)]]
-       (is (esi/exists? @util/elastic-connection elastic-index-name))))))
+       (is (esi-helper/exists? @util/elastic-connection elastic-index-name))))))
 
 ;; Tests adding a collection that is rebalancing its granules from small_collections to a separate
 ;; granule index

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -9,7 +9,6 @@
    [clj-time.format :as f]
    [clojurewerkz.elastisch.query :as esq]
    [clojurewerkz.elastisch.rest.document :as esd]
-   [cmr.transmit.cache.consistent-cache :as consistent-cache]
    [cmr.common-app.services.search.datetime-helper :as datetime-helper]
    [cmr.common.cache :as c]
    [cmr.common.cache.fallback-cache :as fallback-cache]
@@ -20,9 +19,11 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as util]
+   [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.services.index-service :as index-service]
    [cmr.redis-utils.redis-cache :as redis-cache]
+   [cmr.transmit.cache.consistent-cache :as consistent-cache]
    [cmr.transmit.metadata-db :as meta-db]))
 
 (def coll-gran-aggregate-cache-key
@@ -102,7 +103,7 @@
   "Searches across all the granule indexes to aggregate by collection. Returns a map of collection
    concept id to collection information. The collection will only be in the map if it has granules."
   [context]
-  (-> (esd/search (es/context->conn context)
+  (-> (es-helper/search (es/context->conn context)
                   "1_*" ;; Searching all indexes
                   ["granule"] ;; With the granule type.
                   {:query (esq/match-all)
@@ -117,7 +118,7 @@
   [context granules-updated-in-last-n]
   (let [revision-date (t/minus (tk/now) (t/seconds granules-updated-in-last-n))
         revision-date-str (datetime-helper/utc-time->elastic-time revision-date)]
-   (-> (esd/search (es/context->conn context)
+   (-> (es-helper/search (es/context->conn context)
                    "1_*" ;; Searching all indexes
                    ["granule"] ;; With the granule type.
                    {:query {:filtered {:query (esq/match-all)

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -10,6 +10,7 @@
    [clojurewerkz.elastisch.query :as esq]
    [clojurewerkz.elastisch.rest.document :as esd]
    [cmr.common-app.services.search.datetime-helper :as datetime-helper]
+   [cmr.common-app.services.search.elastic-search-index :as esi]
    [cmr.common.cache :as c]
    [cmr.common.cache.fallback-cache :as fallback-cache]
    [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
@@ -20,7 +21,6 @@
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as util]
    [cmr.elastic-utils.es-helper :as es-helper]
-   [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.services.index-service :as index-service]
    [cmr.redis-utils.redis-cache :as redis-cache]
    [cmr.transmit.cache.consistent-cache :as consistent-cache]
@@ -103,7 +103,7 @@
   "Searches across all the granule indexes to aggregate by collection. Returns a map of collection
    concept id to collection information. The collection will only be in the map if it has granules."
   [context]
-  (-> (es-helper/search (es/context->conn context)
+  (-> (es-helper/search (esi/context->conn context)
                   "1_*" ;; Searching all indexes
                   ["granule"] ;; With the granule type.
                   {:query (esq/match-all)
@@ -118,7 +118,7 @@
   [context granules-updated-in-last-n]
   (let [revision-date (t/minus (tk/now) (t/seconds granules-updated-in-last-n))
         revision-date-str (datetime-helper/utc-time->elastic-time revision-date)]
-   (-> (es-helper/search (es/context->conn context)
+   (-> (es-helper/search (esi/context->conn context)
                    "1_*" ;; Searching all indexes
                    ["granule"] ;; With the granule type.
                    {:query {:filtered {:query (esq/match-all)

--- a/indexer-app/src/cmr/indexer/system.clj
+++ b/indexer-app/src/cmr/indexer/system.clj
@@ -35,15 +35,15 @@
    [cmr.transmit.config :as transmit-config]))
 
 (def ^:private old-component-order
-  "Defines the order to start the components."
+  "Defines the order to start the components with old ES."
   [:log :caches :db :scheduler :queue-broker :web :nrepl])
 
 (def ^:private new-component-order
-  "Defines the order to start the components."
+  "Defines the order to start the components with new ES."
   [:log :caches :new-db :scheduler :queue-broker :web :nrepl])
 
 (def ^:private both-component-order
-  "Defines the order to start the components."
+  "Defines the order to start the components with both ES engines."
   [:log :caches :db :new-db :scheduler :queue-broker :web :nrepl])
 
 (def system-holder

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -15,6 +15,7 @@
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.services.errors :as e]
    [cmr.common.util :as util]
+   [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.search.services.query-walkers.collection-concept-id-extractor :as cex]
    [cmr.search.services.query-walkers.provider-id-extractor :as pex]
    [cmr.transmit.indexer :as indexer])
@@ -175,16 +176,12 @@
                  "1_services")
    :type-name "service"})
 
-(defn context->conn
-  [context]
-  (get-in context [:system :search-index :conn]))
-
 (defn get-collection-permitted-groups
   "NOTE: Use for debugging only. Gets collections along with their currently permitted groups. This
   won't work if more than 10,000 collections exist in the CMR."
   [context]
   (let [index-info (common-esi/concept-type->index-info context :collection nil)
-        results (esd/search (context->conn context)
+        results (es-helper/search (common-esi/context->search-conn context)
                             (:index-name index-info)
                             [(:type-name index-info)]
                             :query (q/match-all)

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -42,7 +42,6 @@
             (name k)))
         rebalancing-targets-map))
 
-
 (defn- fetch-concept-type-index-names
   "Fetch index names for each concept type from index-set app"
   [context]

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -29,6 +29,7 @@
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as u]
+   [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.search.data.elastic-search-index :as idx]
    [cmr.search.data.metadata-retrieval.metadata-cache :as metadata-cache]
    [cmr.search.results-handlers.provider-holdings :as ph]
@@ -490,7 +491,7 @@
         params (dissoc (common-params/sanitize-params params) :sort-key)
         _ (pv/validate-deleted-granules-params params)
         query (make-deleted-granules-query params)
-        results (esd/search (common-idx/context->conn context)
+        results (es-helper/search (common-idx/context->search-conn context)
                             deleted-granule-index-name
                             deleted-granule-type-name
                             query)


### PR DESCRIPTION
This is the initial setup of making CMR Backend Search Engine configurable. 

Two new config parameter are added: CMR_INDEX_ES_ENGINE and CMR_SEARCH_ES_ENGINE. CMR_INDEX_ES_ENGINE can have values of `old`, `new` and `both`, where `old` means the current ES 1.6.2 version; `new` means the latest ES version we want to upgrade to; `both` means that both the old and new ES clusters would be running as the backend engines for indexer. CMR_SEARCH_ES_ENGINE can have values of `old` and `new` only, as we only want to search one ES cluster at a time (this can be changed later if we want to search both and do comparison, but I don't see it happening for now).

I put in some helper functions (in `cmr.elastic-utils.es-helper` and `cmr.elastic-utils.es-index-helper`) that wrap the calls to ES directly so we can have different interface to interact with the two different backend ES engines, but I didn't go all the way to wrap all ES calls. The thinking is that not only the function call to different ES will be different via different libraries, the JSON payload may also be different, or the call and payload to different ES may be the same for certain actions. So it does not make sense to put all the wrappers in place and only to get them thrown away later. So the real implementation of various actions to ES will be added when we work on the individual JIRA ticket for that action (e.g. get, delete, scroll, bulk, etc). The wrapper namespace is only for demonstration purpose. 