### PR TITLE
CMR-6532

### DIFF
--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -357,12 +357,13 @@
   ([concept-type params options]
    (let [response (get-search-failure-data
                    (find-concepts-in-format mime-types/json concept-type params options))
-         {:keys [status body]} response
+         {:keys [status headers body]} response
          {:keys [echo-compatible include-facets]} params]
      (if (and echo-compatible include-facets)
        (dj/parse-echo-json-result body)
        (if (= status 200)
          {:status status
+          :hits (Integer/parseInt (get headers "CMR-Hits"))
           :results (dj/parse-json-result concept-type body)}
          response)))))
 


### PR DESCRIPTION
Fixed `CMR-hits` header to match the actual result items returned when items returned is less than the full page size.