### PR TITLE
CMR-6685 improved anti-value detection and error handling while re-indexing autocomplete suggestions

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -258,6 +258,7 @@
   [term]
   (let [rx (re-pattern #"(none|not (provided|applicable))")]
     (or (nil? term)
+        (= "" (s/trim term))
         (some? (re-find rx (s/lower-case term))))))
 
 (defn anti-value-suggestion?

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -282,9 +282,10 @@
   "Convert collection concept metadata to UMM-C and pull facet fields
   to be indexed as autocomplete suggestion doc"
   [context collections provider-id]
-  (let [parsed-concepts (->> collections
+  (let [parse-coll (partial parse-collection context)
+        parsed-concepts (->> collections
                              (remove :deleted)
-                             (map parse-collection)
+                             (map parse-coll)
                              (remove nil?))
         collection-permissions (map (fn [collection]
                                       (let [permissions (collection-util/get-coll-permitted-group-ids context provider-id collection)]

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -26,4 +26,17 @@
 
        {:value "none"} true
        {:value "not applicable"} true
-       {:value "not provided"} true))
+       {:value "not provided"} true)
+
+  (testing "null values don't fail indexing"
+    (is (= [false
+            true
+            true
+            true
+            true]
+           (map #(index-svc/anti-value-suggestion? %)
+                [{:value "ice-sat"}
+                 {:value nil}
+                 {:value "none"}
+                 {:value "not applicable"}
+                 {:value "NOT PROVIDED"}])))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -26,17 +26,8 @@
 
        {:value "none"} true
        {:value "not applicable"} true
-       {:value "not provided"} true)
-
-  (testing "null values don't fail indexing"
-    (is (= [false
-            true
-            true
-            true
-            true]
-           (map #(index-svc/anti-value-suggestion? %)
-                [{:value "ice-sat"}
-                 {:value nil}
-                 {:value "none"}
-                 {:value "not applicable"}
-                 {:value "NOT PROVIDED"}])))))
+       {:value "not provided"} true
+       {:value ""} true
+       {:value "      "} true
+       {:value "\n\t"} true
+       {:value nil} true))


### PR DESCRIPTION
Failed nil-check assertions have been replaced by return values. Additionally catching empty-strings as anti-values.