### PR TITLE
CMR-6629 As a client application, I want to pass an Earthdata Login token without an app id because Earthdata Login may not need it and I may not have it

### DIFF
--- a/access-control-app/docs/api.md
+++ b/access-control-app/docs/api.md
@@ -47,6 +47,10 @@ Content-Type is a standard HTTP header that specifies the content type of the bo
 
 All Access Control API operations require specifying a token obtained from URS or ECHO. The token should be specified using the `Echo-Token` header.
 
+#### <a name="authorization-header"></a> Authorization Header
+
+The token can alternatively be specified using the `Authorization: Bearer` header, and by specifying a Bearer token.
+
 #### <a name="cmr-revision-id-header"></a> Cmr-Revision-Id Header
 
 The revision id header allows specifying the revision id to use when saving the concept.  It is optional for all acl update.  The update will be rejected when 1. the revision id specified is not an integer. 2. the revision id specified <= current revision id of the acl - a HTTP Status code of 409 will be returned indicating a conflict.

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -24,7 +24,8 @@
   "Returns the token the user passed in the headers or parameters"
   [params headers]
   (let [non-empty-string #(when-not (str/blank? %) %)]
-    (or (non-empty-string (:token params))
+    (or (non-empty-string (get headers tc/authorization-header))
+        (non-empty-string (:token params))
         (non-empty-string (get headers tc/token-header)))))
 
 (defn- get-client-id

--- a/common-app-lib/src/cmr/common_app/api/routes.clj
+++ b/common-app-lib/src/cmr/common_app/api/routes.clj
@@ -92,7 +92,7 @@
    :headers {CONTENT_TYPE_HEADER "text/plain; charset=utf-8"
              CORS_ORIGIN_HEADER "*"
              CORS_METHODS_HEADER "POST, GET, OPTIONS"
-             CORS_CUSTOM_ALLOWED_HEADER "Echo-Token, Accept, Content-Type, Client-Id, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id"
+             CORS_CUSTOM_ALLOWED_HEADER "Echo-Token, Accept, Content-Type, Client-Id, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, Authorization"
              ;; the value in seconds for how long the response to the preflight request can be cached
              ;; set to 30 days
              CORS_MAX_AGE_HEADER "2592000"}})

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -14,8 +14,8 @@
   {:default "1.15.3"})
 
 (defconfig launchpad-token-enforced
-  "Flag for whether or not launchpad token is enforeced."
-  {:default false
+  "Flag for whether or not launchpad token is enforced."
+  {:default false 
    :type Boolean})
 
 (defconfig release-version

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -69,6 +69,10 @@ application/vnd.nasa.cmr.umm+json;version=1.14
 
 All Ingest API operations require specifying a token obtained from URS or ECHO. The token should be specified using the `Echo-Token` header.
 
+#### <a name="authorization-header"></a> Authorization Header
+
+The token can alternatively be specified using the `Authorization: Bearer` header, and by specifying a Bearer token.
+
 #### <a name="accept-header"></a> Accept Header
 
 The Accept header specifies the format of the response message. The Accept header will default to XML for the normal Ingest APIs. `application/json` can be specified if you prefer responses in JSON.

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -212,7 +212,7 @@ The Maximum URL Length supported by CMR is indirectly controlled by the Request 
 
 #### <a name="cors-header-support"></a> CORS Header support
 
-The CORS headers are supported on search endpoints. Check [CORS Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) for an explanation of CORS headers. Custom CORS request headers supported are Echo-Token and Client-Id. Custom response headers supported are CMR-Hits, CMR-Request-Id, X-Request-Id and CMR-Scroll-Id.
+The CORS headers are supported on search endpoints. Check [CORS Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) for an explanation of CORS headers. Custom CORS request headers supported are Echo-Token, Authorization, and Client-Id. Custom response headers supported are CMR-Hits, CMR-Request-Id, X-Request-Id and CMR-Scroll-Id.
 
 #### <a name="query-parameters"></a> Query Parameters
 
@@ -278,6 +278,8 @@ These are query parameters that control what extra data is included with collect
   * Accept - specifies the MimeType to return search results in. Default is "application/xml".
     * `curl -H "Accept: application/xml" -i "%CMR-ENDPOINT%/collections"`
   * `Echo-Token` - specifies an ECHO token to use to authenticate yourself.
+  * `Authorization: Bearer` - specifies an URS Authorization Bearer token to use to authenticate yourself.
+    * `curl -H "Authorization: Bearer <access_token>" -i "%CMR-ENDPOINT%/collections"`
   * `Client-Id` - Indicates a name for the client using the CMR API. Specifying this helps Operations monitor query performance per client. It can also make it easier for them to identify your requests if you contact them for assistance.
   * `X-Request-Id` - This provides standard X-Request-Id support to allow user to pass in some random ID which will be logged on the server side for debugging purpose.
   * `CMR-Request-Id` - This header serves the same purpose as X-Request-Id header. It's kept to support legacy systems.  

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -278,7 +278,7 @@ These are query parameters that control what extra data is included with collect
   * Accept - specifies the MimeType to return search results in. Default is "application/xml".
     * `curl -H "Accept: application/xml" -i "%CMR-ENDPOINT%/collections"`
   * `Echo-Token` - specifies an ECHO token to use to authenticate yourself.
-  * `Authorization: Bearer` - specifies an URS Authorization Bearer token to use to authenticate yourself.
+  * `Authorization: Bearer` - specifies an EDL Authorization Bearer token to use to authenticate yourself.
     * `curl -H "Authorization: Bearer <access_token>" -i "%CMR-ENDPOINT%/collections"`
   * `Client-Id` - Indicates a name for the client using the CMR API. Specifying this helps Operations monitor query performance per client. It can also make it easier for them to identify your requests if you contact them for assistance.
   * `X-Request-Id` - This provides standard X-Request-Id support to allow user to pass in some random ID which will be logged on the server side for debugging purpose.

--- a/system-int-test/test/cmr/system_int_test/header_test.clj
+++ b/system-int-test/test/cmr/system_int_test/header_test.clj
@@ -154,6 +154,7 @@
                               (get-in [:headers "Access-Control-Allow-Headers"])
                               (string/split #", "))]
       (is (some #{"Echo-Token"} allowed-headers))
+      (is (some #{"Authorization"} allowed-headers))
       (is (some #{"Client-Id"} allowed-headers))
       (is (some #{"CMR-Request-Id"} allowed-headers))
       (is (some #{"X-Request-Id"} allowed-headers))

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -41,6 +41,9 @@
 (def token-header
   "echo-token")
 
+(def authorization-header 
+  "authorization")
+
 (def revision-id-header
   "cmr-revision-id")
 


### PR DESCRIPTION
Aswell as Echo-Token=<token>:<app-id>, Authorization: Bearer <access_token>, which EDL supports.

Better, at the discretion of CMR, would be implementing CMR-6630. Precise details are in work in #analysis-authn-authz in EOSDIS Slack, but the gist is that you could use a different, more standard header for tokens without an app ID to be consistent with the rest of the enterprise and possibly ease implementation / compatibility. It seems likely that token would be "Authorization=bearer <token>"

Example of how apps will pass tokens 

Both giver and receiver applications will be in the same ECHO EDL group.

HTTP request with header: