### PR TITLE
CMR-6318 updates for autocomplete for ES migration

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/query_model.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_model.clj
@@ -236,6 +236,17 @@
     ;; The value of the field
     value])
 
+(defrecord MultiMatchCondition
+    [
+     ;; The fields being searched
+     fields
+     
+     ;; The value to search for
+     value
+
+     ;; Multi-match options
+     opts])
+
 (defrecord MatchFilterCondition
   [
     ;; The field being searched
@@ -369,6 +380,12 @@
   [field value]
   (->MatchCondition field value))
 
+(defn multi-match
+  ([fields values]
+   (multi-match fields values {}))
+  ([fields value opts]
+   (->MultiMatchCondition fields value opts)))
+
 (defn match-filter
   ([field value filter]
   (->MatchFilterCondition field value filter)))
@@ -458,4 +475,5 @@
   MatchNoneCondition
   MatchCondition
   MatchFilterCondition
+  MultiMatchCondition
   RelatedItemQueryCondition)

--- a/common-app-lib/src/cmr/common_app/services/search/query_model.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_model.clj
@@ -381,8 +381,8 @@
   (->MatchCondition field value))
 
 (defn multi-match
-  ([fields values]
-   (multi-match fields values {}))
+  ([fields value]
+   (multi-match fields value {}))
   ([fields value opts]
    (->MultiMatchCondition fields value opts)))
 

--- a/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
@@ -330,6 +330,14 @@
   (condition->elastic
    [{:keys [field value]} _]
    {:match {field value}})
+  
+  cmr.common_app.services.search.query_model.MultiMatchCondition
+  (condition->elastic
+    [{:keys [fields value opts]}]
+    (let [opts (dissoc opts :fields :query)]
+      {:multi_match (assoc {:fields fields
+                            :query value}
+                           opts)}))
 
   cmr.common_app.services.search.query_model.MatchFilterCondition
   (condition->elastic

--- a/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
@@ -333,11 +333,9 @@
   
   cmr.common_app.services.search.query_model.MultiMatchCondition
   (condition->elastic
-    [{:keys [fields value opts]}]
-    (let [opts (dissoc opts :fields :query)]
-      {:multi_match (assoc {:fields fields
-                            :query value}
-                           opts)}))
+    [{:keys [fields value opts]} _]
+    {:multi_match (merge {:fields fields :query value}
+                         opts)})
 
   cmr.common_app.services.search.query_model.MatchFilterCondition
   (condition->elastic

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -18,6 +18,9 @@
 (def string-field-mapping
   {:type "keyword"})
 
+(def search-as-you-type-field-mapping
+  {:type "search_as_you_type"})
+
 (def english-string-field-mapping
   "Used for analyzed text fields"
   {:type "text"

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -712,7 +712,7 @@
   {:concept-id (-> m/string-field-mapping m/stored m/doc-values)
    :type {:type "text" :store true}
    :fields {:type "text" :store true}
-   :value {:type "text" :analyzer "autocomplete_analyzer" :store true}})
+   :value {:type "search_as_you_type" :store true}})
 
 (defmapping variable-mapping :variable
   "Defines the elasticsearch mapping for storing variables. These are the

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -101,18 +101,7 @@
 (def autocomplete-settings {:index
                             {:number_of_shards (elastic-autocomplete-index-num-shards)
                              :number_of_replicas 1
-                             :refresh_interval "1s"}
-                           :analysis
-                            {:filter
-                             {:autocomplete_filter
-                              {:type "edge_ngram"
-                               :min_gram 1
-                               :max_gram 8}}
-                             :analyzer
-                             {:autocomplete_analyzer
-                              {:type "custom"
-                               :tokenizer "standard"
-                               :filter ["lowercase" "autocomplete_filter"]}}}})
+                             :refresh_interval "1s"}})
 
 (def service-setting {:index
                        {:number_of_shards (elastic-service-index-num-shards)
@@ -709,10 +698,9 @@
 (defmapping autocomplete-mapping :suggestion
   "Defines the elasticsearch mapping for storing autocomplete suggestions.
    These are the fields that will be stored in an Elasticsearch document."
-  {:concept-id (-> m/string-field-mapping m/stored m/doc-values)
-   :type {:type "text" :store true}
-   :fields {:type "text" :store true}
-   :value {:type "search_as_you_type" :store true}})
+  {:type (m/stored m/string-field-mapping)
+   :fields (m/not-indexed (m/stored m/string-field-mapping))
+   :value (m/stored m/search-as-you-type-field-mapping)})
 
 (defmapping variable-mapping :variable
   "Defines the elasticsearch mapping for storing variables. These are the

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -466,8 +466,16 @@
                           subscription-latest-sub-sort-fields)]
     (concat (or specified-sort default-sort) sub-sort-fields)))
 
+(defmethod q2e/query->sort-params :autocomplete
+  [query]
+  (let [{:keys [concept-type sort-keys]} query
+        specified-sort (q2e/sort-keys->elastic-sort concept-type sort-keys)
+        default-sort (q2e/sort-keys->elastic-sort concept-type (q/default-sort-keys concept-type))]
+    (or specified-sort default-sort)))
+
 (extend-protocol c2s/ComplexQueryToSimple
   cmr.search.models.query.CollectionQueryCondition
   (reduce-query-condition
     [condition context]
     (update-in condition [:condition] c2s/reduce-query-condition context)))
+

--- a/search-app/src/cmr/search/models/query.clj
+++ b/search-app/src/cmr/search/models/query.clj
@@ -183,8 +183,7 @@
 
 (defmethod common-qm/default-sort-keys :autocomplete
   [_]
-  [{:field :_score :order :desc}
-   {:field :value :order :asc}])
+  [{:field :_score :order :desc}])
 
 (defmethod common-qm/concept-type->default-query-attribs :granule
   [_]

--- a/search-app/src/cmr/search/results_handlers/autocomplete_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/autocomplete_results_handler.clj
@@ -1,9 +1,9 @@
 (ns cmr.search.results-handlers.autocomplete-results-handler
   "Handles the Autocomplete JSON results format and related functions"
   (:require
-    [cmr.common-app.services.search.elastic-results-to-query-results :as elastic-results]))
+    [cmr.common-app.services.search.elastic-results-to-query-results :as er]))
 
-(defmethod elastic-results/elastic-result->query-result-item [:autocomplete :json]
+(defmethod er/elastic-result->query-result-item [:autocomplete :json]
   [context query elastic-result]
   (let [{[type] :type
          [value] :value
@@ -14,12 +14,12 @@
      :value value
      :fields field}))
 
-(defmethod elastic-results/elastic-results->query-results [:autocomplete :json]
-  [context query elastic-results]
-  (let [hits (get-in elastic-results [:hits :total])
-        took (:took elastic-results)
-        elastic-matches (get-in elastic-results [:hits :hits])
-        items (mapv #(elastic-results/elastic-result->query-result-item context query %) elastic-matches)]
+(defmethod er/elastic-results->query-results [:autocomplete :json]
+  [context query elastic-result]
+  (let [hits (get-in elastic-result [:hits :total :value])
+        took (:took elastic-result)
+        elastic-matches (get-in elastic-result [:hits :hits])
+        items (mapv #(er/elastic-result->query-result-item context query %) elastic-matches)]
     {:items items
      :hits hits
      :took took}))

--- a/search-app/src/cmr/search/services/autocomplete_service.clj
+++ b/search-app/src/cmr/search/services/autocomplete_service.clj
@@ -5,12 +5,21 @@
     [cmr.common-app.services.search.query-model :as qm]
     [cmr.common-app.services.search.group-query-conditions :as gc]))
 
+(defn- build-autocomplete-condition
+  [term types]
+  (let [root (qm/multi-match ["value" "value._2gram" "value._3gram"]
+                             term
+                             {:type "phrase_prefix"})]
+    (if (empty? types)
+      root
+      (gc/and-conds [root
+                     (gc/or-conds (map #(qm/text-condition :type %)
+                                       types))]))))
+
 (defn autocomplete
   "Execute elasticsearch query to get autocomplete suggestions"
   [context term types opts]
-  (let [condition (if (empty? types)
-                    (qm/match :value term)
-                    (qm/match-filter :value term (gc/or-conds (map (partial qm/text-condition :type) types))))
+  (let [condition (build-autocomplete-condition term types)
         query (qm/query {:concept-type :autocomplete
                          :page-size (:page-size opts)
                          :offset (:offset opts)

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -252,7 +252,7 @@
   ([query]
    (get-autocomplete-suggestions query nil))
   ([query opts]
-   (client/get (url/autocomplete-url query) opts)))
+   (client/get (url/autocomplete-url query) (merge opts {:throw-exceptions false}))))
 
 (defn get-autocomplete-json
   "Execute autocomplete query and parse json response"

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
@@ -25,6 +25,11 @@
                             {:value "asia" :type "spatial_keyword"}
                             {:value "australia" :type "spatial_keyword"}
                             {:value "europe" :type "spatial_keyword"}
+                            {:value "gulf of mexico" :type "spatial_keyword"}
+                            {:value "gulf of lion" :type "spatial_keyword"}
+                            {:value "gulf of sidra" :type "spatial_keyword"}
+                            {:value "gulf of thailand" :type "spatial_keyword"}
+                            {:value "persian gulf" :type "spatial_keyword"}
                             {:value "north america" :type "spatial_keyword"}
                             {:value "south america" :type "spatial_keyword"}
                             {:value "arctic ocean" :type "spatial_keyword"}
@@ -35,7 +40,7 @@
 (defn autocomplete-fixture
   [f]
   (let [conn (esr/connect (url/elastic-root))
-        documents (map #(esd/create conn "1_autocomplete" "suggestion" %) test-values)]
+        documents (map #(esd/create conn "1_autocomplete" "_doc" %) test-values)]
     (doseq [doc documents] (debug "ingested " doc))
     (index/wait-until-indexed)
     (f)
@@ -73,7 +78,7 @@
      (is (:CMR-Took headers))))
 
   (testing "entries return in descending score order"
-   (let [response (query->json-response-body "q=bar")
+   (let [response (query->json-response-body "q=at")
          entries (response-body->entries response)
          a (first entries)
          b (second entries)]
@@ -91,8 +96,8 @@
     "full value match"
     "q=foo" 1
 
-    "full value with extra value match"
-    "q=foos" 1
+    "full value with extra value should not match"
+    "q=foos" 0
 
     "case sensitivity test"
     "q=FOO" 1
@@ -139,16 +144,16 @@
         (is (= expected (count entry)))))
 
     "page size 0"
-    "q=an&page_size=0" 0 10
+    "q=gulf&page_size=0" 0 5
 
     "page size 1"
-    "q=an&page_size=1" 1 10
+    "q=gulf&page_size=1" 1 5
 
     "page size 2"
-    "q=an&page_size=2" 2 10
+    "q=gulf&page_size=2" 2 5
 
     "page size 100"
-    "q=an*&page_size=100" 10 10))
+    "q=gulf*&page_size=100" 5 5))
 
   (testing "page_num should default to 1"
    (let [a (as-> (query->json-response-body "q=b") response


### PR DESCRIPTION
Autocomplete tests and code updated to be compatible with the updated version of elasticsearch