### PR TITLE
CMR-6450 Port Autocomplete changes to ES update branch

### DIFF
--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -11,7 +11,7 @@
 (defconfig collection-umm-version
   "Defines the latest collection umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"
-  {:default "1.15.2"})
+  {:default "1.15.3"})
 
 (defconfig launchpad-token-enforced
   "Flag for whether or not launchpad token is enforeced."

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -21,6 +21,7 @@
    [cmr.indexer.data.concepts.collection.collection-util :as collection-util]
    [cmr.indexer.data.concepts.collection.community-usage-metrics :as metrics]
    [cmr.indexer.data.concepts.collection.data-center :as data-center]
+   [cmr.indexer.data.concepts.collection.distributed-format-util :as dist-util]
    [cmr.indexer.data.concepts.collection.humanizer :as humanizer]
    [cmr.indexer.data.concepts.collection.instrument :as instrument]
    [cmr.indexer.data.concepts.collection.keyword :as k]
@@ -172,10 +173,12 @@
 
 (defn- get-granule-data-format
   "Returns the Format field from
-  ArchiveAndDistributionInformation -> FileDistributionInformation"
+   ArchiveAndDistributionInformation -> FileDistributionInformation. This also parses the format
+   string for multiple values and filters out encoded information."
   [file-distribution-information]
   (->> file-distribution-information
        (map :Format)
+       (mapcat dist-util/parse-distribution-formats)
        distinct
        (remove nil?)))
 

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/distributed_format_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/distributed_format_util.clj
@@ -1,4 +1,4 @@
-(ns cmr.umm-spec.xml-to-umm-mappings.distributed-format-util
+(ns cmr.indexer.data.concepts.collection.distributed-format-util
   "Defines a utility to parse out multiple distribution format values as a
    string into vector components."
   (:require

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -105,7 +105,18 @@
 (def autocomplete-settings {:index
                             {:number_of_shards (elastic-autocomplete-index-num-shards)
                              :number_of_replicas 1
-                             :refresh_interval "1s"}})
+                             :refresh_interval "1s"}
+                           :analysis
+                            {:filter
+                             {:autocomplete_filter
+                              {:type "edge_ngram"
+                               :min_gram 1
+                               :max_gram 8}}
+                             :analyzer
+                             {:autocomplete_analyzer
+                              {:type "custom"
+                               :tokenizer "standard"
+                               :filter ["lowercase" "autocomplete_filter"]}}}})
 
 (def service-setting {:index
                        {:number_of_shards (elastic-service-index-num-shards)
@@ -686,7 +697,8 @@
    These are the fields that will be stored in an Elasticsearch document."
   {:type (m/stored m/string-field-mapping)
    :fields (m/not-indexed (m/stored m/string-field-mapping))
-   :value (m/stored m/search-as-you-type-field-mapping)})
+   :value (m/stored {:type "text"          
+                     :analyzer "autocomplete_analyzer"})})
 
 (defmapping variable-mapping :variable
   "Defines the elasticsearch mapping for storing variables. These are the

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -247,7 +247,7 @@
         :let [key (key humanized-field)
               key-name (-> key
                            name
-                           (s/replace #"(\.humanized(_?2)?|-sn|-id)" ""))
+                           (s/replace #"((_\.)?humanized(_?2)?|-sn|-id)" ""))
               value-map (as-> humanized-field h
                           (val h)
                           (map util/remove-nil-keys h)
@@ -261,7 +261,7 @@
   This is case-insensitive"
   [term]
   {:pre [(some? term)]}
-  (let [anti-value-matcher (re-matcher #"(na|none|not (provided|applicable))"
+  (let [anti-value-matcher (re-matcher #"(none|not (provided|applicable))"
                                        (s/lower-case term))]
     (some? (re-find anti-value-matcher))))
 

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -247,7 +247,7 @@
         :let [key (key humanized-field)
               key-name (-> key
                            name
-                           (s/replace #"((_\.)?humanized(_?2)?|-sn|-id)" ""))
+                           (s/replace #"([_\.]?humanized(_?2)?|-sn|-id)" ""))
               value-map (as-> humanized-field h
                           (val h)
                           (map util/remove-nil-keys h)

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/distributed_format_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/distributed_format_util.clj
@@ -1,9 +1,9 @@
-(ns cmr.umm-spec.test.xml-to-umm-mappings.distributed-format-util
+(ns cmr.indexer.test.data.concepts.collection.distributed-format-util
   "This namespace conducts unit tests on the distribution-format-util namespace."
   (:require
     [clojure.test :refer :all]
     [cmr.common.util :as common-util :refer [are3]]
-    [cmr.umm-spec.xml-to-umm-mappings.distributed-format-util :as util]))
+    [cmr.indexer.data.concepts.collection.distributed-format-util :as util]))
 
 (deftest replace-comma-space-and-with-comma-space-test
   "Test the replacement of ', and' with ', ' both with correct and not correct data."

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -28,6 +28,8 @@
         _ (api-core/verify-provider-exists request-context provider-id)
         _ (acl/verify-ingest-management-permission
             request-context :update :provider-object provider-id)
+        _ (acl/verify-subscription-management-permission
+            request-context :update :provider-object provider-id)
         _ (common-enabled/validate-write-enabled request-context "ingest")
         concept (validate-and-prepare-subscription-concept concept)
         concept-with-user-id (api-core/set-user-id concept request-context headers)
@@ -43,4 +45,6 @@
 (defn delete-subscription
   "Deletes the subscription with the given provider id and native id."
   [provider-id native-id request]
+  (acl/verify-subscription-management-permission
+    (:request-context request) :update :provider-object provider-id)
   (api-core/delete-concept :subscription provider-id native-id request))

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -100,6 +100,7 @@
                                  (af/refresh-acl-cache-job "ingest-acl-cache-refresh")
                                  jvm-info/log-jvm-statistics-job))
               :caches {acl/token-imp-cache-key (acl/create-token-imp-cache)
+                       acl/token-smp-cache-key (acl/create-token-smp-cache)
                        ;; Caches a map of tokens to the security identifiers
                        context-augmenter/token-sid-cache-name (context-augmenter/create-token-sid-cache)
                        context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -98,6 +98,11 @@
   "An ACL for managing access to ingest management functions."
   "INGEST_MANAGEMENT_ACL")
 
+;; Email subscription management acl
+(def email-subscription-management
+  "An ACL for managing access to email subscription functions."
+  "EMAIL_SUBSCRIPTION_MANAGEMENT")
+
 (def tag-acl
   "An ACL for managing access to tag modification functions."
   "TAG_GROUP")
@@ -376,10 +381,34 @@
   tool related operations"
   grant-all-variable)
 
-(def grant-all-subscription
-  "Creates an ACL in mock echo granting registered users ability to do all
+(def grant-all-subscription-ima
+  "Creates an ingest-management-acl in mock echo granting guest and registered users ability to do all
   subscription related operations"
   grant-all-variable)
+
+(defn grant-all-subscription-esm
+  "Creates an email-subscription-management acl in mock echo granting guest and registered users ability to do all
+  subscription related operations" 
+  [context provider-guid guest-permissions registered-permissions]
+  (grant context
+         [{:permissions guest-permissions
+           :user_type :guest}
+          {:permissions registered-permissions
+           :user_type :registered}]
+         :provider_identity
+         {:target email-subscription-management
+          :provider_id provider-guid}))
+
+(defn grant-all-subscription-group-esm
+  "Creates an email-subscription-management acl in mock echo granting group ability to do all
+  subscription related operations"
+  [context provider-guid group-id group-permissions]
+  (grant context
+         [{:permissions group-permissions
+           :group_id group-id}]
+         :provider_identity
+         {:target email-subscription-management
+          :provider_id provider-guid}))
 
 (defn grant-create-read-groups
   "Creates an ACL in mock echo granting registered users and guests ability to create and read

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1336,7 +1336,7 @@ For temporal range search, the default is inclusive on the range boundaries. Thi
 
 The collection's temporal range or the temporal range of the granules in the collection can be searched. `options[temporal][limit_to_granules]=true` will indicate that the temporal search should find collections based on the minimum and maximum values of each collection's granules' temporal range. If a collection does not have any granules it will search the collection's temporal range.
 
-If a temporal range search is performed, the search results will be sorted by the temporal overlap across all ranges provided, with usage score being the tie-breaker. If a keyword search is performed in conjunction with the temporal range search, search results are first sorted by relevancy score, then by temporal overlap, then usage score.
+If a temporal range search is performed, the search results will be sorted by the temporal overlap across all ranges provided, with usage score being the tie-breaker. If a keyword search is performed in conjunction with the temporal range search, search results are first sorted by relevancy score, then by temporal overlap, then usage score. If a keyword search is used in conjuction with usage-score sort key, the usage-score will be used instead of relevancy score.
 
 #### <a name="c-project"></a> Find collections by project
 
@@ -4670,7 +4670,7 @@ __Sample response__
 ```
 #### <a name="subscription-access-control"></a> Subscription Access Control
 
-Access to subscription is granted through the provider via the INGEST_MANAGEMENT_ACL.
+Access to subscription is granted through the provider via the INGEST_MANAGEMENT_ACL and EMAIL_SUBSCRIPTION_MANAGEMENT
 
 ### <a name="community-usage-metrics"></a> Community Usage Metrics
 

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -50,7 +50,8 @@
    ;;
    ;; ACL support - required here to avoid circular dependencies
    [cmr.search.services.acls.collection-acls]
-   [cmr.search.services.acls.granule-acls]))
+   [cmr.search.services.acls.granule-acls]
+   [cmr.search.services.acls.subscription-acls]))
 
 (defn build-routes [system]
   (let [relative-root-url (get-in system [:public-conf :relative-root-url])]

--- a/search-app/src/cmr/search/data/elastic_relevancy_scoring.clj
+++ b/search-app/src/cmr/search/data/elastic_relevancy_scoring.clj
@@ -68,7 +68,7 @@
   (let [use-keyword-sort? (keywords-extractor/contains-keyword-condition? query)
         use-usage-sort? (seq (->> query
                                   :sort-keys
-                                  (filter #(= :usage-relevancy-score (:field %)))))
+                                  (filter #(= :usage-relevancy-score (:field %)))))        
         use-temporal-sort? (and (temporal-conditions/contains-temporal-conditions? query)
                                 (sort-use-temporal-relevancy))]
     (seq

--- a/search-app/src/cmr/search/data/elastic_relevancy_scoring.clj
+++ b/search-app/src/cmr/search/data/elastic_relevancy_scoring.clj
@@ -58,41 +58,51 @@
 
    The algorithm is to currently compare scores in the following order (we only go to the next level
    in the scoring system in the case of a tie at the higher level):
-   1. keyword boost
-   2. temporal overlap
-   3. community usage
-   4. temporal end date of the collection
-   5. processing level."
+   1. community usage, if usage_score sort key present
+   2. keyword boost
+   3. temporal overlap
+   4. relevancy with community usage secondary
+   5. temporal end date of the collection
+   6. processing level."
   [query]
   (let [use-keyword-sort? (keywords-extractor/contains-keyword-condition? query)
+        use-usage-sort? (seq (->> query
+                                  :sort-keys
+                                  (filter #(= :usage-relevancy-score (:field %)))))
         use-temporal-sort? (and (temporal-conditions/contains-temporal-conditions? query)
                                 (sort-use-temporal-relevancy))]
     (seq
      (concat
-      (when use-keyword-sort?
-        (if (sort-bin-keyword-scores)
-          [{:_script {:type :number
-                      :script {:params {:binSize (keyword-score-bin-size)}
-                               :source keyword-score-bin-script}
-                      :order :desc}}]
-          [{:_score {:order :desc}}]))
-      (when use-temporal-sort?
-        [{:_script (temporal-to-elastic/temporal-overlap-sort-script query)}])
-      ;; We only include this if one of the others is present
-      (when (and (or use-temporal-sort? use-keyword-sort?)
-                 (sort-use-relevancy-score))
-        [{:_script {:type :number
-                    :script {:params {:binSize  (community-usage-bin-size)}
-                             :source community-usage-bin-script
-                             ; :missing 0
-                             }
-                    :order :desc}}])
-      ;; If end-date is nil, collection is ongoing so use today so ongoing
-      ;; collections will be at the top
-      (when use-keyword-sort?
-        [{:end-date {:order :desc
-                     :missing (time-coerce/to-long (time/now))}}
-         {:processing-level-id-lowercase-humanized {:order :desc}}])))))
+       (when use-usage-sort?
+         [{:_script {:params {:binSize (community-usage-bin-size)}
+                     :type :number
+                     :script community-usage-bin-script
+                     :order :desc
+                     :missing 0}}])
+       (when use-keyword-sort?
+         (if (sort-bin-keyword-scores)
+           [{:_script {:params {:binSize (keyword-score-bin-size)}
+                       :script keyword-score-bin-script
+                       :type :number
+                       :order :desc}}]
+           [{:_score {:order :desc}}]))
+       (when use-temporal-sort?
+         [{:_script (temporal-to-elastic/temporal-overlap-sort-script query)}])
+       ;; We only include this if one of the others is present
+       (when (and (or use-temporal-sort? use-keyword-sort?)
+                  (not use-usage-sort?)
+                  (sort-use-relevancy-score))
+         [{:_script {:params {:binSize (community-usage-bin-size)}
+                     :type :number
+                     :script community-usage-bin-script
+                     :order :desc
+                     :missing 0}}])
+       ;; If end-date is nil, collection is ongoing so use today so ongoing
+       ;; collections will be at the top
+       (when use-keyword-sort?
+         [{:end-date {:order :desc
+                      :missing (time-coerce/to-long (time/now))}}
+          {:processing-level-id-lowercase.humanized {:order :desc}}])))))
 
 (defn- temporal-sort-order
   "If there are temporal ranges in the query and temporal relevancy sorting is turned on,

--- a/search-app/src/cmr/search/services/acl_service.clj
+++ b/search-app/src/cmr/search/services/acl_service.clj
@@ -5,7 +5,7 @@
     [cmr.transmit.config :as tc]))
 
 (defmulti acls-match-concept?
-  "Returns true if any of the acls match the concept.
+  "Returns true if any of the catalog item acls match the concept.
 
   Implementations for this multimethod should be placed in the namespaces for the
   respective concept types under `cmr.search.services.acl-service.TYPE-acls`. If
@@ -13,27 +13,27 @@
   (fn [context acls concept]
     (:concept-type concept)))
 
-;; services currently have no ACLs, so return `true` for all ACL checks
+;; services currently have no catalog item ACLs, so return `true` for all ACL checks
 (defmethod acls-match-concept? :service
   [context acls concept]
   true)
 
-;; tools currently have no ACLs, so return `true` for all ACL checks
+;; tools currently have no catalog item ACLs, so return `true` for all ACL checks
 (defmethod acls-match-concept? :tool
   [context acls concept]
   true)
 
-;; tags have no acls so we always assume it matches
+;; tags have no catalog item acls so we always assume it matches
 (defmethod acls-match-concept? :tag
   [context acls concept]
   true)
 
-;; variables currently have no ACLs, so return `true` for all ACL checks
+;; variables currently have no catalog item ACLs, so return `true` for all ACL checks
 (defmethod acls-match-concept? :variable
   [context acls concept]
   true)
 
-;; subscriptions currently have no ACLs, so return `true` for all ACL checks
+;; subscriptions currently have no catalog item ACLs, so return `true` for all ACL checks
 (defmethod acls-match-concept? :subscription
   [context acls concept]
   true)
@@ -41,6 +41,17 @@
 (defmethod acls-match-concept? :default
   [context acls concept]
   false)
+
+(defn- esm-acls-match-concept-provider?
+  "Returns true if any of the EMAIL_SUBSCRIPTION_MANAGEMENT acls matches the concept provider.
+  This ACL applies to subscription concept only. For all other concept types. it returns true"
+  [esm-acls concept]
+  ;; the esm-acls are all the EMAIL_SUBSCRIPTION_MANAGEMENT ACLs that
+  ;; grant the current user read permissions. All we need to check is
+  ;; if any of these read permissions are granted on the provider-id of the concept.
+  (if (= :subscription (:concept-type concept))
+    (some #(= (:provider-id concept) (get-in % [:provider-identity :provider-id])) esm-acls)
+    true))
 
 ;; XXX To be fixed with CMR-4394
 ;;
@@ -101,8 +112,12 @@
       concepts
       (let [acls (acl-helper/get-acls-applicable-to-token context)
             applicable-field (-> concepts first :concept-type concept-type->applicable-field)
-            applicable-acls (filterv (comp applicable-field :catalog-item-identity) acls)]
+            applicable-acls (filterv (comp applicable-field :catalog-item-identity) acls)
+            esm-acls (acl-helper/get-esm-acls-applicable-to-token context)]
         (doall (remove nil? (pmap (fn [concept]
-                                    (when (acls-match-concept? context applicable-acls concept)
+                                    ;; when there are both catalog item acl match and the esm
+                                    ;; acl match, return the concept.
+                                    (when (and (acls-match-concept? context applicable-acls concept)
+                                               (esm-acls-match-concept-provider? esm-acls concept))
                                       concept))
                                   concepts)))))))

--- a/search-app/src/cmr/search/services/acls/acl_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_helper.clj
@@ -6,8 +6,18 @@
    [cmr.common.util :as util]))
 
 (defn get-acls-applicable-to-token
-  "Retrieves the ACLs that are applicable to the current user."
+  "Retrieves the catalog item ACLs that are applicable to the current user."
   [context]
   (let [acls (af/get-acls context [:catalog-item])
         sids (util/lazy-get context :sids)]
     (filter (partial acl/acl-matches-sids-and-permission? sids :read) acls)))
+
+(defn get-esm-acls-applicable-to-token
+  "Retrieves the EMAIL_SUBSCRIPTION_MANAGEMENT ACLs that are applicable to the current user.
+  i.e. grant read permission to the current user."
+  [context]
+  (let [acls (af/get-acls context [:provider-object])
+        ;; only get EMAIL_SUBSCRIPTION_MANAGEMENT ACLS
+        esm-acls (filter #(= "EMAIL_SUBSCRIPTION_MANAGEMENT" (get-in % [:provider-identity :target])) acls)
+        sids (util/lazy-get context :sids)]
+    (filter (partial acl/acl-matches-sids-and-permission? sids :read) esm-acls)))

--- a/search-app/src/cmr/search/services/acls/subscription_acls.clj
+++ b/search-app/src/cmr/search/services/acls/subscription_acls.clj
@@ -1,0 +1,25 @@
+(ns cmr.search.services.acls.subscription-acls
+  "Contains functions for manipulating subscription acls"
+  (:require
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.query-execution :as qe]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common.util :as util]
+   [cmr.search.services.acls.acl-helper :as acl-helper]
+   [cmr.transmit.config :as tc]))
+
+(defmethod qe/add-acl-conditions-to-query :subscription
+  [context query]
+  ;; return unmodified query if the context has a system token
+  ;; otherwise, get the provider-ids from the EMAIL_SUBSCRIPTION_MANAGEMENT ACLs
+  ;; that grant the read permission to the current user, and add provider-id
+  ;; constraint to the query.
+  (if (tc/echo-system-token? context)
+    query
+    (let [;; esm-acls that grant read permission to the current user
+          esm-acls (acl-helper/get-esm-acls-applicable-to-token context)
+          provider-ids (if (seq esm-acls)
+                         (map #(get-in % [:provider-identity :provider-id]) esm-acls)
+                         ["non-existing-provider-id"])
+          acl-cond (qm/string-conditions :provider-id provider-ids true)]
+      (update-in query [:condition] #(gc/and-conds [acl-cond %])))))

--- a/search-app/src/cmr/search/services/autocomplete_service.clj
+++ b/search-app/src/cmr/search/services/autocomplete_service.clj
@@ -5,16 +5,13 @@
     [cmr.common-app.services.search.query-model :as qm]
     [cmr.common-app.services.search.group-query-conditions :as gc]))
 
-(defn- build-autocomplete-condition
+(defn build-autocomplete-condition
   [term types]
-  (let [root (qm/multi-match ["value" "value.*gram"]
-                             term
-                             {:type "phrase_prefix"})]
+  (let [root (qm/match :value term)]
     (if (empty? types)
       root
       (gc/and-conds [root
-                     (gc/or-conds (map #(qm/text-condition :type %)
-                                       types))]))))
+                     (gc/or-conds (map #(qm/text-condition :type %) types))]))))
 
 (defn autocomplete
   "Execute elasticsearch query to get autocomplete suggestions"

--- a/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
@@ -32,9 +32,20 @@
 
 (defn grant-all-subscription-fixture
   "A test fixture that grants all users the ability to create and modify subscriptions."
-  [f]
-  (echo-util/grant-all-subscription (s/context))
-  (f))
+  [providers guest-permissions registered-permissions]
+  (fn [f]
+    ;; grant INGEST_MANAGEMENT_ACL permission.
+    (echo-util/grant-all-subscription-ima (s/context))
+    (let [providers (for [[provider-guid provider-id] providers]
+                      {:provider-guid provider-guid
+                       :provider-id provider-id})]
+      (doseq [provider-map providers]
+        ;; grant EMAIL_SUBSCRIPTION_MANAGEMENT permission for each provider.
+        (echo-util/grant-all-subscription-esm (s/context)
+                                              (:provider-id provider-map)
+                                              guest-permissions
+                                              registered-permissions)))
+    (f)))
 
 (defn make-subscription-concept
   "Convenience function for creating a subscription concept"

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -96,6 +96,7 @@
          "kms"
          "providers"
          "token-imp"
+         "token-smp"
          "token-sid"
          "token-user-id"
          "token-user-ids"

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -11,8 +11,27 @@
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
    [cmr.system-int-test.utils.subscription-util :as subscription-util]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
-                                           "provguid2" "PROV2"}))
+(use-fixtures :each
+              (join-fixtures
+               [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
+                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV1"} 
+                                                                  [:read :update]
+                                                                  [:read :update])
+                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV2"}
+                                                                  [:read]
+                                                                  [:read :update])]))
+
+(deftest subscription-ingest-on-prov2-test
+  (testing "ingest on PROV2, guest is not granted ingest permission for EMAIL_SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+          guest-token (echo-util/login-guest (system/context))
+          response (ingest/ingest-concept concept {:token guest-token})]
+      (is (= ["You do not have permission to perform that action."] (:errors response)))))
+  (testing "ingest on PROV2, registered user is granted ingest permission for EMAIL_SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+          user1-token (echo-util/login (system/context) "user1")
+          response (ingest/ingest-concept concept {:token user1-token})]
+      (is (= 201 (:status response))))))
 
 (deftest subscription-ingest-test
   (testing "ingest of a new subscription concept"

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -79,10 +79,6 @@
                                            :Topic "value"
                                            :Term "None"}))
 
-(def sk10 (umm-spec-common/science-keyword {:Category "missing"
-                                            :Topic "value"
-                                            :Term "na"}))
-
 (def sk11 (umm-spec-common/science-keyword {:Category "EARTH SCIENCE"
                                             :Topic "BIOSPHERE"
                                             :Term "Nothofagus"}))
@@ -116,7 +112,7 @@
                                                    {:provider-id "PROV1"
                                                     :concept-type :collection
                                                     :format-key :echo10})
-        coll4 (fu/make-coll 1 "PROV1" (fu/science-keywords sk1 sk2 sk3 sk4 sk5 sk6 sk7 sk8 sk9 sk10 sk11))]
+        coll4 (fu/make-coll 1 "PROV1" (fu/science-keywords sk1 sk2 sk3 sk4 sk5 sk6 sk7 sk8 sk9 sk11))]
 
     (index/wait-until-indexed)
     (index/reindex-suggestions)
@@ -131,12 +127,12 @@
                        autocomplete-reindex-fixture]))
 
 
-#_(deftest reindex-suggestions-test
+(deftest reindex-suggestions-test
   (testing "Ensure that response is in proper format and results are correct"
     (compare-autocomplete-results
       (get-in (search/get-autocomplete-json "q=level2") [:feed :entry])
-      [{:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
-       {:type "instrument" :value "lVIs" :fields "lVIs"}]))
+      [{:type "instrument" :value "lVIs" :fields "lVIs"}
+       {:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}]))
 
   (testing "Ensure science keywords are being indexed properly"
     (are3
@@ -146,17 +142,17 @@
 
       "shorter match"
       "q=solar"
-      [{:type "science_keywords" :value "Solar Irradiance" :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
-       {:type "science_keywords" :value "Solar Irradiance" :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
-       {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}
-       {:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}]
+      [{:type "science_keywords" :value "Solar Irradiance" :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
+       {:type "science_keywords" :value "Solar Irradiance" :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
+       {:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
+       {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}]
 
       "more complete match"
       "q=solar irradiation"
-      [{:type "science_keywords" :value "Solar Irradiance" :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
-       {:type "science_keywords" :value "Solar Irradiance" :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
-       {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}
-       {:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}]))
+      [{:type "science_keywords" :value "Solar Irradiance" :fields "Atmosphere:Atmospheric Radiation:Solar Irradiance"}
+       {:type "science_keywords" :value "Solar Irradiance" :fields "Sun-Earth Interactions:Solar Activity:Solar Irradiance"}
+       {:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}
+       {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}]))
 
   (testing "Anti-value filtering"
     (are3
@@ -164,25 +160,22 @@
       (let [results (get-in (search/get-autocomplete-json (str "q=" query)) [:feed :entry])]
         (compare-autocomplete-results results expected))
 
-      "excludes 'NA'"
-      "na" [{:value "Nothofagus" :type "science_keywords" :fields "Biosphere:Nothofagus"}]
-
       "excludes 'None'"
       "none" [{:value "Nothofagus" :type "science_keywords" :fields "Biosphere:Nothofagus"}]
 
       "excludes 'Not Applicable'"
-      "not applicable" [{:type "science_keywords" :value "Nothofagus" :fields "Biosphere:Nothofagus"}
-                        {:type "instrument" :value "ATM" :fields "ATM"}
+      "not applicable" [{:type "project" :value "ACRIM" :fields "ACRIM"}
+                        {:type "science_keywords" :value "Nothofagus" :fields "Biosphere:Nothofagus"}
                         {:type "platform" :value "ACRIMSAT" :fields "ACRIMSAT"}
-                        {:type "instrument" :value "ACRIM" :fields "ACRIM"}
+                        {:type "instrument" :value "ATM" :fields "ATM"}
+                        {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}                        
                         {:type "science_keywords" :value "Alpha" :fields "Popular:Alpha"}
-                        {:type "project" :value "ACRIM" :fields "ACRIM"}
-                        {:type "organization" :value "ACRIM SCF" :fields "ACRIM SCF"}]
+                        {:type "instrument" :value "ACRIM" :fields "ACRIM"}]
 
       "excludes 'Not Provided'"
-      "not provided" [{:type "science_keywords" :value "Nothofagus" :fields "Biosphere:Nothofagus"}
+      "not provided" [{:type "project" :value "PROJ2" :fields "PROJ2"}
+                      {:type "science_keywords" :value "Nothofagus" :fields "Biosphere:Nothofagus"}
                       {:type "project" :value "proj1" :fields "proj1"}
-                      {:type "project" :value "PROJ2" :fields "PROJ2"}
                       {:type "processing_level" :value "PL1" :fields "PL1"}]
 
       "does not filter 'not' prefixed values"

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete_collection_facet_search_test.clj
@@ -96,8 +96,8 @@
     "full value match"
     "q=foo" 1
 
-    "full value with extra value should not match"
-    "q=foos" 0
+    "extra values can match"
+    "q=foos" 1
 
     "case sensitivity test"
     "q=FOO" 1

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_data_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_data_format_test.clj
@@ -1,0 +1,55 @@
+(ns cmr.system-int-test.search.collection-search-data-format-test
+  "This tests ingesting and searching for collections in different formats."
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.system-int-test.data2.umm-spec-collection :as umm-spec-collection]
+   [cmr.system-int-test.utils.humanizer-util :as hu]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+
+(use-fixtures :each (join-fixtures
+                      [(ingest/reset-fixture {"provguid1" "PROV1"
+                                              "provguid2" "PROV2"})
+                       hu/grant-all-humanizers-fixture
+                       hu/save-sample-humanizers-fixture]))
+
+(def sample-data-format-collection-test
+  {:ArchiveAndDistributionInformation
+    {:FileArchiveInformation
+      [{:Format "Binary"
+        :FormatType "Native"
+        :FormatDescription "Use the something app to open the binary file."}
+       {:Format "netCDF-4"
+        :FormatType "Supported"
+        :FormatDescription "An acsii file also exists."}]
+     :FileDistributionInformation
+      [{:Format "NetCDF-4"
+        :FormatType "Supported"
+        :FormatDescription "An acsii file also exists."}
+       {:Format "NetCDF-5"
+        :FormatType "Supported"
+        :FormatDescription "An acsii file also exists."}
+       {:Format "NetCDF-6 and NetCDF-7 or NetCDF-8, and NetCDF-9"
+        :FormatType "Supported"
+        :FormatDescription "An acsii file also exists."}]}})
+
+(deftest collection-with-file-formats-ingest-test
+  "Test the ingest and indexing behavior by searching on data format of a collection that was
+   ingested. Also test to make sure one of the data formats was parsed correctly and humanized."
+
+  (testing "ingest and search by data format of a collection with data formats."
+    (let [concept (umm-spec-collection/collection-concept sample-data-format-collection-test)
+          {:keys [concept-id revision-id]} (ingest/ingest-concept concept)]
+      (index/wait-until-indexed)
+      (is (= 1
+             (-> (search/make-raw-search-query :collection ".umm_json?granule_data_format=NetCDF-9")
+                 (:body)
+                 (json/decode true)
+                 (:hits))))
+      ;; The humanizer fixture contains a Humanizer with NetCDF-4 assigned NetCDF.
+      ;; Check to see that the humanizer exits for the data format.
+      (is (string/includes? (search/get-humanizers-report) "NetCDF-4,NetCDF")))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -339,7 +339,7 @@
         "DIF .native extension" [c3-dif c4-dif] :dif "native" nil
         "ISO MENDS .native extension" [c5-iso c6-iso] :iso19115 "native" nil
         "SMAP ISO .native extension" [c7-smap] :iso-smap "native" nil
-        "UMM JSON .native extension" [c10-umm-json] {:format :umm-json, :version "1.15.2"} "native" nil
+        "UMM JSON .native extension" [c10-umm-json] {:format :umm-json, :version "1.15.3"} "native" nil
         "ECHO10 accept application/metadata+xml" [c1-echo c2-echo] :echo10 nil "application/metadata+xml"
         "DIF accept application/metadata+xml" [c3-dif c4-dif] :dif nil "application/metadata+xml"
         "ISO MENDS accept application/metadata+xml" [c5-iso c6-iso] :iso19115 nil "application/metadata+xml"

--- a/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
@@ -1,5 +1,5 @@
 (ns cmr.system-int-test.search.subscription.concept-retrieval-test
-  "Integration test for service retrieval via the following endpoints:
+  "Integration test for subscription retrieval via the following endpoints:
 
   * /concepts/:concept-id
   * /concepts/:concept-id/:revision-id"
@@ -18,8 +18,9 @@
 (use-fixtures
  :each
  (join-fixtures
-  [(ingest/reset-fixture {"provguid1" "PROV1"})
-   subscription/grant-all-subscription-fixture]))
+  [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
+   (subscription/grant-all-subscription-fixture {"provguid1" "PROV1"} [:read :update] [:read :update])
+   (subscription/grant-all-subscription-fixture {"provguid2" "PROV2"} [:update] [:read :update])]))
 
 (defn- assert-retrieved-concept
   "Verify the retrieved concept by checking against the expected subscription name,
@@ -27,6 +28,18 @@
   [concept-id revision-id accept-format expected-subscription-name]
   (let [{:keys [status body]} (search/retrieve-concept
                                concept-id revision-id {:accept accept-format})]
+    (is (= 200 status))
+    (is (= expected-subscription-name
+           (:Name (json/parse-string body true))))))
+
+(defn- assert-retrieved-concept-with-registered-user
+  "Verify the retrieved concept by checking against the expected subscription name,
+  which we have deliberately set to be different for each concept revision."
+  [concept-id revision-id accept-format expected-subscription-name]
+  (let [user1-token (e/login (s/context) "user1")
+        {:keys [status body]} (search/retrieve-concept
+                               concept-id revision-id {:accept accept-format
+                                                       :query-params {:token user1-token}})]
     (is (= 200 status))
     (is (= expected-subscription-name
            (:Name (json/parse-string body true))))))
@@ -58,6 +71,49 @@
     (is (= err-code status))
     (is (= [err-message] errors))))
 
+(deftest retrieve-subscription-by-concept-id-various-read-permission
+  ;; We support UMM JSON format; No format and any format are also accepted.
+  (doseq [accept-format [mt/umm-json]];; nil mt/any]]
+    (let [suffix (if accept-format
+                   (mt/mime-type->format accept-format)
+                   "nil")
+          ;; append result format to subscription name to make it unique
+          ;; for different formats so that the test can be run for multiple formats
+          sub1-r1-name (str "s1-r1" suffix)
+          sub1-r2-name (str "s1-r2" suffix)
+          native-id (str "subscription1" suffix)
+          sub1-r1 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
+                                                                :Name  sub1-r1-name
+                                                                :native-id native-id})
+          sub1-r2 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
+                                                                :Name sub1-r2-name
+                                                                :native-id native-id})
+          concept-id (:concept-id sub1-r1)]
+      (index/wait-until-indexed)
+      (testing "Sanity check that the test subscription got updated and its revision id was incremented"
+        (is (= concept-id (:concept-id sub1-r2)))
+        (is (= 1 (:revision-id sub1-r1)))
+        (is (= 2 (:revision-id sub1-r2))))
+
+      ;; no read permission granted for guest on provider "PROV2" so, no subscription could be found.
+      (testing "retrieval by subscription concept-id and revision id returns error"
+        (assert-retrieved-concept-error concept-id 1 accept-format 404
+          (format "Concept with concept-id [%s] and revision-id [1] could not be found." concept-id))
+        (assert-retrieved-concept-error concept-id 2 accept-format 404
+          (format "Concept with concept-id [%s] and revision-id [2] could not be found." concept-id)))
+
+      (testing "retrieval by only subscription concept-id returns error"
+        (assert-retrieved-concept-error concept-id nil accept-format 404
+          (format "Concept with concept-id [%s] could not be found." concept-id)))
+
+      ;; read permission is granted for registered user, subscriptions will be found
+      (testing "retrieval by subscription concept-id and revision id returns the specified revision"
+        (assert-retrieved-concept-with-registered-user concept-id 1 accept-format sub1-r1-name)
+        (assert-retrieved-concept-with-registered-user concept-id 2 accept-format sub1-r2-name))
+
+      (testing "retrieval by only subscription concept-id returns the latest revision"
+        (assert-retrieved-concept-with-registered-user concept-id nil accept-format sub1-r2-name)))))
+
 (deftest retrieve-subscription-by-concept-id
   ;; We support UMM JSON format; No format and any format are also accepted.
   (doseq [accept-format [mt/umm-json]];; nil mt/any]]
@@ -86,7 +142,7 @@
         (assert-retrieved-concept concept-id 1 accept-format sub1-r1-name)
         (assert-retrieved-concept concept-id 2 accept-format sub1-r2-name))
 
-      (testing "retrieval by only service concept-id returns the latest revision"
+      (testing "retrieval by only subscription concept-id returns the latest revision"
         (assert-retrieved-concept concept-id nil accept-format sub1-r2-name))
 
       (testing "retrieval by non-existent revision returns error"
@@ -102,7 +158,7 @@
           "Concept with concept-id [SUB404404404-PROV1] and revision-id [1] does not exist."))
 
       (testing "retrieval of deleted concept"
-        ;; delete the service concept
+        ;; delete the subscription concept
         (ingest/delete-concept sub1-concept (subscription/token-opts (e/login (s/context) "user1")))
         (index/wait-until-indexed)
 
@@ -116,7 +172,7 @@
                          "a deleted concept and does not contain metadata.")
                     concept-id)))))))
 
-(deftest retrieve-service-with-invalid-format
+(deftest retrieve-subscription-with-invalid-format
   (testing "unsupported accept header results in error"
     (let [unsupported-mt "unsupported/mime-type"]
       (assert-retrieved-concept-error "SUB1111-PROV1" nil unsupported-mt 400

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
@@ -16,7 +16,8 @@
 (use-fixtures :each
               (join-fixtures
                [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
-                subscription/grant-all-subscription-fixture]))
+                (subscription/grant-all-subscription-fixture
+                  {"provguid1" "PROV1" "provguid2" "PROV2"} [:read :update] [:read :update])]))
 
 (deftest search-subscription-all-revisions
   (let [token (e/login (s/context) "user1")

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
@@ -4,24 +4,101 @@
    [clojure.test :refer :all]
    [cmr.common.mime-types :as mime-types]
    [cmr.common.util :refer [are3]]
-   [cmr.mock-echo.client.echo-util :as e]
-   [cmr.system-int-test.data2.core :as d]
-   [cmr.system-int-test.data2.umm-json :as data-umm-json]
-   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
-   [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
-   [cmr.system-int-test.data2.umm-spec-service :as data-umm-s]
-   [cmr.system-int-test.system :as s]
-   [cmr.system-int-test.utils.association-util :as au]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.core :as data2-core]
+   [cmr.system-int-test.system :as system]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
-   [cmr.system-int-test.utils.subscription-util :as subscriptions]
-   [cmr.umm-spec.versioning :as umm-version]))
+   [cmr.system-int-test.utils.subscription-util :as subscriptions]))
 
 (use-fixtures :each
               (join-fixtures
-               [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
-                subscriptions/grant-all-subscription-fixture]))
+               [(ingest/reset-fixture {"provguid1" "PROV1" 
+                                       "provguid2" "PROV2" 
+                                       "provguid3" "PROV3"
+                                       "provguid4" "PROV4"})
+                (subscriptions/grant-all-subscription-fixture
+                  {"provguid1" "PROV1" "provguid2" "PROV2"} [:read :update] [:read :update])
+                ;; No read permission granted for guest for PROV3
+                (subscriptions/grant-all-subscription-fixture
+                  {"provguid3" "PROV3"} [:update] [:read :update])
+                ;; No read permission granted for any user_types for PROV4.
+                (subscriptions/grant-all-subscription-fixture
+                  {"provguid4" "PROV4"} [:update] [:update])]))
+
+(deftest search-for-subscriptions-user-read-permission-test
+  ;; EMAIL_SUBSCRIPTION_MANAGEMENT ACL grants only update permission for guest on PROV3,
+  ;; so subscription for PROV3 can be ingested but can't be searched by guest.
+  ;; but it's searchable by registered users because read permission is granted.
+  (let [subscription3 (subscriptions/ingest-subscription-with-attrs {:native-id "Sub3"
+                                                                     :Name "Subscription3"
+                                                                     :SubscriberId "SubId3"
+                                                                     :CollectionConceptId "C1-PROV3"
+                                                                     :provider-id "PROV3"})
+        guest-token (echo-util/login-guest (system/context))
+        user1-token (echo-util/login (system/context) "user1")]
+    (index/wait-until-indexed)
+    (is (= 201 (:status subscription3)))
+    (are3 [expected-subscriptions query]
+      (do
+        (testing "XML references format"
+          (data2-core/assert-refs-match expected-subscriptions (subscriptions/search-refs query)))
+        (testing "JSON format"
+          (subscriptions/assert-subscription-search expected-subscriptions (subscriptions/search-json query))))
+
+      "Find all returns nothing for guest"
+      [] {:token guest-token}
+
+      "Find all returns all for registered user"
+      [subscription3] {:token user1-token}
+
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      ;; name Param
+      "By name case sensitive - exact match returns nothing for guest"
+      [] {:name "Subscription3" :token guest-token}
+
+      "By name case sensitive - exact match returns the right subscription for registered user"
+      [subscription3] {:name "Subscription3" :token user1-token} )))
+
+(deftest search-for-subscriptions-group-read-permission-test
+  (let [subscription4 (subscriptions/ingest-subscription-with-attrs {:native-id "Sub4"
+                                                                     :Name "Subscription4"
+                                                                     :SubscriberId "SubId4"
+                                                                     :CollectionConceptId "C1-PROV4"
+                                                                     :provider-id "PROV4"})
+        ;; create two groups
+        group1-concept-id (echo-util/get-or-create-group (system/context) "group1")
+        group2-concept-id (echo-util/get-or-create-group (system/context) "group2")
+        ;; create two user tokens, associated with two groups
+        user1g-token (echo-util/login (system/context) "user1g" [group1-concept-id])
+        user2g-token (echo-util/login (system/context) "user2g" [group2-concept-id])]
+    (index/wait-until-indexed)
+
+    ;; grant one group read permission
+    (echo-util/grant-all-subscription-group-esm (system/context) "PROV4" group1-concept-id [:read])
+    
+    (is (= 201 (:status subscription4)))
+    (are3 [expected-subscriptions query]
+      (do
+        (testing "XML references format"
+          (data2-core/assert-refs-match expected-subscriptions (subscriptions/search-refs query)))
+        (testing "JSON format"
+          (subscriptions/assert-subscription-search expected-subscriptions (subscriptions/search-json query))))
+
+      "Find all returns nothing for user2g"
+      [] {:token user2g-token}
+
+      "Find all returns all for user1g"
+      [subscription4] {:token user1g-token}
+
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      ;; name Param
+      "By name case sensitive - exact match returns nothing for user2g"
+      [] {:name "Subscription4" :token user2g-token}
+
+      "By name case sensitive - exact match returns the right subscription for user1g"
+      [subscription4] {:name "Subscription4" :token user1g-token} )))
 
 (deftest search-for-subscriptions-validation-test
   (testing "Unrecognized parameters"
@@ -93,7 +170,7 @@
     (are3 [expected-subscriptions query]
       (do
         (testing "XML references format"
-          (d/assert-refs-match expected-subscriptions (subscriptions/search-refs query)))
+          (data2-core/assert-refs-match expected-subscriptions (subscriptions/search-refs query)))
         (testing "JSON format"
           (subscriptions/assert-subscription-search expected-subscriptions (subscriptions/search-json query))))
 
@@ -322,7 +399,7 @@
     (index/wait-until-indexed)
 
     (are3 [sort-key expected-subscriptions]
-      (is (d/refs-match-order?
+      (is (data2-core/refs-match-order?
            expected-subscriptions
            (subscriptions/search-refs {:sort-key sort-key})))
 

--- a/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/umm_json_search_test.clj
@@ -95,8 +95,8 @@
         "Retrieve specified version 1.0 with URL extension"
         "1.0" nil "umm_json_v1_0"
 
-        "Retrieve specified version 1.15.2 with URL extension"
-        "1.15.2" nil "umm_json_v1_15_2"))
+        "Retrieve specified version 1.15.3 with URL extension"
+        "1.15.3" nil "umm_json_v1_15_3"))
 
     (testing "find collections in umm-json format"
       (are3 [collections params]

--- a/umm-spec-lib/resources/example-data/iso19115/artificial_test_data.xml
+++ b/umm-spec-lib/resources/example-data/iso19115/artificial_test_data.xml
@@ -537,6 +537,17 @@ Main NCEI website providing links to access data and data services.
                     </gmd:maintenanceAndUpdateFrequency>
                 </gmd:MD_MaintenanceInformation>
             </gmd:resourceMaintenance>
+            <gmd:resourceFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>Binary</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                    <gmd:specification>
+                        <gco:CharacterString>FormatDescription: ABC Binary FormatType:Supported</gco:CharacterString>
+                    </gmd:specification>
+                </gmd:MD_Format>
+            </gmd:resourceFormat>
             <gmd:descriptiveKeywords>
                 <gmd:MD_Keywords>
                     <gmd:keyword>
@@ -978,7 +989,18 @@ Data cover the three date ranges below: 1/12/1972 to 4/16/1972 6/25/1973 to 7/19
     </gmd:identificationInfo>
     <gmd:distributionInfo>
         <gmd:MD_Distribution>
-            <gmd:distributor>
+            <gmd:distributionFormat xlink:href="FileDistributionInformation_0">
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>NetCDF-4</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:version gco:nilReason="inapplicable"/>
+                    <gmd:specification>
+                        <gco:CharacterString>FormatType: Supported FormatDescription: some more notes</gco:CharacterString>
+                    </gmd:specification>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+            <gmd:distributor xlink:href="FileDistributionInformation_0">
                 <gmd:MD_Distributor>
                     <gmd:distributorContact>
                         <gmd:CI_ResponsibleParty>
@@ -1042,7 +1064,7 @@ Data may be searched and downloaded using online services provided by NCEI using
                             </gmd:orderingInstructions>
                         </gmd:MD_StandardOrderProcess>
                     </gmd:distributionOrderProcess>
-                    <gmd:distributorFormat>
+                    <gmd:distributorFormat xlink:href="FileDistributionInformation_0">
                         <gmd:MD_Format>
                             <gmd:name>
                                 <gco:CharacterString>Originator data format</gco:CharacterString>
@@ -1052,6 +1074,37 @@ Data may be searched and downloaded using online services provided by NCEI using
                     </gmd:distributorFormat>
                 </gmd:MD_Distributor>
             </gmd:distributor>
+            <gmd:transferOptions xlink:href="FileDistributionInformation_Media_0">
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:offLine>
+                        <gmd:MD_Medium>
+                            <gmd:name>
+                                <gmd:MD_MediumNameCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_MediumNameCode" codeListValue="onLine">onLine</gmd:MD_MediumNameCode>
+                            </gmd:name>
+                        </gmd:MD_Medium>
+                    </gmd:offLine>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions xlink:href="FileDistributionInformation_AverageFileSize_0">
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:unitsOfDistribution>
+                        <gco:CharacterString>MB</gco:CharacterString>
+                    </gmd:unitsOfDistribution>
+                    <gmd:transferSize>
+                        <gco:Real>100</gco:Real>
+                    </gmd:transferSize>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
+            <gmd:transferOptions xlink:href="FileDistributionInformation_TotalCollectionFileSize_0">
+                <gmd:MD_DigitalTransferOptions>
+                    <gmd:unitsOfDistribution>
+                        <gco:CharacterString>GB</gco:CharacterString>
+                    </gmd:unitsOfDistribution>
+                    <gmd:transferSize>
+                        <gco:Real>1000</gco:Real>
+                    </gmd:transferSize>
+                </gmd:MD_DigitalTransferOptions>
+            </gmd:transferOptions>
         </gmd:MD_Distribution>
     </gmd:distributionInfo>
     <gmd:dataQualityInfo>

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-c-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-c-json-schema.json
@@ -1,0 +1,1411 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "UMM-C",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "MetadataLanguage": {
+      "description": "The language used in the metadata record.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/LanguageType"
+    },
+    "MetadataDates": {
+      "description": "Dates related to activities involving the metadata record itself.  For example, Future Review date is the date that the metadata record is scheduled to be reviewed.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/DateType"
+      },
+      "minItems": 0
+    },
+    "DirectoryNames": {
+      "description": "Formerly called Internal Directory Name (IDN) Node (IDN_Node). This element has been used historically by the GCMD internally to identify association, responsibility and/or ownership of the dataset, service or supplemental information. Note: This field only occurs in the DIF. When a DIF record is retrieved in the ECHO10 or ISO 19115 formats, this element will not be translated.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DirectoryNameType"
+      },
+      "minItems": 0
+    },
+    "EntryTitle": {
+      "description": "The title of the collection or service described by the metadata.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/EntryTitleType"
+    },
+    "DOI": {
+        "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used. While this element is not required, NASA metadata providers are strongly encouraged to include DOI and DOI Authority for their collections.",
+        "$ref": "umm-cmn-json-schema.json#/definitions/DoiType"
+    },
+    "Abstract": {
+      "description": "A brief description of the collection or service the metadata represents.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/AbstractType"
+    },
+    "Purpose": {
+      "description": "Suggested usage or purpose for the collection data or service.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/PurposeType"
+    },
+    "DataLanguage": {
+      "description": "Describes the language used in the preparation, storage, and description of the collection. It is the language of the collection data themselves.   It does not refer to the language used in the metadata record (although this may be the same language).",
+      "$ref": "umm-cmn-json-schema.json#/definitions/LanguageType"
+    },
+    "DataDates": {
+      "description": "Dates related to activities involving the collection data.  For example, Creation date is the date that the collection data first entered the data archive system.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/DateType"
+      },
+      "minItems": 1
+    },
+    "DataCenters": {
+      "description": "Information about the data centers responsible for this collection and its metadata.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/DataCenterType"
+      },
+      "minItems": 1
+    },
+    "ContactGroups": {
+      "description": "Information about the personnel groups responsible for this collection and its metadata.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/ContactGroupType"
+      }
+    },
+    "ContactPersons": {
+      "description": "Information about the personnel responsible for this collection and its metadata.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/ContactPersonType"
+      }
+    },
+    "CollectionDataType": {
+      "description": "Identifies the collection as a Science Quality collection or a non-science-quality collection such as a Near-Real-Time collection.",
+      "$ref": "#/definitions/CollectionDataTypeEnum"
+    },
+    "ProcessingLevel": {
+      "description": "The identifier for the processing level of the collection (e.g., Level0, Level1A).",
+      "$ref": "#/definitions/ProcessingLevelType"
+    },
+    "CollectionCitations": {
+      "description": "Information required to properly cite the collection in professional scientific literature. This element provides information for constructing a citation for the item itself, and is not designed for listing bibliographic references of scientific research articles arising from search results. A list of references related to the research results should be in the Publication Reference element.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/ResourceCitationType"
+      },
+      "minItems": 0
+    },
+    "CollectionProgress": {
+      "description": "This element describes the production status of the data set. There are five choices for Data Providers: PLANNED refers to data sets to be collected in the future and are thus unavailable at the present time. For Example: The Hydro spacecraft has not been launched, but information on planned data sets may be available. ACTIVE refers to data sets currently in production or data that is continuously being collected or updated. For Example: data from the AIRS instrument on Aqua is being collected continuously. COMPLETE refers to data sets in which no updates or further data collection will be made. For Example: Nimbus-7 SMMR data collection has been completed. DEPRECATED refers to data sets that have been retired, but still can be retrieved. Usually newer products exist that replace the retired data set. NOT APPLICABLE refers to data sets in which a collection progress is not applicable such as a calibration collection. There is a sixth value of NOT PROVIDED that should not be used by a data provider. It is currently being used as a value when a correct translation cannot be done with the current valid values, or when the value is not provided by the data provider.",
+      "$ref": "#/definitions/CollectionProgressEnum"
+    },
+    "Quality": {
+      "description": "Free text description of the quality of the collection data.  Description may include: 1) succinct description of the quality of data in the collection; 2) Any quality assurance procedures followed in producing the data in the collection; 3) indicators of collection quality or quality flags - both validated or invalidated; 4) recognized or potential problems with quality; 5) established quality control mechanisms; and 6) established quantitative quality measurements.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/QualityType"
+    },
+    "UseConstraints": {
+      "description": "Designed to protect privacy and/or intellectual property by allowing the author to specify how the collection may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness. Note: Use Constraints describe how the item may be used once access has been granted; and is distinct from Access Constraints, which refers to any constraints in accessing the item.",
+      "$ref": "#/definitions/UseConstraintsType"
+    },
+    "AccessConstraints": {
+      "description": "Allows the author to constrain access to the collection. This includes any special restrictions, legal prerequisites, limitations and/or warnings on obtaining collection data. Some words that may be used in this element's value include: Public, In-house, Limited, None. The value field is used for special ACL rules (Access Control Lists (http://en.wikipedia.org/wiki/Access_control_list)). For example it can be used to hide metadata when it isn't ready for public consumption.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/AccessConstraintsType"
+    },
+    "ArchiveAndDistributionInformation": {
+      "description": "This element and all of its sub elements exist for display purposes. It allows a data provider to provide archive and distribution information up front to an end user, to help them decide if they can use the product.",
+      "$ref": "#/definitions/ArchiveAndDistributionInformationType"
+    },
+    "PublicationReferences": {
+      "description": "Describes key bibliographic citations pertaining to the collection.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/PublicationReferenceType"
+      },
+      "minItems": 0
+    },
+    "ISOTopicCategories": {
+      "description": "Identifies the topic categories from the EN ISO 19115-1:2014 Geographic Information – Metadata – Part 1: Fundamentals (http://www.isotc211.org/) Topic Category Code List that pertain to this collection, based on the Science Keywords associated with the collection. An ISO Topic Category is a high-level thematic classification to assist in the grouping of and search for available collections.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000
+      },
+      "minItems": 0
+    },
+    "ScienceKeywords": {
+      "description": "Controlled Science Keywords describing the collection.  The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS).",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/ScienceKeywordType"
+      },
+      "minItems": 1
+    },
+    "AncillaryKeywords": {
+      "description": "Allows authors to provide words or phrases outside of the controlled Science Keyword vocabulary, to further describe the collection.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/AncillaryKeywordStringType"
+      },
+      "minItems": 0
+    },
+    "AdditionalAttributes": {
+      "description": "The data’s distinctive attributes of the collection (i.e. attributes used to describe the unique characteristics of the collection which extend beyond those defined).",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/AdditionalAttributeType"
+      },
+      "minItems": 0
+    },
+    "MetadataAssociations": {
+      "description": "This element is used to identify other services, collections, visualizations, granules, and other metadata types and resources that are associated with or dependent on the data described by the metadata. This element is also used to identify a parent metadata record if it exists. This usage should be reserved for instances where a group of metadata records are subsets that can be better represented by one parent metadata record, which describes the entire set. In some instances, a child may point to more than one parent. The EntryId is the same as the element described elsewhere in this document where it contains and ID, and Version.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/MetadataAssociationType"
+      },
+      "minItems": 1
+    },
+    "TemporalExtents": {
+      "description": "This class contains attributes which describe the temporal range of a specific collection. Temporal Extent includes a specification of the Temporal Range Type of the collection, which is one of Range Date Time, Single Date Time, or Periodic Date Time",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/TemporalExtentType"
+      },
+      "minItems": 1
+    },
+    "PaleoTemporalCoverages": {
+      "description": "For paleoclimate or geologic data, PaleoTemporalCoverage is the length of time represented by the data collected. PaleoTemporalCoverage should be used when the data spans time frames earlier than yyyy-mm-dd = 0001-01-01.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PaleoTemporalCoverageType"
+      },
+      "minItems": 0
+    },
+    "TemporalKeywords": {
+      "description": "One or more words or phrases that describe the temporal resolution of the dataset.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+      },
+      "minItems": 0
+    },
+    "SpatialExtent": {
+      "$ref": "#/definitions/SpatialExtentType"
+    },
+    "TilingIdentificationSystems": {
+      "description": "Name of the two-dimensional tiling system for the collection.  Previously called TwoDCoordinateSystem.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TilingIdentificationSystemType"
+      },
+      "minItems": 0
+    },
+    "SpatialInformation": {
+      "description": "The reference frame or system in which altitudes (elevations) are given. The information contains the datum name, distance units and encoding method, which provide the definition for the system. This field also stores the characteristics of the reference frame or system from which depths are measured. The additional information in the field is geometry reference data etc.",
+      "$ref": "#/definitions/SpatialInformationType"
+    },
+    "SpatialKeywords": {
+      "description": "This is deprecated and will be removed. Use LocationKeywords instead. Controlled hierarchical keywords used to specify the spatial location of the collection.   The controlled vocabulary for spatial keywords is maintained in the Keyword Management System (KMS).  The Spatial Keyword hierarchy includes one or more of the following layers: Location_Category (e.g., Continent), Location_Type (e.g. Africa), Location_Subregion1 (e.g., Central Africa), Location_Subregion2 (e.g., Cameroon), and Location_Subregion3.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+      },
+      "minItems": 1
+    },
+    "LocationKeywords": {
+      "description": "Controlled hierarchical keywords used to specify the spatial location of the collection.   The controlled vocabulary for spatial keywords is maintained in the Keyword Management System (KMS).  The Spatial Keyword hierarchy includes one or more of the following layers: Category (e.g., Continent), Type (e.g. Africa), Subregion1 (e.g., Central Africa), Subregion2 (e.g., Cameroon), and Subregion3. DetailedLocation exists outside the hierarchy.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LocationKeywordType"
+      }
+    },
+    "Platforms": {
+      "description": "Information about the relevant platform(s) used to acquire the data in the collection. Platform types are controlled in the Keyword Management System (KMS), and include Spacecraft, Aircraft, Vessel, Buoy, Platform, Station, Network, Human, etc.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/PlatformType"
+      },
+      "minItems": 1
+    },
+    "Projects": {
+      "description": "The name of the scientific program, field campaign, or project from which the data were collected. This element is intended for the non-space assets such as aircraft, ground systems, balloons, sondes, ships, etc. associated with campaigns. This element may also cover a long term project that continuously creates new data sets — like MEaSUREs from ISCCP and NVAP or CMARES from MISR. Project also includes the Campaign sub-element to support multiple campaigns under the same project.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/ProjectType"
+      },
+      "minItems": 1
+    },
+    "RelatedUrls": {
+      "description": "This element describes any data/service related URLs that include project home pages, services, related data archives/servers, metadata extensions, direct links to online software packages, web mapping services, links to images, or other data.",
+      "type": "array",
+      "items": {
+        "$ref": "umm-cmn-json-schema.json#/definitions/RelatedUrlType"
+      },
+      "minItems": 1
+    },
+    "ShortName": {
+      "description": "The short name associated with the collection.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/ShortNameType"
+    },
+    "Version": {
+      "description": "The Version of the collection.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/VersionType"
+    },
+    "VersionDescription": {
+      "description": "The Version Description of the collection.",
+      "$ref": "umm-cmn-json-schema.json#/definitions/VersionDescriptionType"
+    }
+  },
+  "required": ["ShortName", "Version", "EntryTitle", "Abstract", "DataCenters", "ProcessingLevel", "ScienceKeywords", "TemporalExtents", "SpatialExtent", "Platforms", "CollectionProgress"],
+
+
+
+  "definitions": {
+    "UseConstraintsDescriptionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This sub-element either contains a license summary or free-text description that details the permitted use or limitation of this collection.",
+      "properties": {
+        "Description": {
+          "description": "This sub-element either contains a license summary or free-text description that details the permitted use or limitation of this collection.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        }
+      }
+    },
+    "UseConstraintsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element defines how the data may or may not be used after access is granted to assure the protection of privacy or intellectual property. This includes license text, license URL, or any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the data set. Data providers may request acknowledgement of the data from users and claim no responsibility for quality and completeness of data.",
+      "properties": {
+        "Description": {
+          "$ref": "#/definitions/UseConstraintsDescriptionType"
+        },
+        "LicenseUrl": {
+          "description": "This element holds the URL and associated information to access the License on the web. If this element is used the LicenseText element cannot be used.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/OnlineResourceType"
+        },
+        "LicenseText": {
+          "description": "This element holds the actual license text. If this element is used the LicenseUrl element cannot be used.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000
+        }
+      },
+      "anyOf": [
+          {"required": ["Description"]},
+          {"required": ["LicenseUrl"]},
+          {"required": ["LicenseText"]}
+      ],
+      "not": {"required": ["LicenseUrl", "LicenseText"]}
+    },
+    "DirectoryNameType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Formerly called Internal Directory Name (IDN) Node (IDN_Node). This element has been used historically by the GCMD internally to identify association, responsibility and/or ownership of the dataset, service or supplemental information. Note: This field only occurs in the DIF. When a DIF record is retrieved in the ECHO10 or ISO 19115 formats, this element will not be translated.",
+      "properties": {
+        "ShortName": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/ShortNameType"
+        },
+        "LongName": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/LongNameType"
+        }
+      },
+      "required": ["ShortName"]
+    },
+    "ProcessingLevelType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element contains the Processing Level Id and the Processing Level Description",
+      "properties": {
+        "ProcessingLevelDescription": {
+          "description": "Description of the meaning of the Processing Level Id, e.g., the Description for the Level4 Processing Level Id might be 'Model output or results from analyses of lower level data'",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "Id": {
+          "description": "An identifier indicating the level at which the data in the collection are processed, ranging from Level0 (raw instrument data at full resolution) to Level4 (model output or analysis results).  The value of Processing Level Id is chosen from a controlled vocabulary.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      },
+      "required": ["Id"]
+    },
+    "PaleoTemporalCoverageType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "For paleoclimate or geologic data, PaleoTemporalCoverage is the length of time represented by the data collected. PaleoTemporalCoverage should be used when the data spans time frames earlier than yyyy-mm-dd = 0001-01-01.",
+      "properties": {
+        "ChronostratigraphicUnits": {
+          "description": "Hierarchy of terms indicating units of geologic time, i.e., eon (e.g, Phanerozoic), era (e.g., Cenozoic), period (e.g., Paleogene), epoch (e.g., Oligocene), and stage or age (e.g, Chattian).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ChronostratigraphicUnitType"
+          },
+          "minItems": 0
+        },
+        "StartDate": {
+          "description": "A string indicating the number of years furthest back in time, including units, e.g., 100 Ga.  Units may be Ga (billions of years before present), Ma (millions of years before present), ka (thousands of years before present) or ybp (years before present).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "EndDate": {
+          "description": "A string indicating the number of years closest to the present time, including units, e.g., 10 ka.  Units may be Ga (billions of years before present), Ma (millions of years before present), ka (thousands of years before present) or ybp (years before present).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    },
+    "ChronostratigraphicUnitType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Eon": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Era": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Epoch": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Stage": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "DetailedClassification": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Period": {
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        }
+      },
+      "required": ["Eon"]
+    },
+    "SpatialExtentType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Specifies the geographic and vertical (altitude, depth) coverage of the data.",
+      "properties": {
+        "SpatialCoverageType": {
+          "description": "Denotes whether the collection's spatial coverage requires horizontal, vertical, horizontal and vertical, orbit, or vertical and orbit in the spatial domain and coordinate system definitions.",
+          "$ref": "#/definitions/SpatialCoverageTypeEnum"
+        },
+        "HorizontalSpatialDomain": {
+          "$ref": "#/definitions/HorizontalSpatialDomainType"
+        },
+        "VerticalSpatialDomains": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VerticalSpatialDomainType"
+          }
+        },
+        "OrbitParameters": {
+          "$ref": "#/definitions/OrbitParametersType"
+        },
+        "GranuleSpatialRepresentation": {
+          "$ref": "#/definitions/GranuleSpatialRepresentationEnum"
+        }
+      },
+      "required": ["GranuleSpatialRepresentation"]
+    },
+    "SpatialCoverageTypeEnum": {
+      "type": "string",
+      "enum": ["HORIZONTAL", "VERTICAL", "ORBITAL", "HORIZONTAL_VERTICAL", "ORBITAL_VERTICAL", "HORIZONTAL_ORBITAL", "HORIZONTAL_VERTICAL_ORBITAL"]
+    },
+    "HorizontalSpatialDomainType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about a collection with horizontal spatial coverage.",
+      "properties": {
+        "ZoneIdentifier": {
+          "description": "The appropriate numeric or alpha code used to identify the various zones in the collection's grid coordinate system.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Geometry": {
+          "$ref": "#/definitions/GeometryType"
+        },
+        "ResolutionAndCoordinateSystem": {
+          "description": "Specifies the horizontal spatial extents coordinate system and its resolution.",
+          "$ref": "#/definitions/ResolutionAndCoordinateSystemType"
+        }
+      },
+      "required": ["Geometry"]
+    },
+    "GeometryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "CoordinateSystem": {
+          "$ref": "#/definitions/CoordinateSystemEnum"
+        },
+        "Points": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PointType"
+          },
+          "minItems": 1
+        },
+        "BoundingRectangles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BoundingRectangleType"
+          },
+          "minItems": 1
+        },
+        "GPolygons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GPolygonType"
+          },
+          "minItems": 1
+        },
+        "Lines": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LineType"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["CoordinateSystem"],
+      "anyOf": [{
+        "required": ["Points"]
+      }, {
+        "required": ["BoundingRectangles"]
+      }, {
+        "required": ["GPolygons"]
+      }, {
+        "required": ["Lines"]
+      }]
+    },
+    "CoordinateSystemEnum": {
+      "type": "string",
+      "enum": ["CARTESIAN", "GEODETIC"]
+    },
+    "PointType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The longitude and latitude values of a spatially referenced point in degrees.",
+      "properties": {
+        "Longitude": {
+          "$ref": "#/definitions/LongitudeType"
+        },
+        "Latitude": {
+          "$ref": "#/definitions/LatitudeType"
+        }
+      },
+      "required": ["Longitude", "Latitude"]
+    },
+    "LatitudeType": {
+      "description": "The latitude value of a spatially referenced point, in degrees.  Latitude values range from -90 to 90.",
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "LongitudeType": {
+      "description": "The longitude value of a spatially referenced point, in degrees.  Longitude values range from -180 to 180.",
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "BoundingRectangleType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "WestBoundingCoordinate": {
+          "$ref": "#/definitions/LongitudeType"
+        },
+        "NorthBoundingCoordinate": {
+          "$ref": "#/definitions/LatitudeType"
+        },
+        "EastBoundingCoordinate": {
+          "$ref": "#/definitions/LongitudeType"
+        },
+        "SouthBoundingCoordinate": {
+          "$ref": "#/definitions/LatitudeType"
+        }
+      },
+      "required": ["WestBoundingCoordinate", "NorthBoundingCoordinate", "EastBoundingCoordinate", "SouthBoundingCoordinate"]
+    },
+    "GPolygonType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Boundary": {
+          "$ref": "#/definitions/BoundaryType"
+        },
+        "ExclusiveZone": {
+          "$ref": "#/definitions/ExclusiveZoneType"
+        }
+      },
+      "required": ["Boundary"]
+    },
+    "BoundaryType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A boundary is set of points connected by straight lines representing a polygon on the earth. It takes a minimum of three points to make a boundary. Points must be specified in counter-clockwise order and closed (the first and last vertices are the same).",
+      "properties": {
+        "Points": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PointType"
+          },
+          "minItems": 4
+        }
+      },
+      "required": ["Points"]
+    },
+    "ExclusiveZoneType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Contains the excluded boundaries from the GPolygon.",
+      "properties": {
+        "Boundaries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BoundaryType"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["Boundaries"]
+    },
+    "LineType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Points": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PointType"
+          },
+          "minItems": 2
+        }
+      },
+      "required": ["Points"]
+    },
+    "VerticalSpatialDomainType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Type": {
+          "description": "Describes the type of the area of vertical space covered by the collection locality.",
+          "$ref": "#/definitions/VerticalSpatialDomainTypeEnum"
+        },
+        "Value": {
+          "description": "Describes the extent of the area of vertical space covered by the collection. Must be accompanied by an Altitude Encoding Method description. The datatype for this attribute is the value of the attribute VerticalSpatialDomainType. The unit for this attribute is the value of either DepthDistanceUnits or AltitudeDistanceUnits.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      },
+      "required": ["Type", "Value"]
+    },
+    "VerticalSpatialDomainTypeEnum": {
+      "type": "string",
+      "enum": ["Atmosphere Layer", "Maximum Altitude", "Maximum Depth", "Minimum Altitude", "Minimum Depth"]
+    },
+    "OrbitParametersType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Orbit parameters for the collection used by the Orbital Backtrack Algorithm.",
+      "properties": {
+        "SwathWidth": {
+          "description": "Width of the swath at the equator in Kilometers.",
+          "type": "number"
+        },
+        "Period": {
+          "description": "Orbital period in decimal minutes.",
+          "type": "number"
+        },
+        "InclinationAngle": {
+          "description": "Inclination of the orbit. This is the same as (180-declination) and also the same as the highest latitude achieved by the satellite. Data Unit: Degree.",
+          "type": "number"
+        },
+        "NumberOfOrbits": {
+          "description": "Indicates the number of orbits.",
+          "type": "number"
+        },
+        "StartCircularLatitude": {
+          "description": "The latitude start of the orbit relative to the equator. This is used by the backtrack search algorithm to treat the orbit as if it starts from the specified latitude. This is optional and will default to 0 if not specified.",
+          "type": "number"
+        }
+      },
+      "required": ["SwathWidth", "Period", "InclinationAngle", "NumberOfOrbits"]
+    },
+    "GranuleSpatialRepresentationEnum": {
+      "type": "string",
+      "enum": ["CARTESIAN", "GEODETIC", "ORBIT", "NO_SPATIAL"]
+    },
+    "TilingIdentificationSystemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about a two-dimensional tiling system related to this collection.",
+      "properties": {
+        "TilingIdentificationSystemName": {
+          "$ref": "#/definitions/TilingIdentificationSystemNameEnum"
+        },
+        "Coordinate1": {
+          "$ref": "#/definitions/TilingCoordinateType"
+        },
+        "Coordinate2": {
+          "$ref": "#/definitions/TilingCoordinateType"
+        }
+      },
+      "required": ["TilingIdentificationSystemName", "Coordinate1", "Coordinate2"]
+    },
+    "TilingCoordinateType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines the minimum and maximum value for one dimension of a two dimensional coordinate system.",
+      "properties": {
+        "MinimumValue": {
+          "type": "number"
+        },
+        "MaximumValue": {
+          "type": "number"
+        }
+      }
+    },
+    "TilingIdentificationSystemNameEnum": {
+       "type": "string",
+       "enum": ["CALIPSO", "MISR", "MODIS Tile EASE", "MODIS Tile SIN", "WELD Alaska Tile", "WELD CONUS Tile", "WRS-1", "WRS-2"]
+    },
+    "SpatialInformationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This entity stores the reference frame or system from which horizontal and vertical spatial domains are measured. The horizontal reference frame includes a Geodetic Model, Geographic Coordinates, and Local Coordinates. The Vertical reference frame includes altitudes (elevations) and depths.",
+      "properties": {
+        "VerticalCoordinateSystem": {
+          "$ref": "#/definitions/VerticalCoordinateSystemType"
+        },
+        "SpatialCoverageType": {
+          "description": "Denotes whether the spatial coverage of the collection is horizontal, vertical, horizontal and vertical, orbit, or vertical and orbit.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      },
+      "required": ["SpatialCoverageType"]
+    },
+    "VerticalCoordinateSystemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "AltitudeSystemDefinition": {
+          "$ref": "#/definitions/AltitudeSystemDefinitionType"
+        },
+        "DepthSystemDefinition": {
+          "$ref": "#/definitions/DepthSystemDefinitionType"
+        }
+      }
+    },
+    "AltitudeDistanceUnitsEnum": {
+      "description": "The units in which altitude measurements are recorded.",
+      "type": "string",
+      "enum": ["HectoPascals", "Kilometers", "Millibars"]
+    },
+    "DepthDistanceUnitsEnum": {
+      "description": "The units in which depth measurements are recorded.",
+      "type": "string",
+      "enum": ["Fathoms", "Feet", "HectoPascals", "Meters", "Millibars"]
+    },
+    "AltitudeSystemDefinitionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The reference frame or system from which altitude is measured. The term 'altitude' is used instead of the common term 'elevation' to conform to the terminology in Federal Information Processing Standards 70-1 and 173. The information contains the datum name, distance units and encoding method, which provide the definition for the system.",
+      "properties": {
+        "DatumName": {
+          "description": "The identification given to the level surface taken as the surface of reference from which measurements are compared.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "DistanceUnits": {
+          "description": "The units in which measurements are recorded.",
+          "$ref": "#/definitions/AltitudeDistanceUnitsEnum"
+        },
+        "Resolutions": {
+          "description": "The minimum distance possible between two adjacent values, expressed in distance units of measure for the collection.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 0
+        }
+      }
+    },
+    "DepthSystemDefinitionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The reference frame or system from which depth is measured. The information contains the datum name, distance units and encoding method, which provide the definition for the system.",
+      "properties": {
+        "DatumName": {
+          "description": "The identification given to the level surface taken as the surface of reference from which measurements are compared.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "DistanceUnits": {
+          "description": "The units in which measurements are recorded.",
+          "$ref": "#/definitions/DepthDistanceUnitsEnum"
+        },
+        "Resolutions": {
+          "description": "The minimum distance possible between two adjacent values, expressed in distance units of measure for the collection.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 0
+        }
+      }
+    },
+    "ResolutionAndCoordinateSystemType": {
+      "description": "This class defines the horizontal spatial extents coordinate system and the data product's horizontal data resolution. The horizontal data resolution is defined as the smallest horizontal distance between successive elements of data in a dataset. This is synonymous with terms such as ground sample distance, sample spacing and pixel size. It is to be noted that the horizontal data resolution could be different in the two horizontal dimensions. Also, it is different from the spatial resolution of an instrument, which is the minimum distance between points that an instrument can see as distinct.",
+      "type": "object",
+      "oneOf": [{
+        "additionalProperties": false,
+        "properties": {
+          "Description": {
+            "description": "This element holds a description about the resoultion and coordinate system for people to read.",
+            "$ref": "#/definitions/DescriptionType"
+          },
+          "GeodeticModel": {
+            "description": "This element describes the geodetic model for the data product.",
+            "$ref": "#/definitions/GeodeticModelType"
+          }
+        },
+        "required": ["GeodeticModel"]
+      }, {
+        "additionalProperties": false,
+        "properties": {
+          "Description": {
+            "description": "This element holds a description about the resoultion and coordinate system for people to read.",
+            "$ref": "#/definitions/DescriptionType"
+          },
+          "GeodeticModel": {
+            "description": "This element describes the geodetic model for the data product.",
+            "$ref": "#/definitions/GeodeticModelType"
+          },
+          "HorizontalDataResolution": {
+            "description": "This class defines a number of the data products horizontal data resolution. The horizontal data resolution is defined as the smallest horizontal distance between successive elements of data in a dataset. This is synonymous with terms such as ground sample distance, sample spacing and pixel size. It is to be noted that the horizontal data resolution could be different in the two horizontal dimensions. Also, it is different from the spatial resolution of an instrument, which is the minimum distance between points that an instrument can see as distinct.",
+            "$ref": "#/definitions/HorizontalDataResolutionType"
+          }
+        },
+        "required": ["HorizontalDataResolution"]
+      }, {
+        "additionalProperties": false,
+        "properties": {
+          "Description": {
+            "description": "This element holds a description about the resoultion and coordinate system for people to read.",
+            "$ref": "#/definitions/DescriptionType"
+          },
+          "GeodeticModel": {
+            "description": "This element describes the geodetic model for the data product.",
+            "$ref": "#/definitions/GeodeticModelType"
+          },
+          "LocalCoordinateSystem": {
+            "description": "This element describes the local coordinate system for the data product.",
+            "$ref": "#/definitions/LocalCoordinateSystemType"
+          }
+        },
+        "required": ["LocalCoordinateSystem"]
+      }]
+    },
+    "DescriptionType": {
+      "description": "This element defines what a description is.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "GeodeticModelType": {
+      "description": "This element describes the geodetic model for the data product.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "HorizontalDatumName": {
+          "description": "The identification given to the reference system used for defining the coordinates of points.",
+          "$ref": "#/definitions/DatumNameType"
+        },
+        "EllipsoidName": {
+          "description": "Identification given to established representation of the Earth's shape.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "SemiMajorAxis": {
+          "description": "Radius of the equatorial axis of the ellipsoid.",
+          "type": "number"
+        },
+        "DenominatorOfFlatteningRatio": {
+          "description": "The ratio of the Earth's major axis to the difference between the major and the minor.",
+          "type": "number"
+        }
+      }
+    },
+    "DatumNameType": {
+      "description": "The identification given to the level surface taken as the surface of reference from which measurements are compared.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "HorizontalDataResolutionType": {
+      "description": "This class defines a number of the data products horizontal data resolution. The horizontal data resolution is defined as the smallest horizontal distance between successive elements of data in a dataset. This is synonymous with terms such as ground sample distance, sample spacing and pixel size. It is to be noted that the horizontal data resolution could be different in the two horizontal dimensions. Also, it is different from the spatial resolution of an instrument, which is the minimum distance between points that an instrument can see as distinct.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "VariesResolution": {
+          "description": "Varies Resolution object describes a data product that has a number of resolution values.",
+          "$ref": "#/definitions/HorizontalDataResolutionVariesType"
+        },
+        "PointResolution": {
+          "description": "Point Resolution object describes a data product that is from a point source.",
+          "$ref": "#/definitions/HorizontalDataResolutionPointType"
+        },
+        "NonGriddedResolutions": {
+          "description": "Non Gridded Resolutions object describes resolution data for non gridded data products.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HorizontalDataResolutionNonGriddedType"
+          },
+          "minItems": 1
+        },
+        "NonGriddedRangeResolutions": {
+          "description": "Non Gridded Range Resolutions object describes range resolution data for non gridded data products.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HorizontalDataResolutionNonGriddedRangeType"
+          },
+          "minItems": 1
+        },
+        "GriddedResolutions": {
+          "description": "Gridded Resolutions object describes resolution data for gridded data products.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HorizontalDataResolutionGriddedType"
+          },
+          "minItems": 1
+        },
+        "GriddedRangeResolutions": {
+          "description": "Gridded Range Resolutions object describes range resolution data for gridded data products.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HorizontalDataResolutionGriddedRangeType"
+          },
+          "minItems": 1
+        },
+        "GenericResolutions": {
+          "description": "Generic Resolutions object describes general resolution data for a data product where it is not known if a data product is gridded or not.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HorizontalDataGenericResolutionType"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "HorizontalDataResolutionVariesType": {
+      "description": "Varies Resolution object describes a data product that has a number of resolution values.",
+      "type": "string",
+      "enum": ["Varies"]
+    },
+    "HorizontalDataResolutionPointType": {
+      "description": "Point Resolution object describes a data product that is from a point source.",
+      "type": "string",
+      "enum": ["Point"]
+    },
+    "HorizontalDataResolutionNonGriddedType": {
+      "description": "Non Gridded Resolutions object describes resolution data for non gridded data products.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "XDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "YDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "Unit": {
+          "description": "Units of measure used for the XDimension and YDimension values.",
+          "$ref": "#/definitions/HorizontalDataResolutionUnitEnum"
+        },
+        "ViewingAngleType": {
+          "description": "This element describes the angle of the measurement with respect to the instrument that gives an understanding of the specified resolution.",
+          "$ref": "#/definitions/HorizontalResolutionViewingAngleType"
+        },
+        "ScanDirection": {
+          "description": "This element describes the instrument scanning direction.",
+          "$ref": "#/definitions/HorizontalResolutionScanDirectionType"
+        }
+      },
+      "anyOf": [{
+        "required": ["XDimension", "Unit"]
+      }, {
+        "required": ["YDimension", "Unit"]
+      }]
+    },
+    "HorizontalDataResolutionNonGriddedRangeType": {
+      "description": "Non Gridded Range Resolutions object describes range resolution data for non gridded data products.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "MinimumXDimension": {
+          "description": "The minimum, minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "MinimumYDimension": {
+          "description": "The minimum, minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "MaximumXDimension": {
+          "description": "The maximum, minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "MaximumYDimension": {
+          "description": "The maximum, minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "Unit": {
+          "description": "Units of measure used for the XDimension and YDimension values.",
+          "$ref": "#/definitions/HorizontalDataResolutionUnitEnum"
+        },
+        "ViewingAngleType": {
+          "description": "This element describes the angle of the measurement with respect to the instrument that gives an understanding of the specified resolution.",
+          "$ref": "#/definitions/HorizontalResolutionViewingAngleType"
+        },
+        "ScanDirection": {
+          "description": "This element describes the instrument scanning direction.",
+          "$ref": "#/definitions/HorizontalResolutionScanDirectionType"
+        }
+      },
+      "anyOf": [{
+        "required": ["MinimumXDimension", "MaximumXDimension", "Unit"]
+      }, {
+        "required": ["MinimumYDimension", "MaximumYDimension", "Unit"]
+      }]
+    },
+    "HorizontalDataResolutionGriddedType": {
+      "description": "Gridded Resolutions object describes resolution data for gridded data products.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "XDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "YDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "Unit": {
+          "description": "Units of measure used for the XDimension and YDimension values.",
+          "$ref": "#/definitions/HorizontalDataResolutionUnitEnum"
+        }
+      },
+      "anyOf": [{
+        "required": ["XDimension", "Unit"]
+      }, {
+        "required": ["YDimension", "Unit"]
+      }]
+    },
+    "HorizontalDataResolutionGriddedRangeType": {
+      "description": "Gridded Range Resolutions object describes range resolution data for gridded data products.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "MinimumXDimension": {
+          "description": "The minimum, minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "MinimumYDimension": {
+          "description": "The minimum, minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "MaximumXDimension": {
+          "description": "The maximum, minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "MaximumYDimension": {
+          "description": "The maximum, minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "Unit": {
+          "description": "Units of measure used for the XDimension and YDimension values.",
+          "$ref": "#/definitions/HorizontalDataResolutionUnitEnum"
+        }
+      },
+      "anyOf": [{
+        "required": ["MinimumXDimension", "MaximumXDimension", "Unit"]
+      }, {
+        "required": ["MinimumYDimension", "MaximumYDimension", "Unit"]
+      }]
+    },
+    "HorizontalDataGenericResolutionType": {
+      "description": "Generic Resolutions object describes general resolution data for a data product where it is not known if a data product is gridded or not.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "XDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plane in the X axis. In most cases this is along the longitudinal axis.",
+          "type": "number"
+        },
+        "YDimension": {
+          "description": "The minimum difference between two adjacent values on a horizontal plan in the Y axis. In most cases this is along the latitudinal axis.",
+          "type": "number"
+        },
+        "Unit": {
+          "description": "Units of measure used for the XDimension and YDimension values.",
+          "$ref": "#/definitions/HorizontalDataResolutionUnitEnum"
+        }
+      },
+      "anyOf": [{
+        "required": ["XDimension", "Unit"]
+      }, {
+        "required": ["YDimension", "Unit"]
+      }]
+    },
+    "HorizontalDataResolutionUnitEnum": {
+      "description": "Units of measure used for the geodetic latitude and longitude resolution values (e.g., decimal degrees).",
+      "type": "string",
+      "enum": ["Decimal Degrees", "Kilometers", "Meters", "Statute Miles", "Nautical Miles", "Not provided"]
+    },
+    "HorizontalResolutionViewingAngleType": {
+      "description": "This element describes the angle of the measurement with respect to the instrument that give an understanding of the specified resolution.",
+      "type": "string",
+      "enum": ["At Nadir", "Scan Extremes"]
+    },
+    "HorizontalResolutionScanDirectionType": {
+      "description": "This element describes the instrument scanning direction.",
+      "type": "string",
+      "enum": ["Along Track", "Cross Track"]
+    },
+    "LocalCoordinateSystemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "GeoReferenceInformation": {
+          "description": "The information provided to register the local system to the Earth (e.g. control points, satellite ephemeral data, and inertial navigation data).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "Description": {
+          "description": "A description of the Local Coordinate System and geo-reference information.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        }
+      }
+    },
+    "CollectionDataTypeEnum": {
+      "description": "This element is used to identify the collection as a Science Quality Collection or as a non-science-quality collection such as a Near Real Time collection. If a collection does not contain this field, it will be assumed to be of science-quality.",
+      "type": "string",
+      "enum": ["SCIENCE_QUALITY", "NEAR_REAL_TIME", "OTHER"]
+    },
+    "CollectionProgressEnum": {
+      "description": "This element describes the production status of the data set. There are five choices for Data Providers: PLANNED refers to data sets to be collected in the future and are thus unavailable at the present time. For Example: The Hydro spacecraft has not been launched, but information on planned data sets may be available. ACTIVE refers to data sets currently in production or data that is continuously being collected or updated. For Example: data from the AIRS instrument on Aqua is being collected continuously. COMPLETE refers to data sets in which no updates or further data collection will be made. For Example: Nimbus-7 SMMR data collection has been completed. DEPRECATED refers to data sets that have been retired, but still can be retrieved. Usually newer products exist that replace the retired data set. NOT APPLICABLE refers to data sets in which a collection progress is not applicable such as a calibration collection. There is a sixth value of NOT PROVIDED that should not be used by a data provider. It is currently being used as a value when a correct translation cannot be done with the current valid values, or when the value is not provided by the data provider.",
+      "type": "string",
+      "enum": ["ACTIVE", "PLANNED", "COMPLETE", "DEPRECATED", "NOT APPLICABLE", "NOT PROVIDED"]
+    },
+    "LocationKeywordType": {
+      "description": "This element defines a mapping to the GCMD KMS hierarchical location list. It replaces SpatialKeywords. Each tier must have data in the tier above it.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Category":{
+          "description": "Top-level controlled keyword hierarchical level that contains the largest general location where the collection data was taken from.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+          },
+        "Type":{
+          "description": "Second-tier controlled keyword hierarchical level that contains the regional location where the collection data was taken from",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+          },
+        "Subregion1":{
+          "description": "Third-tier controlled keyword heirarchical level that contains the regional sub-location where the collection data was taken from",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Subregion2":{
+          "description": "Fourth-tier controlled keyword heirarchical level that contains the regional sub-location where the collection data was taken from",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "Subregion3":{
+          "description": "Fifth-tier controlled keyword heirarchical level that contains the regional sub-location where the collection data was taken from",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        },
+        "DetailedLocation":{
+          "description": "Uncontrolled keyword heirarchical level that contains the specific location where the collection data was taken from. Exists outside the heirarchy.",
+          "$ref": "umm-cmn-json-schema.json#/definitions/KeywordStringType"
+        }
+      },
+      "required": ["Category"]
+    },
+    "ArchiveDistributionFormatTypeEnum": {
+      "description": "Defines the possible values of wether or not the Archive or Distribution file format is a native or supported format.",
+      "type": "string",
+      "enum": ["Native", "Supported"]
+    },
+    "ArchiveDistributionFormatDescriptionType": {
+      "description": "Allows a data provider to provide supporting information about the stated format.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "ArchiveDistributionUnitEnum": {
+      "description": "Defines the possible values for the archive and distribution size units.",
+      "type": "string",
+      "enum": ["KB", "MB", "GB", "TB", "PB", "NA"]
+    },
+    "DistributionMediaType": {
+      "description": "This element defines the media by which the end user can obtain the distributable item. Examples of media include: CD-ROM, 9 track tape, diskettes, hard drives, online, transparencies, hardcopy, etc.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "FileArchiveInformationType": {
+      "description": "This element defines a single archive artifact which a data provider would like to inform an end user that it exists.",
+      "anyOf": [{
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Format": {
+            "description": "This element defines a single format for an archival artifact. Examples of format include: ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "FormatType": {
+            "description": "Allows the provider to state whether the archivable item's format is its native format or another supported format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatTypeEnum"
+          },
+          "FormatDescription": {
+            "description": "Allows the record provider to provide supporting documentation about the Format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatDescriptionType"
+          },
+          "AverageFileSize": {
+            "description": "An approximate average size of the archivable item. This gives an end user an idea of the magnitude for each archivable file if more than 1 exists.",
+            "type": "number"
+          },
+          "AverageFileSizeUnit": {
+            "description": "Unit of measure for the average file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "TotalCollectionFileSize": {
+            "description": "An approximate total size of all of the archivable items within a collection. This gives an end user an idea of the magnitude for all of archivable files combined.",
+            "type": "number"
+          },
+          "TotalCollectionFileSizeUnit": {
+            "description": "Unit of measure for the total collection file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "Description": {
+            "description": "Provides the data provider a way to convey more information about the archivable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "required": ["Format"],
+        "dependencies": {
+          "AverageFileSize": ["AverageFileSizeUnit"],
+          "TotalCollectionFileSize": ["TotalCollectionFileSizeUnit"]
+        }
+      }, {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Format": {
+            "description": "This element defines a single format for an archival artifact. Examples of format include: ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "FormatType": {
+            "description": "Allows the provider to state whether the archivable item's format is its native format or another supported format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatTypeEnum"
+          },
+          "FormatDescription": {
+            "description": "Allows the record provider to provide supporting documentation about the Format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatDescriptionType"
+          },
+          "AverageFileSize": {
+            "description": "An approximate average size of the archivable item. This gives an end user an idea of the magnitude for each archivable file if more than 1 exists.",
+            "type": "number"
+          },
+          "AverageFileSizeUnit": {
+            "description": "Unit of measure for the average file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "TotalCollectionFileSizeBeginDate": {
+            "description": "The date of which this collection started to collect data.  This date is used by users to be able to calculate the current total collection file size. The date needs to be in the yyyy-MM-ddTHH:mm:ssZ format; for example: 2018-01-01T10:00:00Z.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "Description": {
+            "description": "Provides the data provider a way to convey more information about the archivable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "required": ["Format"],
+        "dependencies": {
+          "AverageFileSize": ["AverageFileSizeUnit"],
+          "TotalCollectionFileSizeBeginDate": ["AverageFileSize"]
+        }
+      }]
+    },
+    "FileDistributionInformationType": {
+      "description": "This element defines a single artifact that is distributed by the data provider. This element only includes the distributable artifacts that can be obtained by the user without the user having to invoke a service. These should be documented in the UMM-S specification.",
+      "anyOf": [{
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Format": {
+            "description": "This element defines a single format for a distributable artifact. Examples of format include: ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "FormatType": {
+            "description": "Allows the provider to state whether the distributable item's format is its native format or another supported format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatTypeEnum"
+          },
+          "FormatDescription": {
+            "description": "Allows the record provider to provide supporting documentation about the Format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatDescriptionType"
+          },
+          "Media": {
+            "description": "This element defines the media by which the end user can obtain the distributable item. Each media type is listed separately. Examples of media include: CD-ROM, 9 track tape, diskettes, hard drives, online, transparencies, hardcopy, etc.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/DistributionMediaType"
+            },
+            "minItems": 1
+          },
+          "AverageFileSize": {
+            "description": "An approximate average size of the distributable item. This gives an end user an idea of the magnitude for each distributable file if more than 1 exists.",
+            "type": "number"
+          },
+          "AverageFileSizeUnit": {
+            "description": "Unit of measure for the average file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "TotalCollectionFileSize": {
+            "description": "An approximate total size of all of the distributable items within a collection. This gives an end user an idea of the magnitude for all of distributable files combined.",
+            "type": "number"
+          },
+          "TotalCollectionFileSizeUnit": {
+            "description": "Unit of measure for the total collection file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "Description": {
+            "description": "Provides the data provider a way to convey more information about the distributable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "Fees": {
+            "description": "Conveys the price one has to pay to obtain the distributable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        },
+        "required": ["Format"],
+        "dependencies": {
+          "AverageFileSize": ["AverageFileSizeUnit"],
+          "TotalCollectionFileSize": ["TotalCollectionFileSizeUnit"]
+        }
+      }, {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Format": {
+            "description": "This element defines a single format for a distributable artifact. Examples of format include: ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "FormatType": {
+            "description": "Allows the provider to state whether the distributable item's format is its native format or another supported format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatTypeEnum"
+          },
+          "FormatDescription": {
+            "description": "Allows the record provider to provide supporting documentation about the Format.",
+            "$ref": "#/definitions/ArchiveDistributionFormatDescriptionType"
+          },
+          "Media": {
+            "description": "This element defines the media by which the end user can obtain the distributable item. Each media type is listed separately. Examples of media include: CD-ROM, 9 track tape, diskettes, hard drives, online, transparencies, hardcopy, etc.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/DistributionMediaType"
+            },
+            "minItems": 1
+          },
+          "AverageFileSize": {
+            "description": "An approximate average size of the distributable item. This gives an end user an idea of the magnitude for each distributable file if more than 1 exists.",
+            "type": "number"
+          },
+          "AverageFileSizeUnit": {
+            "description": "Unit of measure for the average file size.",
+            "$ref": "#/definitions/ArchiveDistributionUnitEnum"
+          },
+          "TotalCollectionFileSizeBeginDate": {
+            "description": "The date of which this collection started to collect data.  This date is used by users to be able to calculate the current total collection file size. The date needs to be in the yyyy-MM-ddTHH:mm:ssZ format; for example: 2018-01-01T10:00:00Z.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "Description": {
+            "description": "Provides the data provider a way to convey more information about the distributable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "Fees": {
+            "description": "Conveys the price one has to pay to obtain the distributable item.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          }
+        },
+        "required": ["Format"],
+        "dependencies": {
+          "AverageFileSize": ["AverageFileSizeUnit"],
+          "TotalCollectionFileSizeBeginDate": ["AverageFileSize"]
+        }
+      }]
+    },
+    "ArchiveAndDistributionInformationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This element and all of its sub elements exist for display purposes. It allows a data provider to provide archive and distribution information up front to an end user, to help them decide if they can use the product.",
+      "properties": {
+        "FileArchiveInformation": {
+          "description": "This element defines a single archive artifact which a data provider would like to inform an end user that it exists.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FileArchiveInformationType"
+          },
+          "minItems": 1
+        },
+        "FileDistributionInformation": {
+          "description": "This element defines a single artifact that is distributed by the data provider. This element only includes the distributable artifacts that can be obtained by the user without the user having to invoke a service. These should be documented in the UMM-S specification.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FileDistributionInformationType"
+          },
+          "minItems": 1
+        }
+      },
+      "anyOf": [{
+        "required": ["FileArchiveInformation"]
+      }, {
+        "required": ["FileDistributionInformation"]
+      }]
+    }
+  }
+}

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-cmn-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-cmn-json-schema.json
@@ -1,0 +1,1241 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "LanguageType": {
+      "description": "Describes the language used in the preparation, storage, and description of the collection. It is the language of the collection data themselves.   It does not refer to the language used in the metadata record (although this may be the same language). The name of the language used for this field is defined in ISO 639.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 25
+    },
+    "DateType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Specifies the date and its type.",
+      "properties": {
+        "Date": {
+          "description": "This is the date that an event associated with the collection or its metadata occurred.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "Type": {
+          "description": "This is the type of event associated with the date.  For example, Creation, Last Revision.  Type is chosen from a picklist.",
+          "$ref": "#/definitions/LineageDateEnum"
+        }
+      },
+      "required": ["Date", "Type"]
+    },
+    "EntryIdType": {
+      "description": "This is the ID of the metadata record.  It is only unique when combined with the version.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "DataCenterType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines a data center which is either an organization or institution responsible for distributing, archiving, or processing the data, etc.",
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the data center.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataCenterRoleEnum"
+          },
+          "minItems": 1
+        },
+        "ShortName": {
+          "description": "This is the short name of the data center.",
+           "$ref": "#/definitions/DataCenterShortNameType"
+        },
+        "LongName": {
+          "description": "This is the long name of the data center.",
+           "$ref": "#/definitions/LongNameType"
+        },
+        "Uuid": {
+          "description": "Uuid of the data center.",
+          "$ref": "#/definitions/UuidType"
+        },
+        "ContactGroups": {
+          "description": "This is the contact groups of the data center.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContactGroupType"
+          }
+        },
+        "ContactPersons": {
+          "description": "This is the contact persons of the data center.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContactPersonType"
+          }
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the data center.",
+          "$ref": "#/definitions/ContactInformationType"
+        }
+      },
+      "required": ["Roles", "ShortName"]
+    },
+    "ContactGroupType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the data contact.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataContactRoleEnum"
+          },
+          "minItems": 1
+        },
+        "Uuid": {
+          "description": "Uuid of the data contact.",
+          "$ref": "#/definitions/UuidType"
+        },
+        "NonDataCenterAffiliation": {
+          "description": "This is the contact person or group that is not affiliated with the data centers.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the data contact.",
+          "$ref": "#/definitions/ContactInformationType"
+        },
+        "GroupName": {
+          "description": "This is the contact group name.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "required": ["Roles", "GroupName"]
+    },
+    "ContactPersonType": {
+      "type": "object",
+      "properties": {
+        "Roles": {
+          "description": "This is the roles of the data contact.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataContactRoleEnum"
+          },
+          "minItems": 1
+        },
+        "Uuid": {
+          "description": "Uuid of the data contact.",
+          "$ref": "#/definitions/UuidType"
+        },
+        "NonDataCenterAffiliation": {
+          "description": "This is the contact person or group that is not affiliated with the data centers.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInformation": {
+          "description": "This is the contact information of the data contact.",
+          "$ref": "#/definitions/ContactInformationType"
+        },
+        "FirstName": {
+          "description": "First name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "MiddleName": {
+          "description": "Middle name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "LastName": {
+          "description": "Last name of the individual.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "required": ["Roles", "LastName"]
+    },
+    "ContactInformationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines the contact information of a data center or data contact.",
+      "properties": {
+        "RelatedUrls": {
+          "description": "A URL associated with the contact, e.g., the home page for the DAAC which is responsible for the collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RelatedUrlType"
+          },
+          "minItems": 0
+        },
+        "ServiceHours": {
+          "description": "Time period when the contact answers questions or provides services.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ContactInstruction": {
+          "description": "Supplemental instructions on how or when to contact the responsible party.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "ContactMechanisms": {
+          "description": "Mechanisms of contacting.",
+          "type": "array",
+          "items": {
+             "$ref": "#/definitions/ContactMechanismType"
+          }
+        },
+         "Addresses": {
+          "description": "Contact addresses.",
+          "type": "array",
+          "items": {
+             "$ref": "#/definitions/AddressType"
+          }
+        }
+      }
+    },
+    "ContactMechanismType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Method for contacting the data contact. A contact can be available via phone, email, Facebook, or Twitter.",
+      "properties": {
+        "Type": {
+          "description": "This is the method type for contacting the responsible party - phone, email, Facebook, or Twitter.",
+          "$ref": "#/definitions/ContactMechanismTypeEnum"
+        },
+        "Value": {
+          "description": "This is the contact phone number, email address, Facebook address, or Twitter handle associated with the contact method.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        }
+      },
+      "required": ["Type", "Value"]
+    },
+    "AddressType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This entity contains the physical address details for the contact.",
+      "properties": {
+        "StreetAddresses": {
+          "description": "An address line for the street address, used for mailing or physical addresses of organizations or individuals who serve as contacts for the collection.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "minItems": 0
+        },
+        "City": {
+          "description": "The city portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "StateProvince": {
+          "description": "The state or province portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "Country": {
+          "description": "The country of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "PostalCode": {
+          "description": "The zip or other postal code portion of the physical address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20
+        }
+      }
+    },
+    "RelatedUrlType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents Internet sites that contain information related to the data, as well as related Internet sites such as project home pages, related data archives/servers, metadata extensions, online software packages, web mapping services, and calibration/validation data.",
+      "properties": {
+        "Description": {
+          "description": "Description of the web page at this URL.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "URLContentType": {
+            "description": "A keyword describing the distinct content type of the online resource to this resource. (e.g., 'DATACENTER URL', 'DATA CONTACT URL', 'DISTRIBUTION URL').",
+            "$ref": "#/definitions/RelatedURLContentTypeEnum"
+        },
+        "Type": {
+            "description": "A keyword describing the type of the online resource to this resource. This helps the GUI to know what to do with this resource. (e.g., 'GET DATA', 'GET SERVICE', 'GET VISUALIZATION').",
+            "$ref": "#/definitions/RelatedUrlTypeEnum"
+        },
+        "Subtype": {
+            "description": "A keyword describing the subtype of the online resource to this resource. This further helps the GUI to know what to do with this resource. (e.g., 'MEDIA', 'BROWSE', 'OPENDAP', 'OPENSEARCH', 'WEB COVERAGE SERVICES', 'WEB FEATURE SERVICES', 'WEB MAPPING SERVICES', 'SSW', 'ESI').",
+            "$ref": "#/definitions/RelatedURLSubTypeEnum"
+        },
+        "URL": {
+          "description": "The URL for the relevant web page (e.g., the URL of the responsible organization's home page, the URL of the collection landing page, the URL of the download site for the collection).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "GetData": {
+               "description": "The data distribution information for the relevant web page (e.g., browse, media).",
+               "$ref": "#/definitions/GetDataType"
+        },
+        "GetService": {
+            "description": "The service distribution for the relevant web page (e.g., OPeNDAP, OpenSearch, WCS, WFS, WMS).",
+            "$ref": "#/definitions/GetServiceType"
+        }
+      },
+      "required": ["URL", "URLContentType", "Type"]
+    },
+    "GetDataType": {
+        "description": "Represents the information needed for a DistributionURL where data is retrieved.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Format": {
+                "description": "The format of the data.",
+                "$ref": "#/definitions/GetDataTypeFormatEnum"
+            },
+            "MimeType": {
+                "description": "The mime type of the service.",
+                "$ref": "#/definitions/URLMimeTypeEnum"
+            },
+            "Size": {
+                "description": "The size of the data.",
+               "type": "number"
+            },
+            "Unit": {
+                "description": "Unit of information, together with Size determines total size in bytes of the data.",
+                "type": "string",
+                "enum": ["KB", "MB", "GB", "TB", "PB"]
+            },
+            "Fees": {
+                "description": "The fee for ordering the collection data.  The fee is entered as a number, in US Dollars.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "Checksum": {
+                "description": "The checksum, usually a SHA1 or md5 checksum for the data file.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 50
+            }
+        },
+        "required": ["Format", "Size", "Unit"]
+    },
+    "GetServiceType": {
+        "description": "Represents a Service through a URL where the service will act on data and return the result to the caller.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Format": {
+                "description": "The format of the data.",
+                "$ref": "#/definitions/GetDataTypeFormatEnum"
+            },
+            "MimeType": {
+                "description": "The mime type of the service.",
+                "$ref": "#/definitions/URLMimeTypeEnum"
+            },
+            "Protocol": {
+                "description": "The protocol of the service.",
+                "type": "string",
+                "enum": ["HTTP", "HTTPS", "FTP", "FTPS", "Not provided"]
+            },
+            "FullName": {
+                "description": "The full name of the service.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "DataID": {
+                "description": "The data identifier of the data provided by the service. Typically, this is a file name.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "DataType": {
+                "description": "The data type of the data provided by the service.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+            },
+            "URI": {
+                "description": "The URI of the data provided by the service.",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1024
+                },
+                "minItems": 1
+            }
+        },
+        "required": [ "MimeType", "Protocol", "FullName", "DataID", "DataType"]
+    },
+    "OnlineResourceType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Describes the online resource pertaining to the data.",
+      "properties": {
+        "Linkage": {
+          "description": "The URL of the website related to the online resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Protocol": {
+          "description": "The protocol of the linkage for the online resource, such as https, svn, ftp, etc.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ApplicationProfile": {
+          "description": "The application profile holds the name of the application that can service the data. For example if the URL points to a word document, then the applicationProfile is MS-Word.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Name": {
+          "description": "The name of the online resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Description": {
+          "description": "The description of the online resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Function": {
+          "description": "The function of the online resource. In ISO where this class originated the valid values are: download, information, offlineAccess, order, and search.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "MimeType": {
+          "description": "The mime type of the online resource.",
+          "$ref": "#/definitions/URLMimeTypeEnum"
+        }
+      },
+      "required": ["Linkage"]
+    },
+    "ResourceCitationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Building block text fields used to construct the recommended language for citing the collection in professional scientific literature.  The citation language constructed from these fields references the collection itself, and is not designed for listing bibliographic references of scientific research articles arising from search results. A list of references related to the research results should be in the Publication Reference element.",
+      "properties": {
+        "Version": {
+          "description": "The version of the collection.",
+          "$ref": "#/definitions/VersionType"
+        },
+        "Title": {
+          "description": "The title of the collection; this is the same as the collection Entry Title.",
+          "$ref": "#/definitions/TitleType"
+        },
+        "Creator": {
+          "description": "The name of the organization(s) or individual(s) with primary intellectual responsibility for the collection's development.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Editor": {
+          "description": "The individual(s) responsible for changing the data in the collection.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "SeriesName": {
+          "description": "The name of the data series, or aggregate data of which the data is a part.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "ReleaseDate": {
+          "description": "The date when the collection was made available for release.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "ReleasePlace": {
+          "description": "The name of the city (and state or province and country if needed) where the collection was made available for release.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Publisher": {
+          "description": "The name of the individual or organization that made the collection available for release.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "IssueIdentification": {
+          "description": "The volume or issue number of the publication (if applicable).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "DataPresentationForm": {
+          "description": "The mode in which the data are represented, e.g. atlas, image, profile, text, etc.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "OtherCitationDetails": {
+          "description": "Additional free-text citation information.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "OnlineResource": {
+          "description": "The URL of the landing page for the collection.",
+          "$ref": "#/definitions/OnlineResourceType"
+        }
+      }
+    },
+    "DoiType": {
+      "oneOf": [{
+        "type": "object",
+        "additionalProperties": false,
+        "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection. Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL. The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used. While this element is not required, NASA metadata providers are strongly encouraged to include DOI and DOI Authority for their collections. For those that want to specify that a DOI is not applicable for their record use the second option.",
+        "properties": {
+          "Authority": {
+            "description": "The DOI organization that is responsible for creating the DOI is described in the Authority element. For ESDIS records the value of https://doi.org/ should be used.",
+            "$ref": "#/definitions/AuthorityType"
+          },
+          "DOI": {
+            "description": "This element stores the DOI (Digital Object Identifier) that identifies the collection.  Note: The values should start with the directory indicator which in ESDIS' case is 10.  If the DOI was registered through ESDIS, the beginning of the string should be 10.5067. The DOI URL is not stored here; it should be stored as a RelatedURL.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "required": ["DOI"]
+      }, {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "This element stores the fact that the DOI (Digital Object Identifier) is not applicable.",
+        "properties": {
+          "MissingReason": {
+            "description": "This element stores the fact that a DOI (Digital Object Identifier) is not applicable for this record.",
+            "type": "string",
+            "enum": ["Not Applicable"]
+          },
+          "Explanation": {
+            "description": "This element describes the reason the DOI is not applicable.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "required": ["MissingReason"]
+      }]
+    },
+    "AccessConstraintsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about any constraints for accessing the data set. This includes any special restrictions, legal prerequisites, limitations and/or warnings on obtaining the data set.",
+      "properties": {
+        "Description": {
+          "description": "Free-text description of the constraint.  In DIF, this field is called Access_Constraint.   In ECHO, this field is called RestrictionComment.  Examples of text in this field are Public, In-house, Limited.  Additional detailed instructions on how to access the collection data may be entered in this field.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "Value": {
+          "description": "Numeric value that is used with Access Control Language (ACLs) to restrict access to this collection.  For example, a provider might specify a collection level ACL that hides all collections with a value element set to 15.   In ECHO, this field is called RestrictionFlag.  This field does not exist in DIF.",
+          "type": "number"
+        }
+      },
+      "required": ["Description"]
+    },
+    "MetadataAssociationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Used to identify other services, collections, visualizations, granules, and other metadata types and resources that are associated with or dependent on the this collection, including parent-child relationships.",
+      "properties": {
+        "Type": {
+          "description": "The type of association between this collection metadata record and the target metadata record.   Choose type from the drop-down list.",
+          "$ref": "#/definitions/MetadataAssociateTypeEnum"
+        },
+        "Description": {
+          "description": "Free-text description of the association between this collection record and the target metadata record.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        },
+        "EntryId": {
+          "description": "Shortname of the target metadata record that is associated with this collection record.",
+          "$ref": "#/definitions/EntryIdType"
+        },
+        "Version": {
+          "description": "The version of the target metadata record that is associated with this collection record.",
+          "$ref": "#/definitions/VersionType"
+        }
+      },
+      "required": ["EntryId"]
+    },
+    "PublicationReferenceType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Describes key bibliographic citations pertaining to the data.",
+      "properties": {
+        "OnlineResource": {
+          "description": "The URL of the website related to the bibliographic citation.",
+          "$ref": "#/definitions/OnlineResourceType"
+        },
+        "Title": {
+          "description": "The title of the publication in the bibliographic citation.",
+          "$ref": "#/definitions/TitleType"
+        },
+        "Publisher": {
+          "description": "The publisher of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "DOI": {
+          "description": "The Digital Object Identifier (DOI) of the publication.",
+          "$ref": "#/definitions/DoiType"
+        },
+        "Author": {
+          "description": "The author of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "PublicationDate": {
+          "description": "The date of the publication.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "Series": {
+          "description": "The name of the series of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Edition": {
+          "description": "The edition of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Volume": {
+          "description": "The publication volume number.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Issue": {
+          "description": "The issue of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ReportNumber": {
+          "description": "The report number of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "PublicationPlace": {
+          "description": "The pubication place of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "Pages": {
+          "description": "The publication pages that are relevant.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ISBN": {
+          "description": "The ISBN of the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 13
+        },
+        "OtherReferenceDetails": {
+          "description": "Additional free-text reference information about the publication.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4000
+        }
+      }
+    },
+   "ScienceKeywordType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Enables specification of Earth science keywords related to the collection.  The Earth Science keywords are chosen from a controlled keyword hierarchy maintained in the Keyword Management System (KMS).",
+      "properties": {
+        "Category": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "Topic": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "Term": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel1": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel2": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "VariableLevel3": {
+          "$ref": "#/definitions/KeywordStringType"
+        },
+        "DetailedVariable": {
+          "$ref": "#/definitions/KeywordStringType"
+        }
+      },
+      "required": ["Category", "Topic", "Term"]
+    },
+    "AdditionalAttributeType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Additional unique attributes of the collection, beyond those defined in the UMM model, which the data provider deems useful for end-user understanding of the data in the collection.  Additional attributes are also called Product Specific Attributes (PSAs) or non-core attributes.  Examples are HORIZONTALTILENUMBER, VERTICALTILENUMBER.",
+      "properties": {
+        "Name": {
+          "description": "The name (1 word description) of the additional attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Description": {
+          "description": "Free-text description of the additional attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "Value": {
+          "description": "Value of the additional attribute if it is the same for all granules across the collection.  If the value of the additional attribute may differ by granule, leave this collection-level value blank.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "DataType": {
+          "description": "Data type of the values of the additional attribute.",
+          "$ref": "#/definitions/DataTypeEnum"
+        },
+        "MeasurementResolution": {
+          "description": "The smallest unit increment to which the additional attribute value is measured.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ParameterRangeBegin": {
+          "description": "The minimum value of the additional attribute over the whole collection.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ParameterRangeEnd": {
+          "description": "The maximum value of the additional attribute over the whole collection.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ParameterUnitsOfMeasure": {
+          "description": "The standard unit of measurement for the additional attribute.  For example, meters, hertz.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ParameterValueAccuracy": {
+          "description": "An estimate of the accuracy of the values of the additional attribute. For example, for AVHRR: Measurement error or precision-measurement error or precision of a data product parameter. This can be specified in percent or the unit with which the parameter is measured.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ValueAccuracyExplanation": {
+          "description": "Describes the method used for determining the parameter value accuracy that is given for this additional attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "Group": {
+          "description": "Identifies a namespace for the additional attribute name.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "UpdateDate": {
+          "description": "The date this additional attribute information was updated.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": ["Name", "DataType", "Description"]
+    },
+    "PlatformType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Describes the relevant platforms used to acquire the data in the collection. Platform type vocabulary is controlled and includes Spacecraft, Aircraft, Vessel, Buoy, Platform, Station, Network, Human, etc.",
+      "properties": {
+        "Type": {
+          "description": "The most relevant platform type.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "ShortName": {
+          "$ref": "#/definitions/PlatformShortNameType"
+        },
+        "LongName": {
+          "$ref": "#/definitions/PlatformLongNameType"
+        },
+        "Characteristics": {
+          "description": "Platform-specific characteristics, e.g., Equator Crossing Time, Inclination Angle, Orbital Period. The characteristic names must be unique on this platform; however the names do not have to be unique across platforms.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CharacteristicType"
+          },
+          "minItems": 0
+        },
+        "Instruments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstrumentType"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["ShortName"]
+    },
+    "CharacteristicType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This entity is used to define characteristics.",
+      "properties": {
+        "Name": {
+          "description": "The name of the characteristic attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Description": {
+          "description": "Description of the Characteristic attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "Value": {
+          "description": "The value of the Characteristic attribute.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "Unit": {
+          "description": "Units associated with the Characteristic attribute value.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20
+        },
+        "DataType": {
+          "description": "The datatype of the Characteristic/attribute.",
+          "$ref": "#/definitions/DataTypeEnum"
+        }
+      },
+      "required": ["Name", "Description", "DataType", "Unit", "Value"]
+    },
+    "InstrumentType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about the device used to measure or record data in this collection, including direct human observation. In cases where instruments have a single child instrument or the instrument and child instrument are used synonymously (e.g. AVHRR), both Instrument and ComposedOf should be recorded. The child instrument information is represented in a separate section.",
+      "properties": {
+        "ShortName": {
+          "$ref": "#/definitions/PlatformShortNameType"
+        },
+        "LongName": {
+          "$ref": "#/definitions/PlatformLongNameType"
+        },
+        "Characteristics": {
+          "description": "Instrument-specific characteristics, e.g., Wavelength, SwathWidth, Field of View. The characteristic names must be unique on this instrument; however the names do not have to be unique across instruments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CharacteristicType"
+          },
+          "minItems": 0
+        },
+        "Technique": {
+          "description": "The expanded name of the primary sensory instrument. (e.g. Advanced Spaceborne Thermal Emission and Reflective Radiometer, Clouds and the Earth's Radiant Energy System, Human Observation).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "NumberOfInstruments": {
+          "description": "Number of instruments used on the instrument when acquiring the granule data.",
+          "type": "integer"
+        },
+        "ComposedOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstrumentChildType"
+          },
+          "minItems": 0
+        },
+        "OperationalModes": {
+          "description": "The operation mode applied on the instrument when acquiring the granule data.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20
+          },
+          "minItems": 0
+        }
+      },
+      "required": ["ShortName"]
+    },
+    "InstrumentChildType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Child object on an instrument. Has all the same fields as instrument, minus the list of child instruments.",
+      "properties": {
+        "ShortName": {
+          "$ref": "#/definitions/PlatformShortNameType"
+        },
+        "LongName": {
+          "$ref": "#/definitions/PlatformLongNameType"
+        },
+        "Characteristics": {
+          "description": "Instrument-specific characteristics, e.g., Wavelength, SwathWidth, Field of View. The characteristic names must be unique on this instrument; however the names do not have to be unique across instruments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CharacteristicType"
+          },
+          "minItems": 0
+        },
+        "Technique": {
+          "description": "The expanded name of the primary sensory instrument. (e.g. Advanced Spaceborne Thermal Emission and Reflective Radiometer, Clouds and the Earth's Radiant Energy System, Human Observation).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        }
+      },
+      "required": ["ShortName"]
+    },
+    "ProjectType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information describing the scientific endeavor(s) with which the collection is associated. Scientific endeavors include campaigns, projects, interdisciplinary science investigations, missions, field experiments, etc.",
+      "properties": {
+        "ShortName": {
+          "description": "The unique identifier by which a project or campaign/experiment is known. The campain/project is the scientific endeavor associated with the acquisition of the collection. Collections may be associated with multiple campaigns.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "LongName": {
+          "description": "The expanded name of the campaign/experiment (e.g. Global climate observing system).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 300
+        },
+        "Campaigns": {
+          "description": "The name of the campaign/experiment (e.g. Global climate observing system).",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "minItems": 0
+        },
+        "StartDate": {
+          "description": "The starting date of the campaign.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "EndDate": {
+          "description": "The ending data of the campaign.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": ["ShortName"]
+    },
+    "TemporalExtentType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information which describes the temporal range or extent of a specific collection.",
+      "properties": {
+        "PrecisionOfSeconds": {
+          "description": "The precision (position in number of places to right of decimal point) of seconds used in measurement.",
+          "type": "integer"
+        },
+        "EndsAtPresentFlag": {
+          "description": "Setting the Ends At Present Flag to 'True' indicates that a data collection which covers, temporally, a discontinuous range, currently ends at the present date.  Setting the Ends at Present flag to 'True' eliminates the need to continuously update the Range Ending Time for collections where granules are continuously being added to the collection inventory.",
+          "type": "boolean"
+        },
+        "RangeDateTimes": {
+          "description": "Stores the start and end date/time of a collection.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RangeDateTimeType"
+          },
+          "minItems": 1
+        },
+        "SingleDateTimes": {
+          "type": "array",
+          "items": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "PeriodicDateTimes": {
+          "description": "Temporal information about a collection having granules collected at a regularly occurring period.   Information includes the start and end dates of the period, duration unit and value, and cycle duration unit and value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PeriodicDateTimeType"
+          },
+          "minItems": 1
+        }
+      },
+      "oneOf": [{
+        "required": ["RangeDateTimes"]
+      }, {
+        "required": ["SingleDateTimes"]
+      }, {
+        "required": ["PeriodicDateTimes"]
+      }]
+    },
+    "RangeDateTimeType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Stores the start and end date/time of a collection.",
+      "properties": {
+        "BeginningDateTime": {
+          "description": "The time when the temporal coverage period being described began.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "EndingDateTime": {
+          "description": "The time when the temporal coverage period being described ended.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": ["BeginningDateTime"]
+    },
+    "PeriodicDateTimeType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Information about Periodic Date Time collections, including the name of the temporal period in addition to the start and end dates, duration unit and value, and cycle duration unit and value.",
+      "properties": {
+        "Name": {
+          "description": "The name given to the recurring time period. e.g. 'spring - north hemi.'",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "StartDate": {
+          "description": "The date (day and time) of the first occurrence of this regularly occurring period which is relevant to the collection coverage.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "EndDate": {
+          "description": "The date (day and time) of the end occurrence of this regularly occurring period which is relevant to the collection coverage.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "DurationUnit": {
+          "description": "The unit specification for the period duration.",
+          "$ref": "#/definitions/DurationUnitEnum"
+        },
+        "DurationValue": {
+          "description": "The number of PeriodDurationUnits in the RegularPeriodic period. e.g. the RegularPeriodic event 'Spring-North Hemi' might have a PeriodDurationUnit='MONTH' PeriodDurationValue='3' PeriodCycleDurationUnit='YEAR' PeriodCycleDurationValue='1' indicating that Spring-North Hemi lasts for 3 months and has a cycle duration of 1 year. The unit for the attribute is the value of the attribute PeriodDurationValue.",
+          "type": "integer"
+        },
+        "PeriodCycleDurationUnit": {
+          "description": "The unit specification of the period cycle duration.",
+          "$ref": "#/definitions/DurationUnitEnum"
+        },
+        "PeriodCycleDurationValue": {
+          "type": "integer"
+        }
+      },
+      "required": ["Name", "StartDate", "EndDate", "DurationUnit", "DurationValue", "PeriodCycleDurationUnit", "PeriodCycleDurationValue"]
+    },
+    "UuidType": {
+      "description": "A Level 3 UUID, see wiki link http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29",
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89abAB][0-9a-f]{3}-[0-9a-f]{12}"
+    },
+    "LineageDateEnum": {
+      "description": "The name of supported lineage date types",
+      "type": "string",
+      "enum": ["CREATE", "UPDATE", "DELETE", "REVIEW"]
+    },
+    "VersionType": {
+      "description": "The version of the metadata record.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "VersionDescriptionType": {
+      "description": "Free-text description of the version of the resource such as a Collection.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "AuthorityType": {
+      "description": "The Authority (who created it or owns it) of a unique identifier.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "EntryTitleType": {
+      "description": "The title of the data described by the metadata.",
+      "$ref": "#/definitions/TitleType"
+    },
+    "TitleType": {
+      "description": "A title type that defines the min and max lengths of all titles.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1030
+    },
+    "AbstractType": {
+      "description": "A brief description of the collection. This allows potential users to determine if the collection is useful for their needs.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40000
+    },
+    "PurposeType": {
+      "description": "Describes the purpose and/or intended use of data in this collection.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10000
+    },
+    "DataCenterRoleEnum": {
+      "description": "Defines the possible values of a data center role.",
+      "type": "string",
+      "enum": ["ARCHIVER", "DISTRIBUTOR", "PROCESSOR", "ORIGINATOR"]
+    },
+    "DataContactRoleEnum": {
+      "description": "Defines the possible values of a data contact role.",
+      "type": "string",
+      "enum": ["Data Center Contact", "Technical Contact", "Science Contact", "Investigator", "Metadata Author", "User Services", "Science Software Development"]
+    },
+    "ContactMechanismTypeEnum": {
+      "description": "Defines the possible contact mechanism types.",
+      "type": "string",
+      "enum": ["Direct Line", "Email", "Facebook", "Fax", "Mobile", "Modem", "Primary", "TDD/TTY Phone", "Telephone", "Twitter", "U.S. toll free", "Other"]
+    },
+    "ShortNameType": {
+      "description": "The unique name.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 85
+    },
+    "DataCenterShortNameType": {
+      "description": "The unique name of the data center.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 85,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,84}"
+    },
+    "PlatformShortNameType": {
+      "description": "The unique name of the platform.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,79}"
+    },
+    "LongNameType": {
+      "description": "The expanded or long name related to the short name.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "PlatformLongNameType": {
+      "description": "The expanded or long name related to the short name of the platform.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{0,1023}"
+    },
+    "QualityType": {
+      "description": "Free-text information about the quality of the data in the collection or any quality assurance procedures followed in producing the data described in the metadata. Suggestions for information to include in the Quality field: Description should be succinct. Include indicators of data quality or quality flags. Include recognized or potential problems with quality. Established quality control mechanisms should be included. Established quantitative quality measurements should be included.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 12000
+    },
+    "MetadataAssociateTypeEnum": {
+      "description": "The set of supported values for MetadataAssociationType.Type.",
+      "type": "string",
+      "enum": ["SCIENCE ASSOCIATED", "DEPENDENT", "INPUT", "PARENT", "CHILD", "RELATED", "LARGER CITATION WORKS"]
+    },
+    "KeywordStringType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,79}"
+    },
+    "AncillaryKeywordStringType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "[\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=,][\\w\\-&'()\\[\\]/.\"#$%\\^@!*+=, ]{1,254}"
+    },
+    "DataTypeEnum": {
+      "description": "This entity contains the additional attribute data types.",
+      "type": "string",
+      "enum": ["STRING", "FLOAT", "INT", "BOOLEAN", "DATE", "TIME", "DATETIME", "DATE_STRING", "TIME_STRING", "DATETIME_STRING"]
+    },
+    "DurationUnitEnum": {
+      "type": "string",
+      "enum": ["DAY", "MONTH", "YEAR"]
+    },
+    "RelatedURLContentTypeEnum": {
+      "type": "string",
+      "enum": ["CollectionURL", "PublicationURL", "DataCenterURL", "DistributionURL", "DataContactURL", "VisualizationURL"]
+    },
+    "RelatedUrlTypeEnum": {
+      "type": "string",
+      "enum": ["DATA SET LANDING PAGE", "DOWNLOAD SOFTWARE", "EXTENDED METADATA", "GET DATA", "GET RELATED VISUALIZATION",
+               "GOTO WEB TOOL", "PROFESSIONAL HOME PAGE", "PROJECT HOME PAGE", "USE SERVICE API", "VIEW RELATED INFORMATION", "HOME PAGE"]
+    },
+    "RelatedURLSubTypeEnum": {
+      "type": "string",
+      "enum": ["MOBILE APP", "APPEEARS", "DATA COLLECTION BUNDLE", "DATA TREE", "DATACAST URL", "DIRECT DOWNLOAD", "EOSDIS DATA POOL",
+               "Earthdata Search", "GIOVANNI", "GoLIVE Portal", "IceBridge Portal", "LAADS", "LANCE", "MIRADOR", "MODAPS", "NOAA CLASS", "NOMADS",
+               "Order", "PORTAL", "Subscribe", "USGS EARTH EXPLORER", "VERTEX", "VIRTUAL COLLECTION", "MAP", "WORLDVIEW", "LIVE ACCESS SERVER (LAS)",
+               "MAP VIEWER", "SIMPLE SUBSET WIZARD (SSW)", "SUBSETTER", "GRADS DATA SERVER (GDS)", "MAP SERVICE", "OPENDAP DATA", "OpenSearch",
+               "SERVICE CHAINING", "TABULAR DATA STREAM (TDS)", "THREDDS DATA", "WEB COVERAGE SERVICE (WCS)", "WEB FEATURE SERVICE (WFS)",
+               "WEB MAP SERVICE (WMS)", "WEB MAP TILE SERVICE (WMTS)", "ALGORITHM DOCUMENTATION", "ALGORITHM THEORETICAL BASIS DOCUMENT (ATBD)",
+               "ANOMALIES", "CASE STUDY", "DATA CITATION POLICY", "DATA QUALITY", "DATA RECIPE", "DELIVERABLES CHECKLIST", "GENERAL DOCUMENTATION",
+               "HOW-TO", "IMPORTANT NOTICE", "INSTRUMENT/SENSOR CALIBRATION DOCUMENTATION", "MICRO ARTICLE", "PI DOCUMENTATION",
+               "PROCESSING HISTORY", "PRODUCT HISTORY", "PRODUCT QUALITY ASSESSMENT", "PRODUCT USAGE", "PRODUCTION HISTORY", "PUBLICATIONS",
+               "READ-ME", "REQUIREMENTS AND DESIGN", "SCIENCE DATA PRODUCT SOFTWARE DOCUMENTATION", "SCIENCE DATA PRODUCT VALIDATION",
+               "USER FEEDBACK PAGE", "USER'S GUIDE"]
+    },
+    "URLMimeTypeEnum": {
+      "type": "string",
+      "enum": ["application/json", "application/xml", "application/x-netcdf", "application/gml+xml",
+               "application/vnd.google-earth.kml+xml", "image/gif", "image/tiff", "image/bmp", "text/csv",
+               "text/xml", "application/pdf", "application/x-hdf", "application/xhdf5",
+               "application/octet-stream", "application/vnd.google-earth.kmz", "image/jpeg", "image/png",
+               "image/vnd.collada+xml", "text/html", "text/plain", "Not provided"]
+    },
+    "GetDataTypeFormatEnum": {
+      "type": "string",
+      "enum": ["ascii", "binary", "GRIB", "BUFR", "HDF4", "HDF5", "HDF-EOS4", "HDF-EOS5", "jpeg", "png", "tiff", "geotiff", "kml", "Not provided"]
+    }
+  }
+}

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-search-results-json-schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-c-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "granule-count": {
+          "description": "A number >= 0 that indicates the number of granules for the collection.",
+          "type": "number"
+        },
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["collection"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "user-id": {
+          "description": "The id of the user who created this item revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "deleted": {
+          "description": "Indicates if the item represents a tombstone",
+          "type": "boolean"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        },
+        "has-variables": {
+          "description": "Indicates if there are variables associated with the collection",
+          "type": "boolean"
+        },
+        "has-formats": {
+          "description": "Indicates if there are multiple supported formats for any services associated with the collection",
+          "type": "boolean"
+        },
+        "has-transforms": {
+          "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
+          "type": "boolean"
+        },
+        "has-spatial-subsetting": {
+          "description": "Indicates if any associated services support spatial subsetting",
+          "type": "boolean"
+        },
+        "has-temporal-subsetting": {
+          "description": "Indicates if any associated services support temporal subsetting",
+          "type": "boolean"
+        },
+        "associations": {
+          "description": "Contains variables and services associated with the collection",
+          "$ref": "#/definitions/AssociationsType"
+        }
+      },
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date"]
+    },
+    "AssociationsType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Variables and Services associated with the collection.",
+      "properties": {
+        "variables": {
+          "description": "The concept ids of variables assciated with the collection",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConceptIdType"
+          },
+          "minItems": 0
+        },
+        "services": {
+          "description": "The concept ids of services assciated with the collection",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConceptIdType"
+          },
+          "minItems": 0
+        }
+      }
+    },
+    "ConceptIdType": {
+      "description": "The concept id of a concept.",
+      "type": "string",
+      "minLength": 4,
+      "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+    }
+  },
+  "title": "UMM Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/collection.clj
@@ -75,6 +75,13 @@
      (dissoc :ComposedOf)
      (dissoc :NumberOfInstruments)))
 
+(defn- remove-format-descriptions
+  "Remove FormatDescription from the passed in file information maps.
+   This is for 1.15.3 -> 1.15.2 in :ArchiveAndDistributionInformation :FileArchiveInformation and
+   :FileDistributionInformation."
+  [file-informations]
+  (map #(dissoc % :FormatDescription) file-informations))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Collection Migration Implementations
 
@@ -304,3 +311,15 @@
 (defmethod interface/migrate-umm-version [:collection "1.15.2" "1.15.1"]
   [context c & _]
   (spatial-extent/migrate-down-to-1_15_1 c))
+
+(defmethod interface/migrate-umm-version [:collection "1.15.2" "1.15.3"]
+  [context c & _]
+  ;; Don't need to migrate anyting - FormatDescription was added to FileArchiveInformation
+  ;; and FileDistributionInformation.]
+  c)
+
+(defmethod interface/migrate-umm-version [:collection "1.15.3" "1.15.2"]
+  [context c & _]
+  (-> c
+      (update-in [:ArchiveAndDistributionInformation :FileArchiveInformation] remove-format-descriptions)
+      (update-in [:ArchiveAndDistributionInformation :FileDistributionInformation] remove-format-descriptions)))

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_collection_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_collection_models.clj
@@ -367,6 +367,9 @@
    ;; yyyy-MM-ddTHH:mm:ssZ format; for example: 2018-01-01T10:00:00Z.
    TotalCollectionFileSizeBeginDate
 
+   ;; Allows the record provider to provide supporting documentation about the Format.
+   FormatDescription
+
    ;; Unit of measure for the total collection file size.
    TotalCollectionFileSizeUnit
 
@@ -676,10 +679,6 @@
 ;; user that it exists.
 (defrecord FileArchiveInformationType
   [
-   ;; This element defines a single format for an archival artifact. Examples of format include:
-   ;; ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.
-   Format
-
    ;; Allows the provider to state whether the archivable item's format is its native format or
    ;; another supported format.
    FormatType
@@ -688,12 +687,21 @@
    ;; magnitude for each archivable file if more than 1 exists.
    AverageFileSize
 
-   ;; Unit of measure for the average file size.
-   AverageFileSizeUnit
+   ;; This element defines a single format for an archival artifact. Examples of format include:
+   ;; ascii, binary, GRIB, BUFR, HDF4, HDF5, HDF-EOS4, HDF-EOS5, jpeg, png, tiff, geotiff, kml.
+   Format
 
    ;; An approximate total size of all of the archivable items within a collection. This gives an
    ;; end user an idea of the magnitude for all of archivable files combined.
    TotalCollectionFileSize
+
+   ;; The date of which this collection started to collect data. This date is used by users to be
+   ;; able to calculate the current total collection file size. The date needs to be in the
+   ;; yyyy-MM-ddTHH:mm:ssZ format; for example: 2018-01-01T10:00:00Z.
+   TotalCollectionFileSizeBeginDate
+
+   ;; Allows the record provider to provide supporting documentation about the Format.
+   FormatDescription
 
    ;; Unit of measure for the total collection file size.
    TotalCollectionFileSizeUnit
@@ -701,10 +709,8 @@
    ;; Provides the data provider a way to convey more information about the archivable item.
    Description
 
-   ;; The date of which this collection started to collect data. This date is used by users to be
-   ;; able to calculate the current total collection file size. The date needs to be in the
-   ;; yyyy-MM-ddTHH:mm:ssZ format; for example: 2018-01-01T10:00:00Z.
-   TotalCollectionFileSizeBeginDate
+   ;; Unit of measure for the average file size.
+   AverageFileSizeUnit
   ])
 (record-pretty-printer/enable-record-pretty-printing FileArchiveInformationType)
 

--- a/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/dif10_expected_conversion.clj
@@ -339,7 +339,7 @@
 (defn- expected-file-dist-info
   "Created expected FileDistributionInformation for ArchiveAndDistributionInformation map."
   [file-dist-infos]
-  (when-let [file-dist-infos (mapcat conversion-util/expand-file-dist-infos file-dist-infos)]
+  (when file-dist-infos
     (for [file-dist-info file-dist-infos]
       (-> file-dist-info
           (select-keys [:Fees :Format :FormatType

--- a/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/echo10_expected_conversion.clj
@@ -42,7 +42,7 @@
    In ECHO 10 there is only 1 price (fees) but there can be many data formats. The first fee
    applies to all data formats."
   [file-dist-infos]
-  (when-let [file-dist-infos (seq (mapcat conversion-util/expand-file-dist-infos file-dist-infos))]
+  (when file-dist-infos
    (let [price (find-first-available-distribution-price file-dist-infos)]
     (for [file-dist-info file-dist-infos]
       (-> file-dist-info

--- a/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/expected_conversion_util.clj
@@ -12,8 +12,7 @@
   [cmr.umm-spec.models.umm-common-models :as cmn]
   [cmr.umm-spec.test.location-keywords-helper :as lkt]
   [cmr.umm-spec.url :as url]
-  [cmr.umm-spec.util :as su]
-  [cmr.umm-spec.xml-to-umm-mappings.distributed-format-util :as format-util]))
+  [cmr.umm-spec.util :as su]))
 
 (def coll-progress-enum-list
   "The enum list for CollectionProgress in v1.10. that could be converted from
@@ -223,12 +222,3 @@
                  (update pr :OnlineResource dif-online-resource)
                  pr))
       check-nil-pub-ref))
-
-(defn expand-file-dist-infos
-  "Parse each format to see if the format contains multiple values. If it does
-   then replace the distribution info that exists and add new ones for each
-   multple format that exists."
-  [file-dist-info]
-  (let [formats (:Format file-dist-info)
-        parsed-format (format-util/parse-distribution-formats formats)]
-    (map #(assoc file-dist-info :Format %) parsed-format)))

--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
@@ -130,6 +130,7 @@
       (-> file-dist-info
           (dissoc :TotalCollectionFileSizeBeginDate)
           (update :Media expected-dist-media)
+          (update :FormatDescription expected-file-archive-description)
           umm-c/map->FileDistributionInformationType))))
 
 (defn- expected-file-archive-info
@@ -140,6 +141,7 @@
       (-> file-archive-info
           (dissoc :TotalCollectionFileSizeBeginDate)
           (update :Description expected-file-archive-description)
+          (update :FormatDescription expected-file-archive-description)
           umm-c/map->FileArchiveInformationType))))
 
 (defn expected-archive-dist-info

--- a/umm-spec-lib/src/cmr/umm_spec/versioning.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/versioning.clj
@@ -10,7 +10,7 @@
   "A map of concept type to a sequence of valid UMM Schema versions, with the newest one last.
   The sequence must be updated when new schema versions are added for the concept type."
   {:collection ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6" "1.7" "1.8" "1.9" "1.10" "1.11" "1.12"
-                "1.13" "1.14" "1.15" "1.15.1" "1.15.2"]
+                "1.13" "1.14" "1.15" "1.15.1" "1.15.2" "1.15.3"]
    :granule ["1.4" "1.5" "1.6" "1.6.1"]
    :variable ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6"]
    :service ["1.0" "1.1" "1.2" "1.3" "1.3.1"]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/dif10.clj
@@ -20,7 +20,6 @@
    [cmr.umm-spec.xml-to-umm-mappings.dif10.paleo-temporal :as pt]
    [cmr.umm-spec.xml-to-umm-mappings.dif10.related-url :as ru]
    [cmr.umm-spec.xml-to-umm-mappings.dif10.spatial :as spatial]
-   [cmr.umm-spec.xml-to-umm-mappings.distributed-format-util :as format-util]
    [cmr.umm-spec.xml-to-umm-mappings.get-umm-element :as get-umm-element]
    [cmr.umm.dif.date-util :refer [parse-dif-end-date]]))
 
@@ -198,28 +197,6 @@
         :OnlineResource (when-let [linkage (value-of data-set-citation "Online_Resource")]
                           {:Linkage linkage})}))))
 
-(defn- add-distribution-infos
-  "This function creates a distribution information map."
-  [media size unit fees format]
-  {:Media media
-   :AverageFileSize size
-   :AverageFileSizeUnit unit
-   :Format format
-   :Fees fees
-   :FormatType "Native"})
-
-(defn- add-dist-info-for-multi-formats
-  "This method takes the value of a format and parses it into multiple formats
-   if the metadata includes multiple formats. Then this function creates new
-   distribution information maps for each format."
-  [media size unit formats fees]
-  (when (or media size unit formats fees)
-    (let [distributions
-          (map
-               #(add-distribution-infos media size unit fees %)
-               (format-util/parse-distribution-formats formats))]
-      (seq distributions))))
-
 (defn- parse-archive-dist-info
   "Parses ArchiveAndDistributionInformation out of DIF XML into UMM-C"
   [doc]
@@ -231,12 +208,17 @@
                     media (value-of distribution "Distribution_Media")
                     media (when media
                             [media])
-                    formats (value-of distribution "Distribution_Format")
+                    format (value-of distribution "Distribution_Format")
                     fees (value-of distribution "Fees")]]
-          (when (or fees formats Size Unit)
-             (add-dist-info-for-multi-formats media Size Unit formats fees)))]
+          (when (or fees format Size Unit)
+            {:Media media
+             :AverageFileSize Size
+             :AverageFileSizeUnit Unit
+             :Format format
+             :Fees fees
+             :FormatType "Native"}))]
     (when (seq distributions)
-      {:FileDistributionInformation (flatten distributions)})))
+      {:FileDistributionInformation distributions})))
 
 (defn parse-dif10-xml
   "Returns collection map from DIF10 collection XML document."

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -12,7 +12,6 @@
    [cmr.umm-spec.spatial-conversion :as spatial-conversion]
    [cmr.umm-spec.util :as u]
    [cmr.umm-spec.xml-to-umm-mappings.characteristics-data-type-normalization :as char-data-type-normalization]
-   [cmr.umm-spec.xml-to-umm-mappings.distributed-format-util :as format-util]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.data-contact :as dc]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.related-url :as ru]
    [cmr.umm-spec.xml-to-umm-mappings.echo10.spatial :as spatial]
@@ -185,15 +184,8 @@
   [price format]
   (util/remove-nil-keys
     {:Fees price
-     :Format format
+     :Format (value-of format ".")
      :FormatType "Native"}))
-
-(defn add-data-formats
-  "This function parses out the multiple formats that can exist in the
-   ECHO 10 DataFormat element and puts them in their own UMM-C
-   FileDistributionInformation elements."
-  [price formats]
-  (map #(add-data-format price %) (format-util/parse-distribution-formats (value-of formats "."))))
 
 (defn parse-and-set-archive-dist-info
   "Parses price and data formats out of Echo 10 XML into UMM-C. The price
@@ -206,7 +198,7 @@
       [{:Fees price
         :Format u/not-provided
         :FormatType "Native"}]
-      (mapcat #(add-data-formats price %) (select doc "Collection/DataFormat")))))
+      (map #(add-data-format price %) formats))))
 
 (defn parse-archive-dist-info
   "Parses ArchiveAndDistributionInformation out of Echo 10 XML into UMM-C"

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/shared_iso_parsing_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_shared/shared_iso_parsing_util.clj
@@ -26,23 +26,22 @@
   create the map. The function that creates it should pass back the following:
   (re-pattern \"key:|key:|key<etc.>\")"
   [description-string description-regex]
-  (let [description-string (-> description-string
-                               (string/replace description-regex
-                                            #(str key-split-string
-                                                  %1
-                                                  value-split-string))
-                               string/trim
-                               (string/replace #"\s+HSTRING" key-split-string)
-                               (string/replace #":TSTRING\s+" (str ":" value-split-string)))
-        description-string-list (string/split description-string (re-pattern key-split-string))]
-    (->> description-string-list
-         ;; split each string in the description-str-list
-         (map #(string/split % #":TSTRING"))
-         ;; keep the ones with values.
-         (filter #(= 2 (count %)))
-         (into {})
-         ;; remove "nil" valued keys
-         (util/remove-map-keys #(= "nil" %)))))
+  (when-let [description-string (-> description-string
+                                    (string/replace description-regex
+                                                    #(str key-split-string
+                                                          %1
+                                                          value-split-string))
+                                    string/trim
+                                    (string/replace #"\s+HSTRING" key-split-string)
+                                    (string/replace #":TSTRING\s+" (str ":" value-split-string)))]
+      (->> (string/split description-string (re-pattern key-split-string))
+           ;; split each string in the description-str-list
+           (map #(string/split % #":TSTRING"))
+           ;; keep the ones with values.
+           (filter #(= 2 (count %)))
+           (into {})
+           ;; remove "nil" valued keys
+           (util/remove-map-keys #(= "nil" %)))))
 
 (defn convert-key-strings-to-keywords
   "This function converts strings that are keys to keywords.

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/collection.clj
@@ -2359,3 +2359,38 @@
                             :HorizontalResolutionProcessingLevelEnum]
                            "Point"))
              result)))))
+
+(def sample-collection-1-15-3
+  {:ArchiveAndDistributionInformation
+    {:FileArchiveInformation
+      [{:Format "Binary"
+        :FormatType "Native"
+        :FormatDescription "Use the something app to open the binary file."}
+       {:Format "netCDF-4"
+        :FormatType "Supported"
+        :FormatDescription "An acsii file also exists."}]
+     :FileDistributionInformation
+       [{:Format "netCDF-4"
+         :FormatType "Supported"
+         :FormatDescription "An acsii file also exists."}
+        {:Format "netCDF-5"
+         :FormatType "Supported"
+         :FormatDescription "An acsii file also exists."}]}})
+
+(deftest migrate-1-15-3-to-1-15-2
+  "Test the migration of collections from 1.15.3 to 1.15.2."
+
+  (testing "Remove FormatDescription"
+    (let [result (vm/migrate-umm {} :collection "1.15.3" "1.15.2" sample-collection-1-15-3)]
+      (is (= {:ArchiveAndDistributionInformation
+               {:FileArchiveInformation
+                 [{:Format "Binary"
+                   :FormatType "Native"}
+                  {:Format "netCDF-4"
+                   :FormatType "Supported"}]
+                :FileDistributionInformation
+                 [{:Format "netCDF-4"
+                   :FormatType "Supported"}
+                  {:Format "netCDF-5"
+                   :FormatType "Supported"}]}}
+             result)))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/echo10.clj
@@ -53,44 +53,24 @@
 
   (let [base-record (slurp (io/resource "example-data/echo10/artificial_test_data.xml"))
         expected-single-dataformat-without-price {:FileDistributionInformation [{:FormatType "Native",
-                                                                                 :Format "XLS"}
-                                                                                {:FormatType "Native",
-                                                                                 :Format "PDF"}
-                                                                                {:FormatType "Native",
-                                                                                 :Format "PNG"}]}
+                                                                                 :Format "XLS, PDF, PNG"}]}
         actual-single-dataformat-without-price (-> base-record
                                                    (string/replace #"<Price>0</Price>" "")
                                                    (string/replace #"<DataFormat>HTML</DataFormat>" ""))
         expected-multi-dataformat-without-price {:FileDistributionInformation [{:FormatType "Native",
-                                                                                :Format "XLS"}
-                                                                               {:FormatType "Native",
-                                                                                :Format "PDF"}
-                                                                               {:FormatType "Native",
-                                                                                :Format "PNG"}
+                                                                                :Format "XLS, PDF, PNG"}
                                                                                {:FormatType "Native",
                                                                                 :Format "HTML"}]}
         actual-multi-dataformat-without-price (-> base-record
                                                   (string/replace #"<Price>0</Price>" ""))
         expected-single-dataformat-with-price {:FileDistributionInformation [{:FormatType "Native",
                                                                               :Fees "0",
-                                                                              :Format "XLS"}
-                                                                             {:FormatType "Native",
-                                                                              :Fees "0",
-                                                                              :Format "PDF"}
-                                                                             {:FormatType "Native",
-                                                                              :Fees "0",
-                                                                              :Format "PNG"}]}
+                                                                              :Format "XLS, PDF, PNG"}]}
         actual-single-dataformat-with-price (-> base-record
                                                 (string/replace #"<DataFormat>HTML</DataFormat>" ""))
         expected-multi-dataformat-with-price {:FileDistributionInformation [{:FormatType "Native",
                                                                              :Fees "0",
-                                                                             :Format "XLS"}
-                                                                            {:FormatType "Native",
-                                                                             :Fees "0",
-                                                                             :Format "PDF"}
-                                                                            {:FormatType "Native",
-                                                                             :Fees "0",
-                                                                             :Format "PNG"}
+                                                                             :Format "XLS, PDF, PNG"}
                                                                             {:FormatType "Native",
                                                                              :Fees "0",
                                                                              :Format "HTML"}]}

--- a/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso_shared/archive_and_dist_info.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso_shared/archive_and_dist_info.clj
@@ -1,0 +1,61 @@
+(ns cmr.umm-spec.test.xml-to-umm-mappings.iso-shared.archive-and-dist-info
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [cmr.common.util :refer [are3]]
+   [cmr.umm-spec.xml-to-umm-mappings.iso-shared.archive-and-dist-info :as arch-dist-info]
+   [cmr.umm-spec.xml-to-umm-mappings.iso19115-2 :as iso]))
+
+(deftest parse-archive-info-test
+  "Test the archive information parsing."
+  (are3 [expected archive]
+    (is (= expected
+           (arch-dist-info/parse-archive-info archive iso/archive-info-xpath)))
+
+    "ISO MENDS Collection Description string"
+    '({:FormatType "Supported"
+       :AverageFileSize nil
+       :Format "Binary"
+       :TotalCollectionFileSize nil
+       :FormatDescription "ABC Binary"
+       :TotalCollectionFileSizeUnit nil
+       :Description nil
+       :AverageFileSizeUnit nil})
+    (slurp (io/file (io/resource "example-data/iso19115/artificial_test_data.xml")))
+
+    "Test with empty map"
+    '()
+    {}
+
+    "Test with nil input"
+    '()
+    nil))
+
+(deftest parse-dist-info-test
+  "Test the distribution information parsing."
+  (are3 [expected dist]
+    (is (= expected
+           (arch-dist-info/parse-dist-info dist iso/dist-info-xpath)))
+
+    "ISO MENDS Collection Description string"
+    '({:FormatType "Supported"
+       :FormatDescription "some more notes",
+       :AverageFileSize 100,
+       :Fees
+       "\nDigital data may be downloaded from NCEI at no charge in most cases. For custom orders of digital data or to obtain a copy of analog materials, please contact NCEI Information Services for information about current fees.\n",
+       :Format "NetCDF-4",
+       :TotalCollectionFileSize 1000,
+       :TotalCollectionFileSizeUnit "GB",
+       :Description
+       "\nData may be searched and downloaded using online services provided by NCEI using the online resource URLs in this record. Contact NCEI Information Services for custom orders. When requesting data from NCEI, the desired data set may be referred to by the unique package identification number listed in this metadata record.\n",
+       :AverageFileSizeUnit "MB",
+       :Media ["onLine"]})
+    (slurp (io/file (io/resource "example-data/iso19115/artificial_test_data.xml")))
+
+    "Test with empty map"
+    nil
+    {}
+
+    "Test with nil input"
+    nil
+    nil))


### PR DESCRIPTION
Logic for autocomplete ported to ES 7 style. Reverting to use original edge_ngram analyzer instead of search_as_you_type due to scoring changes. 

Scoring has still changed somewhat but it closer to original than the initial implementation.

Removed `na` from anti-value list as sodium may be shortened to its elemental symbol.