### PR TITLE
CMR-6507 Update lein yagni plugin so that it will work in CMR to identify unused code

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -87,8 +87,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -104,7 +103,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -30,8 +30,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -42,7 +41,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -60,8 +60,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -78,7 +77,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/cmr-exchange/api-versioning/project.clj
+++ b/cmr-exchange/api-versioning/project.clj
@@ -61,8 +61,7 @@
                     :plugins [[jonase/eastwood "0.3.1"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.6"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -92,7 +91,6 @@
                           ["check-vers"]]
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
                     ;["eastwood"]

--- a/cmr-exchange/cmr-client/project.clj
+++ b/cmr-exchange/cmr-client/project.clj
@@ -42,8 +42,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              :cljs {:source-paths ^:replace ["src/cljs" "src/cljc"]}
              :docs {:dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
                     :plugins [[lein-codox "0.10.3"]

--- a/cmr-exchange/dev-env-manager/project.clj
+++ b/cmr-exchange/dev-env-manager/project.clj
@@ -75,8 +75,7 @@
              :test {:plugins [[lein-ancient "0.6.14"]
                               [jonase/eastwood "0.2.5"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              :lint {:source-paths ^:replace ["src"]}
              :docs {:dependencies [[clojang/codox-theme "0.2.0-SNAPSHOT"]]
                     :plugins [[lein-codox "0.10.3"]

--- a/cmr-exchange/exchange-query/project.clj
+++ b/cmr-exchange/exchange-query/project.clj
@@ -59,8 +59,7 @@
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.7"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -89,7 +88,6 @@
                           ["check-vers"]]
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
                     ;["eastwood"]

--- a/cmr-exchange/graph/project.clj
+++ b/cmr-exchange/graph/project.clj
@@ -56,8 +56,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.0"]]

--- a/cmr-exchange/jar-plugin-lib/project.clj
+++ b/cmr-exchange/jar-plugin-lib/project.clj
@@ -53,8 +53,7 @@
                     :plugins [[jonase/eastwood "0.3.3"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.6"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -85,7 +84,6 @@
             ;; Lintint
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
             ;["eastwood"]

--- a/cmr-exchange/metadata-proxy/project.clj
+++ b/cmr-exchange/metadata-proxy/project.clj
@@ -74,8 +74,7 @@
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.2"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.7"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -131,7 +130,6 @@
                           ["check-vers"]]
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
                     ;["eastwood"]

--- a/cmr-exchange/mission-control/project.clj
+++ b/cmr-exchange/mission-control/project.clj
@@ -35,8 +35,7 @@
                     :plugins [[jonase/eastwood "0.3.3"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.6"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:plugins [[lein-ltest "0.3.0"]]}}
   :aliases {
             ;; Dev & Testing Aliases

--- a/cmr-exchange/nlp/project.clj
+++ b/cmr-exchange/nlp/project.clj
@@ -63,8 +63,7 @@
                     :plugins [[jonase/eastwood "0.3.4"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.7"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -101,7 +100,6 @@
                           ["check-vers"]]
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
                     ;["eastwood"]

--- a/cmr-exchange/ous-plugin/project.clj
+++ b/cmr-exchange/ous-plugin/project.clj
@@ -74,8 +74,7 @@
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.2"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.7"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]
                               [test2junit "1.4.2"]]
@@ -106,7 +105,6 @@
                           ["check-vers"]]
             "kibit" ["with-profile" "+lint" "kibit"]
             "eastwood" ["with-profile" "+lint" "eastwood" "{:namespaces [:source-paths]}"]
-            "yagni" ["with-profile" "+lint" "yagni"]
             "lint" ["do"
                     ["kibit"]]
                     ;["eastwood"]

--- a/cmr-exchange/ses-plugin/project.clj
+++ b/cmr-exchange/ses-plugin/project.clj
@@ -62,8 +62,7 @@
                     :plugins [[jonase/eastwood "0.3.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.2"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.7"]]}
+                              [lein-kibit "0.1.6"]]}
              :test {:dependencies [[clojusc/ltest "0.3.0"]]
                     :plugins [[lein-ltest "0.3.0"]]
                     :test-selectors {:unit #(not (or (:integration %) (:system %)))

--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -59,8 +59,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -82,7 +81,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -39,8 +39,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -51,7 +50,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -82,8 +82,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -94,7 +93,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -126,8 +126,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -150,8 +149,6 @@
             ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed"
             ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni"
-            ["with-profile" "lint" "yagni"]
             "check-deps"
             ["with-profile" "lint" "ancient" ":all"]
             "check-sec"

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -39,8 +39,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -51,7 +50,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -71,8 +71,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -102,7 +101,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -42,8 +42,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -57,7 +56,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -66,8 +66,7 @@
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
                               [lein-kibit "0.1.6"]
-                              [lein-shell "0.5.0"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-shell "0.5.0"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -95,7 +94,6 @@
                            "src/cmr/ingest/services"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -58,8 +58,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -75,8 +74,6 @@
             ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed"
             ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni"
-            ["with-profile" "lint" "yagni"]
             "check-deps"
             ["with-profile" "lint" "ancient" ":all"]
             "check-sec"

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -64,8 +64,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -82,7 +81,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -41,8 +41,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -53,7 +52,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/oracle-lib/project.clj
+++ b/oracle-lib/project.clj
@@ -44,8 +44,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -60,7 +59,6 @@
             "eastwood" ["with-profile" "lint" "eastwood"
                         "{:namespaces [:source-paths] :exclude-namespaces [cmr.oracle.connection]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/orbits-lib/project.clj
+++ b/orbits-lib/project.clj
@@ -1,5 +1,5 @@
 (def jruby-version
-  "The version of JRuby to use. This is the same as used in the collection renderer 
+  "The version of JRuby to use. This is the same as used in the collection renderer
    java package to prevent classpath issues"
   "9.2.6.0")
 
@@ -41,8 +41,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -58,7 +57,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -42,8 +42,7 @@
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
                               [lein-kibit "0.1.6"]
-                              [lein-shell "0.5.0"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-shell "0.5.0"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -65,5 +64,4 @@
                           ["with-profile" "lint" "kibit"]]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]
             ;; Alias to test2junit for consistency with lein-test-out
-            "test-out" ["test2junit"]
-            "yagni" ["with-profile" "lint" "yagni"]})
+            "test-out" ["test2junit"]})

--- a/schema-validation-lib/project.clj
+++ b/schema-validation-lib/project.clj
@@ -33,8 +33,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -45,7 +44,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -88,8 +88,7 @@
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
                               [lein-kibit "0.1.6"]
-                              [lein-shell "0.5.0"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-shell "0.5.0"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -104,7 +103,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]})

--- a/search-relevancy-test/project.clj
+++ b/search-relevancy-test/project.clj
@@ -56,8 +56,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -68,7 +67,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/spatial-lib/project.clj
+++ b/spatial-lib/project.clj
@@ -49,8 +49,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -61,7 +60,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -74,8 +74,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -86,7 +85,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -39,8 +39,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -51,7 +50,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/umm-lib/project.clj
+++ b/umm-lib/project.clj
@@ -48,8 +48,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -60,7 +59,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/umm-spec-lib/project.clj
+++ b/umm-spec-lib/project.clj
@@ -52,8 +52,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -65,7 +64,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -42,8 +42,7 @@
                     :plugins [[jonase/eastwood "0.2.5"]
                               [lein-ancient "0.6.15"]
                               [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]
-                              [venantius/yagni "0.1.4"]]}
+                              [lein-kibit "0.1.6"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}}
@@ -56,7 +55,6 @@
                           ["with-profile" "lint" "kibit"]]
             "eastwood" ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
             "bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
-            "yagni" ["with-profile" "lint" "yagni"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]
             "lint" ["do" ["check"] ["kibit"] ["eastwood"]]


### PR DESCRIPTION
After a lot of troubleshooting I was unable to get yagni to produce useful output. At best it would produce a long list of functions/vars that would purport to be unreferenced, but upon checking manually I would find that not to be true.  At worst it would throw an exception. For the vars that it claimed were referenceless, sometimes the references would exist outside the app in question, sometimes within the app, but in my checking I couldn't find a non-false positive.  We've decided to simply remove this utility instead of keeping it around, as it wasn't being used in any case.