### PR TITLE
CMR-6235 Updated autocomplete parameters and response to follow CMR standards

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1133,29 +1133,27 @@ Note: ISO 8601 does not allow open-ended time intervals but the CMR API does all
 
 Auto-completion assistance for building queries. This functionality may be used to help build queries. The facet autocomplete functionality does not search for collections directly. Instead it will return suggestions of facets to help narrow a search by providing a list of available facets to construct a CMR collections search.
     
-    curl "%CMR-ENDPOINT%/autocomplete?q=<term>[&types=<types>]"
+    curl "%CMR-ENDPOINT%/autocomplete?q=<term>[&type\[\]=<type1>[&type\[\]=<type2>]"
         
 Collection facet autocompletion results are paged. See [Paging Details](#paging-details) for more information on how to page through autocomplete search results.
 
 #### Autocomplete Parameters
   * `q` The string on which to search. The term is case insensitive.
-  * `types` Comma separated list of types to include in the results set. If left blank all facet types will be returned.
+  * `type[]` Optional list of types to include in the search. This may be any number of valid facet types.
  
 __Example Query__
 
      curl "%CMR-ENDPOINT%/autocomplete?q=ice"
  
 __Example Result__
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+CMR-Hits: 15
 
-```json
 {
-  "query": {
-    "query": "ice",
-    "types": []
-  },
-  "results": {
-    "hits": 5,
-    "items": [
+  "feed": {
+    "entry": [
       {
         "score": 9.115073,
         "type": "instrument",
@@ -1188,18 +1186,17 @@ __Example Result__
 
 __Example Query__
 
-     curl "%CMR-ENDPOINT%/autocomplete?q=ice&types=platform,project"
+     curl "%CMR-ENDPOINT%/autocomplete?q=ice&type[]=platform&type[]=project"
      
 __Example Result with Type Filter__
-```json
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+CMR-Hits: 3
+
 {
-  "query": {
-    "query": "ice",
-    "types": ["platform","project"]
-  },
-  "results": {
-    "hits": 3,
-    "items": [
+  "feed": {
+    "entry": [
       {
         "score": 9.013778,
         "type": "platform",

--- a/search-app/src/cmr/search/api/autocomplete.clj
+++ b/search-app/src/cmr/search/api/autocomplete.clj
@@ -27,13 +27,22 @@
   [s]
   (string/lower-case (string/trim s)))
 
+(defn- ac-results->response-header-map
+  [results]
+  (let [hits (str (:hits results 0))]
+    {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)
+     common-routes/CORS_ORIGIN_HEADER  "*"
+     common-routes/HITS_HEADER hits}))
+
+(defn- ac-results->response-body
+  [results]
+  {:feed
+   {:entry (:items results)}})
+
 (defn- process-autocomplete-query
   "Process and autocomplete and return value"
   [ctx query types params]
   (let [term (lower-case-and-trim query)
-        types (when types
-                (filter #(not (empty? %))
-                        (map lower-case-and-trim (string/split types #","))))
         page-size (string-param-or-default->int (:page-size params) page-size-default)
         offset (if (:page-num params)
                  (* page-size (string-param-or-default->int (:page-num params) page-num-default))
@@ -44,30 +53,20 @@
                            :page-size page-size
                            :offset offset)
         results (ac/autocomplete ctx term opts)
-        cmr-hits (str (count (:items results)))]
+        headers (ac-results->response-header-map results)
+        body (ac-results->response-body results)]
     {:status 200
-     :headers {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)
-               common-routes/CORS_ORIGIN_HEADER  "*"
-               common-routes/HITS_HEADER cmr-hits}
-     :body {:query {:query term
-                    :types (if types types [])}
-            :results results}}))
+     :headers headers
+     :body body}))
 
 (defn- get-autocomplete-suggestions-handler
   "Validate params and invoke autocomplete"
   [ctx path-w-extension params headers]
   (let [opts (core-api/process-params :autocomplete params path-w-extension headers mt/json)
         query (:q opts)
-        types (:types opts)]
+        types (:type opts)]
     (when-not query
-      (svc-errors/throw-service-errors
-       :bad-request
-       ["Missing param [q]"
-        "Usage [/autocomplete?q=<term>[&types=[&page-size=[&page-number=]]]]"
-        "q : query string to search for suggestions"
-        "types : comma separated list of types"
-        "offset : maximum number of suggestions : default 0"
-        "page_size : results page : default 20"]))
+      (svc-errors/throw-service-errors :bad-request ["Missing param [q]"]))
     (process-autocomplete-query ctx query types opts)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/search-app/src/cmr/search/api/autocomplete.clj
+++ b/search-app/src/cmr/search/api/autocomplete.clj
@@ -43,9 +43,11 @@
   "Process and autocomplete and return value"
   [ctx query types params]
   (let [term (lower-case-and-trim query)
-        page-size (string-param-or-default->int (:page-size params) page-size-default)
-        offset (if (:page-num params)
-                 (* page-size (string-param-or-default->int (:page-num params) page-num-default))
+        page-size (string-param-or-default->int (:page_size params) page-size-default)
+        offset (if (:page_num params)
+                 ;; page_num was provided, convert to offset by multiplying by page_size
+                 (* page-size (string-param-or-default->int (:page_num params) page-num-default))
+                 ;; page_num was not provided, check for 'offset' instead
                  (if (:offset params)
                    (string-param-or-default->int (:offset params) page-num-default)
                    page-num-default))
@@ -65,7 +67,7 @@
   (let [opts (core-api/process-params :autocomplete params path-w-extension headers mt/json)
         query (:q opts)
         types (:type opts)]
-    (when-not query
+    (when (empty? query)
       (svc-errors/throw-service-errors :bad-request ["Missing param [q]"]))
     (process-autocomplete-query ctx query types opts)))
 

--- a/search-app/src/cmr/search/api/autocomplete.clj
+++ b/search-app/src/cmr/search/api/autocomplete.clj
@@ -43,10 +43,12 @@
         opts (assoc params :types types
                            :page-size page-size
                            :offset offset)
-        results (ac/autocomplete ctx term opts)]
+        results (ac/autocomplete ctx term opts)
+        cmr-hits (str (count (:items results)))]
     {:status 200
      :headers {common-routes/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)
-               common-routes/CORS_ORIGIN_HEADER  "*"}
+               common-routes/CORS_ORIGIN_HEADER  "*"
+               common-routes/HITS_HEADER cmr-hits}
      :body {:query {:query term
                     :types (if types types [])}
             :results results}}))

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -212,7 +212,8 @@
 
 (defmethod cpv/valid-parameter-options :autocomplete
   [_]
-  {})
+  {:q cpv/string-param-options
+   :type cpv/string-plus-or-options})
 
 (defmethod cpv/valid-query-level-params :collection
   [_]

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -253,9 +253,8 @@
    (get-autocomplete-suggestions term nil))
   ([term opts]
    (client/get (url/autocomplete-url term) opts))
-  ([term types-list opts]
-   (let [types (str/join "," types-list)]
-     (client/get (url/autocomplete-url term types) opts))))
+  ([term types opts]
+   (client/get (url/autocomplete-url term types) opts)))
 
 (defn- parse-timeline-interval
   "Parses the timeline response interval component into a more readable and comparable format."

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -249,12 +249,10 @@
 
 (defn get-autocomplete-suggestions
   "Executes a query to the autocomplete endpoint with the given value and returns the results."
-  ([term]
-   (get-autocomplete-suggestions term nil))
-  ([term opts]
-   (client/get (url/autocomplete-url term) opts))
-  ([term types opts]
-   (client/get (url/autocomplete-url term types) opts)))
+  ([query]
+   (get-autocomplete-suggestions query nil))
+  ([query opts]
+   (client/get (url/autocomplete-url query) opts)))
 
 (defn- parse-timeline-interval
   "Parses the timeline response interval component into a more readable and comparable format."

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -1,7 +1,6 @@
 (ns cmr.system-int-test.utils.url-helper
   "helper to provide the urls to various service endpoints"
   (:require
-   [clojure.string :as string]
    [cmr.common.config :as config]
    [cmr.elastic-utils.config :as es-config]
    [cmr.transmit.config :as transmit-config]

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -1,7 +1,7 @@
 (ns cmr.system-int-test.utils.url-helper
   "helper to provide the urls to various service endpoints"
   (:require
-   [clojure.string :as str]
+   [clojure.string :as string]
    [cmr.common.config :as config]
    [cmr.elastic-utils.config :as es-config]
    [cmr.transmit.config :as transmit-config]
@@ -241,13 +241,16 @@
   (format "http://localhost:%s/%ss" (transmit-config/search-port) (name type)))
 
 (defn autocomplete-url
-  "Autocomplete URL with query term and optional types"
+  "Autocomplete URL with query term and optional types collection"
   ([term]
-   (if term
-    (format "http://localhost:%s/autocomplete?q=%s" (transmit-config/search-port) term)
-    (format "http://localhost:%s/autocomplete" (transmit-config/search-port))))
+   (if-not term
+    (format "http://localhost:%s/autocomplete" (transmit-config/search-port)))
+    (format "http://localhost:%s/autocomplete?q=%s" (transmit-config/search-port) term))
   ([term types]
-   (format "http://localhost:%s/autocomplete?q=%s&types=%s" (transmit-config/search-port) term types)))
+   (format "http://localhost:%s/autocomplete?q=%s&%s"
+           (transmit-config/search-port)
+           term
+           (string/join "&" (map #(str "type[]=" %) types)))))
 
 (defn enable-search-writes-url
   []

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -244,15 +244,10 @@
   "Autocomplete URL with query term and optional types collection"
   ([]
    (autocomplete-url nil))
-  ([term]
-   (if-not term
-    (format "http://localhost:%s/autocomplete" (transmit-config/search-port))
-    (format "http://localhost:%s/autocomplete?q=%s" (transmit-config/search-port) term)))
-  ([term types]
-   (format "http://localhost:%s/autocomplete?q=%s&%s"
-           (transmit-config/search-port)
-           term
-           (string/join "&" (map #(str "type[]=" %) types)))))
+  ([query]
+   (if-not query
+     (format "http://localhost:%s/autocomplete" (transmit-config/search-port))
+     (format "http://localhost:%s/autocomplete?%s" (transmit-config/search-port) query))))
 
 (defn enable-search-writes-url
   []

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -244,9 +244,9 @@
   ([]
    (autocomplete-url nil))
   ([query]
-   (if-not query
-     (format "http://localhost:%s/autocomplete" (transmit-config/search-port))
-     (format "http://localhost:%s/autocomplete?%s" (transmit-config/search-port) query))))
+   (if query
+     (format "http://localhost:%s/autocomplete?%s" (transmit-config/search-port) query)
+     (format "http://localhost:%s/autocomplete" (transmit-config/search-port)))))
 
 (defn enable-search-writes-url
   []

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -242,10 +242,12 @@
 
 (defn autocomplete-url
   "Autocomplete URL with query term and optional types collection"
+  ([]
+   (autocomplete-url nil))
   ([term]
    (if-not term
-    (format "http://localhost:%s/autocomplete" (transmit-config/search-port)))
-    (format "http://localhost:%s/autocomplete?q=%s" (transmit-config/search-port) term))
+    (format "http://localhost:%s/autocomplete" (transmit-config/search-port))
+    (format "http://localhost:%s/autocomplete?q=%s" (transmit-config/search-port) term)))
   ([term types]
    (format "http://localhost:%s/autocomplete?q=%s&%s"
            (transmit-config/search-port)

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
@@ -36,6 +36,13 @@
      (is (contains? data :results))
      (is (contains? (:results data) :items))))
 
+  (testing "returns CMR-Hits header"
+   (let [response (search/get-autocomplete-suggestions "foo")
+         headers (:headers response)]
+     (is (:CMR-Hits headers))
+     (println (json/parse-string (:body response) true))
+     (is (= "1" (:CMR-Hits headers)))))
+
   (testing "partial value match search"
    (let [response (search/get-autocomplete-suggestions "f")
          body (:body response)
@@ -87,4 +94,7 @@
 (deftest autocomplete-usage-test
   (testing "missing query param response test"
            (let [response (search/get-autocomplete-suggestions nil {:throw-exceptions false})]
-             (is (= 400 (:status response))))))
+             (is (= 400 (:status response)))))
+
+  (testing "types array"
+           (is (= true false))))

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
@@ -5,6 +5,7 @@
     [cheshire.core :as json]
     [clojurewerkz.elastisch.rest :as esr]
     [clojurewerkz.elastisch.rest.document :as esd]
+    [cmr.common.util :refer [are3]]
     [cmr.system-int-test.utils.url-helper :as url]
     [cmr.system-int-test.utils.ingest-util :as ingest]
     [cmr.system-int-test.utils.index-util :as index]
@@ -27,6 +28,19 @@
                      [(ingest/reset-fixture)
                       autocomplete-fixture]))
 
+(defn- query->json-response-body
+  ([query]
+   (query->json-response-body query nil))
+  ([query opts]
+  (let [response (search/get-autocomplete-suggestions query opts)
+        body (:body response)
+        data (json/parse-string body true)]
+    data)))
+
+(defn- response-body->entries
+  [data]
+  (:entry (:feed data)))
+
 (deftest autocomplete-response-test
   (testing "response form test"
      (let [response (search/get-autocomplete-suggestions "q=foo")
@@ -42,88 +56,77 @@
        (is (= "1" (:CMR-Hits headers))))))
 
 (deftest autocomplete-functionality-test
-  (testing "partial value match search"
-   (let [response (search/get-autocomplete-suggestions "q=f")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 1 (count (:entry (:feed data)))))))
+  (testing "value search"
+   (are3
+    [query expected]
+    (is (= expected (count (response-body->entries (query->json-response-body query)))))
 
-  (testing "full value match search"
-   (let [response (search/get-autocomplete-suggestions "q=foo")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 1 (count (:entry (:feed data)))))))
+    "partial value"
+    "q=f" 1
 
-  (testing "full value with extra value match search"
-   (let [response (search/get-autocomplete-suggestions "q=foos")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 0 (count (:entry (:feed data)))))))
+    "full value match"
+    "q=foo" 1
 
-  (testing "case sensitivity test"
-   (let [response (search/get-autocomplete-suggestions "q=FOO")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 1 (count (:entry (:feed data)))))))
+    "full value with extra value match"
+    "q=foos" 0
 
-  (testing "bad value search with no results"
-   (let [response (search/get-autocomplete-suggestions "q=zee")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 0 (count (:entry (:feed data)))))))
+    "case sensitivity test"
+    "q=FOO" 1
 
-  (testing "search with type filter"
-   (let [response (search/get-autocomplete-suggestions "q=foo&type[]=instrument")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 1 (count (:entry (:feed data)))))))
+    "no result test"
+    "q=zee" 0
 
-  (testing "search with multiple types filter"
-   (let [response (search/get-autocomplete-suggestions
-                    "q=b&type[]=instrument&type[]=platform&type[]=project&type[]=provider")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 2 (count (:entry (:feed data)))))))
+    "search with type filter"
+    "q=foo&type[]=instrument" 1
 
-  (testing "search with type filter with no results"
-   (let [response (search/get-autocomplete-suggestions "q=foo&type[]=platform")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (= 0 (count (:entry (:feed data))))))))
+    "search with multiple types filter"
+    "q=b&type[]=instrument&type[]=platform&type[]=project&type[]=provider" 2
+
+    "search with type filter with no results"
+    "q=foo&type[]=platform" 0)))
 
 (deftest autocomplete-usage-test
-  (testing "missing query param response test"
-   (let [response (search/get-autocomplete-suggestions nil {:throw-exceptions false})]
-     (is (= 400 (:status response)))))
+  (testing "invalid or missing query param tests"
+   (are3
+    [query]
+    (is (= 400 (:status (search/get-autocomplete-suggestions query {:throw-exceptions false}))))
 
-  (testing "empty string query response test"
-   (let [response (search/get-autocomplete-suggestions "q=  " {:throw-exceptions false})]
-     (is (= 400 (:status response)))))
+    "no query param provided"
+    nil
 
-  (testing "page_size 0 test"
-   (let [response (search/get-autocomplete-suggestions "q=*&page_size=0")
-         headers (:headers response)
-         body (json/parse-string (:body response) true)
-         entry (:entry (:feed body))]
-     (is (= "3" (:CMR-Hits headers)))
-     (is (= 0 (count entry)))))
+    "blank query provided"
+    "q=  "))
 
-  (testing "page_size 2 test"
-   (let [response (search/get-autocomplete-suggestions "q=*&page_size=2")
-         headers (:headers response)
-         body (json/parse-string (:body response) true)
-         entry (:entry (:feed body))]
-     (is (= "3" (:CMR-Hits headers)))
-     (is (= 2 (count entry)))))
+  (testing "page_size test"
+   (are3
+    [query expected cmr-hits]
+    (do
+      (let [response (search/get-autocomplete-suggestions query)
+            headers (:headers response)
+            body (json/parse-string (:body response) true)
+            entry (:entry (:feed body))]
+        (is (= (str cmr-hits) (:CMR-Hits headers)))
+        (is (= expected (count entry)))))
+
+    "page size 0"
+    "q=*&page_size=0" 0 3
+
+    "page size 1"
+    "q=*&page_size=1" 1 3
+
+    "page size 2"
+    "q=*&page_size=2" 2 3
+
+    "page size 3"
+    "q=*&page_size=3" 3 3
+
+    "page size 100"
+    "q=*&page_size=100" 3 3))
 
   (testing "page_num should yield different 'first' results test"
-   (let [page-one-response (search/get-autocomplete-suggestions "q=b&page_size=1")
-         page-one-headers  (:headers page-one-response)
-         page-one-body     (json/parse-string (:body page-one-response) true)
-         page-one-entry    (first (:entry (:feed page-one-body)))
+   (let [page-one-entry (as-> (query->json-response-body "q=b&page_size=1") response
+                              (first (response-body->entries response)))
 
-         page-two-response (search/get-autocomplete-suggestions "q=b&page_size=1&page_num=1")
-         page-two-headers  (:headers page-two-response)
-         page-two-body     (json/parse-string (:body page-two-response) true)
-         page-two-entry    (first (:entry (:feed page-two-body)))]
+         page-two-entry (as-> (query->json-response-body "q=b&page_size=1&page_num=1") response
+                              (first (response-body->entries response)))]
      (is (not (= page-one-entry page-two-entry))))))

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
@@ -27,74 +27,70 @@
                      [(ingest/reset-fixture)
                       autocomplete-fixture]))
 
-(deftest autocomplete-suggest-test
-  (testing "returned result form test"
-   (let [response (search/get-autocomplete-suggestions "foo")
-         body (:body response)
-         data (json/parse-string body true)]
-     (is (contains? data :query))
-     (is (contains? data :results))
-     (is (contains? (:results data) :items))))
+(deftest autocomplete-response-test
+  (testing "response form test"
+     (let [response (search/get-autocomplete-suggestions "foo")
+           body (:body response)
+           data (json/parse-string body true)]
+       (is (contains? data :feed))
+       (is (contains? (:feed data) :entry))))
 
   (testing "returns CMR-Hits header"
-   (let [response (search/get-autocomplete-suggestions "foo")
-         headers (:headers response)]
-     (is (:CMR-Hits headers))
-     (println (json/parse-string (:body response) true))
-     (is (= "1" (:CMR-Hits headers)))))
+     (let [response (search/get-autocomplete-suggestions "foo")
+           headers (:headers response)]
+       (is (:CMR-Hits headers))
+       (is (= "1" (:CMR-Hits headers))))))
 
+(deftest autocomplete-functionality-test
   (testing "partial value match search"
    (let [response (search/get-autocomplete-suggestions "f")
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 1 (count (:items (:results data)))))))
+     (is (= 1 (count (:entry (:feed data)))))))
 
   (testing "full value match search"
    (let [response (search/get-autocomplete-suggestions "foo")
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 1 (count (:items (:results data)))))))
+     (is (= 1 (count (:entry (:feed data)))))))
 
   (testing "full value with extra value match search"
    (let [response (search/get-autocomplete-suggestions "foos")
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 0 (count (:items (:results data)))))))
+     (is (= 0 (count (:entry (:feed data)))))))
 
   (testing "case sensitivity test"
    (let [response (search/get-autocomplete-suggestions "FOO")
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 1 (count (:items (:results data)))))))
+     (is (= 1 (count (:entry (:feed data)))))))
 
   (testing "bad value search with no results"
    (let [response (search/get-autocomplete-suggestions "zee")
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 0 (count (:items (:results data)))))))
+     (is (= 0 (count (:entry (:feed data)))))))
 
   (testing "search with type filter"
    (let [response (search/get-autocomplete-suggestions "foo" ["instrument"] nil)
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 1 (count (:items (:results data)))))))
+     (is (= 1 (count (:entry (:feed data)))))))
 
   (testing "search with multiple types filter"
    (let [response (search/get-autocomplete-suggestions "foo" ["instrument" "platform" "project" "provider"] nil)
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 1 (count (:items (:results data)))))))
+     (is (= 1 (count (:entry (:feed data)))))))
 
   (testing "search with type filter with no results"
    (let [response (search/get-autocomplete-suggestions "foo" ["platform"] nil)
          body (:body response)
          data (json/parse-string body true)]
-     (is (= 0 (count (:items (:results data))))))))
+     (is (= 0 (count (:entry (:feed data))))))))
 
 (deftest autocomplete-usage-test
   (testing "missing query param response test"
-           (let [response (search/get-autocomplete-suggestions nil {:throw-exceptions false})]
-             (is (= 400 (:status response)))))
-
-  (testing "types array"
-           (is (= true false))))
+     (let [response (search/get-autocomplete-suggestions nil {:throw-exceptions false})]
+       (is (= 400 (:status response))))))


### PR DESCRIPTION
Autocomplete parameters have been updated to follow CMR standard parameter format.
Response has been modified to follow standard CMR responses.

<h2>Changes</h2>

- _types_ has been removed and no longer accepts CSV values
- _types_ has been replaced by an optional list of _type[]_
  * e.g.  `&type[]=instrument&type[]=platform`
- CMR-Hits value now included in response header denoting total number of hits found
  * may be different than total returned in response if using paging options
- response format now follows standard CMR response structure
```
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
CMR-Hits: 1

{
  "feed": {
    "entry": [
      {
        "score": 88.00000,
        "type": "instrument",
        "value": "flux capacitor"
      }
    ]
  }
}
```
 