### PR TITLE
CMR-6222: As a CMR Developer, I Want to Run Dev-system on Top of ES 7.5.2

### DIFF
--- a/elastic-utils-lib/.gitignore
+++ b/elastic-utils-lib/.gitignore
@@ -9,4 +9,5 @@ pom.xml.asc
 /.nrepl-port
 /es_data
 test2junit
+/resources/docker/data
 build.xml

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -8,7 +8,7 @@
                [potemkin]]
   :dependencies [[cheshire "5.8.1"]
                  [clj-http "2.3.0"]
-                 [clojurewerkz/elastisch "2.2.2"]
+                 [clojurewerkz/elastisch "5.0.0-beta1"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.6"]
                  [log4j/log4j "1.2.17"]

--- a/elastic-utils-lib/resources/docker/docker-compose.yml
+++ b/elastic-utils-lib/resources/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+services:
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+    container_name: cmr-es-elastic
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - ELASTIC_PASSWORD=kibana
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ${PWD}/data/elastic:/usr/share/elasticsearch/data
+    ports:
+      - 9209:9200
+    networks:
+      - cmr-es-net
+
+volumes:
+  data:
+    driver: local
+  logs:
+    driver: local
+
+networks:
+  cmr-es-net:

--- a/elastic-utils-lib/src/cmr/elastic_utils/connect.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/connect.clj
@@ -49,7 +49,7 @@
   "Waits for the elasticsearch cluster health to reach yellow. Pass in a elasticsearch store that
   has a :conn key with the elastisch connection"
   [elastic-store]
-  (when (:timed_out (admin/cluster-health (:conn elastic-store) :wait_for_status "yellow" :timeout "3s"))
+  (when (:timed_out (admin/cluster-health (:conn elastic-store) {:wait_for_status "yellow" :timeout "3s"}))
     (errors/internal-error! "Timed out waiting for elasticsearch to reach a healthy state")))
 
 (defn- get-elastic-health

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
@@ -1,0 +1,19 @@
+(ns cmr.elastic-utils.es-helper
+  "Defines helper functions for invoking ES"
+  (:require
+   [clojurewerkz.elastisch.rest.document :as doc]))
+
+(defn search
+  "Performs a search query across one or more indexes and one or more mapping types"
+  [conn index mapping-type opts]
+  (doc/search conn index mapping-type opts))
+
+(defn count-query
+  "Performs a count query over one or more indexes and types"
+  [conn index mapping-type query]
+  (doc/count conn index mapping-type query))
+
+(defn scroll
+  "Performs a count query over one or more indexes and types"
+  [conn scroll-id opts]
+  (doc/scroll conn scroll-id opts))

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
@@ -14,6 +14,6 @@
   (doc/count conn index mapping-type query))
 
 (defn scroll
-  "Performs a count query over one or more indexes and types"
+  "Performs a scroll query, fetching the next page of results from a query given a scroll id"
   [conn scroll-id opts]
   (doc/scroll conn scroll-id opts))

--- a/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
@@ -1,0 +1,33 @@
+(ns cmr.elastic-utils.es-index-helper
+  "Defines helper functions for invoking ES index"
+  (:require
+   [clojurewerkz.elastisch.rest.index :as esi]))
+
+(defn exists?
+  [conn index-name]
+  (esi/exists? conn index-name))
+
+(defn update-mapping
+  "Register or modify specific mapping definition"
+  [conn index-name-or-names type-name opts]
+  (esi/update-mapping conn index-name-or-names type-name opts))
+
+(defn create
+  "Create an index"
+  [conn index-name opts]
+  (esi/create conn index-name opts))
+
+(defn refresh
+ "refresh an index"
+  [conn index-name]
+  (esi/refresh conn index-name))
+
+(defn delete
+  "delete an index"
+  [conn index-name]
+  (esi/delete conn index-name))
+
+(defn update-aliases
+  "update index aliases"
+  [conn actions]
+  (esi/update-aliases conn actions))


### PR DESCRIPTION
This PR runs dev-system against the external Elasticsearch 7.5.2 that is running locally via docker. The ES can be started by running `docker-compose up` in the `resources/docker` directory under `elastic-utils-lib`. The dev-system can be started successfully and most of the search integration tests can also run successfully with the code changes in this PR. 

I tried `https://github.com/spandex-project/spandex`, but found it too low level and is too big a departure from our existing code base. On the other end, the Elastisch 5.0.0-beta1 release fixed most of upgrade issues for us and aligns well with our existing code base. So I decided to continue using the Elastisch library and add in fixes in the helper namespaces in `elastic-utils-lib` when necessary.

This PR will not run in CI because CI still depends on embedded ES which is covered in CMR-6133, so don't be alarmed if you see build failure on this branch.