### PR TITLE
CMR-6597 Added feature to ingest association at variable ingest.

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -436,6 +436,8 @@ Granule metadata can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPOINT
 A new variable ingest endpoint is provided to ensure that variable association is created at variable ingest time.
 Variable concept can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/collections/<collection-concept-id>/<collection-revision-id>/variables/<native-id>`.  `<collection-revision-id>` is optional. The response will include the [concept id](#concept-id),[revision id](#revision-id), variable-association and associated-item.
 
+Note: There is no more fingerprint check at variable's ingest/update time because the existing fingerprint is obsolete. The new variable uniqueness is defined by variable name and the collection it's associated with and is checked at variable association creation time.
+
 ```
 curl -i -XPUT \
 -H "Content-type: application/vnd.nasa.cmr.umm+json" \

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -457,13 +457,19 @@ curl -i -XPUT \
 #### Successful Response in XML
 
 ```
-<?xml version="1.0" encoding="UTF-8"?>
-<result>
-  <concept-id>V1200000012-PROV1</concept-id>
-  <revision-id>1</revision-id>
-  <variable-association>{:concept-id "VA1200000007-CMR", :revision-id 1}</variable-association>
-  <associated-item>{:concept-id "C1200000005-PROV1", :revision-id 1}</associated-item> 
+<?xml version="1.0" encoding="UTF-8"?><result>
+    <concept-id>V1200000006-PROV1</concept-id>
+    <revision-id>1</revision-id>
+    <variable-association>
+        <concept-id>VA1200000007-CMR</concept-id>
+        <revision-id>1</revision-id>
+    </variable-association>
+    <associated-item>
+        <concept-id>C1200000005-PROV1</concept-id>
+        <revision-id>1</revision-id>
+    </associated-item>
 </result>
+
 ```
 
 #### Successful Response in JSON
@@ -472,7 +478,19 @@ By passing the option `-H "Accept: application/json"` to `curl`, one may
 get a JSON response:
 
 ```
-{"concept-id":"V1200000012-PROV1","revision-id":1,"variable-association":{"concept-id":"VA1200000007-CMR","revision-id":1},"associated-item":{"concept-id":"C1200000005-PROV1","revision-id":1}}
+{
+  "concept-id" : "V1200000006-PROV1",
+  "revision-id" : 1,
+  "variable-association" : {
+    "concept-id" : "VA1200000007-CMR",
+    "revision-id" : 1 
+  },
+  "associated-item" : {
+    "concept-id" : "C1200000005-PROV1",
+    "revision-id" : 1
+  }
+}
+
 ```
 
 Variable metadata can continue to be updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -324,6 +324,8 @@ Collection metadata can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPO
 
     curl -i -XDELETE -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/collections/sampleNativeId15
 
+Note: When a collection is deleted, all the associaitons will be deleted(tombstoned) too. With the new requirement that a variable can not exist without an association with a collection, since each variable can only be associated with one collection, all the variables associated with the deleted collection will be deleted too.
+
 #### Successful Response in XML
 
 ```

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -431,7 +431,51 @@ Granule metadata can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPOINT
 
 ### <a name="create-update-variable"></a> Create / Update a Variable
 
-Variable metadata can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
+A new variable ingest endpoint is provided to ensure that variable association is created at variable ingest time.
+Variable metadata can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/collections/<collection-concept-id>/<collection-revision-id>/variables/<native-id>`.  `<collection-revision-id>` is optional. The response will include the [concept id](#concept-id),[revision id](#revision-id), variable-association and associated-item.
+
+```
+curl -i -XPUT \
+-H "Content-type: application/vnd.nasa.cmr.umm+json" \
+-H "Echo-Token: XXXX" \
+%CMR-ENDPOINT%/collections/C1200000005-PROV1/1/variables/sampleVariableNativeId33 -d \
+"{\"ValidRange\":{},
+  \"Dimensions\":\"11\",
+  \"Scale\":\"1.0\",
+  \"Offset\":\"0.0\",
+  \"FillValue\":\"-9999.0\",
+  \"Units\":\"m\",
+  \"ScienceKeywords\":[{\"Category\":\"sk-A\",
+                        \"Topic\":\"sk-B\",
+                        \"Term\":\"sk-C\"}],
+  \"Name\":\"A-name\",
+  \"VariableType\":\"SCIENCE_VARIABLE\",
+  \"LongName\":\"A long UMM-Var name\",
+  \"DimensionsName\":\"H2OFunc\",
+  \"DataType\":\"float32\"}"
+```
+#### Successful Response in XML
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <concept-id>V1200000012-PROV1</concept-id>
+  <revision-id>1</revision-id>
+  <variable-association>{:concept-id "VA1200000007-CMR", :revision-id 1}</variable-association>
+  <associated-item>{:concept-id "C1200000005-PROV1", :revision-id 1}</associated-item> 
+</result>
+```
+
+#### Successful Response in JSON
+
+By passing the option `-H "Accept: application/json"` to `curl`, one may
+get a JSON response:
+
+```
+{"concept-id":"V1200000012-PROV1","revision-id":1,"variable-association":{"concept-id":"VA1200000007-CMR","revision-id":1},"associated-item":{"concept-id":"C1200000005-PROV1","revision-id":1}}
+```
+
+Variable metadata can continue to be updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
 
 ```
 curl -i -XPUT \

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -434,7 +434,7 @@ Granule metadata can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPOINT
 ### <a name="create-update-variable"></a> Create / Update a Variable
 
 A new variable ingest endpoint is provided to ensure that variable association is created at variable ingest time.
-Variable metadata can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/collections/<collection-concept-id>/<collection-revision-id>/variables/<native-id>`.  `<collection-revision-id>` is optional. The response will include the [concept id](#concept-id),[revision id](#revision-id), variable-association and associated-item.
+Variable concept can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/collections/<collection-concept-id>/<collection-revision-id>/variables/<native-id>`.  `<collection-revision-id>` is optional. The response will include the [concept id](#concept-id),[revision id](#revision-id), variable-association and associated-item.
 
 ```
 curl -i -XPUT \
@@ -495,7 +495,7 @@ get a JSON response:
 
 ```
 
-Variable metadata can continue to be updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
+Variable concept can continue to be updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
 
 ```
 curl -i -XPUT \
@@ -539,7 +539,7 @@ get a JSON response:
 
 ### <a name="delete-variable"></a> Delete a Variable
 
-Variable metadata can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id) of the tombstone.
+Variable concept can be deleted by sending an HTTP DELETE the URL `%CMR-ENDPOINT%/providers/<provider-id>/variables/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id) of the tombstone.
 
 ```
 curl -i -X DELETE \

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -45,7 +45,7 @@
    mt/json :json})
 
 (defn- create-nested-elements
-  "Create xml element for the nested maps."
+  "Create nested elements for the nested maps."
   [m]
   (reduce-kv (fn [memo k v]
                  (conj memo (xml/element (keyword k) {} (if (map? v) 

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -44,6 +44,16 @@
    mt/xml :xml
    mt/json :json})
 
+(defn- create-nested-elements
+  "Create xml element for the nested maps."
+  [m]
+  (reduce-kv (fn [memo k v]
+                 (conj memo (xml/element (keyword k) {} (if (map? v) 
+                                                          (create-nested-elements v)
+                                                          v))))
+             []
+             m))
+
 (defn- result-map->xml
   "Converts all keys in a map to tags with values given by the map values to form a trivial
   xml document.
@@ -60,10 +70,7 @@
    (xml/element
     :result
     {}
-    (reduce-kv (fn [memo k v]
-                 (conj memo (xml/element (keyword k) {} (if (map? v) (str v) v))))
-               []
-               m))))
+    (create-nested-elements m))))
 
 (defn get-ingest-result-format
   "Returns the requested ingest result format parsed from the Accept header or :xml

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -61,7 +61,7 @@
     :result
     {}
     (reduce-kv (fn [memo k v]
-                 (conj memo (xml/element (keyword k) {} v)))
+                 (conj memo (xml/element (keyword k) {} (if (map? v) (str v) v))))
                []
                m))))
 

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -78,6 +78,21 @@
 
 (def ingest-routes
   (routes
+    ;; variable ingest routes with association
+    (api-core/set-default-error-format
+     :xml
+     (context "/collections/:coll-concept-id" [coll-concept-id]
+       (context "/:coll-revision-id" [coll-revision-id]
+         (context "/variables/:native-id" [native-id]
+          (PUT "/"
+           request
+           (variables/ingest-variable
+             nil native-id request coll-concept-id coll-revision-id))))
+       (context "/variables/:native-id" [native-id]
+         (PUT "/"
+           request
+           (variables/ingest-variable
+             nil native-id request coll-concept-id)))))
     ;; Provider ingest routes
     (api-core/set-default-error-format
      :xml

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -92,7 +92,7 @@
          (PUT "/"
            request
            (variables/ingest-variable
-             nil native-id request coll-concept-id)))))
+             nil native-id request coll-concept-id nil)))))
     ;; Provider ingest routes
     (api-core/set-default-error-format
      :xml

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -29,8 +29,6 @@
   "Processes a request to create or update a variable."
   ([provider-id native-id request]
    (ingest-variable provider-id native-id request nil nil))
-  ([provider-id native-id request coll-concept-id]
-   (ingest-variable provider-id native-id request coll-concept-id nil))
   ([provider-id native-id request coll-concept-id coll-revision-id]
    (let [provider-id (if coll-concept-id
                        (last (string/split coll-concept-id #"C[0-9]+-"))

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -49,11 +49,13 @@
            variable (spec/parse-metadata request-context :variable concept-format metadata)
            _ (v/umm-spec-validate-variable
                variable request-context (not (ingest-config/validate-umm-var-keywords)))
-           concept-with-user-id (util/remove-nil-keys
-                                  (-> concept
-                                      (api-core/set-user-id request-context headers)
-                                      (assoc :coll-concept-id coll-concept-id
-                                             :coll-revision-id coll-revision-id)))
+           concept-with-user-id
+            (util/remove-nil-keys
+              (-> concept
+                  (api-core/set-user-id request-context headers)
+                  (assoc :coll-concept-id coll-concept-id
+                         :coll-revision-id (when coll-revision-id
+                                             (read-string coll-revision-id)))))
            ;; Log the ingest attempt
            _ (info (format "Ingesting variable %s from client %s"
                            (api-core/concept->loggable-string concept-with-user-id)

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -36,17 +36,14 @@
          concept (api-core/body->concept!
                   :variable provider-id native-id body content-type headers)]
 
-     ;; Ensures the associated collection is visible and not deleted.
-     (v/validate-variable-associated-collection
-       request-context
-       coll-concept-id
-       coll-revision-id)
-
      (lt-validation/validate-launchpad-token request-context)
      (api-core/verify-provider-exists request-context provider-id)
      (acl/verify-ingest-management-permission
        request-context :update :provider-object provider-id)
      (common-enabled/validate-write-enabled request-context "ingest")
+     ;; Ensures the associated collection is visible and not deleted.
+     (v/validate-variable-associated-collection
+       request-context coll-concept-id coll-revision-id)
      (let [concept (validate-and-prepare-variable-concept concept)
            {concept-format :format metadata :metadata} concept
            variable (spec/parse-metadata request-context :variable concept-format metadata)

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -1,7 +1,6 @@
 (ns cmr.ingest.api.variables
   "Variable ingest functions in support of the ingest API."
   (:require
-   [cheshire.core :as json]
    [clojure.string :as string]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
@@ -36,6 +35,12 @@
          {:keys [body content-type headers request-context]} request
          concept (api-core/body->concept!
                   :variable provider-id native-id body content-type headers)]
+
+     ;; Ensures the associated collection is visible and not deleted.
+     (v/validate-variable-associated-collection
+       request-context
+       coll-concept-id
+       coll-revision-id)
 
      (lt-validation/validate-launchpad-token request-context)
      (api-core/verify-provider-exists request-context provider-id)

--- a/ingest-app/src/cmr/ingest/services/ingest_service/variable.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/variable.clj
@@ -1,6 +1,6 @@
 (ns cmr.ingest.services.ingest-service.variable
   (:require
-   [cmr.common.util :refer [defn-timed]]
+   [cmr.common.util :as util :refer [defn-timed]]
    [cmr.transmit.metadata-db2 :as mdb2]
    [cmr.umm-spec.fingerprint-util :as fingerprint]
    [cmr.umm-spec.umm-spec-core :as spec]))
@@ -22,8 +22,12 @@
   (let [metadata (:metadata concept)
         variable (spec/parse-metadata context :variable (:format concept) metadata)
         concept (add-extra-fields-for-variable context concept variable)
-        {:keys [concept-id revision-id]} (mdb2/save-concept context
-                                          (assoc concept :provider-id (:provider-id concept)
-                                                         :native-id (:native-id concept)))]
-      {:concept-id concept-id
-       :revision-id revision-id}))
+        {:keys [concept-id revision-id variable-association associated-item]}
+          (mdb2/save-concept context
+            (assoc concept :provider-id (:provider-id concept)
+                           :native-id (:native-id concept)))]
+     (util/remove-nil-keys
+       {:concept-id concept-id
+        :revision-id revision-id
+        :variable-association variable-association
+        :associated-item associated-item})))

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -50,16 +50,20 @@
         (is (= concept1-concept-id concept-id))
         (is (= 2 revision-id))))
 
-    (testing "save variable with the same data, but a different native id is not allowed"
-      (let [concept2 (assoc concept1 :native-id "different-native-id")
-            {:keys [status errors]} (util/save-concept concept2)]
-        (is (= 409 status))
-        (is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
-                             "Instrument short name, variable short name, units and dimensions "
-                             "must be unique. The following variable with the same fingerprint "
-                             "but different native id was found: [%s].")
-                        concept1-concept-id)]
-               errors))))
+    ;; Uniqueness of variable name and association collection info is checked at association creation,
+    ;; after the old fingerprint check is removed. However, many tests that assumed the old way of
+    ;; ingesting variables without collection info are obsolete. They either need to be removed completely
+    ;; or modified to suit the new variable ingest condition.
+    ;;(testing "save variable with the same data, but a different native id is not allowed"
+     ;; (let [concept2 (assoc concept1 :native-id "different-native-id")
+      ;;      {:keys [status errors]} (util/save-concept concept2)]
+       ;; (is (= 409 status))
+        ;;(is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
+         ;;                    "Instrument short name, variable short name, units and dimensions "
+          ;;                   "must be unique. The following variable with the same fingerprint "
+           ;;                  "but different native id was found: [%s].")
+            ;;            concept1-concept-id)]
+             ;;  errors))))
 
     (testing "save variable with same data but different provider"
       (let [concept3 (assoc concept1 :provider-id "PROV2")

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_save_test.clj
@@ -53,7 +53,7 @@
     ;; Uniqueness of variable name and association collection info is checked at association creation,
     ;; after the old fingerprint check is removed. However, many tests that assumed the old way of
     ;; ingesting variables without collection info are obsolete. They either need to be removed completely
-    ;; or modified to suit the new variable ingest condition.
+    ;; or modified to suit the new variable ingest condition. The test cleanup ticket is CMR-6603.
     ;;(testing "save variable with the same data, but a different native id is not allowed"
      ;; (let [concept2 (assoc concept1 :native-id "different-native-id")
       ;;      {:keys [status errors]} (util/save-concept concept2)]

--- a/metadata-db-app/src/cmr/metadata_db/api/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/concepts.clj
@@ -75,9 +75,15 @@
   (let [concept (-> concept
                     clojure.walk/keywordize-keys
                     (update-in [:concept-type] keyword))
-        {:keys [concept-id revision-id]} (concept-service/save-concept-revision context concept)]
+        ;; get variable-association and associated-item when applicable.
+        {:keys [concept-id revision-id variable-association associated-item]}
+          (concept-service/save-concept-revision context concept)]
     {:status 201
-     :body (json/generate-string {:revision-id revision-id :concept-id concept-id})
+     :body (json/generate-string (util/remove-nil-keys
+                                   {:revision-id revision-id
+                                    :concept-id concept-id
+                                    :variable-association variable-association
+                                    :associated-item associated-item}))
      :headers rh/json-header}))
 
 (defn- delete-concept

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_constraints.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_constraints.clj
@@ -159,9 +159,7 @@
    :acl [(unique-field-constraint :acl-identity)]
    :service [(partial pfn-constraint :service-name)]
    :tool [(partial pfn-constraint :tool-name)]
-   :subscription [(partial pfn-constraint :subscription-name)]
-   ;; will remove this fingerprint check when updating tests later.
-   :variable [(unique-field-constraint :fingerprint)]})
+   :subscription [(partial pfn-constraint :subscription-name)]})
 
 (defn perform-post-commit-constraint-checks
   "Perform the post commit constraint checks aggregating any constraint

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_constraints.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_constraints.clj
@@ -160,6 +160,7 @@
    :service [(partial pfn-constraint :service-name)]
    :tool [(partial pfn-constraint :tool-name)]
    :subscription [(partial pfn-constraint :subscription-name)]
+   ;; will remove this fingerprint check when updating tests later.
    :variable [(unique-field-constraint :fingerprint)]})
 
 (defn perform-post-commit-constraint-checks

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -470,11 +470,10 @@
         association (merge (first associations)
                            {:source-concept-id (:concept-id concept)
                             :source-concept-type :variable
-                            :user-id (:user-id concept)})
-        mdb-context (assoc context :system
-                           (get-in context [:system :embedded-systems :metadata-db]))]
+                            :user-id (:user-id concept)})]
+        ;; context passed from perform-post-commit-association is already a mdb-context.
     (debug "associate-variable validation-time:" validation-time)
-    (update-association mdb-context association :insert)))
+    (update-association context association :insert)))
 
 (defn- perform-post-commit-association
   "Performs a post commit variable association. If failed, roll back

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -3,10 +3,11 @@
   (:require
    [clj-time.core :as t]
    [clojure.set :as set]
-   [clojure.string]
+   [clojure.string :as string]
    [cmr.common.concepts :as cu]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.log :refer (debug error info warn trace)]
+   [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.services.messages :as cmsg]
    [cmr.common.time-keeper :as time-keeper]
@@ -19,7 +20,8 @@
    [cmr.metadata-db.services.messages :as msg]
    [cmr.metadata-db.services.provider-service :as provider-service]
    [cmr.metadata-db.services.search-service :as search]
-   [cmr.metadata-db.services.util :as util])
+   [cmr.metadata-db.services.util :as util]
+   [cmr.metadata-db.services.variable-association-validation :as var-assoc-validation])
   ;; Required to get code loaded
   ;; XXX This is really awful, and we do it a lot in the CMR. What we've got
   ;;     as a result of this is a leak from implementation into a separate part
@@ -79,6 +81,56 @@
   #{:tag :tag-association :humanizer :variable-association :service-association})
 
 ;;; utility methods
+(def ^:private native-id-separator-character
+  "This is the separator character used when creating the native id for an association."
+  "/")
+
+(def ^:private association-conflict-error-message
+  "Failed to %s %s [%s] with collection [%s] because it conflicted with a concurrent %s on the
+  same %s and collection. This means that someone is sending the same request to the CMR at the
+  same time.")
+
+(def ^:private association-unknown-error-message
+  "Failed to %s %s [%s] with collection [%s] due to unknown type of error.")
+
+(defn- context->user-id
+  "Returns user id of the token in the context. Throws an error if no token is provided"
+  [context]
+  (if-let [token (:token context)]
+    (cutil/lazy-get context :user-id)
+    (errors/throw-service-error
+     :unauthorized "Associations cannot be modified without a valid user token.")))
+
+(defn- association->native-id
+  "Returns the native id of the given association."
+  [association]
+  (let [{coll-concept-id :concept-id
+         coll-revision-id :revision-id
+         source-concept-id :source-concept-id} association
+        native-id (str source-concept-id native-id-separator-character coll-concept-id)]
+    (if coll-revision-id
+      (str native-id native-id-separator-character coll-revision-id)
+      native-id)))
+
+(defn- association->concept-map
+  [variable-association]
+  (let [{:keys [source-concept-id originator-id native-id user-id data errors]
+         coll-concept-id :concept-id
+         coll-revision-id :revision-id} variable-association]
+    {:concept-type :variable-association
+     :native-id native-id
+     :user-id user-id
+     :format mt/edn
+     :metadata (pr-str
+                 (cutil/remove-nil-keys
+                   {:variable-concept-id source-concept-id
+                    :originator-id originator-id
+                    :associated-concept-id coll-concept-id
+                    :associated-revision-id coll-revision-id
+                    :data data}))
+     :extra-fields {:variable-concept-id source-concept-id
+                    :associated-concept-id coll-concept-id
+                    :associated-revision-id coll-revision-id}}))
 
 (defn validate-system-level-concept
   "Validates that system level concepts are only associated with the system level provider,
@@ -195,6 +247,12 @@
   [_db _provider concept]
   concept)
 
+(defn- variable-missing-coll-info-msg
+  "Returns the message for variable missing collection info"
+  [native-id]
+  (format "Variable [%s] can not be ingested without collection info."
+          native-id))
+
 (defn- set-or-generate-revision-id
   "Get the next available revision id from the DB for the given concept or
   one if the concept has never been saved."
@@ -206,6 +264,12 @@
           existing-revision-id (:revision-id (or previous-revision
                                                  (c/get-concept db concept-type provider concept-id)))
           revision-id (if existing-revision-id (inc existing-revision-id) 1)]
+      ;; The first revision of a variable without collection info will be rejected.
+      ;; will do this together with tests later.
+      ;;(when (and (= :variable (:concept-type concept))
+       ;;          (= 1 revision-id)
+        ;;         (nil? (:coll-concept-id concept)))
+        ;;(cmsg/data-error :invalid-data variable-missing-coll-info-msg (:native-id concept)))
       (assoc concept :revision-id revision-id))))
 
 (defn- check-concept-revision-id
@@ -303,12 +367,132 @@
     ;; else
     (errors/internal-error! (:error-message result) (:throwable result))))
 
+(defmulti save-concept-revision
+  "Store a concept record, which could be a tombstone, and return the revision."
+  (fn [context concept]
+    (boolean (:deleted concept))))
+
+(defn- save-concept-in-mdb
+  "Save the given concept in metadata-db using the given embedded metadata-db context."
+  [mdb-context concept]
+  (let [{:keys [concept-id revision-id]} (save-concept-revision mdb-context concept)]
+    {:concept-id concept-id, :revision-id revision-id}))
+
+(defn- delete-association
+  "Delete the association with the given native-id using the given embedded metadata-db context."
+  [mdb-context source-concept-type native-id]
+  (let [source-concept-type-str (name source-concept-type)
+        assoc-concept-type (keyword (str source-concept-type-str "-association"))
+        existing-concept (first (search/find-concepts mdb-context
+                                                      {:concept-type assoc-concept-type
+                                                       :native-id native-id
+                                                       :exclude-metadata true
+                                                       :latest true}))
+        concept-id (:concept-id existing-concept)]
+    (if concept-id
+      (if (:deleted existing-concept)
+        {:message {:warnings [(format "%s association [%s] is already deleted."
+                                      (string/capitalize source-concept-type-str) concept-id)]}}
+        (let [concept {:concept-type assoc-concept-type
+                       :concept-id concept-id
+                       :user-id (context->user-id mdb-context)
+                       :deleted true}]
+          (save-concept-in-mdb mdb-context concept)))
+      {:message {:warnings [(msg/delete-association-not-found
+                             source-concept-type native-id)]}})))
+
+(defn- update-association
+  "Based on the input operation type (:insert or :delete), insert or delete the given association
+  using the embedded metadata-db, returns the association result in the format of
+  {:variable-association {:concept-id VA1-CMR :revision-id 1}
+   :associated-item {:concept_id C5-PROV1 :revision_id 2}}
+  or
+  {errors: [Collection [C6-PROV1] does not exist or is not visible.],
+  associated_item: {concept_id: C6-PROV1}}."
+  [mdb-context association operation]
+  ;; save each association if there is no errors on it, otherwise returns the errors.
+  (let [{:keys [source-concept-id source-concept-type errors]
+         coll-concept-id :concept-id
+         coll-revision-id :revision-id} association
+        native-id (association->native-id association)
+        source-concept-type-str (name source-concept-type)
+        assoc-concept-type (keyword (str source-concept-type-str "-association"))
+        association (assoc association :native-id native-id)
+        associated-item (cutil/remove-nil-keys
+                         {:concept-id coll-concept-id :revision-id coll-revision-id})]
+    (if (seq errors)
+      {:errors errors :associated-item associated-item}
+      (try
+        (let [{:keys [concept-id revision-id message]} ;; only delete-association could potentially return message
+              (if (= :insert operation)
+                (save-concept-in-mdb
+                  mdb-context (association->concept-map association))
+                (delete-association mdb-context source-concept-type native-id))]
+          (if (some? message)
+            (merge {:associated-item associated-item} message)
+            {assoc-concept-type {:concept-id concept-id :revision-id revision-id}
+             :associated-item associated-item}))
+        (catch clojure.lang.ExceptionInfo e ; Report a specific error in the case of a conflict, otherwise throw error
+          (let [exception-data (ex-data e)
+                type (:type exception-data)
+                errors (:errors exception-data)]
+            (cond
+              (= :conflict type)  {:errors (format association-conflict-error-message
+                                                   (if (= :insert operation) "associate" "dissociate")
+                                                   source-concept-type-str
+                                                   source-concept-id
+                                                   coll-concept-id
+                                                   (if (= :insert operation) "association" "dissociation")
+                                                   source-concept-type-str)
+                                   :associated-item associated-item}
+              (= :can-not-associate type) {:errors errors
+                                           :associated-item associated-item}
+              :else {:errors (format association-unknown-error-message
+                                                   (if (= :insert operation) "associate" "dissociate")
+                                                   source-concept-type-str
+                                                   source-concept-id
+                                                   coll-concept-id)})))))))
+
+(defn- associate-variable
+  "Associate variable concept to collection defined by coll-concept-id
+  and coll-revision-id in concept."
+  [context concept]
+  (let [;; associations is a list of one association.
+        associations [(cutil/remove-nil-keys
+                        (assoc {} :concept-id (:coll-concept-id concept)
+                                  :revision-id (:coll-revision-id concept)))]
+        var-concept-id (:concept-id concept)
+        [validation-time associations] (cutil/time-execution
+                                         (var-assoc-validation/validate-associations
+                                           context var-concept-id associations))
+        ;; association is created together with variable so the user-id
+        ;; in association is the same as the user-id in variable concept.
+        association (merge (first associations)
+                           {:source-concept-id (:concept-id concept)
+                            :source-concept-type :variable
+                            :user-id (:user-id concept)})
+        mdb-context (assoc context :system
+                           (get-in context [:system :embedded-systems :metadata-db]))]
+    (debug "associate-variable validation-time:" validation-time)
+    (update-association mdb-context association :insert)))
+
+(defn- perform-post-commit-association
+  "Performs a post commit variable association. If failed, roll back
+  variable ingest."
+  [context concept rollback-function]
+  (let [result (associate-variable context concept)]
+    ;;{:variable-association {:concept-id "VA1-CMR" :revision_id 1} :associated-item {:concept-id "C5-PROV1"}}]
+    (when-let [errors (:errors result)]
+      (rollback-function)
+      (errors/throw-service-errors :conflict errors))
+    result))
+
 ;; dynamic is here only for testing purposes to test failure cases.
 (defn ^:dynamic try-to-save
   "Try to save a concept. The concept must include a revision-id. Ensures that revision-id and
   concept-id constraints are enforced as well as post commit uniqueness constraints. Returns the
   concept if successful, otherwise throws an exception."
-  [db provider concept]
+  [db provider context concept]
   {:pre [(:revision-id concept)]}
   (let [result (c/save-concept db provider concept)
         ;; When there are constraint violations we send in a rollback function to delete the
@@ -334,7 +518,20 @@
           provider
           concept
           rollback-fn)
-        concept)
+
+        ;; Perform post commit variable association
+        (if (and (= :variable (:concept-type concept))
+                   (not (nil? (:coll-concept-id concept)))
+                   (not (:deleted concept)))
+          ;; If errors occur, rollback, otherwise return variable concept with the association info:
+          ;; {:variable_association {:concept_id VA1-CMR :revision_id 1},
+          ;;  :associated_item {:concept_id C5-PROV1 :revision_id 2}}
+          (let [assoc-info (perform-post-commit-association
+                             context
+                             concept
+                             rollback-fn)]
+             (merge concept assoc-info))
+           concept))
       (handle-save-errors concept result))))
 
 ;;; service methods
@@ -489,11 +686,6 @@
         provider (provider-service/get-provider-by-id context provider-id true)]
     (distinct (map :concept-id (c/get-expired-concepts db provider :collection)))))
 
-(defmulti save-concept-revision
-  "Store a concept record, which could be a tombstone, and return the revision."
-  (fn [context concept]
-    (boolean (:deleted concept))))
-
 (defn- tombstone-associations
   "Tombstone the associations that matches the given search params,
   skip-publication? flag controls if association deletion event should be generated,
@@ -594,7 +786,7 @@
           (cv/validate-concept tombstone)
           (validate-concept-revision-id db provider tombstone previous-revision)
           (let [revisioned-tombstone (->> (set-or-generate-revision-id db provider tombstone previous-revision)
-                                          (try-to-save db provider))]
+                                          (try-to-save db provider context))]
             ;; delete the associated variable associations if applicable
             (delete-associations context concept-type concept-id nil :variable-association)
             ;; delete the associated service associations if applicable
@@ -675,7 +867,7 @@
     (let [concept (->> concept
                        (set-or-generate-revision-id db provider)
                        (set-deleted-flag false)
-                       (try-to-save db provider))
+                       (try-to-save db provider context))
           revision-id (:revision-id concept)]
       ;; publish tombstone delete event if the previous concept revision is a granule tombstone
       (when (and (= :granule concept-type)
@@ -834,7 +1026,7 @@
                               (update-in [:revision-id] inc)
                               (assoc :deleted true :metadata ""))]
             (try
-              (try-to-save db provider tombstone)
+              (try-to-save db provider context tombstone)
               (ingest-events/publish-event
                context (ingest-events/concept-expire-event c))
               (catch clojure.lang.ExceptionInfo e

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -520,8 +520,8 @@
 
         ;; Perform post commit variable association
         (if (and (= :variable (:concept-type concept))
-                   (not (nil? (:coll-concept-id concept)))
-                   (not (:deleted concept)))
+                 (:coll-concept-id concept)
+                 (not (:deleted concept)))
           ;; If errors occur, rollback, otherwise return variable concept with the association info:
           ;; {:variable_association {:concept_id VA1-CMR :revision_id 1},
           ;;  :associated_item {:concept_id C5-PROV1 :revision_id 2}}

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -459,8 +459,8 @@
   [context concept]
   (let [;; associations is a list of one association.
         associations [(cutil/remove-nil-keys
-                        (assoc {} :concept-id (:coll-concept-id concept)
-                                  :revision-id (:coll-revision-id concept)))]
+                        {:concept-id (:coll-concept-id concept)
+                         :revision-id (:coll-revision-id concept)})]
         var-concept-id (:concept-id concept)
         [validation-time associations] (cutil/time-execution
                                          (var-assoc-validation/validate-associations

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -480,7 +480,6 @@
   variable ingest."
   [context concept rollback-function]
   (let [result (associate-variable context concept)]
-    ;;{:variable-association {:concept-id "VA1-CMR" :revision_id 1} :associated-item {:concept-id "C5-PROV1"}}]
     (when-let [errors (:errors result)]
       (rollback-function)
       (errors/throw-service-errors :conflict errors))

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -265,7 +265,7 @@
                                                  (c/get-concept db concept-type provider concept-id)))
           revision-id (if existing-revision-id (inc existing-revision-id) 1)]
       ;; The first revision of a variable without collection info will be rejected.
-      ;; will do this together with tests later.
+      ;; will do this later in CMR-6605t
       ;;(when (and (= :variable (:concept-type concept))
        ;;          (= 1 revision-id)
         ;;         (nil? (:coll-concept-id concept)))

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -702,7 +702,7 @@
                                         :concept-id var-concept-id
                                         :deleted true
                                         :user-id "cmr"
-                                        :skip-publication skip-publication?}))
+                                        :skip-publication false}))
       (doseq [association associations]
         (save-concept-revision context {:concept-type assoc-type
                                         :concept-id (:concept-id association)
@@ -802,7 +802,6 @@
             (delete-associations context concept-type concept-id nil :variable-association)
             ;; delete the associated service associations if applicable
             (delete-associations context concept-type concept-id nil :service-association)
-
             ;; skip publication flag is set for tag association when its associated
             ;; collection revision is force deleted. In this case, the association is no longer
             ;; needed to be indexed, so we don't publish the deletion event.

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -227,3 +227,28 @@
           provider-id
           field-name
           field-value))
+
+(defn inaccessible-collection
+  [concept-id]
+  (format "Collection [%s] does not exist or is not visible." concept-id))
+
+(defn tombstone-collection
+  [assoc-type {:keys [concept-id revision-id]}]
+  (format (str "Collection with concept id [%s] revision id [%s] is a tombstone. We don't allow "
+               "%s association with individual collection revisions that are tombstones.")
+          concept-id revision-id (name assoc-type)))
+
+(defn inaccessible-collection-revision
+  [{:keys [concept-id revision-id]}]
+  (format "Collection with concept id [%s] revision id [%s] does not exist or is not visible."
+          concept-id revision-id))
+
+(defn delete-association-not-found
+  [assoc-type native-id]
+  (let [[identifier concept-id revision-id] (str/split native-id #"/")]
+    (if revision-id
+      (format (str "%s [%s] is not associated with the specific collection concept revision "
+                   "concept id [%s] and revision id [%s].")
+              (str/capitalize (name assoc-type)) identifier concept-id revision-id)
+      (format "%s [%s] is not associated with collection [%s]."
+              (str/capitalize (name assoc-type)) identifier concept-id))))

--- a/metadata-db-app/src/cmr/metadata_db/services/messages.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/messages.clj
@@ -228,21 +228,6 @@
           field-name
           field-value))
 
-(defn inaccessible-collection
-  [concept-id]
-  (format "Collection [%s] does not exist or is not visible." concept-id))
-
-(defn tombstone-collection
-  [assoc-type {:keys [concept-id revision-id]}]
-  (format (str "Collection with concept id [%s] revision id [%s] is a tombstone. We don't allow "
-               "%s association with individual collection revisions that are tombstones.")
-          concept-id revision-id (name assoc-type)))
-
-(defn inaccessible-collection-revision
-  [{:keys [concept-id revision-id]}]
-  (format "Collection with concept id [%s] revision id [%s] does not exist or is not visible."
-          concept-id revision-id))
-
 (defn delete-association-not-found
   [assoc-type native-id]
   (let [[identifier concept-id revision-id] (str/split native-id #"/")]

--- a/metadata-db-app/src/cmr/metadata_db/services/variable_association_validation.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/variable_association_validation.clj
@@ -1,0 +1,163 @@
+(ns cmr.metadata-db.services.variable-association-validation
+  "Functions for validating variable association to collection."
+  (:require
+   [clojure.set :as set]
+   [clojure.string :as string]
+   [cmr.common-app.services.search.query-execution :as qe]
+   [cmr.common-app.services.search.query-model :as cqm]
+   [cmr.common-app.services.search.related-item-resolver :as related-item-resolver]
+   [cmr.common.util :as util]
+   [cmr.metadata-db.services.messages :as msg]
+   [cmr.metadata-db.services.search-service :as mdb-ss]))
+
+(defmethod qe/concept-type-specific-query-processing :collection
+  [context query]
+  [context (related-item-resolver/resolve-related-item-conditions query context)])
+
+(defn- append-error
+  "Returns the association with the given error message appended to it."
+  [association error-msg]
+  (update association :errors concat [error-msg]))
+
+(defn- validate-association-conflict-for-collection 
+  "Make sure we don't have both associations with the collection revision-id and without revision-id."
+  [context variable-concept-id variable-association]
+  (let [vas (->> (mdb-ss/find-concepts context
+                                      {:concept-type :variable-association
+                                       :variable-concept-id variable-concept-id
+                                       :associated-concept-id (:concept-id variable-association)
+                                       :exclude-metadata true
+                                       :latest true})
+                 (filter #(not (:deleted %))))
+        coll-revision-ids (map #(get-in % [:extra-fields :associated-revision-id]) vas)
+        not-nil-revision-ids (remove nil? coll-revision-ids)]
+    (cond
+      ;; there is no existing variable association found, no need to validate
+      (= 0 (count coll-revision-ids))
+      nil
+
+      ;; there are existing variable associations and they are all on collection revisions
+      (= (count coll-revision-ids) (count not-nil-revision-ids))
+      (when-not (:revision-id variable-association)
+        (format (str "There are already variable associations with variable concept id [%s] on "
+                     "collection [%s] revision ids [%s], cannot create variable association "
+                     "on the same collection without revision id.")
+                variable-concept-id (:concept-id variable-association) (string/join ", " coll-revision-ids)))
+
+      ;; there are existing variable associations and they are all on collection without revision
+      (= 0 (count not-nil-revision-ids))
+      (when-let [revision-id (:revision-id variable-association)]
+        (format (str "There are already variable associations with variable concept id [%s] on "
+                     "collection [%s] without revision id, cannot create variable association "
+                     "on the same collection with revision id [%s].")
+                variable-concept-id (:concept-id variable-association) revision-id))
+
+      ;; there are conflicts within the existing variable associations in metadata-db already
+      :else
+      (format (str "Variable can only be associated with a collection or a collection revision, "
+                   "never both at the same time. There are already conflicting variable associations "
+                   "in metadata-db with variable concept id [%s] on collection [%s] , "
+                   "please delete one of the conflicting variable associations.")
+              variable-concept-id (:concept-id variable-association)))))
+
+(defn- validate-association-conflict
+  "Validates the association (either on a specific revision or over the whole collection)
+  does not conflict with one or more existing associations in Metadata DB. Tag/Variable
+  cannot be associated with a collection revision and the same collection without revision
+  at the same time. Returns the association with errors appended if applicable."
+  [context assoc-var-id association]
+  (if-let [error-msg (validate-association-conflict-for-collection
+                       context assoc-var-id association)]
+    (append-error association error-msg)
+    association))
+
+(defn- validate-collection-concept-id
+  "Validates the association collection concept-id is not in the set of inaccessible-concept-ids,
+  returns the association with errors appended if applicable."
+  [inaccessible-concept-ids association]
+  (if (contains? inaccessible-concept-ids (:concept-id association))
+    (append-error association (msg/inaccessible-collection (:concept-id association)))
+    association))
+
+(defn- validate-collection-revision
+  "Validates the association collection revision is not in the set of tombstone-coll-revisions
+  and inaccessible-coll-revisions, returns the association with errors appended if applicable."
+  [tombstone-coll-revisions inaccessible-coll-revisions association]
+  (let [coll-revision (select-keys association [:concept-id :revision-id])]
+    (if (contains? tombstone-coll-revisions coll-revision)
+      (append-error association (msg/tombstone-collection :variable coll-revision))
+      (if (contains? inaccessible-coll-revisions coll-revision)
+        (append-error association (msg/inaccessible-collection-revision coll-revision))
+        association))))
+
+(defn- validate-collection-identifier
+  "Validates the association concept-id and revision-id (if given) satisfy association rules,
+  i.e. collection specified exist and are viewable by the token,
+  collection specified are not tombstones."
+  [context inaccessible-concept-ids tombstone-coll-revisions
+    inaccessible-coll-revisions association]
+  (if (:revision-id association)
+    (validate-collection-revision
+      tombstone-coll-revisions inaccessible-coll-revisions association)
+    (validate-collection-concept-id inaccessible-concept-ids association)))
+
+(defn- get-bad-collection-revisions
+  "Returns the bad collection revisions of the given associations partitioned into a set of
+  collection revisions that are tombstones and a set of collection revisions that are inaccessible."
+  [context associations]
+  (when (seq associations)
+    (let [query (cqm/query {:concept-type :collection
+                            :condition (cqm/string-conditions
+                                         :concept-id (map :concept-id associations) true)
+                            :page-size :unlimited
+                            :result-format :query-specified
+                            :result-fields [:concept-id :revision-id :deleted]
+                            :all-revisions? true
+                            :skip-acls? false})
+          collections (->> (qe/execute-query context query)
+                           :items
+                           (map #(select-keys % [:concept-id :revision-id :deleted])))
+          ids-fn (fn [coll] (select-keys coll [:concept-id :revision-id]))
+          colls-set (set (map ids-fn associations))
+          matched-colls (filter #(contains? colls-set (ids-fn %)) collections)
+          tombstone-coll-revisions (set (map ids-fn (filter :deleted matched-colls)))
+          inaccessible-coll-revisions (set/difference
+                                        colls-set
+                                        (set (map ids-fn matched-colls)))]
+      {:tombstones tombstone-coll-revisions
+       :inaccessibles inaccessible-coll-revisions})))
+
+(defn- get-inaccessible-concept-ids
+  "Returns the collection concept-ids within the given list that are invalid,
+  i.e. the collections for the given concept-ids do not exist or are not viewable by the token."
+  [context coll-concept-ids]
+  (when (seq coll-concept-ids)
+    (let [query (cqm/query {:concept-type :collection
+                            :condition (cqm/string-conditions :concept-id coll-concept-ids true)
+                            :page-size :unlimited
+                            :result-format :query-specified
+                            :result-fields [:concept-id]
+                            :skip-acls? false})
+          concept-ids (->> (qe/execute-query context query)
+                           :items
+                           (map :concept-id))]
+      (set/difference (set coll-concept-ids) (set concept-ids)))))
+
+(defn- partition-associations
+  "Returns the associations as a list partitioned by if there is a revision-id."
+  [associations]
+  (let [has-revision-id? #(contains? % :revision-id)
+        {concept-id-only-assocs false revision-assocs true} (group-by has-revision-id? associations)]
+    [concept-id-only-assocs revision-assocs]))
+
+(defn validate-associations
+  "Validate if the collection is accessible or tombstoned, and if the association has conflict."
+  [context assoc-var-id associations]
+  (let [[concept-id-only-assocs revision-assocs] (partition-associations associations)
+        inaccessible-concept-ids (get-inaccessible-concept-ids
+                                   context (map :concept-id concept-id-only-assocs))
+        {:keys [tombstones inaccessibles]} (get-bad-collection-revisions context associations)]
+    (->> associations
+         (map #(validate-collection-identifier
+                 context inaccessible-concept-ids tombstones inaccessibles %))
+         (map #(validate-association-conflict context assoc-var-id %)))))

--- a/metadata-db-app/src/cmr/metadata_db/services/variable_association_validation.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/variable_association_validation.clj
@@ -1,18 +1,8 @@
 (ns cmr.metadata-db.services.variable-association-validation
   "Functions for validating variable association to collection."
   (:require
-   [clojure.set :as set]
    [clojure.string :as string]
-   [cmr.common-app.services.search.query-execution :as qe]
-   [cmr.common-app.services.search.query-model :as cqm]
-   [cmr.common-app.services.search.related-item-resolver :as related-item-resolver]
-   [cmr.common.util :as util]
-   [cmr.metadata-db.services.messages :as msg]
    [cmr.metadata-db.services.search-service :as mdb-ss]))
-
-(defmethod qe/concept-type-specific-query-processing :collection
-  [context query]
-  [context (related-item-resolver/resolve-related-item-conditions query context)])
 
 (defn- append-error
   "Returns the association with the given error message appended to it."
@@ -71,93 +61,7 @@
     (append-error association error-msg)
     association))
 
-(defn- validate-collection-concept-id
-  "Validates the association collection concept-id is not in the set of inaccessible-concept-ids,
-  returns the association with errors appended if applicable."
-  [inaccessible-concept-ids association]
-  (if (contains? inaccessible-concept-ids (:concept-id association))
-    (append-error association (msg/inaccessible-collection (:concept-id association)))
-    association))
-
-(defn- validate-collection-revision
-  "Validates the association collection revision is not in the set of tombstone-coll-revisions
-  and inaccessible-coll-revisions, returns the association with errors appended if applicable."
-  [tombstone-coll-revisions inaccessible-coll-revisions association]
-  (let [coll-revision (select-keys association [:concept-id :revision-id])]
-    (if (contains? tombstone-coll-revisions coll-revision)
-      (append-error association (msg/tombstone-collection :variable coll-revision))
-      (if (contains? inaccessible-coll-revisions coll-revision)
-        (append-error association (msg/inaccessible-collection-revision coll-revision))
-        association))))
-
-(defn- validate-collection-identifier
-  "Validates the association concept-id and revision-id (if given) satisfy association rules,
-  i.e. collection specified exist and are viewable by the token,
-  collection specified are not tombstones."
-  [context inaccessible-concept-ids tombstone-coll-revisions
-    inaccessible-coll-revisions association]
-  (if (:revision-id association)
-    (validate-collection-revision
-      tombstone-coll-revisions inaccessible-coll-revisions association)
-    (validate-collection-concept-id inaccessible-concept-ids association)))
-
-(defn- get-bad-collection-revisions
-  "Returns the bad collection revisions of the given associations partitioned into a set of
-  collection revisions that are tombstones and a set of collection revisions that are inaccessible."
-  [context associations]
-  (when (seq associations)
-    (let [query (cqm/query {:concept-type :collection
-                            :condition (cqm/string-conditions
-                                         :concept-id (map :concept-id associations) true)
-                            :page-size :unlimited
-                            :result-format :query-specified
-                            :result-fields [:concept-id :revision-id :deleted]
-                            :all-revisions? true
-                            :skip-acls? false})
-          collections (->> (qe/execute-query context query)
-                           :items
-                           (map #(select-keys % [:concept-id :revision-id :deleted])))
-          ids-fn (fn [coll] (select-keys coll [:concept-id :revision-id]))
-          colls-set (set (map ids-fn associations))
-          matched-colls (filter #(contains? colls-set (ids-fn %)) collections)
-          tombstone-coll-revisions (set (map ids-fn (filter :deleted matched-colls)))
-          inaccessible-coll-revisions (set/difference
-                                        colls-set
-                                        (set (map ids-fn matched-colls)))]
-      {:tombstones tombstone-coll-revisions
-       :inaccessibles inaccessible-coll-revisions})))
-
-(defn- get-inaccessible-concept-ids
-  "Returns the collection concept-ids within the given list that are invalid,
-  i.e. the collections for the given concept-ids do not exist or are not viewable by the token."
-  [context coll-concept-ids]
-  (when (seq coll-concept-ids)
-    (let [query (cqm/query {:concept-type :collection
-                            :condition (cqm/string-conditions :concept-id coll-concept-ids true)
-                            :page-size :unlimited
-                            :result-format :query-specified
-                            :result-fields [:concept-id]
-                            :skip-acls? false})
-          concept-ids (->> (qe/execute-query context query)
-                           :items
-                           (map :concept-id))]
-      (set/difference (set coll-concept-ids) (set concept-ids)))))
-
-(defn- partition-associations
-  "Returns the associations as a list partitioned by if there is a revision-id."
-  [associations]
-  (let [has-revision-id? #(contains? % :revision-id)
-        {concept-id-only-assocs false revision-assocs true} (group-by has-revision-id? associations)]
-    [concept-id-only-assocs revision-assocs]))
-
 (defn validate-associations
-  "Validate if the collection is accessible or tombstoned, and if the association has conflict."
+  "Validate if the association has conflict."
   [context assoc-var-id associations]
-  (let [[concept-id-only-assocs revision-assocs] (partition-associations associations)
-        inaccessible-concept-ids (get-inaccessible-concept-ids
-                                   context (map :concept-id concept-id-only-assocs))
-        {:keys [tombstones inaccessibles]} (get-bad-collection-revisions context associations)]
-    (->> associations
-         (map #(validate-collection-identifier
-                 context inaccessible-concept-ids tombstones inaccessibles %))
-         (map #(validate-association-conflict context assoc-var-id %)))))
+  (map #(validate-association-conflict context assoc-var-id %) associations))

--- a/metadata-db-app/src/cmr/metadata_db/system.clj
+++ b/metadata-db-app/src/cmr/metadata_db/system.clj
@@ -6,6 +6,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.services.jvm-info :as jvm-info]
+   [cmr.common-app.services.search.elastic-search-index :as common-idx]
    [cmr.common.api.web-server :as web]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.jobs :as jobs]
@@ -26,7 +27,7 @@
 
 (def ^:private component-order
   "Defines the order to start the components."
-  [:log :caches :db :queue-broker :scheduler :unclustered-scheduler :web :nrepl])
+  [:log :caches :search-index :db :queue-broker :scheduler :unclustered-scheduler :web :nrepl])
 
 (def system-holder
   "Required for jobs"
@@ -50,6 +51,7 @@
               :parallel-chunk-size (config/parallel-chunk-size)
               :caches {acl/token-imp-cache-key (acl/create-token-imp-cache)
                        common-health/health-cache-key (common-health/create-health-cache)}
+              :search-index (common-idx/create-elastic-search-index)
               :scheduler (jobs/create-clustered-scheduler `system-holder :db mdb-jobs/jobs)
               :unclustered-scheduler (jobs/create-scheduler
                                       `system-holder [jvm-info/log-jvm-statistics-job])

--- a/metadata-db-app/src/cmr/metadata_db/system.clj
+++ b/metadata-db-app/src/cmr/metadata_db/system.clj
@@ -6,7 +6,6 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.services.jvm-info :as jvm-info]
-   [cmr.common-app.services.search.elastic-search-index :as common-idx]
    [cmr.common.api.web-server :as web]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.jobs :as jobs]
@@ -27,7 +26,7 @@
 
 (def ^:private component-order
   "Defines the order to start the components."
-  [:log :caches :search-index :db :queue-broker :scheduler :unclustered-scheduler :web :nrepl])
+  [:log :caches :db :queue-broker :scheduler :unclustered-scheduler :web :nrepl])
 
 (def system-holder
   "Required for jobs"
@@ -51,7 +50,6 @@
               :parallel-chunk-size (config/parallel-chunk-size)
               :caches {acl/token-imp-cache-key (acl/create-token-imp-cache)
                        common-health/health-cache-key (common-health/create-health-cache)}
-              :search-index (common-idx/create-elastic-search-index)
               :scheduler (jobs/create-clustered-scheduler `system-holder :db mdb-jobs/jobs)
               :unclustered-scheduler (jobs/create-scheduler
                                       `system-holder [jvm-info/log-jvm-statistics-job])

--- a/metadata-db-app/test/cmr/metadata_db/test/services/concept_service.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/concept_service.clj
@@ -109,11 +109,11 @@
   (testing "must be called with a revision-id"
     (let [db (memory/create-db [example-concept])]
       (is (thrown-with-msg? AssertionError #"Assert failed: .*revision-id"
-                            (cs/try-to-save db {:provider-id "PROV1"}
+                            (cs/try-to-save db {:provider-id "PROV1"} nil
                                             (dissoc example-concept :revision-id))))))
   (testing "valid with revision-id"
     (let [db (memory/create-db [example-concept])
-          result (cs/try-to-save db {:provider-id "PROV1"} (assoc example-concept :revision-id 2))]
+          result (cs/try-to-save db {:provider-id "PROV1"} nil (assoc example-concept :revision-id 2))]
       (is (= 2 (:revision-id result)))))
   (testing "conflicting concept-id and revision-id"
     (tu/assert-exception-thrown-with-errors
@@ -121,6 +121,7 @@
       [(messages/concept-id-and-revision-id-conflict (:concept-id example-concept) 1)]
       (cs/try-to-save (memory/create-db [example-concept])
                       {:provider-id "PROV1"}
+                      nil
                       (assoc example-concept :revision-id 1)))))
 
 (deftest delete-expired-concepts-test
@@ -142,7 +143,7 @@
 
           fake-save (fn [& args]
                       (when-not @saved
-                        (orig-save db {:provider-id "PROV1"} expired-2)
+                        (orig-save db {:provider-id "PROV1"} nil expired-2)
                         (reset! saved true))
                       (apply orig-save args))]
       ;; replace cs/try-to-save with our overridden function for this test

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -322,6 +322,33 @@
      :metadata metadata
      :format mime-type}))
 
+(defn ingest-variable
+  "Ingest a variable using the new association endpoint."
+  ([variable]
+   (ingest-variable variable {}))
+  ([variable options]
+   (let [{:keys [metadata format concept-id revision-id native-id coll-concept-id coll-revision-id]} variable
+         {:keys [client-id user-id validate-keywords validate-umm-c cmr-request-id x-request-id]} options
+         accept-format (:accept-format options)
+         headers (util/remove-nil-keys {"Cmr-Concept-id" concept-id
+                                        "Cmr-Revision-id" revision-id
+                                        "Cmr-Validate-Keywords" validate-keywords
+                                        "Cmr-Validate-Umm-C" validate-umm-c
+                                        "Echo-Token" "mock-echo-system-token" 
+                                        "User-Id" user-id
+                                        "Client-Id" client-id
+                                        "CMR-Request-Id" cmr-request-id
+                                        "X-Request-Id" x-request-id})
+         params {:method :put
+                 :url (url/ingest-variable-url coll-concept-id coll-revision-id native-id)
+                 :body  metadata
+                 :content-type format
+                 :headers headers
+                 :throw-exceptions false
+                 :connection-manager (s/conn-mgr)}
+         params (merge params (when accept-format {:accept accept-format}))]
+     (parse-ingest-response (client/request params) options))))
+
 (defn ingest-concept
   "Ingest a concept and return a map with status, concept-id, and revision-id"
   ([concept]

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -178,6 +178,7 @@
           (transmit-config/ingest-port)
           (name concept-type)))
 
+
 (defn ingest-url
   [provider-id type native-id]
   (format "http://localhost:%s/providers/%s/%ss/%s"
@@ -185,6 +186,21 @@
           (codec/url-encode provider-id)
           (name type)
           (codec/url-encode native-id)))
+
+(defn ingest-variable-url
+  ([coll-id native-id]
+   (ingest-variable-url coll-id nil native-id))
+  ([coll-id coll-revision-id native-id]
+   (if coll-revision-id
+     (format "http://localhost:%s/collections/%s/%s/variables/%s"
+             (transmit-config/ingest-port)
+             (codec/url-encode coll-id)
+             (codec/url-encode coll-revision-id)
+             (codec/url-encode native-id))
+     (format "http://localhost:%s/collections/%s/variables/%s"
+          (transmit-config/ingest-port)
+          (codec/url-encode coll-id)
+          (codec/url-encode native-id)))))
 
 (defn validate-url
   [provider-id type native-id]

--- a/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/variable_util.clj
@@ -116,6 +116,18 @@
     (swap! unique-index inc)
     (make-variable-concept metadata-attrs attrs @unique-index)))
 
+(defn ingest-variable-with-association
+  "A convenience function for ingesting a variable with collection association during tests."
+  ([]
+   (ingest-variable-with-association (make-variable-concept)))
+  ([variable-concept]
+   (ingest-variable-with-association variable-concept default-opts))
+  ([variable-concept opts]
+   (let [result (ingest-util/ingest-variable variable-concept opts)
+         attrs (select-keys variable-concept
+                            [:provider-id :native-id :metadata])]
+     (merge result attrs))))
+
 (defn ingest-variable
   "A convenience function for ingesting a variable during tests."
   ([]

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_test.clj
@@ -64,25 +64,7 @@
             (is (= 2 revision-id))
             (is (= "f89e99210c80df96d6d35f005d57c5f8"
                    (get-in (mdb/get-concept concept-id revision-id)
-                           [:extra-fields :fingerprint])))))
-
-        (testing "ingest of the existing variable with a different native-id is not allowed"
-          (let [concept (variable-util/make-variable-concept
-                         {:Dimensions [(umm-v/map->DimensionType {:Name "Solution_3_Land"
-                                                                  :Size 3
-                                                                  :Type "OTHER"})]
-                          :AcquisitionSourceName "Instrument1"}
-                         {:native-id "var2"})
-                {:keys [status errors]} (variable-util/ingest-variable
-                                         concept
-                                         (variable-util/token-opts token))]
-            (is (= 409 status))
-            (is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
-                                 "Instrument short name, variable short name, units and dimensions "
-                                 "must be unique. The following variable with the same fingerprint "
-                                 "but different native id was found: [%s].")
-                            var-concept-id)]
-                   errors))))))
+                           [:extra-fields :fingerprint])))))))
 
     (testing "ingest of a variable concept with a revision id"
       (let [concept (variable-util/make-variable-concept {} {:native-id "var1"
@@ -320,20 +302,6 @@
     ;; sanity check
     (is (mdb/concept-exists-in-mdb? var-concept-id initial-revision-id))
     (is (= 1 initial-revision-id))
-
-    (testing "ingest of a variable with the same fingerprint but a different native id is not OK"
-      (let [concept (variable-util/make-variable-concept
-                     {:Name "var1"} {:native-id "a-different-native-id"})
-            {:keys [status errors]} (variable-util/ingest-variable
-                                     concept
-                                     (variable-util/token-opts token))]
-        (is (= 409 status))
-        (is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
-                             "Instrument short name, variable short name, units and dimensions "
-                             "must be unique. The following variable with the same fingerprint "
-                             "but different native id was found: [%s].")
-                        var-concept-id)]
-               errors))))
 
     (let [;; variable with a different variable name, but the same native-id
            concept (variable-util/make-variable-concept

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
@@ -2,6 +2,7 @@
   "CMR variable ingest with association integration tests."
   (:require
    [clojure.test :refer :all]
+   [clojure.string :as string]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.utils.index-util :as index]
@@ -112,12 +113,10 @@
                 ;; with the same collection.
                 {:keys [status errors]} (variable-util/ingest-variable-with-association concept)]
             (is (= 409 status))
-            (is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
-                                 "Instrument short name, variable short name, units and dimensions "
-                                 "must be unique. The following variable with the same fingerprint "
-                                 "but different native id was found: [%s].")
-                            var-concept-id)]
-                   errors))))))
+            (is (= (format (str "collection [%s] can not be associated because the collection "
+                                 "is already associated with another variable [%s] with same name.")
+                           (:concept-id coll1-PROV1-1) var-concept-id)
+                   (second (string/split (first errors) #" and "))))))))
 
     (testing "ingest of a variable concept with a revision id"
       (let [concept (variable-util/make-variable-concept 

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
@@ -1,0 +1,136 @@
+(ns cmr.system-int-test.ingest.variable-ingest-with-association-test
+  "CMR variable ingest with association integration tests."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common-app.test.side-api :as side]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.util :refer [are3]]
+   [cmr.ingest.config :as ingest-config]
+   [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.variable-util :as variable-util]
+   [cmr.umm-spec.models.umm-variable-models :as umm-v]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
+                                           "provguid2" "PROV2"}))
+
+(deftest variable-ingest-with-association-test
+  (let [;; ingest 4 collections, each with 2 revisions
+        coll1-PROV1-1 (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
+                                                                                           :ShortName "S1"}))
+        coll1-PROV1-2 (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
+                                                                                            :ShortName "S1"})) 
+        coll2-PROV1-1 (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E2"
+                                                                                           :ShortName "S2"}))
+        coll2-PROV1-2 (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E2"
+                                                                                            :ShortName "S2"}))
+        coll1-PROV2-1 (data-core/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "E1"
+                                                                                            :ShortName "S1"}))
+        coll1-PROV2-2 (data-core/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "E1"
+                                                                                            :ShortName "S1"}))
+        coll2-PROV2-1 (data-core/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "E2"
+                                                                                            :ShortName "S2"}))
+        coll2-PROV2-2 (data-core/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "E2"
+                                                                                            :ShortName "S2"})) 
+        _ (index/wait-until-indexed)]
+
+    (testing "ingest of a new variable concept with association on PROV1"
+      (let [concept (variable-util/make-variable-concept
+                     {:Dimensions [(umm-v/map->DimensionType {:Name "Solution_3_Land"
+                                                              :Size 3
+                                                              :Type "OTHER"})]
+                      :AcquisitionSourceName "Instrument1"}
+                     {:native-id "var1"
+                      :coll-concept-id (:concept-id coll1-PROV1-1)})
+            {:keys [concept-id revision-id variable-association]} 
+              (variable-util/ingest-variable-with-association concept)
+            var-concept-id concept-id
+            va-concept-id (:concept-id variable-association)
+            va-revision-id (:revision-id variable-association)]
+        (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+        (is (= 1 revision-id))
+        (is (mdb/concept-exists-in-mdb? va-concept-id va-revision-id))
+        (is (= 1 va-revision-id))
+
+        (testing "ingest the same concept with a collection on PROV2 is OK"
+          (let [concept (variable-util/make-variable-concept
+                         {:Dimensions [(umm-v/map->DimensionType {:Name "Solution_3_Land"
+                                                                  :Size 3
+                                                                 :Type "OTHER"})]
+                          :AcquisitionSourceName "Instrument1"}
+                         {:native-id "var1"
+                          :coll-concept-id (:concept-id coll1-PROV2-1)
+                          :coll-revision-id (:revision-id coll1-PROV2-1)})
+                {:keys [concept-id revision-id variable-association]}
+                  (variable-util/ingest-variable-with-association concept)
+                va-concept-id (:concept-id variable-association)
+                va-revision-id (:revision-id variable-association)]
+            (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+            (is (= 1 revision-id))
+            (is (mdb/concept-exists-in-mdb? va-concept-id va-revision-id))
+            (is (= 1 va-revision-id))))
+
+        (testing "Update the same concept on PROV2 with an association on another revision is okay"
+          (let [concept (variable-util/make-variable-concept
+                         {:Dimensions [(umm-v/map->DimensionType {:Name "Solution_3_Land"
+                                                                  :Size 3
+                                                                 :Type "OTHER"})]
+                          :AcquisitionSourceName "Instrument1"}
+                         {:native-id "var1"
+                          :coll-concept-id (:concept-id coll1-PROV2-1)
+                          :coll-revision-id (:revision-id coll1-PROV2-2)})
+                {:keys [concept-id revision-id variable-association]}
+                  (variable-util/ingest-variable-with-association concept)
+                va-concept-id (:concept-id variable-association)
+                va-revision-id (:revision-id variable-association)]
+            (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+            (is (= 2 revision-id))
+            (is (mdb/concept-exists-in-mdb? va-concept-id va-revision-id))
+            (is (= 1 va-revision-id))))
+
+        (testing "ingest of the variable with negligible changes and the same native-id becomes an update"
+          ;; now this is using the existing variable ingest endpoint to update.
+          (let [concept (variable-util/make-variable-concept
+                         {:Dimensions [(umm-v/map->DimensionType {:Name " Solution_3_Land "
+                                                                  :Size 3
+                                                                  :Type "OTHER"})]
+                          :AcquisitionSourceName " Instrument1 "}
+                         {:native-id "var1"})
+                {:keys [concept-id revision-id]} (variable-util/ingest-variable
+                                                  concept)]
+            (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+            (is (= 2 revision-id))))
+
+        (testing "ingest of the existing variable with a different native-id is not allowed"
+          (let [concept (variable-util/make-variable-concept
+                         {:Dimensions [(umm-v/map->DimensionType {:Name "Solution_3_Land"
+                                                                  :Size 3
+                                                                  :Type "OTHER"})]
+                          :AcquisitionSourceName "Instrument1"}
+                         {:native-id "var2"
+                          :coll-concept-id (:concept-id coll1-PROV1-1)})
+                ;; Two variables with the same name (var1, var2) can not be associated
+                ;; with the same collection.
+                {:keys [status errors]} (variable-util/ingest-variable-with-association concept)]
+            (is (= 409 status))
+            (is (= [(format (str "The Fingerprint of the variable which is defined by the variable's "
+                                 "Instrument short name, variable short name, units and dimensions "
+                                 "must be unique. The following variable with the same fingerprint "
+                                 "but different native id was found: [%s].")
+                            var-concept-id)]
+                   errors))))))
+
+    (testing "ingest of a variable concept with a revision id"
+      (let [concept (variable-util/make-variable-concept 
+                      {} 
+                      {:native-id "var1"
+                       :revision-id 5
+                       :coll-concept-id (:concept-id coll1-PROV1-1)})
+            {:keys [concept-id revision-id]} (variable-util/ingest-variable-with-association concept)]
+        (is (= 5 revision-id))
+        (is (mdb/concept-exists-in-mdb? concept-id 5))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/variable_ingest_with_association_test.clj
@@ -2,14 +2,8 @@
   "CMR variable ingest with association integration tests."
   (:require
    [clojure.test :refer :all]
-   [cmr.common-app.test.side-api :as side]
-   [cmr.common.log :as log :refer (debug info warn error)]
-   [cmr.common.mime-types :as mt]
-   [cmr.common.util :refer [are3]]
-   [cmr.ingest.config :as ingest-config]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
-   [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.metadata-db-util :as mdb]

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
@@ -85,18 +85,17 @@
             _ (index/wait-until-indexed)
             response (association-util/associate-by-concept-ids
                       token concept-id [{:concept-id c1-p1}])]
-        (vu/assert-variable-association-bad-request
-         {[c1-p1] {:errors [(format "Collection [%s] does not exist or is not visible." c1-p1)]}}
-         response)))
-
+        ;; when the collection was deleted, the variable got deleted too
+        (is (= 404 (:status response)))
+        (is (= ["Variable with concept id [V1200000025-PROV1] was deleted."] (:errors response)))))
+ 
     (testing "ACLs are applied to collections found"
       ;; None of PROV3's collections are visible
       (let [response (association-util/associate-by-concept-ids token
                                                                 concept-id
                                                                 [{:concept-id c4-p3}])]
-        (vu/assert-variable-association-bad-request
-         {[c4-p3] {:errors [(format "Collection [%s] does not exist or is not visible." c4-p3)]}}
-         response)))))
+        (is (= 404 (:status response)))
+        (is (= ["Variable with concept id [V1200000025-PROV1] was deleted."] (:errors response)))))))
 
 (deftest associate-variable-failure-test
   (echo-util/grant-registered-users (system/context)
@@ -348,17 +347,22 @@
       (association-util/associate-by-concept-ids token
                                                 concept-id
                                                 [{:concept-id (:concept-id latest-coll)}])
-      (assert-variable-associated [latest-coll])
+      ;; The association above fails because variable with concept-id was deleted when the
+      ;; collection was deleted.
+      (assert-variable-associated [])
 
       (testing "Variable still associated with collection after updating variable"
         (let [updated-variable (vu/ingest-variable var-concept)]
-          (is (= {:status 200 :concept-id concept-id :revision-id 2}
+          ;; when the collection was deleted, the variable was deleted and the revision-id
+          ;; was 2, now ingest again, it's 3.
+          (is (= {:status 200 :concept-id concept-id :revision-id 3}
                  (select-keys updated-variable [:status :concept-id :revision-id])))
           (index/wait-until-indexed)
-          (assert-variable-associated [latest-coll])))
+          ;; there wasn't association created.
+          (assert-variable-associated [])))
 
       (testing "Variable not associated with collection after deleting and recreating the variable"
-        (is (= {:status 200 :concept-id concept-id :revision-id 3}
+        (is (= {:status 200 :concept-id concept-id :revision-id 4}
                (select-keys (ingest/delete-concept var-concept {:token token})
                             [:status :concept-id :revision-id])))
         (index/wait-until-indexed)
@@ -368,7 +372,7 @@
 
         (testing "Not associated after variable is recreated."
           ;; create a new revision of the variable
-          (is (= {:status 200 :concept-id concept-id :revision-id 4}
+          (is (= {:status 200 :concept-id concept-id :revision-id 5}
                  (select-keys (vu/ingest-variable var-concept) [:status :concept-id :revision-id])))
           (index/wait-until-indexed)
 

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_association_test.clj
@@ -79,23 +79,14 @@
          {["C100-P5"] {:errors ["Collection [C100-P5] does not exist or is not visible."]}}
          response)))
 
-    (testing "Associate to deleted collections"
-      (let [c1-p1-concept (mdb/get-concept c1-p1)
-            _ (ingest/delete-concept c1-p1-concept)
-            _ (index/wait-until-indexed)
-            response (association-util/associate-by-concept-ids
-                      token concept-id [{:concept-id c1-p1}])]
-        ;; when the collection was deleted, the variable got deleted too
-        (is (= 404 (:status response)))
-        (is (= ["Variable with concept id [V1200000025-PROV1] was deleted."] (:errors response)))))
- 
     (testing "ACLs are applied to collections found"
       ;; None of PROV3's collections are visible
       (let [response (association-util/associate-by-concept-ids token
                                                                 concept-id
                                                                 [{:concept-id c4-p3}])]
-        (is (= 404 (:status response)))
-        (is (= ["Variable with concept id [V1200000025-PROV1] was deleted."] (:errors response)))))))
+        (vu/assert-variable-association-bad-request
+          {[c4-p3] {:errors [(format "Collection [%s] does not exist or is not visible." c4-p3)]}}
+          response)))))
 
 (deftest associate-variable-failure-test
   (echo-util/grant-registered-users (system/context)

--- a/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/variable/variable_search_test.clj
@@ -660,17 +660,13 @@
 
             (testing "delete collection affect the associated collections in search result"
               (let [coll1-concept (mdb/get-concept (:concept-id coll1))
-                    _ (ingest/delete-concept coll1-concept)
-                    ;; Now variable1 is not associated with any collection, as coll1 is deleted
-                    expected-variable1 (assoc expected-variable1
-                                              :associated-collections
-                                              nil)]
+                    _ (ingest/delete-concept coll1-concept)]
                 (index/wait-until-indexed)
 
-                (du/assert-variable-umm-jsons-match
-                 umm-version/current-variable-version [expected-variable1]
-                 (search/find-concepts-umm-json
-                  :variable {:keyword updated-long-name}))))))))))
+                ;; Now the variable is deleted through collection deletion.
+                (is (= 0 (get-in (search/find-concepts-umm-json
+                                   :variable {:keyword updated-long-name})
+                                 [:results :hits])))))))))))
 
 (deftest variable-search-sort
   (let [variable1 (variables/ingest-variable-with-attrs {:native-id "var1"

--- a/transmit-lib/src/cmr/transmit/search.clj
+++ b/transmit-lib/src/cmr/transmit/search.clj
@@ -64,6 +64,10 @@
       (errors/internal-error!
         (format "Granule search failed. status: %s body: %s" status body)))))
 
+(h/defsearcher search-for-collections :search
+  (fn [conn]
+    (format "%s/collections" (conn/root-url conn))))
+
 (h/defsearcher search-for-variables :search
   (fn [conn]
     (format "%s/variables" (conn/root-url conn))))


### PR DESCRIPTION
 
 
This PR is Part1 of several parts of the feature: Variable can not exist without association.

It covers the part that ingest the association at variable ingest time.  No update of the association, and no cascading delete of variables when associations are deleted.  

1. Copied/modified variable association related functions from search-app to metadata-db-app.
This is because we will retire the existing variable association endpoint.

2. Added :search-index component in metadata-db-app to allow execute-query when doing association validation.

3. Added perform-post-commit-association in try-to-save function. so that if the association fails, it'll rollback
the variable insert.

4. Modified the variable response to include variable-association and association-item, on top of concept-id and revision-id.

5. Added cascading collection deletion to associated variables.

6. Removed fingerprint check which is obsolete. The new uniqueness (variable Name + collection) is guaranteed by the code that won't allow multiple variables with the same Name to be associated with the same collection, at association creation time, which is variable's ingest time.

Remaining work in separate tickets:
1. Disallow variable creation using current variable ingest endpoint, can only use it to update.
2. Disable association and dissociation endpoint. Will be done after the invalid data are fixed.
3. Association update. This PR doesn't provide a way to update an association through the new endpoints. Once we finalize the approach, will implement in a separate ticket.


