### PR TITLE
CMR-6295 catching parsing exceptions during autocomplete suggestion reindexing

### DIFF
--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -88,6 +88,7 @@
                             (fu/processing-level-id "PL1")
                             {:DataCenters [(data-umm-spec/data-center {:Roles ["ARCHIVER"] :ShortName "DOI/USGS/CMG/WHSC"})]
                              :ScienceKeywords [(:ScienceKeywords (fu/science-keywords sk1 sk2))]})
+
         coll3 (d/ingest-concept-with-metadata-file "CMR-6287/C1000000029-EDF_OPS.xml"
                                                    {:provider-id "PROV1"
                                                     :concept-type :collection
@@ -105,11 +106,10 @@
 
 (deftest reindex-suggestions-test
   (testing "Ensure that response is in proper format and results are correct"
-    (let [results  (get-in (search/get-autocomplete-json "q=level2") [:feed :entry])]
-      (compare-autocomplete-results
-       results
-       [{:score 0.25604635 :type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
-        {:score 0.041718055 :type "instrument" :value "lVIs" :fields "lVIs"}])))
+    (compare-autocomplete-results
+     (get-in (search/get-autocomplete-json "q=level2") [:feed :entry])
+     [{:score 0.25604635 :type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
+      {:score 0.041718055 :type "instrument" :value "lVIs" :fields "lVIs"}]))
 
   (testing "Ensure science keywords are being indexed properly"
     (are3

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -95,7 +95,6 @@
         _ (index/wait-until-indexed)
         _ (index/reindex-suggestions)
         _ (index/wait-until-indexed)]
-    (search/get-autocomplete-json "q=boo")
     (f)))
 
 (use-fixtures :each (join-fixtures

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -2,6 +2,7 @@
   "This tests re-indexes autocomplete suggestions."
   (:require
    [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
@@ -14,25 +15,21 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]))
 
-(use-fixtures :each (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"})
-                       hu/grant-all-humanizers-fixture
-                       hu/save-sample-humanizers-fixture]))
 
 (defn compare-autocomplete-results
- "Compare expected to actual response for the following:
- - Items are ordered by score in descending order
- - Ensure that the other fields match"
- [actual expected]
- (let [scores (map :score actual)
-       actual-scores-descending? (->> actual
-                                      (map :score)
-                                      (apply >=))
-       ; we don't need to actually compare scores
-       expected (map #(dissoc % :score) expected)
-       actual (map #(dissoc % :score) actual)]
-   (is (true? actual-scores-descending?))
-   (is (= expected actual))))
+  "Compare expected to actual response for the following:
+  - Items are ordered by score in descending order
+  - Ensure that the other fields match"
+  [actual expected]
+  (let [scores (map :score actual)
+        actual-scores-descending? (->> actual
+                                       (map :score)
+                                       (apply >=))
+                                        ; we don't need to actually compare scores
+        expected (map #(dissoc % :score) expected)
+        actual (map #(dissoc % :score) actual)]
+    (is (true? actual-scores-descending?))
+    (is (= expected actual))))
 
 (def sk1 (umm-spec-common/science-keyword {:Category "Earth science"
                                            :Topic "Topic1"
@@ -72,16 +69,17 @@
              :Fees "None currently"
              :Format "NetCDF-3"}]})
 
-(deftest reindex-suggestions-test
+(defn autocomplete-reindex-fixture
+  [f]
   (let [coll1 (d/ingest "PROV1"
                         (dc/collection
-                            {:DataCenters [(data-umm-spec/data-center {:Roles ["ARCHIVER"] :ShortName "DOI/USGS/CMG/WHSC"})]
-                             :ArchiveAndDistributionInformation gdf1
-                             :SpatialKeywords ["DC" "Miami"]
-                             :ProcessingLevelId (:ProcessingLevelId (fu/processing-level-id "PL1"))
-                             :Projects [(:Projects (fu/projects "proj1" "PROJ2"))]
-                             :Platforms [(:Platforms (fu/platforms fu/FROM_KMS 2 2 1))]
-                             :ScienceKeywords [(:ScienceKeywords (fu/science-keywords sk1 sk2))]}))
+                         {:DataCenters [(data-umm-spec/data-center {:Roles ["ARCHIVER"] :ShortName "DOI/USGS/CMG/WHSC"})]
+                          :ArchiveAndDistributionInformation gdf1
+                          :SpatialKeywords ["DC" "Miami"]
+                          :ProcessingLevelId (:ProcessingLevelId (fu/processing-level-id "PL1"))
+                          :Projects [(:Projects (fu/projects "proj1" "PROJ2"))]
+                          :Platforms [(:Platforms (fu/platforms fu/FROM_KMS 2 2 1))]
+                          :ScienceKeywords [(:ScienceKeywords (fu/science-keywords sk1 sk2))]}))
 
         coll2 (fu/make-coll 2 "PROV1"
                             (fu/science-keywords sk1 sk3)
@@ -91,28 +89,46 @@
                             {:DataCenters [(data-umm-spec/data-center {:Roles ["ARCHIVER"] :ShortName "DOI/USGS/CMG/WHSC"})]
                              :ScienceKeywords [(:ScienceKeywords (fu/science-keywords sk1 sk2))]})
         coll3 (d/ingest-concept-with-metadata-file "CMR-6287/C1000000029-EDF_OPS.xml"
-                                                         {:provider-id "PROV1"
-                                                          :concept-type :collection
-                                                          :format-key :echo10})
+                                                   {:provider-id "PROV1"
+                                                    :concept-type :collection
+                                                    :format-key :echo10})
+        _ (index/wait-until-indexed)
+        _ (index/reindex-suggestions)
         _ (index/wait-until-indexed)]
+    (search/get-autocomplete-json "q=boo")
+    (f)))
 
-    (index/reindex-suggestions)
-    (index/wait-until-indexed)
-    (testing "Ensure that response is in proper format and results are correct"
+(use-fixtures :each (join-fixtures
+                     [(ingest/reset-fixture {"provguid1" "PROV1"})
+                      hu/grant-all-humanizers-fixture
+                      hu/save-sample-humanizers-fixture
+                      autocomplete-reindex-fixture]))
+
+(deftest reindex-suggestions-test
+  (testing "Ensure that response is in proper format and results are correct"
+    (let [results  (get-in (search/get-autocomplete-json "q=level2") [:feed :entry])]
       (compare-autocomplete-results
-        (get-in (search/get-autocomplete-json "q=level2") [:feed :entry])
-        [{:score 0.25604635 :type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
-         {:score 0.041718055 :type "instrument" :value "lVIs" :fields "lVIs"}]))
-    (testing "Ensure science keywords are being indexed properly"
-        (compare-autocomplete-results
-         (get-in (search/get-autocomplete-json "q=solar") [:feed :entry])
-         [{:score 3.4995544, :type "science_keywords", :value "Solar Irradiance", :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
-          {:score 1.9641972, :type "science_keywords", :value "Solar Irradiance", :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
-          {:score 0.20964509, :type "organization", :value "ACRIM SCF", :fields "ACRIM SCF"}
-          {:score 0.16771607, :type "organization", :value "Langley DAAC User Services", :fields "Langley DAAC User Services"}])
-        (compare-autocomplete-results
-         (get-in (search/get-autocomplete-json "q=solar irradiation") [:feed :entry])
-         [{:score 5.0869484, :type "science_keywords", :value "Solar Irradiance", :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
-          {:score 2.7943783, :type "science_keywords", :value "Solar Irradiance", :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
-          {:score 0.061936468, :type "organization", :value "ACRIM SCF", :fields "ACRIM SCF"}
-          {:score 0.049549174, :type "organization", :value "Langley DAAC User Services", :fields "Langley DAAC User Services"}]))))
+       results
+       [{:score 0.25604635 :type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
+        {:score 0.041718055 :type "instrument" :value "lVIs" :fields "lVIs"}])))
+
+  (testing "Ensure science keywords are being indexed properly"
+    (are3
+     [query expected]
+     (let [actual (get-in (search/get-autocomplete-json query) [:feed :entry])]
+       (compare-autocomplete-results expected actual))          
+
+     "shorter match"
+     "q=solar"
+     [{:score 3.4995544, :type "science_keywords", :value "Solar Irradiance", :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
+      {:score 1.9641972, :type "science_keywords", :value "Solar Irradiance", :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
+      {:score 0.20964509, :type "organization", :value "ACRIM SCF", :fields "ACRIM SCF"}
+      {:score 0.16771607, :type "organization", :value "Langley DAAC User Services", :fields "Langley DAAC User Services"}]
+
+     "more complete match"
+     "q=solar irradiation"
+     [{:score 5.0869484, :type "science_keywords", :value "Solar Irradiance", :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
+      {:score 2.7943783, :type "science_keywords", :value "Solar Irradiance", :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
+      {:score 0.061936468, :type "organization", :value "ACRIM SCF", :fields "ACRIM SCF"}
+      {:score 0.049549174, :type "organization", :value "Langley DAAC User Services", :fields "Langley DAAC User Services"}])))
+

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -25,7 +25,7 @@
         actual-scores-descending? (->> actual
                                        (map :score)
                                        (apply >=))
-                                        ; we don't need to actually compare scores
+        ;; we don't need to actually compare scores
         expected (map #(dissoc % :score) expected)
         actual (map #(dissoc % :score) actual)]
     (is (true? actual-scores-descending?))


### PR DESCRIPTION
Updated autocomplete indexing to be more resilient to parsing errors for badly formatted data. This will prevent the autocomplete from failing midway through a re-index operation.

The root issue is badly formatted data that was attempted to be parsed.