### PR TITLE
CMR-6283 fixed event publishing for autocomplete indexing job

### DIFF
--- a/ingest-app/src/cmr/ingest/services/jobs.clj
+++ b/ingest-app/src/cmr/ingest/services/jobs.clj
@@ -262,9 +262,11 @@
 (defn trigger-autocomplete-suggestions-reindex
   [context]
   (let [providers (map :provider-id (mdb/get-providers context))]
-    (map #(ingest-events/publish-provider-event
-            context
-            (ingest-events/provider-autocomplete-suggestion-reindexing-event %)))))
+    (info "Sending events to reindex autocomplete suggestions in all providers:" (pr-str providers))
+    (doseq [provider providers]
+      (ingest-events/publish-provider-event
+        context
+        (ingest-events/provider-autocomplete-suggestion-reindexing-event provider)))))
 
 (def-stateful-job BulkUpdateStatusTableCleanup
   [_ system]


### PR DESCRIPTION
Was not correctly publishing events to the event queue. This fix changes how autocomplete trigger events are published.