### PR TITLE
CMR-6117 updated cmr-bash-autocomplete to be compatible with zsh

### DIFF
--- a/resources/shell/cmr-bash-autocomplete
+++ b/resources/shell/cmr-bash-autocomplete
@@ -128,6 +128,16 @@ _cmr () {
     return 0
 }
 
-complete -F _cmr cmr
-complete -F _cmr ./bin/cmr
+_cmr_zsh() {
+    compadd '_cmr'
+}
+
+if type complete >/dev/null 2>/dev/null; then
+    # bash
+    complete -F _cmr cmr
+    complete -F _cmr ./bin/cmr
+else if type compdef >/dev/null 2>/dev/null; then
+    # zsh
+    compdef _cmr_zsh cmr
+fi; fi
 #


### PR DESCRIPTION
To test configure your shell to use zsh, source the `cmr` shell resource and verify cmr commands still work.