### PR TITLE
CMR-6458 Remove alias support and update var version to 1.7 in OUS

### DIFF
--- a/cmr-exchange/exchange-query/project.clj
+++ b/cmr-exchange/exchange-query/project.clj
@@ -19,20 +19,20 @@
   :url "https://github.com/cmr-exchange/cmr-exchange-query"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[cheshire "5.8.1"]
+  :dependencies [[cheshire "5.10.0"]
                  [clojusc/trifl "0.4.2"]
                  [clojusc/twig "0.4.1"]
-                 [com.stuartsierra/component "0.4.0"]
+                 [com.stuartsierra/component "1.0.0"]
                  [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
-                 [org.clojure/clojure "1.9.0"]
-                 [ring/ring-codec "1.1.1"]]
+                 [org.clojure/clojure "1.10.1"]
+                 [ring/ring-codec "1.1.2"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"
              "-Xmx2g"]
   :aot [clojure.tools.logging.impl]
   :profiles {:ubercompile {:aot :all
                            :source-paths ["test"]}
-             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]
+             :security {:plugins [[com.livingsocial/lein-dependency-check "1.1.4"]]
                         :dependency-check {:output-format [:all]
                                            :suppression-file "resources/security/suppression.xml"}
                         :source-paths ^:replace ["src"]
@@ -43,11 +43,11 @@
                                      ;; The following is excluded because it stomps on twig's logger
                                      [org.slf4j/slf4j-simple]]}
              :system {:dependencies [[clojusc/system-manager "0.3.0"]]}
-             :local {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+             :local {:dependencies [[org.clojure/tools.namespace "1.0.0"]
                                     [proto-repl "0.3.1"]]
                      :plugins [[lein-project-version "0.1.0"]
                                [lein-shell "0.5.0"]
-                               [venantius/ultra "0.5.4"]]
+                               [venantius/ultra "0.6.0"]]
                      :source-paths ["dev-resources/src"]
                      :jvm-opts ["-Dlogging.color=true"]}
              :dev {:dependencies [[debugger "0.2.1"]]
@@ -56,12 +56,12 @@
                                   :init ~(println (get-banner))}}
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.3.5"]
+                    :plugins [[jonase/eastwood "0.3.11"]
                               [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.1"]
-                              [lein-kibit "0.1.6"]]}
-             :test {:dependencies [[clojusc/ltest "0.3.0"]]
-                    :plugins [[lein-ltest "0.3.0"]
+                              [lein-bikeshed "0.5.2"]
+                              [lein-kibit "0.1.8"]]}
+             :test {:dependencies [[clojusc/ltest "0.4.0"]]
+                    :plugins [[lein-ltest "0.4.0"]
                               [test2junit "1.4.2"]]
                     :jvm-opts ["-Dcmr.testing.config.data=testing-value"]
                     :test2junit-output-dir "junit-test-results"

--- a/cmr-exchange/exchange-query/src/cmr/exchange/query/impl/cmr.clj
+++ b/cmr-exchange/exchange-query/src/cmr/exchange/query/impl/cmr.clj
@@ -32,11 +32,7 @@
    ;; OPeNDAP URL. This is used for subsetting.
    variables
    ;;
-   ;; `variables-aliases` is a list of variable aliases to be specified when creating the
-   ;; OPeNDAP URL. This is used for subsetting.
-   variable-aliases
-   ;;
-   ;; `service-id` concept id for a service. 
+   ;; `service-id` concept id for a service.
    service-id
    ;;
    ;; `subset` is used the same way as `subset` for WCS where latitudes,
@@ -64,8 +60,7 @@
                                 %
                                 #{(keyword "granules[]")
                                   (keyword "temporal[]")
-                                  (keyword "variables[]")
-                                  (keyword "variable-aliases[]")}))
+                                  (keyword "variables[]")}))
 
 (defn ->query-string
   [this]
@@ -86,7 +81,6 @@
         subset (:subset params)
         granules-array (query-util/get-array-param params :granules)
         variables-array (query-util/get-array-param params :variables)
-        variable-aliases-array (query-util/get-array-param params :variable-aliases)
         temporal-array (query-util/get-array-param params :temporal)]
     (log/trace "original bounding-box:" (:bounding-box params))
     (log/trace "bounding-box:" bounding-box)
@@ -95,8 +89,6 @@
       (log/trace "granules-array:" granules-array))
     (when variables-array
       (log/trace "variables-array:" variables-array))
-    (when variable-aliases-array
-      (log/trace "variable-aliases-array:" variable-aliases-array))
     (map->CollectionCmrStyleParams
       (-> params
           (assoc
@@ -107,9 +99,6 @@
            :variables (if (query-util/not-array? variables-array)
                         (query-util/split-comma->sorted-coll (:variables params))
                         variables-array)
-           :variable-aliases (if (query-util/not-array? variable-aliases-array)
-                               (query-util/split-comma->sorted-coll (:variable-aliases params))
-                               variable-aliases-array)
            :exclude-granules (util/bool (:exclude-granules params))
            :subset (if (seq bounding-box)
                     (query-util/bounding-box->subset bounding-box)
@@ -123,8 +112,7 @@
                        temporal-array))
           (dissoc (keyword "granules[]")
                   (keyword "temporal[]")
-                  (keyword "variables[]")
-                  (keyword "variable-aliases[]"))))))
+                  (keyword "variables[]"))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   Implementation of Collections Params API   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cmr-exchange/exchange-query/test/cmr/exchange/query/tests/unit/core.clj
+++ b/cmr-exchange/exchange-query/test/cmr/exchange/query/tests/unit/core.clj
@@ -179,23 +179,21 @@
           :bounding-box nil
           :collection-id "C130"
           :exclude-granules false
-          :format nil 
+          :format nil
           :granules ()
           :subset nil
           :temporal []
-          :variables ()
-          :variable-aliases ()}
+          :variables ()}
          (query/parse {:collection-id "C130"})))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
           :bounding-box nil
           :collection-id "C130"
           :exclude-granules false
-          :format nil 
+          :format nil
           :granules ()
           :subset []
           :temporal []
-          :variables ()
-          :variable-aliases ()}
+          :variables ()}
          (query/parse {:collection-id "C130" :subset []})))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
           :collection-id "C130"
@@ -205,8 +203,8 @@
           :variables ["V234" "V345"]
           :subset nil
           :bounding-box nil
-          :temporal []})
-         (query/parse {:collection-id "C130" :variables ["V234" "V345"]}))
+          :temporal []}
+         (query/parse {:format "nc" :collection-id "C130" :variables ["V234" "V345"]})))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
           :collection-id "C130"
           :format "nc"
@@ -215,8 +213,8 @@
           :variables ["V234" "V345"]
           :subset nil
           :bounding-box nil
-          :temporal []})
-         (query/parse {:collection-id "C130" "variables[]" ["V234" "V345"]}))
+          :temporal []}
+         (query/parse {:format "nc" :collection-id "C130" "variables[]" ["V234" "V345"]})))
   (is (= {:errors ["The following required parameters are missing from the request: [:collection-id]"]}
          (query/parse {:variables ["V234" "V345"]}
                       nil

--- a/cmr-exchange/exchange-query/test/cmr/exchange/query/tests/unit/util.clj
+++ b/cmr-exchange/exchange-query/test/cmr/exchange/query/tests/unit/util.clj
@@ -88,5 +88,5 @@
 (deftest unique-params-keys
   (is (= #{:coverage :rangesubset :timeposition}
          (util/unique-params-keys wcs/map->CollectionWcsStyleParams)))
-  (is (= #{:exclude-granules :variable-aliases :variables :granules :bounding-box :temporal :service-id}
+  (is (= #{:exclude-granules :variables :granules :bounding-box :temporal :service-id}
          (util/unique-params-keys cmr/map->CollectionCmrStyleParams))))

--- a/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
+++ b/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
@@ -189,28 +189,26 @@
   * `vars` - metadata for all the specified variable ids
   * `vars` - metadata for all the specified variable ids
   * `vars` - metadata for all the variables associated in the collection"
-  [search-endpoint user-token coll {:keys [bounding-box variables variable-aliases] :as params}]
+  [search-endpoint user-token coll {:keys [bounding-box variables] :as params}]
   (log/debugf (str "Applying bounding conditions with bounding box %s and "
-                   "variable ids %s and "
-                   "variable aliases %s...")
+                   "variable ids %s")
               bounding-box
-              variables
-              variable-aliases)
+              variables)
   (cond
     ;; Condition 1 - no spatial subsetting and no variables
-    (and (nil? bounding-box) (empty? variables) (empty? variable-aliases))
+    (and (nil? bounding-box) (empty? variables))
     []
 
     ;; Condition 2 - variables but no spatial subsetting
-    (and (nil? bounding-box) (or (seq variables) (seq variable-aliases)))
+    (and (nil? bounding-box) (seq variables))
     (variable/get-metadata search-endpoint user-token params)
 
     ;; Condition 3 - variables and spatial subsetting
-    (and bounding-box (or (seq variables) (seq variable-aliases)))
+    (and bounding-box (or (seq variables)))
     (variable/get-metadata search-endpoint user-token params)
 
     ;; Condition 4 - spatial subsetting but no variables
-    (and bounding-box (empty? variables) (empty? variable-aliases))
+    (and bounding-box (empty? variables))
     (variable/get-metadata search-endpoint
      user-token
      (assoc params :variables (collection/extract-variable-ids coll)))))

--- a/cmr-exchange/ous-plugin/test/cmr/ous/tests/unit/util/query.clj
+++ b/cmr-exchange/ous-plugin/test/cmr/ous/tests/unit/util/query.clj
@@ -8,47 +8,47 @@
 
 (deftest parse
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
-          :bounding-box nil
-          :collection-id "C130"
-          :exclude-granules false
-          :format nil 
-          :granules ()
-          :subset nil
-          :temporal []
-          :variables ()
-          :variable-aliases ()}
+                                                               :bounding-box nil
+                                                               :collection-id "C130"
+                                                               :exclude-granules false
+                                                               :format nil
+                                                               :granules ()
+                                                               :subset nil
+                                                               :temporal []
+                                                               :variables ()}
+
          (query/parse {:collection-id "C130"})))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
-          :bounding-box nil
-          :collection-id "C130"
-          :exclude-granules false
-          :format nil 
-          :granules ()
-          :subset []
-          :temporal []
-          :variables ()
-          :variable-aliases ()}
+                                                               :bounding-box nil
+                                                               :collection-id "C130"
+                                                               :exclude-granules false
+                                                               :format nil
+                                                               :granules ()
+                                                               :subset []
+                                                               :temporal []
+                                                               :variables ()}
+
          (query/parse {:collection-id "C130" :subset []})))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
-          :collection-id "C130"
-          :format "nc"
-          :granules []
-          :exclude-granules false
-          :variables ["V234" "V345"]
-          :subset nil
-          :bounding-box nil
-          :temporal []})
-         (query/parse {:collection-id "C130" :variables ["V234" "V345"]}))
+                                                               :collection-id "C130"
+                                                               :format "nc"
+                                                               :granules []
+                                                               :exclude-granules false
+                                                               :variables ["V234" "V345"]
+                                                               :subset nil
+                                                               :bounding-box nil
+                                                               :temporal []})
+      (query/parse {:collection-id "C130" :variables ["V234" "V345"]}))
   (is (= #cmr.exchange.query.impl.cmr.CollectionCmrStyleParams{
-          :collection-id "C130"
-          :format "nc"
-          :granules []
-          :exclude-granules false
-          :variables ["V234" "V345"]
-          :subset nil
-          :bounding-box nil
-          :temporal []})
-         (query/parse {:collection-id "C130" "variables[]" ["V234" "V345"]}))
+                                                               :collection-id "C130"
+                                                               :format "nc"
+                                                               :granules []
+                                                               :exclude-granules false
+                                                               :variables ["V234" "V345"]
+                                                               :subset nil
+                                                               :bounding-box nil
+                                                               :temporal []})
+      (query/parse {:collection-id "C130" "variables[]" ["V234" "V345"]}))
   (is (= {:errors ["The following required parameters are missing from the request: [:collection-id]"]}
          (query/parse {:variables ["V234" "V345"]})))
   (is (= {:errors ["One or more of the parameters provided were invalid."


### PR DESCRIPTION
This PR:
 removes any reference to variable alias as a search parameter to cmr, this parameter is no longer support due to 1.7 changes
 updates failing tests and modifies current tests to interact with alias changes.
 updates cmr-exchange query dependencies in order to do local builds but doesn't seem to affect CI, which I left in but can remove, we should open a ticket to update all of cmr-exchange dependencies
 
I couldn't find any instance in splunk where alias was actually used as a parameter to a query made to ous in prod, uat, or sit in the past 30 days, so I don't think this change is going to break any clients.