### PR TITLE
CMR-6205: Reduced shapefile thresholds to reduce likelihood of long s…

### DIFF
--- a/search-app/src/cmr/search/middleware/shapefile.clj
+++ b/search-app/src/cmr/search/middleware/shapefile.clj
@@ -36,7 +36,7 @@
 
 (defconfig max-shapefile-size
   "The maximum size in bytes a shapefile can be"
-  {:default 1000000 :type Long})
+  {:default 100000 :type Long})
 
 (defn- progress
   "Progress function for `wrap-multipart-params`. This function simply throws an error if

--- a/search-app/src/cmr/search/services/parameters/converters/shapefile.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/shapefile.clj
@@ -43,11 +43,11 @@
 
 (defconfig max-shapefile-features
   "The maximum number of feature a shapefile can have"
-  {:default 5000 :type Long})
+  {:default 500 :type Long})
   
 (defconfig max-shapefile-points
   "The maximum number of points a shapefile can have"
-  {:default 100000 :type Long})
+  {:default 5000 :type Long})
 
 (defn- unzip-file
   "Unzip a file (of type File) into a temporary directory and return the directory path as a File"


### PR DESCRIPTION
Reduced shapefile thresholds to prevent complex shapefiles from being uploaded and impacting performance