### PR TITLE
CMR-6270 -- updated references to latest  Preview Gem

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -10,9 +10,9 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   {:repo "https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git"
-   :version "cmr_metadata_preview-0.2.0"
+   :version "cmr_metadata_preview-0.2.1"
    :commit-id (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-                  "5dc1e67b1a")})
+                  "1d700ebba34")})
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
Installing reference to the latest version of the Preview Gem which incorporates:
MMT-2135 -- Fixed an alignment problem in the collection-title display.
MMT-1726   -- support UMM-C v1.15. 