### PR TITLE
CMR-5906

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1699,7 +1699,7 @@ Lines are provided as a list of comma separated values representing coordinates 
 
 ##### <a name="c-circle"></a> Circle
 
-Circle defines a circle area on the earth with a center point and a radius. The center parameters must be 3 comma-separated numbers: longitude of the center point, latitude of the center point, radius of the circle in meters. The circle center cannot be on North or South pole. The radius of the circle must be between 10 and 1,000,000.
+Circle defines a circle area on the earth with a center point and a radius. The center parameters must be 3 comma-separated numbers: longitude of the center point, latitude of the center point, radius of the circle in meters. The circle center cannot be on North or South pole. The radius of the circle must be between 10 and 6,000,000.
 
     curl "%CMR-ENDPOINT%/collections?circle=-87.629717,41.878112,1000"
 

--- a/search-app/src/cmr/search/services/parameters/converters/spatial.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/spatial.clj
@@ -10,15 +10,31 @@
    [cmr.spatial.circle :as spatial-circle]
    [cmr.spatial.codec :as spatial-codec]))
 
-(defconfig points-on-circle
-  "The number of vertices of the polygon used to approximate a circle"
+(defconfig min-points-on-circle
+  "The minimum number of vertices of the polygon used to approximate a circle"
   {:default 32 :type Long})
+
+(defconfig max-points-on-circle
+  "The maximum number of vertices of the polygon used to approximate a circle"
+  {:default 100 :type Long})
+
+(defconfig min-radius-for-max-points
+  "The minimum radius in meters to trigger the use of maximum number of vertices of the polygon
+  to approximate the circle"
+  {:default 5000 :type Long})
+
+(defn- points-on-circle
+  "Returns the number of vertices of the polygon to approximate the circle"
+  [circle]
+  (if (< (:radius circle) (min-radius-for-max-points))
+    (min-points-on-circle)
+    (max-points-on-circle)))
 
 (defn- shape->search-shape
   "Returns the search shape of the given shape. For cirle, we convert it into a polygon to search."
   [shape]
   (if (= cmr.spatial.circle.Circle (type shape))
-    (spatial-circle/circle->polygon shape (points-on-circle))
+    (spatial-circle/circle->polygon shape (points-on-circle shape))
     shape))
 
 (defn url-value->spatial-condition

--- a/search-app/src/cmr/search/services/parameters/converters/spatial.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/spatial.clj
@@ -12,16 +12,16 @@
 
 (defconfig min-points-on-circle
   "The minimum number of vertices of the polygon used to approximate a circle"
-  {:default 32 :type Long})
+  {:default 16 :type Long})
 
 (defconfig max-points-on-circle
   "The maximum number of vertices of the polygon used to approximate a circle"
-  {:default 100 :type Long})
+  {:default 32 :type Long})
 
 (defconfig min-radius-for-max-points
   "The minimum radius in meters to trigger the use of maximum number of vertices of the polygon
   to approximate the circle"
-  {:default 5000 :type Long})
+  {:default 50000 :type Long})
 
 (defn- points-on-circle
   "Returns the number of vertices of the polygon to approximate the circle"

--- a/spatial-lib/src/cmr/spatial/circle.clj
+++ b/spatial-lib/src/cmr/spatial/circle.clj
@@ -37,7 +37,7 @@
 
 (def MAX_RADIUS
   "Maximum radius in meters"
-  1000000)
+  6000000)
 
 (def ^:const ^double EARTH_RADIUS_APPROX
   "Radius of the earth in meters for polygon approximation of the circle"

--- a/system-int-test/test/cmr/system_int_test/search/collection_spatial_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_spatial_search_test.clj
@@ -646,13 +646,13 @@
 
       "circle radius too small"
       ["0,0,1.0"]
-      ["Circle radius must be between 10 and 1000000, but was 1.0."]
+      ["Circle radius must be between 10 and 6000000, but was 1.0."]
 
       "circle radius too large"
-      ["0,0,1000001"]
-      ["Circle radius must be between 10 and 1000000, but was 1000001.0."]
+      ["0,0,6000001"]
+      ["Circle radius must be between 10 and 6000000, but was 6000001.0."]
 
       "multiple circles errors"
       ["0,1,r" "0,0,100" "10,20,-100"]
       ["[0,1,r] is not a valid URL encoded circle"
-       "Circle radius must be between 10 and 1000000, but was -100.0."])))
+       "Circle radius must be between 10 and 6000000, but was -100.0."])))

--- a/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_spatial_search_test.clj
@@ -550,13 +550,13 @@
 
       "circle radius too small"
       ["0,0,1.0"]
-      ["Circle radius must be between 10 and 1000000, but was 1.0."]
+      ["Circle radius must be between 10 and 6000000, but was 1.0."]
 
       "circle radius too large"
-      ["0,0,1000001"]
-      ["Circle radius must be between 10 and 1000000, but was 1000001.0."]
+      ["0,0,6000001"]
+      ["Circle radius must be between 10 and 6000000, but was 6000001.0."]
 
       "multiple circles errors"
       ["0,1,r" "0,0,100" "10,20,-100"]
       ["[0,1,r] is not a valid URL encoded circle"
-       "Circle radius must be between 10 and 1000000, but was -100.0."])))
+       "Circle radius must be between 10 and 6000000, but was -100.0."])))


### PR DESCRIPTION
Updated rule to pick the number of points of the polygon to approximate a circle.
Increased the allowable radius to 6000km. Added configuration to make configuring number of points more flexible. Current rule is:
if radius < 5km, 32 points; otherwise 100 points.