### PR TITLE
CMR-5806 roll back

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -55,14 +55,6 @@
   "This CORS header is to define how long in seconds the response of the preflight request can be cached"
   "Access-Control-Max-Age")
 
-(def RESPONSE_STRICT_TRANSPORT_SECURITY_HEADER "Strict-Transport-Security")
-
-(def RESPONSE_X_CONTENT_TYPE_OPTIONS_HEADER "X-Content-Type-Options")
-
-(def RESPONSE_X_FRAME_OPTIONS_HEADER "X-Frame-Options")
-
-(def RESPONSE_X_XSS_PROTECTION_HEADER "X-XSS-Protection")
-
 (defn- search-response-headers
   "Generate headers for search response. CORS response headers can be tested through
   dev-system/resources/cors_headers_test.html"
@@ -224,17 +216,4 @@
           (handler)
           (assoc-in [:headers RESPONSE_REQUEST_ID_HEADER] request-id)
           (assoc-in [:headers RESPONSE_X_REQUEST_ID_HEADER] request-id))
-      ((ring-json/wrap-json-response handler) request))))
-
-(defn add-security-header-response-handler
-  ""
-  [handler]
-  (fn [{context :request-context :as request}]
-    (if-let [request-id (cxt/context->request-id context)]
-      (-> request
-          (handler)
-          (assoc-in [:headers RESPONSE_STRICT_TRANSPORT_SECURITY_HEADER] "max-age=31536000")
-          (assoc-in [:headers RESPONSE_X_CONTENT_TYPE_OPTIONS_HEADER] "nosniff")
-          (assoc-in [:headers RESPONSE_X_FRAME_OPTIONS_HEADER] "SAMEORIGIN")
-          (assoc-in [:headers RESPONSE_X_XSS_PROTECTION_HEADER] "1; mode=block"))
       ((ring-json/wrap-json-response handler) request))))

--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -227,7 +227,7 @@
       ((ring-json/wrap-json-response handler) request))))
 
 (defn add-security-header-response-handler
-  "Adds a number of security related response headers."
+  ""
   [handler]
   (fn [{context :request-context :as request}]
     (if-let [request-id (cxt/context->request-id context)]

--- a/ingest-app/src/cmr/ingest/routes.clj
+++ b/ingest-app/src/cmr/ingest/routes.clj
@@ -46,7 +46,6 @@
       mp/wrap-multipart-params
       (api-errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
-      common-routes/add-security-header-response-handler
       (context/build-request-context-handler system)
       common-routes/pretty-print-response-handler
       params/wrap-params))

--- a/search-app/src/cmr/search/routes.clj
+++ b/search-app/src/cmr/search/routes.clj
@@ -122,7 +122,6 @@
       mixed-arity-param-handler
       (errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
-      common-routes/add-security-header-response-handler
       (cmr-context/build-request-context-handler system)
       common-routes/pretty-print-response-handler
       (shapefile-simplifier/shapefile-simplifier default-error-format)

--- a/system-int-test/test/cmr/system_int_test/header_test.clj
+++ b/system-int-test/test/cmr/system_int_test/header_test.clj
@@ -19,10 +19,6 @@
                                     {:raw? true})
         ingest-request-id (ingest-headers "cmr-request-id")
         ingest-x-request-id (ingest-headers "x-request-id")
-        response-strict-transport-security-header-ingest (ingest-headers "Strict-Transport-Security")
-        response-x-content-type-options-header-ingest (ingest-headers "X-Content-Type-Options")
-        response-x-frame-options-header-ingest (ingest-headers "X-Frame-Options")
-        response-x-xss-protection-header-ingest (ingest-headers "X-XSS-Protection")
         _ (index/wait-until-indexed)
         {search-headers :headers} (search/find-concepts-in-format
                                     "application/echo10+xml" :collection {})
@@ -32,10 +28,6 @@
         cmr-took (search-headers "CMR-Took")
         search-request-id (search-headers "CMR-Request-Id")
         search-x-request-id (search-headers "X-Request-Id")
-        response-strict-transport-security-header-search (search-headers "Strict-Transport-Security")
-        response-x-content-type-options-header-search (search-headers "X-Content-Type-Options")
-        response-x-frame-options-header-search (search-headers "X-Frame-Options")
-        response-x-xss-protection-header-search (search-headers "X-XSS-Protection")
         req-id-regex #"\w{8}-\w{4}-\w{4}-\w{4}-\w{12}"]
     (is (re-matches #"application\/echo10\+xml.*" content-type))
     (is (= aca-origin "*"))
@@ -44,14 +36,6 @@
     (is (= search-request-id search-x-request-id))
     (is (re-matches req-id-regex ingest-request-id))
     (is (re-matches req-id-regex search-request-id))
-    (is (= response-strict-transport-security-header-ingest "max-age=31536000"))
-    (is (= response-x-content-type-options-header-ingest "nosniff"))
-    (is (= response-x-frame-options-header-ingest "SAMEORIGIN"))
-    (is (= response-x-xss-protection-header-ingest "1; mode=block"))
-    (is (= response-strict-transport-security-header-search "max-age=31536000"))
-    (is (= response-x-content-type-options-header-search "nosniff"))
-    (is (= response-x-frame-options-header-search "SAMEORIGIN"))
-    (is (= response-x-xss-protection-header-search "1; mode=block"))
     (is (re-matches #"\d+" cmr-took))))
 
 (defn- cmr-request-id-in-header?


### PR DESCRIPTION
This rolls back @daniel-zamora's commits for CMR-5806 to fix the API doc page issue so that we can create a new release for UAT deployment. The code fix in these commits is good, but because it exposed some other issues on the api doc page and caused api doc page not loading correctly. We will roll this back so that we can create a release with the rest of fixes in Sprint 20.3.1 for UAT deployment.