### PR TITLE
CMR-6239 Investigate and Implement a Solution For 'Time To Live (TTL)' For Elasticsearch 7.5.2 Upgrade

### DIFF
--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -211,11 +211,8 @@
   "Takes a non-tombstoned concept map (a normal revision) and returns an elastic document suitable
    for bulk indexing."
   [context concept]
-  (let [parsed-concept (cp/parse-concept context concept)
-        delete-time (get-in parsed-concept
-                            [:data-provider-timestamps :delete-time])
-        elastic-doc (parsed-concept->elastic-doc context concept parsed-concept)]
-    elastic-doc))
+  (let [parsed-concept (cp/parse-concept context concept)]
+    (parsed-concept->elastic-doc context concept parsed-concept)))
 
 (defn- concept->bulk-elastic-docs
   "Converts a concept map into an elastic document suitable for bulk indexing."

--- a/indexer-app/src/cmr/indexer/services/event_handler.clj
+++ b/indexer-app/src/cmr/indexer/services/event_handler.clj
@@ -82,6 +82,14 @@
                   concept-id revision-id)))
       (indexer/force-delete-all-concept-revision context concept-id revision-id))))
 
+(defmethod handle-ingest-event :expire-concept
+  [context all-revisions-index? {:keys [concept-id revision-id]}]
+  (when (or (= :collection (cc/concept-id->type concept-id))
+            (= :granule (cc/concept-id->type concept-id)))
+    (indexer/delete-concept
+      context concept-id revision-id {:ignore-conflict? true
+                                      :all-revisions-index? all-revisions-index?})))
+
 (defn subscribe-to-events
   "Subscribe to event messages on various queues"
   [context]

--- a/indexer-app/src/cmr/indexer/services/event_handler.clj
+++ b/indexer-app/src/cmr/indexer/services/event_handler.clj
@@ -84,8 +84,7 @@
 
 (defmethod handle-ingest-event :expire-concept
   [context all-revisions-index? {:keys [concept-id revision-id]}]
-  (when (or (= :collection (cc/concept-id->type concept-id))
-            (= :granule (cc/concept-id->type concept-id)))
+  (when (= :granule (cc/concept-id->type concept-id))
     (indexer/delete-concept
       context concept-id revision-id {:ignore-conflict? true
                                       :all-revisions-index? all-revisions-index?})))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -382,9 +382,7 @@
                             (assoc :service-associations service-associations))
                         parsed-concept)
                 elastic-options (-> options
-                                    (select-keys [:all-revisions-index? :ignore-conflict?])
-                                    (assoc :ttl (when delete-time
-                                                  (t/in-millis (t/interval (tk/now) delete-time)))))]
+                                    (select-keys [:all-revisions-index? :ignore-conflict?]))]
             (es/save-document-in-elastic
              context
              concept-indexes

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -53,6 +53,13 @@
   {:action :provider-delete
    :provider-id provider-id})
 
+(defn concept-expire-event
+  "Creates an event representing a concept being expired"
+  [{:keys [concept-id revision-id]}]
+  {:action :expire-concept
+   :concept-id concept-id
+   :revision-id revision-id})
+
 (defn ingest-bulk-update-event
   [provider-id task-id bulk-update-params user-id]
   {:action :bulk-update

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -53,13 +53,6 @@
   {:action :provider-delete
    :provider-id provider-id})
 
-(defn concept-expire-event
-  "Creates an event representing a concept being expired"
-  [{:keys [concept-id revision-id]}]
-  {:action :expire-concept
-   :concept-id concept-id
-   :revision-id revision-id})
-
 (defn ingest-bulk-update-event
   [provider-id task-id bulk-update-params user-id]
   {:action :bulk-update

--- a/ingest-app/src/cmr/ingest/services/jobs.clj
+++ b/ingest-app/src/cmr/ingest/services/jobs.clj
@@ -108,9 +108,7 @@
     (when-let [concept-ids (mdb/get-expired-collection-concept-ids context provider-id)]
       (info "Removing expired collections:" (pr-str concept-ids))
       (doseq [concept-id concept-ids]
-        (let [resp (mdb/save-concept context {:concept-id concept-id :deleted true})]
-          (ingest-events/publish-ingest-event
-           context (ingest-events/concept-expire-event resp)))))))
+       (mdb/save-concept context {:concept-id concept-id :deleted true})))))
 
 (def-stateful-job CleanupExpiredCollections
   [ctx system]

--- a/ingest-app/src/cmr/ingest/services/jobs.clj
+++ b/ingest-app/src/cmr/ingest/services/jobs.clj
@@ -108,7 +108,9 @@
     (when-let [concept-ids (mdb/get-expired-collection-concept-ids context provider-id)]
       (info "Removing expired collections:" (pr-str concept-ids))
       (doseq [concept-id concept-ids]
-        (mdb/save-concept context {:concept-id concept-id :deleted true})))))
+        (let [resp (mdb/save-concept context {:concept-id concept-id :deleted true})]
+          (ingest-events/publish-ingest-event
+           context (ingest-events/concept-expire-event resp)))))))
 
 (def-stateful-job CleanupExpiredCollections
   [ctx system]

--- a/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
@@ -45,6 +45,13 @@
    :concept-id concept-id
    :revision-id revision-id})
 
+(defn concept-expire-event
+  "Creates an event representing a concept being expired"
+  [{:keys [concept-id revision-id]}]
+  {:action :expire-concept
+   :concept-id concept-id
+   :revision-id revision-id})
+
 (defn publish-concept-revision-delete-msg
   "Publishes a message indicating a concept revision was removed."
   [context concept-id revision-id]

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -812,6 +812,8 @@
                               (assoc :deleted true :metadata ""))]
             (try
               (try-to-save db provider tombstone)
+              (ingest-events/publish-event
+               context (ingest-events/concept-expire-event c))
               (catch clojure.lang.ExceptionInfo e
                 ;; Re-throw anything other than a simple conflict.
                 (when-not (-> e ex-data :type (= :conflict))

--- a/system-int-test/src/cmr/system_int_test/utils/metadata_db_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/metadata_db_util.clj
@@ -92,3 +92,10 @@
                    :url (url/mdb-old-revision-cleanup-job-url)
                    :headers {transmit-config/token-header (transmit-config/echo-system-token)}
                    :connection-manager (s/conn-mgr)}))
+
+(defn cleanup-expired-concepts
+  []
+  (client/request {:method :post
+                   :url (url/mdb-expired-concept-cleanup-url)
+                   :headers {transmit-config/token-header (transmit-config/echo-system-token)}
+                   :connection-manager (s/conn-mgr)}))

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -129,6 +129,12 @@
   (format "http://localhost:%s/jobs/old-revision-concept-cleanup"
           (transmit-config/metadata-db-port)))
 
+(defn mdb-expired-concept-cleanup-url
+  "URL to metadata db cleanup expired concepts job"
+  []
+  (format "http://localhost:%s/jobs/expired-concept-cleanup"
+          (transmit-config/metadata-db-port)))
+
 (defn mdb-service-association-search-url
   "URL to search service associations in metadata db."
   []


### PR DESCRIPTION
Collections seems to work already with how mdb saves concepts, but for granules we needed a TTL solution.  I opted for adding a message when the cleanup job is run that tells indexer to un-index the expired granule.