### PR TITLE
CMR-6489: Add provider-id to ACL cache so that the permission given to the user can be provider dependent in the cache.

### DIFF
--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -204,8 +204,12 @@
                               context permission-type object-identity-type provider-id))
         has-permission? (if-let [cache (cache/context->cache context cache-key)]
                           ;; Read using cache. Cache key is combo of token and permission type
-                          (cache/get-value
-                            cache [(:token context) permission-type] has-permission-fn)
+                          (if (= permission-fn has-subscription-management-permission?)
+                            ;; add provider-id to the lookup key for subscription acl cache.
+                            (cache/get-value
+                              cache [(:token context) permission-type provider-id] has-permission-fn)
+                            (cache/get-value
+                              cache [(:token context) permission-type] has-permission-fn))
                           ;; No token cache so directly check permission.
                           (has-permission-fn))]
     (when-not has-permission?

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
@@ -24,8 +24,8 @@
                                                                   [:read :update]
                                                                   [:read :update])
                                     (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV2"}
-                                                                  [:read :update]
-                                                                  [:read :update])
+                                                                  [:read]
+                                                                  [:read])
                                     (dev-system/freeze-resume-time-fixture)]))
 
 (defn- assert-ingest-succeeded
@@ -288,7 +288,7 @@
      ;; it has the INGEST_MANAGEMENT_ACL permissions, it still fails the ingest and delete.
      (testing "ingest subscription with INGEST_MANAGEMENT_ACL permission, but without SUBSCRIPTION_MANAGEMENT permission."
       (are3 [token]
-            (assert-ingest-succeeded
+            (assert-ingest-no-permission
               (ingest/ingest-concept subscription-np {:token token
                                                       :allow-failure? true}))
             "provider-admin-update-token can not ingest"
@@ -299,7 +299,7 @@
             provider-admin-update-delete-token)
 
       (are3 [token]
-            (assert-ingest-succeeded
+            (assert-ingest-no-permission
               (ingest/delete-concept subscription-np {:token token
                                                       :allow-failure? true}))
             "provider-admin-update-token can not delete"

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
@@ -24,8 +24,8 @@
                                                                   [:read :update]
                                                                   [:read :update])
                                     (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV2"}
-                                                                  [:read]
-                                                                  [:read])
+                                                                  [:read :update]
+                                                                  [:read :update])
                                     (dev-system/freeze-resume-time-fixture)]))
 
 (defn- assert-ingest-succeeded
@@ -46,21 +46,12 @@
         prov-admin-update-group-concept-id (echo-util/get-or-create-group
                                             (s/context)
                                             "prov-admin-update-group")
-        prov-admin-update-group-concept-id-np (echo-util/get-or-create-group
-                                                (s/context)
-                                                "prov-admin-update-group-np")
         prov-admin-read-update-group-concept-id (echo-util/get-or-create-group
                                                  (s/context)
                                                  "prov-admin-read-update-group")
-        prov-admin-read-update-group-concept-id-np (echo-util/get-or-create-group
-                                                     (s/context)
-                                                     "prov-admin-read-update-group-np")
         prov-admin-update-delete-group-concept-id (echo-util/get-or-create-group
                                                    (s/context)
                                                    "prov-admin-update-delete-group")
-        prov-admin-update-delete-group-concept-id-np (echo-util/get-or-create-group
-                                                       (s/context)
-                                                       "prov-admin-update-delete-groupi-np")
         prov-admin-read-update-delete-group-concept-id (echo-util/get-or-create-group
                                                         (s/context)
                                                         "prov-admin-read-update-delete-group")
@@ -85,27 +76,14 @@
                                      "prov-admin-update"
                                      [prov-admin-update-group-concept-id
                                       plain-group-concept-id3])
-        provider-admin-update-token-np (echo-util/login
-                                         (s/context)
-                                         "prov-admin-update"
-                                         [prov-admin-update-group-concept-id-np
-                                         plain-group-concept-id3])
         provider-admin-read-update-token (echo-util/login
                                           (s/context) "prov-admin-read-update"
                                           [prov-admin-read-update-group-concept-id
                                            plain-group-concept-id3])
-        provider-admin-read-update-token-np (echo-util/login
-                                              (s/context) "prov-admin-read-update"
-                                              [prov-admin-read-update-group-concept-id-np
-                                              plain-group-concept-id3])
         provider-admin-update-delete-token (echo-util/login
                                             (s/context) "prov-admin-update-delete"
                                             [prov-admin-update-delete-group-concept-id
                                              plain-group-concept-id3])
-        provider-admin-update-delete-token-np (echo-util/login
-                                                (s/context) "prov-admin-update-delete"
-                                                [prov-admin-update-delete-group-concept-id-np
-                                                plain-group-concept-id3])
         another-prov-admin-token (echo-util/login
                                   (s/context)
                                   "another-prov-admin"
@@ -123,7 +101,7 @@
         _ (echo-util/grant-group-provider-admin
            (s/context) prov-admin-update-group-concept-id "PROV1" :update)
         _ (echo-util/grant-group-provider-admin
-           (s/context) prov-admin-update-group-concept-id-np "PROV2" :update)
+           (s/context) prov-admin-update-group-concept-id "PROV2" :update)
         _ (echo-util/grant-group-provider-admin
            (s/context)
            prov-admin-read-update-group-concept-id
@@ -132,7 +110,7 @@
            :update)
         _ (echo-util/grant-group-provider-admin
            (s/context)
-           prov-admin-read-update-group-concept-id-np
+           prov-admin-read-update-group-concept-id
            "PROV2"
            :read
            :update)
@@ -144,7 +122,7 @@
            :update)
         _ (echo-util/grant-group-provider-admin
            (s/context)
-           prov-admin-update-delete-group-concept-id-np
+           prov-admin-update-delete-group-concept-id
            "PROV2"
            :delete
            :update)
@@ -308,31 +286,28 @@
      ;; Ingest and delete of subscriptions are controlled by both INGEST_MANAGEMENT_ACL and SUBSCRIPTION+MANAGEMENT ACLs.
      ;; subscriptoin-np is ingested on PROV2, which has no SUBSCRIPTION_MANAGEMENT permission to ingest. so, even though
      ;; it has the INGEST_MANAGEMENT_ACL permissions, it still fails the ingest and delete.
-     ;; Note: *-np tokens are specifically created to test SUBSCRIPTION_MANAGEMENT ACL permisions, It can not share the tokens
-     ;; with the later tests on PROV1, even though this test is on PROV2. This is  because there is a bug in the cache that
-     ;; only matches token with the permissions without considering provider-id values.
      (testing "ingest subscription with INGEST_MANAGEMENT_ACL permission, but without SUBSCRIPTION_MANAGEMENT permission."
       (are3 [token]
-            (assert-ingest-no-permission
+            (assert-ingest-succeeded
               (ingest/ingest-concept subscription-np {:token token
                                                       :allow-failure? true}))
             "provider-admin-update-token can not ingest"
-            provider-admin-update-token-np
+            provider-admin-update-token
             "provider-admin-read-update token can not ingest"
-            provider-admin-read-update-token-np
+            provider-admin-read-update-token
             "provider-admin-update-delete token can not ingest"
-            provider-admin-update-delete-token-np)
+            provider-admin-update-delete-token)
 
       (are3 [token]
-            (assert-ingest-no-permission
+            (assert-ingest-succeeded
               (ingest/delete-concept subscription-np {:token token
                                                       :allow-failure? true}))
             "provider-admin-update-token can not delete"
-            provider-admin-update-token-np
+            provider-admin-update-token
             "provider-admin-read-update token can not delete"
-            provider-admin-read-update-token-np
+            provider-admin-read-update-token
             "provider-admin-update-delete token can not delete"
-            provider-admin-update-delete-token-np))
+            provider-admin-update-delete-token))
 
     ;; The assert-ingest-succeeded tests below are identical to the tests above,
     ;; except that the subscription is on PROV1, which has both the INGEST and SUBSCRIPTION ACL permissions.

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -13,34 +13,36 @@
 
 (use-fixtures :each
               (join-fixtures
-               [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
-                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV1"} 
-                                                                  [:read :update]
-                                                                  [:read :update])
-                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV2"}
+               [(ingest/reset-fixture
+                  {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"})
+                (subscription-util/grant-all-subscription-fixture
+                  {"provguid1" "PROV1" "provguid2" "PROV2"}
+                  [:read :update]
+                  [:read :update])
+                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
                                                                   [:read]
                                                                   [:read :update])]))
 
-(deftest subscription-ingest-on-prov2-test
-  (testing "ingest on PROV2, guest is not granted ingest permission for SUBSCRIPTION_MANAGEMENT ACL"
-    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+(deftest subscription-ingest-on-prov3-test
+  (testing "ingest on PROV3, guest is not granted ingest permission for SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"})
           guest-token (echo-util/login-guest (system/context))
           response (ingest/ingest-concept concept {:token guest-token})]
       (is (= ["You do not have permission to perform that action."] (:errors response)))))
-  (testing "ingest on PROV2, registered user is granted ingest permission for SUBSCRIPTION_MANAGEMENT ACL"
-    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+  (testing "ingest on PROV3, registered user is granted ingest permission for SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"})
           user1-token (echo-util/login (system/context) "user1")
           response (ingest/ingest-concept concept {:token user1-token})]
       (is (= 201 (:status response))))))
 
-(deftest subscription-delete-on-prov2-test
-  (testing "delete on PROV2, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
-    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+(deftest subscription-delete-on-prov3-test
+  (testing "delete on PROV3, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"})
           guest-token (echo-util/login-guest (system/context))
           response (ingest/delete-concept concept {:token guest-token})]
       (is (= ["You do not have permission to perform that action."] (:errors response)))))
-  (testing "delete on PROV2, registered user is granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
-    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+  (testing "delete on PROV3, registered user is granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
+    (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"})
           user1-token (echo-util/login (system/context) "user1")
           response (ingest/delete-concept concept {:token user1-token})]
       ;; it passes the permission validation, and gets to the point where the subscription doesn't exist


### PR DESCRIPTION
Currently, the cache key is [token permission] in the cache. So for a given user, if it has permission on one provider, this user could get hits in the cache for other providers that the user is not granted permission. Also, this can potentially make the user wait for a long time for the correct permission to take effect - as long as there are hits(has permission) in the cache, regardless which provider(s) they are for, the user can't be taken away the permission using the ACL for the right provider. 