### PR TITLE
CMR-6642

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
@@ -43,7 +43,7 @@
    :concepts [:short-name]
    :iso-topic-categories [:iso-topic-category]
    :related-urls [:type :subtype]
-   :granule-data-format [:granuledataformat :uuid]})
+   :granule-data-format [:short-name :uuid]})
 
 (def FIELD_NOT_PRESENT
   "A string to indicate that a field is not present within a KMS keyword."

--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -179,15 +179,12 @@
 (defmethod lookup-by-umm-c-keyword :granule-data-format
   [kms-index keyword-scheme umm-c-keyword]
   (let [comparison-map (normalize-for-lookup
-                          (csk-extras/transform-keys csk/->kebab-case umm-c-keyword)
-                          (kms-scheme->fields-for-umm-c-lookup keyword-scheme))]
-    (as-> kms-index index
-          (get index keyword-scheme)
-          (map #(set/rename-keys % {:granuledataformat :format}) index)
-          (filter #(= (str/lower-case (:format %))
-                      (str/lower-case (:format comparison-map)))
-                  index)
-          (seq index))))
+                         (csk-extras/transform-keys csk/->kebab-case umm-c-keyword)
+                         (kms-scheme->fields-for-umm-c-lookup keyword-scheme))]
+    (->> (get kms-index keyword-scheme)
+         (filter #(= (str/lower-case (:short-name %))
+                     (str/lower-case (:format comparison-map))))
+         seq)))
 
 (defmethod lookup-by-umm-c-keyword :platforms
   [kms-index keyword-scheme umm-c-keyword]

--- a/dev-system/resources/kms_examples/granuledataformat
+++ b/dev-system/resources/kms_examples/granuledataformat
@@ -1,6 +1,6 @@
-"Keyword Version: draft","Revision: 2019-11-01 11:34:56","Timestamp: 2019-11-05 12:52:55","Terms Of Use: http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: https://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/GranuleDataFormat/?format=xml""Case native"
-granuledataformat,UUID
-"HDF","a0664fe4-ac04-4de7-91ba-ecbccfc0807f"
-"JPEG","7972d59f-0d8d-4332-9a2d-d538d90976ba"
-"Value3","45e4f52a-80ae-4ef3-882f-c2849eb4e18a"
-"hdf","c5796028-6835-49f9-be6c-cf26f363623b"
+"Keyword Version: 9.1.5","Revision: 2020-08-10 07:37:58","Timestamp: 2020-08-10 08:35:54","Terms Of Use: http://gcmd.nasa.gov/r/l/TermsOfUse","The most up to date XML representations can be found here: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/granuledataformat/?format=xml""Case native"
+Short_Name,Long_Name,UUID
+"HDF5","Hierarchical Data Format Version 5","1c406abc-104d-4517-96b8-dbbcf515f00f"
+"JPEG","Joint Photographic Experts Group Format","7443bb2d-1dbb-44d1-bd29-0241d30fbc57"
+"CSV","Comma-Separated Values File","465809cc-e76c-4630-8594-bb8bd7a1a380"
+"HDF4","Hierarchical Data Format Version 4","e5c126f8-0435-4cef-880f-72a1d2d792f2"

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
@@ -86,7 +86,6 @@
                         :errors [(str "Format [8-track tape] was not a valid keyword.")]}]}
              response)))
 
-
   (are3 [attribs]
         (assert-valid-keywords attribs)
 
@@ -97,7 +96,7 @@
                :AverageFileSize 50
                :AverageFileSizeUnit "MB"
                :Fees "None currently"
-               :Format "HDF"}]}}
+               :Format "HDF5"}]}}
 
         "Valid Case Insensitive"
         {:ArchiveAndDistributionInformation
@@ -106,7 +105,7 @@
              :AverageFileSize 50
              :AverageFileSizeUnit "MB"
              :Fees "None currently"
-             :Format "hdf"}]}}
+             :Format "hdf5"}]}}
 
         "Valid Case Sensitive"
         {:ArchiveAndDistributionInformation

--- a/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
@@ -414,19 +414,23 @@
                              [{"value" "ANGOLA",
                                "uuid"
                                "9b0a194d-d617-4fed-9625-df176319892d"}]}]}]}]}
-   :granule-data-format {"granuledataformat"
-                          [{"value" "JPEG", "uuid"
-                            [{"value" "7972d59f-0d8d-4332-9a2d-d538d90976ba",
-                              "uuid" "7972d59f-0d8d-4332-9a2d-d538d90976ba"}]}
-                           {"value" "Value3", "uuid"
-                            [{"value" "45e4f52a-80ae-4ef3-882f-c2849eb4e18a",
-                              "uuid" "45e4f52a-80ae-4ef3-882f-c2849eb4e18a"}]}
-                           {"value" "HDF", "uuid"
-                            [{"value" "a0664fe4-ac04-4de7-91ba-ecbccfc0807f",
-                              "uuid" "a0664fe4-ac04-4de7-91ba-ecbccfc0807f"}]}
-                           {"value" "hdf", "uuid"
-                            [{"value" "c5796028-6835-49f9-be6c-cf26f363623b",
-                              "uuid" "c5796028-6835-49f9-be6c-cf26f363623b"}]}]}})
+   :granule-data-format {"short_name"
+                         [{"value" "HDF5",
+                           "uuid"
+                           [{"value" "1c406abc-104d-4517-96b8-dbbcf515f00f",
+                             "uuid" "1c406abc-104d-4517-96b8-dbbcf515f00f"}]}
+                          {"value" "CSV",
+                           "uuid"
+                           [{"value" "465809cc-e76c-4630-8594-bb8bd7a1a380",
+                             "uuid" "465809cc-e76c-4630-8594-bb8bd7a1a380"}]}
+                          {"value" "HDF4",
+                           "uuid"
+                           [{"value" "e5c126f8-0435-4cef-880f-72a1d2d792f2",
+                             "uuid" "e5c126f8-0435-4cef-880f-72a1d2d792f2"}]}
+                          {"value" "JPEG",
+                           "uuid"
+                           [{"value" "7443bb2d-1dbb-44d1-bd29-0241d30fbc57",
+                             "uuid" "7443bb2d-1dbb-44d1-bd29-0241d30fbc57"}]}]}})
 
 
 (deftest get-keywords-test

--- a/transmit-lib/src/cmr/transmit/kms.clj
+++ b/transmit-lib/src/cmr/transmit/kms.clj
@@ -68,7 +68,7 @@
    :concepts [:short-name :long-name :uuid]
    :iso-topic-categories [:iso-topic-category :uuid]
    :related-urls [:type :subtype :uuid]
-   :granule-data-format [:granuledataformat :uuid]})
+   :granule-data-format [:short-name :long-name :uuid]})
 
 (def keyword-scheme->expected-field-names
   "Maps each keyword scheme to the expected field names to be returned by KMS. We changed


### PR DESCRIPTION
Updated CMR to work with the new KMS granuledataformat format. This is to make sure KMS keywords can be cached in CMR on the new services cluster.

While working on this ticket, I noticed the CMR cache caches granule data format UUID unnecessarily and the search `keywords/granule-data-format` endpoint result is not very meaningful. I filed CMR-6644 to get these sorted out.