### PR TITLE
CMR-6219 updated response code for association actions

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3121,7 +3121,7 @@ Content-Length: 168
 ]
 ```
 
-On occassions when tag association cannot be processed at all due to invalid input, tag association request will return a failure status code with the appropriate error message.
+On occasions when tag association cannot be processed at all due to invalid input, tag association request will return a failure status code with the appropriate error message.
 
 #### <a name="associating-collections-with-a-tag-by-query"></a> Associating Collections with a Tag by query
 
@@ -3687,7 +3687,7 @@ curl -XDELETE -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR
   {"concept_id": "C1200000006-PROV1"},
   {"concept_id": "C1200000007-PROV1"}]'
 
-HTTP/1.1 200 OK
+HTTP/1.1 400 OK
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 
@@ -4005,7 +4005,7 @@ curl -XPOST -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR-E
 '[{"concept_id": "C1200000005-PROV1"},
   {"concept_id": "C1200000006-PROV1"}]'
 
-HTTP/1.1 200 OK
+HTTP/1.1 400 OK
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 
@@ -4042,7 +4042,7 @@ curl -XDELETE -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR
   {"concept_id": "C1200000006-PROV1"},
   {"concept_id": "C1200000007-PROV1"}]'
 
-HTTP/1.1 200 OK
+HTTP/1.1 400 OK
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3687,7 +3687,7 @@ curl -XDELETE -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR
   {"concept_id": "C1200000006-PROV1"},
   {"concept_id": "C1200000007-PROV1"}]'
 
-HTTP/1.1 400 OK
+HTTP/1.1 400 BAD REQUEST
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 
@@ -4005,7 +4005,7 @@ curl -XPOST -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR-E
 '[{"concept_id": "C1200000005-PROV1"},
   {"concept_id": "C1200000006-PROV1"}]'
 
-HTTP/1.1 400 OK
+HTTP/1.1 400 BAD REQUEST
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 
@@ -4042,7 +4042,7 @@ curl -XDELETE -i -H "Content-Type: application/json" -H "Echo-Token: XXXXX" %CMR
   {"concept_id": "C1200000006-PROV1"},
   {"concept_id": "C1200000007-PROV1"}]'
 
-HTTP/1.1 400 OK
+HTTP/1.1 400 BAD REQUEST
 Content-Type: application/json; charset=UTF-8
 Content-Length: 168
 

--- a/search-app/src/cmr/search/api/association.clj
+++ b/search-app/src/cmr/search/api/association.clj
@@ -44,21 +44,7 @@
   concept-type)
 
 (defmethod association-results->status-code :default
-  "If the concept-type is :variable the function will check for any errors in the results, and will return 400 if
-  any are present. Otherwise it will return 200"
-  ([results]
-   (let [errors-during-association (filter #(some? (:errors %)) results)]
-     (if (seq errors-during-association) 400 200)))
-  ([results concept-type]
-   (if (some #{concept-type} '(:variable :service))
-     (association-results->status-code results)
-     200)))
-
-(defmulti association-results->status-code
-  [concept-type results]
-  concept-type)
-
-(defmethod association-results->status-code :default
+  "Return 200 status code"
   [_ _]
   200)
 

--- a/search-app/test/cmr/search/test/api/association.clj
+++ b/search-app/test/cmr/search/test/api/association.clj
@@ -1,0 +1,45 @@
+(ns cmr.search.test.api.association
+  "Tests to verify functionality in cmr.search.api.association namespace."
+  (:require
+    [clojure.test :refer :all]
+    [cmr.common.util :as util]
+    [cmr.search.api.association :as assoc]))
+
+(deftest association-results->status-code
+  (util/are3 [concept-type input return-code]
+   (do
+     (is (= return-code (assoc/association-results->status-code concept-type input))))
+
+   "no error :service returns 200"
+   :service
+   '({:service-association {:concept-id "SA1200000026-CMR" :revision-id 1} :associated-item {:concept-id "C1200000013-PROV1"}}
+     {:service-association {:concept-id "SA1200000027-CMR" :revision-id 1} :associated-item {:concept-id "C1200000019-PROV2"}})
+   200
+
+   "error :service returns 400"
+   :service
+   '({:errors '("Collection [C100-P5] does not exist or is not visible.") :associated-item {:concept-id "C100-P5"}})
+   400
+
+   "no error :variable returns 200"
+   :variable
+   '({:variable-association {:concept-id "VA1200000017-CMR" :revision-id 1} :associated-item {:concept-id "C1200000012-PROV1"}})
+   200
+
+   "error :variable returns 400"
+   :variable
+   '({:errors ["Variable [V1200000015-PROV1] and collection [C1200000013-PROV1] can not be associated because the variable is already associated with another collection [C1200000012-PROV1]."]
+      :associated-item {:concept-id "C1200000013-PROV1"}})
+   400
+
+   ":tag no error returns 200"
+   :tag
+   '({:tag-association {:concept-id "TA1200000026-CMR" :revision-id 1} :tagged-item {:concept-id "C1200000013-PROV1"}}
+     {:tag-association {:concept-id "TA1200000028-CMR" :revision-id 1} :tagged-item {:concept-id "C1200000014-PROV1"}}
+     {:tag-association {:concept-id "TA1200000027-CMR" :revision-id 1} :tagged-item {:concept-id "C1200000015-PROV1"}})
+   200
+
+   ":tag returns 200 even with error"
+   :tag
+   '({:errors ["At least one collection must be provided for tag association."] :status 422})
+   200))

--- a/system-int-test/src/cmr/system_int_test/utils/service_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/service_util.clj
@@ -198,10 +198,28 @@
              (set (comparable-service-associations expected-sas))]
             [status (set (comparable-service-associations body))])))))
 
+(defn assert-service-association-bad-request
+  "Assert the service association response when status code is 200 is correct."
+  ([coll-service-associations response]
+   (assert-service-association-bad-request coll-service-associations response true))
+  ([coll-service-associations response error?]
+   (let [{:keys [status body errors]} response
+         expected-sas (map #(coll-service-association->expected-service-association % error?)
+                           coll-service-associations)]
+     (is (= [400
+             (set (comparable-service-associations expected-sas))]
+            [status (set (comparable-service-associations body))])))))
+
+
 (defn assert-service-dissociation-response-ok?
   "Assert the service association response when status code is 200 is correct."
   [coll-service-associations response]
   (assert-service-association-response-ok? coll-service-associations response false))
+
+(defn assert-service-dissociation-bad-request
+  "Assert the service association response when status code is 400 is correct."
+  [coll-service-associations response]
+  (assert-service-association-bad-request coll-service-associations response true))
 
 (defn- search-for-service-associations
   "Searches for service associations in metadata db using the given parameters."

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -234,16 +234,26 @@
             [status (set (comparable-variable-associations body))])))))
 
 (defn assert-variable-association-bad-request
-  "Assert the variable association response when status code is 200 is correct."
-  [err-msg response]
-  (let [{:keys [status body errors]} response]
-     (is (= 400 status))
-     (is (= errors err-msg))))
+  "Assert the variable association response when status code is 400 is correct."
+  ([coll-variable-associations response]
+   (assert-variable-association-bad-request coll-variable-associations response true))
+  ([coll-variable-associations response error?]
+   (let [{:keys [status body errors]} response
+         expected-tas (map #(coll-variable-association->expected-variable-association % error?)
+                           coll-variable-associations)]
+     (is (= [400
+             (set (comparable-variable-associations expected-tas))]
+            [status (set (comparable-variable-associations body))])))))
 
 (defn assert-variable-dissociation-response-ok?
   "Assert the variable association response when status code is 200 is correct."
   [coll-variable-associations response]
   (assert-variable-association-response-ok? coll-variable-associations response false))
+
+(defn assert-variable-dissociation-bad-request
+  "Assert the variable association error when status code is 400 is correct."
+  [err-msg response]
+  (assert-variable-association-bad-request err-msg response))
 
 (defn assert-variable-associated-with-query
   "Assert the collections found by the variable query matches the given collection revisions"

--- a/system-int-test/test/cmr/system_int_test/search/acls/variable_association.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/variable_association.clj
@@ -71,10 +71,10 @@
                       create-token
                       var-concept-id
                       [{:concept-id coll-concept-id}])]
-        (is (= 200 (:status response)))))
+        (is (= 400 (:status response)))))
     (testing "allowed variable dissociation responses"
       (let [response (au/dissociate-by-concept-ids
                       delete-token
                       var-concept-id
                       [{:concept-id coll-concept-id}])]
-        (is (= 200 (:status response)))))))
+        (is (= 400 (:status response)))))))

--- a/system-int-test/test/cmr/system_int_test/search/service/service_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_association_test.clj
@@ -77,7 +77,7 @@
     (testing "Associate to non-existent collections"
       (let [response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (service-util/assert-service-association-response-ok?
+        (service-util/assert-service-association-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -87,7 +87,7 @@
             _ (index/wait-until-indexed)
             response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c1-p1}])]
-        (service-util/assert-service-association-response-ok?
+        (service-util/assert-service-association-bad-request
          {[c1-p1] {:errors [(format "Collection [%s] does not exist or is not visible." c1-p1)]}}
          response)))
 
@@ -96,7 +96,7 @@
       (let [response (association-util/associate-by-concept-ids token
                                                                 concept-id
                                                                 [{:concept-id c4-p3}])]
-        (service-util/assert-service-association-response-ok?
+        (service-util/assert-service-association-bad-request
          {[c4-p3] {:errors [(format "Collection [%s] does not exist or is not visible." c4-p3)]}}
          response)))
 
@@ -104,7 +104,7 @@
       (let [response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c2-p1}
                                         {:concept-id "C100-P5"}])]
-        (service-util/assert-service-association-response-ok?
+        (service-util/assert-service-association-bad-request
          {[c2-p1] {:concept-id "SA1200000028-CMR"
                    :revision-id 1}
           ["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
@@ -203,7 +203,7 @@
     (testing "Dissociate non-existent collections"
       (let [response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (service-util/assert-service-dissociation-response-ok?
+        (service-util/assert-service-dissociation-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -214,7 +214,7 @@
             _ (index/wait-until-indexed)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id c1-p2-concept-id}])]
-        (service-util/assert-service-dissociation-response-ok?
+        (service-util/assert-service-dissociation-bad-request
          {["C1200000019-PROV2"] {:errors [(format "Collection [%s] does not exist or is not visible."
                                                   c1-p2-concept-id)]}}
          response)))
@@ -224,7 +224,7 @@
       (let [coll-concept-id (:concept-id c4-p3)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id coll-concept-id}])]
-        (service-util/assert-service-dissociation-response-ok?
+        (service-util/assert-service-dissociation-bad-request
          {["C1200000026-PROV3"] {:errors [(format "Collection [%s] does not exist or is not visible."
                                                   coll-concept-id)]}}
          response)))))
@@ -302,7 +302,7 @@
                        {:concept-id (:concept-id coll2) :revision-id 1} ;; success
                        {:concept-id (:concept-id coll3)}])] ;; no service association
 
-        (service-util/assert-service-dissociation-response-ok?
+        (service-util/assert-service-dissociation-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}
           ["C1200000012-PROV1"] {:concept-id "SA1200000016-CMR" :revision-id 2}
           ["C1200000013-PROV1" 1] {:concept-id "SA1200000017-CMR" :revision-id 2}

--- a/system-int-test/test/cmr/system_int_test/search/service/service_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/service_association_test.clj
@@ -77,7 +77,7 @@
     (testing "Associate to non-existent collections"
       (let [response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (service-util/assert-service-association-bad-request
+        (service-util/assert-service-association-response-ok?
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -87,7 +87,7 @@
             _ (index/wait-until-indexed)
             response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c1-p1}])]
-        (service-util/assert-service-association-bad-request
+        (service-util/assert-service-association-response-ok?
          {[c1-p1] {:errors [(format "Collection [%s] does not exist or is not visible." c1-p1)]}}
          response)))
 
@@ -96,7 +96,7 @@
       (let [response (association-util/associate-by-concept-ids token
                                                                 concept-id
                                                                 [{:concept-id c4-p3}])]
-        (service-util/assert-service-association-bad-request
+        (service-util/assert-service-association-response-ok?
          {[c4-p3] {:errors [(format "Collection [%s] does not exist or is not visible." c4-p3)]}}
          response)))
 
@@ -104,7 +104,7 @@
       (let [response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c2-p1}
                                         {:concept-id "C100-P5"}])]
-        (service-util/assert-service-association-bad-request
+        (service-util/assert-service-association-response-ok?
          {[c2-p1] {:concept-id "SA1200000028-CMR"
                    :revision-id 1}
           ["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
@@ -203,7 +203,7 @@
     (testing "Dissociate non-existent collections"
       (let [response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (service-util/assert-service-dissociation-bad-request
+        (service-util/assert-service-dissociation-response-ok?
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -214,7 +214,7 @@
             _ (index/wait-until-indexed)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id c1-p2-concept-id}])]
-        (service-util/assert-service-dissociation-bad-request
+        (service-util/assert-service-dissociation-response-ok?
          {["C1200000019-PROV2"] {:errors [(format "Collection [%s] does not exist or is not visible."
                                                   c1-p2-concept-id)]}}
          response)))
@@ -224,7 +224,7 @@
       (let [coll-concept-id (:concept-id c4-p3)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id coll-concept-id}])]
-        (service-util/assert-service-dissociation-bad-request
+        (service-util/assert-service-dissociation-response-ok?
          {["C1200000026-PROV3"] {:errors [(format "Collection [%s] does not exist or is not visible."
                                                   coll-concept-id)]}}
          response)))))
@@ -302,7 +302,7 @@
                        {:concept-id (:concept-id coll2) :revision-id 1} ;; success
                        {:concept-id (:concept-id coll3)}])] ;; no service association
 
-        (service-util/assert-service-dissociation-bad-request
+        (service-util/assert-service-dissociation-response-ok?
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}
           ["C1200000012-PROV1"] {:concept-id "SA1200000016-CMR" :revision-id 2}
           ["C1200000013-PROV1" 1] {:concept-id "SA1200000017-CMR" :revision-id 2}

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
@@ -75,7 +75,7 @@
     (testing "Associate to non-existent collections"
       (let [response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (vu/assert-variable-association-response-ok?
+        (vu/assert-variable-association-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -85,7 +85,7 @@
             _ (index/wait-until-indexed)
             response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c1-p1}])]
-        (vu/assert-variable-association-response-ok?
+        (vu/assert-variable-association-bad-request
          {[c1-p1] {:errors [(format "Collection [%s] does not exist or is not visible." c1-p1)]}}
          response)))
 
@@ -94,7 +94,7 @@
       (let [response (association-util/associate-by-concept-ids token
                                                                 concept-id
                                                                 [{:concept-id c4-p3}])]
-        (vu/assert-variable-association-response-ok?
+        (vu/assert-variable-association-bad-request
          {[c4-p3] {:errors [(format "Collection [%s] does not exist or is not visible." c4-p3)]}}
          response)))))
 
@@ -192,7 +192,7 @@
                       concept-id
                       (map #(hash-map :concept-id (:concept-id %)) all-prov1-colls))]
        (is (= 200 (:status response1)))
-       (is (= 200 (:status response2)))
+       (is (= 400 (:status response2)))
        (is (string/includes? (:errors (first (:body response2))) 
                              "can not be associated because the variable is already associated with another collection")) 
        (is (= 400 (:status response3)))
@@ -205,7 +205,7 @@
                      prov3-token
                      concept-id
                      (map #(hash-map :concept-id (:concept-id %)) [c1-p2]))]
-       (is (= 200 (:status response)))
+       (is (= 400 (:status response)))
        (is (string/includes? (:errors (first (:body response)))
                              "can not be associated because they do not belong to the same provider")))
 
@@ -223,7 +223,7 @@
     (testing "Dissociate non-existent collections"
       (let [response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id "C100-P5"}])]
-        (vu/assert-variable-dissociation-response-ok?
+        (vu/assert-variable-association-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
@@ -234,7 +234,7 @@
             _ (index/wait-until-indexed)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id c1-p2-concept-id}])]
-        (vu/assert-variable-dissociation-response-ok?
+        (vu/assert-variable-association-bad-request
          {[c1-p2-concept-id] {:errors [(format "Collection [%s] does not exist or is not visible."
                                                c1-p2-concept-id)]}}
          response)))
@@ -244,7 +244,7 @@
       (let [coll-concept-id (:concept-id c4-p3)
             response (association-util/dissociate-by-concept-ids
                       token concept-id [{:concept-id coll-concept-id}])]
-        (vu/assert-variable-dissociation-response-ok?
+        (vu/assert-variable-association-bad-request
          {[coll-concept-id] {:errors [(format "Collection [%s] does not exist or is not visible."
                                               coll-concept-id)]}}
          response)))))
@@ -324,7 +324,7 @@
                         [{:concept-id (:concept-id coll2)
                           :revision-id (:revision-id coll2)}])]
         (is (= 200 (:status response1)))
-        (is (= 200 (:status response2)))
+        (is (= 400 (:status response2)))
         (is (string/includes? (some #(when (not= nil %) %) (map :errors (:body response2)))
                               "can not be associated because the variable is already associated with another collection")))
 
@@ -336,7 +336,7 @@
                        {:concept-id (:concept-id coll1) :revision-id 1} ;; success
                        {:concept-id (:concept-id coll3)}])] ;; no variable association
 
-        (vu/assert-variable-dissociation-response-ok?
+        (vu/assert-variable-dissociation-bad-request
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}
           ["C1200000012-PROV1" 1] {:concept-id "VA1200000016-CMR" :revision-id 2}
           ["C1200000014-PROV1"]


### PR DESCRIPTION
Associations will now return 400 on error during processing. The error is contained in the response body.