### PR TITLE
CMR-6223 There are two ECHO 10 Collection.xsd in the CMR. This change…

### DIFF
--- a/umm-lib/resources/schema/echo10/Collection.xsd
+++ b/umm-lib/resources/schema/echo10/Collection.xsd
@@ -457,7 +457,7 @@ xmlns:xs="http://www.w3.org/2001/XMLSchema">
           collection.</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element minOccurs="0" name="DataFormat">
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="DataFormat">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1" />


### PR DESCRIPTION
…s the second one to match the first. This is necessary for the validation software as it uses the old umm-lib library.