### PR TITLE
CMR-6451: fix autocomplete ACL group id filtering

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -210,7 +210,7 @@
                                true
                                false)
         permitted-group-ids (->> permissions
-                                 (remove #(or (= "registered" %) (= "guest" %)))
+                                 (remove #(= "guest" %))
                                  (s/join ",")
                                  not-empty)]
     (if (seq (re-find sk-matcher))

--- a/search-app/src/cmr/search/services/autocomplete_service.clj
+++ b/search-app/src/cmr/search/services/autocomplete_service.clj
@@ -16,7 +16,14 @@
   (if-not (empty? user-acls)
     (gc/or-conds [public-collections-condition
                   (gc/or-conds
-                   (map #(qm/text-condition :permitted-group-ids %) user-acls))])
+                   ; case insensitive pattern condition to allow searching through
+                   ; concatenated group names
+                   (map (fn [acl-id]
+                          (qm/string-condition :permitted-group-ids
+                                               (format "*%s*" acl-id)
+                                               :false
+                                               :true))
+                        user-acls))])
     public-collections-condition))
 
 (defn- empty-token-with-type

--- a/search-app/src/cmr/search/services/autocomplete_service.clj
+++ b/search-app/src/cmr/search/services/autocomplete_service.clj
@@ -23,7 +23,7 @@
                                                (format "*%s*" acl-id)
                                                :false
                                                :true))
-                        user-acls))])
+                        (into user-acls ["registered"])))])
     public-collections-condition))
 
 (defn- empty-token-with-type

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -131,13 +131,23 @@
                    :AccessConstraints (data-umm-spec/access-constraints
                                          {:Value 1 :Description "Those files are for British eyes only."})})
                 {:format :umm-json})
+        coll6 (d/ingest-umm-spec-collection
+                "PROV2"
+                (data-umm-spec/collection
+                  {:ShortName "short but not so short that it's not unique"
+                   :EntryTitle "Registered Collection"
+                   :Projects (:Projects (fu/projects "REGISTERED"))
+                   :Platforms (:Platforms (fu/platforms "REGISTERED" 2 2 1))})
+                {:format :umm-json})
         c1-echo (d/ingest "PROV1"
                           (dc/collection {:entry-title "c1-echo" :access-value 1})
                           {:format :echo10})
         group1-concept-id (e/get-or-create-group (s/context) "group1")
         group2-concept-id (e/get-or-create-group (s/context) "group2")
+        group3-concept-id (e/get-or-create-group (s/context) "group3")
         group-acl (e/grant-group (s/context) group1-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))
-        group2-acl (e/grant-group (s/context) group2-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))]
+        group2-acl (e/grant-group (s/context) group2-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))
+        group3-acl (e/grant-registered-users (s/context) (e/coll-catalog-item-id "PROV2" (e/coll-id ["Registered Collection"])))]
 
     (ingest/reindex-collection-permitted-groups "mock-echo-system-token")
     (index/wait-until-indexed)
@@ -159,6 +169,7 @@
 
 (deftest token-test
   (let [user1-token (e/login (s/context) "user1" [(e/get-or-create-group (s/context) "group1")])
+        user3-token (e/login (s/context) "user3" [(e/get-or-create-group (s/context) "group3")])
         _ (index/refresh-elastic-index)]
     (testing "Suggestions associated to collections with access constraints are returned"
       (compare-autocomplete-results
@@ -169,7 +180,17 @@
     (testing "Suggestions associated to collections with access constraints not returned without a token"
       (compare-autocomplete-results
        (get-in (search/get-autocomplete-json "q=From") [:feed :entry])
-       []))))
+       []))
+    (testing "Suggestion associated to collections granted to registered users"
+      (compare-autocomplete-results
+       (get-in (search/get-autocomplete-json "q=REGISTERED" {:headers {:echo-token user3-token}}) [:feed :entry])
+       [{:score 4.5634737 :type "project" :value "REGISTERED" :fields "REGISTERED"}
+        {:score 3.2571084 :type "instrument" :value "REGISTERED-p0-i0" :fields "REGISTERED-p0-i0"}
+        {:score 3.187054 :type "platform" :value "REGISTERED-p0" :fields "REGISTERED-p0"}
+        {:score 3.187054 :type "platform" :value "REGISTERED-p1" :fields "REGISTERED-p1"}
+        {:score 3.136525 :type "instrument" :value "REGISTERED-p0-i1" :fields "REGISTERED-p0-i1"}
+        {:score 3.136525 :type "instrument" :value "REGISTERED-p1-i0" :fields "REGISTERED-p1-i0"}
+        {:score 3.136525 :type "instrument" :value "REGISTERED-p1-i1" :fields "REGISTERED-p1-i1"}]))))
 
 (deftest reindex-suggestions-test
   (testing "Ensure that response is in proper format and results are correct"

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -135,7 +135,9 @@
                           (dc/collection {:entry-title "c1-echo" :access-value 1})
                           {:format :echo10})
         group1-concept-id (e/get-or-create-group (s/context) "group1")
-        group-acl (e/grant-group (s/context) group1-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))]
+        group2-concept-id (e/get-or-create-group (s/context) "group2")
+        group-acl (e/grant-group (s/context) group1-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))
+        group2-acl (e/grant-group (s/context) group2-concept-id (e/coll-catalog-item-id "PROV2" (e/coll-id ["Secret Collection"])))]
 
     (ingest/reindex-collection-permitted-groups "mock-echo-system-token")
     (index/wait-until-indexed)


### PR DESCRIPTION
Suggestions are not being found when an autocomplete suggestion is not public but belongs to multiple groups. Updated the test to put the expected items into multiple groups and update the field to support patterned searches