### PR TITLE
CMR-6217 Enforcing group name uniqueness rule when updating groups

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -464,18 +464,38 @@
               :errors [(format "A system group with name [%s] already exists with concept id [%s]."
                                (:name group2)
                                concept_id2)]}
+             (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))
+
+    (testing "Update a group with conflicting name"
+      (is (= {:status 409
+              :errors [(format "A system group with name [%s] already exists with concept id [%s]."
+                               (:name group2)
+                               concept_id2)]}
              (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))))
 
 (deftest update-groups-with-identical-names-but-different-providers
   (let [group1 (test-util/make-group {:name "group1" :provider_id "PROV1"})
+        group1a (test-util/make-group {:name "group2" :provider_id "PROV1"})
         group2 (test-util/make-group {:name "group2" :provider_id "PROV2"})
         token (echo-util/login (test-util/conn-context) "user1")
         {concept_id1 :concept_id} (test-util/create-group token group1)
+        {concept_id1a :concept_id} (test-util/create-group token group1a)
         {concept_id2 :concept_id} (test-util/create-group token group2)]
-    (is (= {:status 200
-            :revision_id 2
-            :concept_id (format "%s" concept_id2)}
-           (test-util/update-group token concept_id2 (assoc group2 :name (:name group1)))))))
+
+    (testing "prevent the same provider from re-using group names"
+      (is (= {:status 409
+              :errors [(format (str "A provider group with name [%s] already exists "
+                                    "with concept id [%s] for provider [%s].")
+                               (:name group1)
+                               concept_id1
+                               (:provider_id group1))]}
+             (test-util/update-group token concept_id1a (assoc group1a :name (:name group1))))))
+
+    (testing "allow different providers to re-use group names"
+      (is (= {:status 200
+              :revision_id 2
+              :concept_id (format "%s" concept_id2)}
+             (test-util/update-group token concept_id2 (assoc group2 :name (:name group1))))))))
 
 (deftest update-group-legacy-guid-test
   (let [group1 (test-util/make-group {:legacy_guid "legacy_guid_1" :name "group1"})

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -473,7 +473,7 @@
                                concept_id2)]}
              (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))))
 
-(deftest update-provider-groups
+(deftest update-provider-groups-test
   (let [group1 (test-util/make-group {:name "group1" :provider_id "PROV1"})
         group1a (test-util/make-group {:name "group2" :provider_id "PROV1"})
         group2 (test-util/make-group {:name "group2" :provider_id "PROV2"})

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -413,13 +413,13 @@
 (deftest update-group-failure-test
   (let [group (test-util/make-group)
         group2 (test-util/make-group {:name "Group2" :members ["user1"]})
-        group2-copy (test-util/make-group {:name "Group2a" :members ["user1"]})
+        group3 (test-util/make-group {:name "Group3" :members ["user1"]})
 
         token (echo-util/login (test-util/conn-context) "user1")
 
         {:keys [concept_id revision_id]} (test-util/create-group token group)
         {concept_id2 :concept_id} (test-util/create-group token group2)
-        {concept_id3 :concept_id} (test-util/create-group token group2-copy)]
+        {concept_id3 :concept_id} (test-util/create-group token group3)]
 
     (testing "Update group with invalid content type"
       (is (= {:status 400,
@@ -464,7 +464,7 @@
               :errors [(format "A system group with name [%s] already exists with concept id [%s]."
                                (:name group2)
                                concept_id2)]}
-             (test-util/update-group token concept_id3 (assoc group2-copy :name (:name group2))))))))
+             (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))))
 
 (deftest update-group-legacy-guid-test
   (let [group1 (test-util/make-group {:legacy_guid "legacy_guid_1" :name "group1"})

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -473,7 +473,7 @@
                                concept_id2)]}
              (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))))
 
-(deftest update-groups-with-identical-names-but-different-providers
+(deftest update-provider-groups
   (let [group1 (test-util/make-group {:name "group1" :provider_id "PROV1"})
         group1a (test-util/make-group {:name "group2" :provider_id "PROV1"})
         group2 (test-util/make-group {:name "group2" :provider_id "PROV2"})

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -286,8 +286,8 @@
         {:keys [concept_id revision_id]} (test-util/create-group token group1)
         group2-concept-id (:concept_id (test-util/create-group token group2))]
     (testing "Delete without token"
-      (is (= {:status 401
-              :errors ["Valid user token required."]}
+      (is (= :status 401
+             :errors ["Valid user token required."]
              (test-util/delete-group nil concept_id))))
 
     (testing "Delete success"
@@ -383,19 +383,33 @@
       (is (empty? (set (:items (test-util/search-for-acls token {:permitted_group group-1-concept-id}))))))))
 
 (deftest update-group-test
-  (let [group (test-util/make-group {:members ["user1" "user2"]})
-        token (echo-util/login (test-util/conn-context) "user1")
-        {:keys [concept_id]} (test-util/create-group token group)]
+  (testing "successful update"
+    (let [group (test-util/make-group {:members ["user1" "user2"]})
+          token (echo-util/login (test-util/conn-context) "user1")
+          {:keys [concept_id]} (test-util/create-group token group)]
 
-    ;; Do not specify members in the update
-    (let [updated-group {:name "Updated Group Name"
-                         :description "Updated group description"}
-          token2 (echo-util/login (test-util/conn-context) "user2")
-          response (test-util/update-group token2 concept_id updated-group)]
-      (is (= {:status 200 :concept_id concept_id :revision_id 2}
-             response))
-      ;; Members should be intact
-      (test-util/assert-group-saved (assoc updated-group :members ["user1" "user2"]) "user2" concept_id 2))))
+      ;; Do not specify members in the update
+      (let [updated-group {:name "Updated Group Name"
+                           :description "Updated group description"}
+            token2 (echo-util/login (test-util/conn-context) "user2")
+            response (test-util/update-group token2 concept_id updated-group)]
+        (is (= {:status 200 :concept_id concept_id :revision_id 2}
+               response))
+        ;; Members should be intact
+        (test-util/assert-group-saved (assoc updated-group :members ["user1" "user2"]) "user2" concept_id 2))))
+  
+  (testing "name collision updates should fail"
+    (let [group1 (test-util/make-group {:name "Group1" :members ["user1"]})
+          group2 (test-util/make-group {:name "Group2" :members ["user1"]})
+          updated-group2 {:name "Group1"
+                          :description "name collision expected"
+                          :members ["user1"]}
+          token (echo-util/login (test-util/conn-context) "user1")
+          {id1 :concept_id} (test-util/create-group token group1)
+          {id2 :concept_id} (test-util/create-group token group2)
+          _ (println token " " id1 " " id2)
+          response (test-util/update-group token id2 updated-group2)]
+      (is (= 400 (:status response))))))
 
 (deftest update-group-with-members-test
   (let [group (test-util/make-group {:members ["user1" "user2"]})

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -466,6 +466,17 @@
                                concept_id2)]}
              (test-util/update-group token concept_id3 (assoc group3 :name (:name group2))))))))
 
+(deftest update-groups-with-identical-names-but-different-providers
+  (let [group1 (test-util/make-group {:name "group1" :provider_id "PROV1"})
+        group2 (test-util/make-group {:name "group2" :provider_id "PROV2"})
+        token (echo-util/login (test-util/conn-context) "user1")
+        {concept_id1 :concept_id} (test-util/create-group token group1)
+        {concept_id2 :concept_id} (test-util/create-group token group2)]
+    (is (= {:status 200
+            :revision_id 2
+            :concept_id (format "%s" concept_id2)}
+           (test-util/update-group token concept_id2 (assoc group2 :name (:name group1)))))))
+
 (deftest update-group-legacy-guid-test
   (let [group1 (test-util/make-group {:legacy_guid "legacy_guid_1" :name "group1"})
 

--- a/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/access_control_group_crud_test.clj
@@ -412,10 +412,14 @@
 
 (deftest update-group-failure-test
   (let [group (test-util/make-group)
-        group2 (test-util/make-group {:name "Group2" :members ["user1"]})        
+        group2 (test-util/make-group {:name "Group2" :members ["user1"]})
+        group2-copy (test-util/make-group {:name "Group2a" :members ["user1"]})
+
         token (echo-util/login (test-util/conn-context) "user1")
+
         {:keys [concept_id revision_id]} (test-util/create-group token group)
-        {concept_id2 :concept_id} (test-util/create-group token group2)]
+        {concept_id2 :concept_id} (test-util/create-group token group2)
+        {concept_id3 :concept_id} (test-util/create-group token group2-copy)]
 
     (testing "Update group with invalid content type"
       (is (= {:status 400,
@@ -456,12 +460,11 @@
              (test-util/update-group token concept_id group))))
 
     (testing "Update a group with conflicting name"
-      (test-util/wait-until-indexed)
       (is (= {:status 409
               :errors [(format "A system group with name [%s] already exists with concept id [%s]."
-                               (:name group)
-                               concept_id)]}
-             (test-util/update-group token concept_id2 (assoc group2 :name (:name group))))))))
+                               (:name group2)
+                               concept_id2)]}
+             (test-util/update-group token concept_id3 (assoc group2-copy :name (:name group2))))))))
 
 (deftest update-group-legacy-guid-test
   (let [group1 (test-util/make-group {:legacy_guid "legacy_guid_1" :name "group1"})

--- a/access-control-app/src/cmr/access_control/services/group_service.clj
+++ b/access-control-app/src/cmr/access_control/services/group_service.clj
@@ -197,7 +197,7 @@
      (auth/verify-can-create-group context group))
 
    (validate-managing-group-id (transmit-config/with-echo-system-token context) managing-group-id)
-
+   ;; Verify there will not be a name collision
    (if-let [concept-id (->> (search-for-groups
                               context {:name (:name group)
                                        :provider (get group :provider-id SYSTEM_PROVIDER_ID)})
@@ -259,11 +259,22 @@
         existing-group (edn/read-string (:metadata existing-concept))]
     (validate-update-group context existing-group updated-group)
     (auth/verify-can-update-group context (assoc existing-group :concept-id concept-id))
+    ;; Verify the name does not conflict with an existing group
+    (when (not= (:name updated-group) (:name existing-group))
+      (when-let [conflicting-concept-id (->> (search-for-groups context {:name (:name updated-group)
+                                                                         :provider (get existing-group :provider-id SYSTEM_PROVIDER_ID)})
+                                              :results
+                                              :items
+                                              (some :concept_id))]
+        (let [concept (mdb/get-latest-concept context conflicting-concept-id)]
+          ;; A name collision was found, reject the update.
+          (errors/throw-service-error :conflict (g-msg/group-already-exists existing-group concept))))
       ;; Avoid clobbering :members by merging the updated-group into existing-group. If updated-group
       ;; specifies :members then it will overwrite the existing value.
+)
     (let [updated-group (merge existing-group updated-group)
           update-result (save-updated-group-concept context existing-concept updated-group)]
-     update-result)))
+      update-result)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Search functions


### PR DESCRIPTION
Preventing non-unique named groups during updates. This enforces the same behavior that is already implemented on creation.