### PR TITLE
CMR-6624 As the CMR, I want the community usage file we take from EMS to use collection shortname as the collection identifier

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/parameter_validation.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/parameter_validation.clj
@@ -408,7 +408,6 @@
    unrecognized-params-in-options-validation
    parameter-options-validation])
 
-
 (defn validate-parameters
   "Applies the list of validations to the parameters throwing an exception if there were any errors.
    An optional list of other errors can be passed in to add to the set that's thrown."

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2286,6 +2286,11 @@ Exclude granule by concept id
 Exclude granule by parent concept id
 
     curl "%CMR-ENDPOINT%/granules?provider=PROV1&provider=PROV2&echo_granule_id\[\]=G1000000002-CMR_PROV1&echo_granule_id\[\]=G1000000003-CMR_PROV1&echo_granule_id\[\]=G1000000006-CMR_PROV2&exclude\[concept_id\]\[\]=C1000000001-CMR_PROV2"
+<<<<<<< e88dc73a07a60f90f5766733cb4e5d77b6a1c396
+=======
+
+#### <a name="g-include-polygons"></a> Include generated orbital polygons.
+>>>>>>> CMR-6624 Updates documentation.
 
 #### <a name="sorting-granule-results"></a> Sorting Granule Results
 
@@ -4601,7 +4606,7 @@ Community usage metrics are metrics showing how many times a particular version 
 
 #### <a name="updating-community-usage-metrics"></a> Updating Community Usage Metrics
 
-Community usage metrics can be updated using the `%CMR-ENDPOINT%/community-usage-metrics` endpoint with a valid ECHO token. The content is a CSV file obtained from the EMS. The 'Product', 'Version', and 'Hosts' columns are parsed from the CSV file and stored as 'short-name', 'version', and 'access-count' respectively in the CMR. Entries with the same Product (short-name) and Version will have the access count aggregated to form a total access count for that collection and version, stored as one entry in the CMR.
+Community usage metrics can be updated using the `%CMR-ENDPOINT%/community-usage-metrics` endpoint with a valid ECHO token. The content is a CSV file obtained from the EMS. The 'Product', 'Version', and 'Hosts' columns are parsed from the CSV file and stored as 'short-name', 'version', and 'access-count' respectively in the CMR. Entries with the same Product (short-name) and Version will have the access count aggregated to form a total access count for that collection and version, stored as one entry in the CMR. The comprehensive parameter accepts a boolean value, true will cause a lookup verification on each line, false will try and short cut the lookup by checking first against the current metrics humanizer, defaults to false.
 
 Note that when sending the data, use the --data-binary option so that the linebreaks in the CSV data are not removed. See the example below.
 

--- a/search-app/src/cmr/search/api/community_usage_metrics.clj
+++ b/search-app/src/cmr/search/api/community_usage_metrics.clj
@@ -21,10 +21,10 @@
 
 (defn- update-community-usage
   "Processes a community usage update request"
-  [context headers body]
+  [context headers params body]
   (acl/verify-ingest-management-permission context :update)
   (mt/extract-header-mime-type #{mt/csv} headers "content-type" true)
-  (let [result (metrics-service/update-community-usage context body)
+  (let [result (metrics-service/update-community-usage context params body)
         status-code (if (= 1 (:revision-id result)) 201 200)]
     (community-usage-metrics-response status-code result)))
 
@@ -33,8 +33,8 @@
   (context "/community-usage-metrics" []
 
     ;; create/update community usage metrics
-    (PUT "/" {:keys [request-context headers body]}
-      (update-community-usage request-context headers (slurp body)))
+    (PUT "/" {:keys [request-context headers params body]}
+      (update-community-usage request-context headers params (slurp body)))
 
     ;; retrieve community usage metrics
     (GET "/" {:keys [request-context]}

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -96,8 +96,6 @@
             searched-short-name (if (= "true" comprehensive)
                                   (comprehensive-collection-short-name-search context short-name)
                                   (efficient-collection-short-name-search context short-name current-metrics))]
-        (def csv-line "PROV1,SHORTNAME1,N/A,1")
-        (def short-name "SHORTNAME1")
         {:short-name (if (seq searched-short-name)
                        searched-short-name
                        (do

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -5,6 +5,9 @@
    [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.string :as str]
+   [cmr.common-app.services.search.parameter-validation :as cpv]
+   [cmr.common-app.services.search.query-execution :as qe]
+   [cmr.common-app.services.search.query-model :as qm]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
@@ -30,15 +33,70 @@
   (when (>= col 0)
     (nth csv-line col)))
 
+(defn- get-short-name-by-entry-title
+  "Query elastic for a collection with a given entry-title, returns short-name"
+  [context entry-title]
+  (when (seq entry-title)
+    (let [condition (qm/string-condition :entry-title (str entry-title "*") true true)
+          query (qm/query {:concept-type :collection
+                           :condition condition
+                           :page-size 1
+                           :all-revisions? true
+                           :result-format :query-specified
+                           :result-fields [:short-name]})
+          results (qe/execute-query context query)
+          short-name (first (map :short-name (:items results)))]
+      short-name)))
+
+(defn- get-collection-by-short-name
+  "Query elastic for collection with a given short-name, returns short-name"
+  [context short-name]
+  (when (seq short-name)
+    (let [condition (qm/string-condition :short-name short-name)
+          query (qm/query {:concept-type :collection
+                           :condition condition
+                           :page-size 1
+                           :all-revisions? true
+                           :result-format :query-specified
+                           :result-fields [:short-name]})
+          results (qe/execute-query context query)
+          short-name (first (map :short-name (:items results)))]
+      short-name)))
+
+(defn- comprehensive-collection-short-name-search
+  "This function checks CMR for a collection with given short-name, if it can't find it
+   Then it will check for a collection with that entry-title and return its short-name.
+   Currently there are providers who are supply non-short-name values in short-name, which breaks usage
+   metrics.  This is a short term solution to this problem, the long term solution is correcting the
+   EMS data which may take a long time to happen."
+  [context short-name]
+  (if (get-collection-by-short-name context short-name)
+    short-name
+    (get-short-name-by-entry-title context short-name)))
+
+(defn- efficient-collection-short-name-search
+  "This function will check the current community-usage-metrics humanizer to see if this shortname exists,
+   if it does, then it will return that short-name, otherwise it will try looking up the short-name via
+   entry-title."
+  [context short-name current-metrics]
+  (if (get current-metrics short-name)
+    short-name
+    (comprehensive-collection-short-name-search context short-name)))
+
 (defn- csv-entry->community-usage-metric
   "Convert a line in the csv file to a community usage metric. Only storing short-name (product),
    version (can be 'N/A' or a version number), and access-count (hosts)"
-  [csv-line product-col version-col hosts-col]
+  [context csv-line product-col version-col hosts-col comprehensive current-metrics]
   (when (seq (remove empty? csv-line)) ; Don't process empty lines
    (let [short-name (read-csv-column csv-line product-col)
-         version (read-csv-column csv-line version-col)]
+         version (read-csv-column csv-line version-col)
+         searched-short-name (if (= "true" comprehensive)
+                              (comprehensive-collection-short-name-search context short-name)
+                              (efficient-collection-short-name-search context short-name current-metrics))]
      {:short-name (if (seq short-name)
-                    short-name
+                    (if (seq searched-short-name)
+                      searched-short-name
+                      short-name)
                     (errors/throw-service-error :invalid-data
                       "Error parsing 'Product' CSV Data. Product may not be empty."))
       :version version
@@ -77,11 +135,19 @@
       (errors/throw-service-error :invalid-data "You posted empty content"))
     (errors/throw-service-error :invalid-data "You posted empty content")))
 
+(defn get-community-usage-metrics
+  "Retrieves the set of community usage metrics from metadata-db."
+  [context]
+  (:community-usage-metrics (json/decode (:metadata (humanizer-service/fetch-humanizer-concept context)) true)))
+
 (defn- community-usage-csv->community-usage-metrics
   "Validate the community usage csv and convert to a list of community usage metrics to save"
-  [community-usage-csv]
-  (let [{:keys [csv-lines product-col version-col hosts-col]} (validate-and-read-csv community-usage-csv)]
-    (map #(csv-entry->community-usage-metric % product-col version-col hosts-col) csv-lines)))
+  [context community-usage-csv comprehensive]
+  (let [{:keys [csv-lines product-col version-col hosts-col]} (validate-and-read-csv community-usage-csv)
+        current-metrics (when (= "false" comprehensive)
+                          (get-community-usage-metrics context))]
+    (map #(csv-entry->community-usage-metric context % product-col version-col hosts-col comprehensive current-metrics)
+         csv-lines)))
 
 (defn- aggregate-usage-metrics
   "Combine access counts for entries with the same short-name and version number."
@@ -99,18 +165,21 @@
   (let [json (json/generate-string metrics)]
     (metrics-json/validate-metrics-json json)))
 
-(defn get-community-usage-metrics
-  "Retrieves the set of community usage metrics from metadata-db."
-  [context]
-  (:community-usage-metrics (json/decode (:metadata (humanizer-service/fetch-humanizer-concept context)) true)))
+(defn- validate-update-community-usage-params
+  "Currently only validates the parameter comprehensive as a boolean."
+  [params]
+  (cpv/validate-parameters
+   nil params
+   [(partial cpv/validate-boolean-param :comprehensive)]))
 
 (defn update-community-usage
   "Create/update the community usage metrics saving them with the humanizers in metadata db. Do not
   Do not overwrite the humanizers, just the community usage metrics. Increment the revision id
   manually to avoid race conditions if multiple updates are happening at the same time.
   Returns the concept id and revision id of the saved humanizer."
-  [context community-usage-csv]
-  (let [metrics (community-usage-csv->community-usage-metrics community-usage-csv)
+  [context params community-usage-csv]
+  (validate-update-community-usage-params params)
+  (let [metrics (community-usage-csv->community-usage-metrics context community-usage-csv (:comprehensive params))
         metrics (seq (aggregate-usage-metrics metrics))] ; Combine access-counts for entries with the same version/short-name
     (validate-metrics metrics)
     (humanizer-service/update-humanizers-metadata context :community-usage-metrics metrics)))

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -169,7 +169,8 @@
   "Currently only validates the parameter comprehensive as a boolean."
   [params]
   (cpv/validate-parameters
-   nil params
+   nil
+   params
    [(partial cpv/validate-boolean-param :comprehensive)]))
 
 (defn update-community-usage

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -4,11 +4,15 @@
    [clojure.test :refer :all]
    [cmr.common.util :as util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as system]
    [cmr.system-int-test.utils.humanizer-util :as humanizer-util]
+   [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
+                                           "provguid2" "PROV2"}))
 
 ;; Intentional space before version and empty CSV line for testing
 (def sample-usage-csv
@@ -64,7 +68,7 @@
         (is (= 2 revision-id))
         (humanizer-util/assert-humanizers-saved
          {:community-usage-metrics [{:short-name "AST_09XT" :version "3" :access-count 156}]}
-         "admin" 
+         "admin"
          concept-id
          revision-id)))))
 
@@ -84,6 +88,105 @@
       (is (= {:status 401
               :errors ["You do not have permission to perform that action."]}
              (humanizer-util/update-community-usage-metrics token sample-usage-csv))))))
+
+(def comprehensive-usage-test-csv
+ "Provider,Product,ProductVersion,Hosts
+  PROV1,SHORTNAME1,N/A,1
+  PROV1,ENTRYTITLE2,N/A,2
+  PROV1,ENTRYTITLE2.1,N/A,3
+  PROV1,SHORTNAME2,N/A,5
+  PROV1,NONEXISTENTCOL1,N/A,6
+  PROV2,SHORTNAME1,N/A,7
+  PROV2,ENTRYTITLE2,N/A,8
+  PROV2,ENTRYTITLE2.1,N/A,9
+  PROV2,SHORTNAME2,N/A,11
+  PROV2,NONEXISTENTCOL2,N/A,12")
+
+(def comprehensive-usage-test-result
+ [{:short-name "SHORTNAME1" :access-count 30}
+  {:short-name "SHORTNAME2" :access-count 16}
+  {:short-name "NONEXISTENTCOL1" :access-count 6}
+  {:short-name "NONEXISTENTCOL2" :access-count 12}])
+
+(deftest update-community-metrics-test-with-comprehensive
+  (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE1"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                          2
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE2"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                          3
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE2.1"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                          {:ShortName "SHORTNAME2"
+                                           :EntryTitle "ENTRYTITLE3"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE1"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
+                                          4
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE2"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
+                                          5
+                                          {:ShortName "SHORTNAME1"
+                                           :EntryTitle "ENTRYTITLE2.1"})
+                                 {:token "mock-echo-system-token"})
+  (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
+                                          {:ShortName "SHORTNAME2"
+                                           :EntryTitle "ENTRYTITLE4"})
+                                 {:token "mock-echo-system-token"})
+  (index/wait-until-indexed)
+  (testing "Create community usage with invalid comprehensive param"
+    (let [response (humanizer-util/update-community-usage-metrics
+                     "mock-echo-system-token"
+                     comprehensive-usage-test-csv
+                     {:http-options {:query-params {:comprehensive "wrong"}}})]
+      (is (= {:status 400
+              :errors
+              ["Parameter comprehensive must take value of true or false but was [wrong]"]}
+             response))))
+
+  (testing "Create community usage with comprehensive is true"
+    (let [response (humanizer-util/update-community-usage-metrics
+                     "mock-echo-system-token"
+                     comprehensive-usage-test-csv
+                     {:http-options {:query-params {:comprehensive "true"}}})]
+      (humanizer-util/assert-humanizers-saved
+       {:community-usage-metrics comprehensive-usage-test-result}
+       "ECHO_SYS"
+       (:concept-id response)
+       (:revision-id response))))
+
+  (testing "Create community usage with comprehensive is false"
+    (let [response (humanizer-util/update-community-usage-metrics
+                     "mock-echo-system-token"
+                     comprehensive-usage-test-csv
+                     {:http-options {:query-params {:comprehensive "false"}}})]
+      (humanizer-util/assert-humanizers-saved
+       {:community-usage-metrics comprehensive-usage-test-result}
+       "ECHO_SYS"
+       (:concept-id response)
+       (:revision-id response))))
+
+  (testing "Create community usage with comprehensive is not included"
+    (let [response (humanizer-util/update-community-usage-metrics
+                     "mock-echo-system-token"
+                     comprehensive-usage-test-csv)]
+      (humanizer-util/assert-humanizers-saved
+       {:community-usage-metrics comprehensive-usage-test-result}
+       "ECHO_SYS"
+       (:concept-id response)
+       (:revision-id response)))))
 
 (deftest update-community-usage-metrics-validation-test
   (let [admin-update-group-concept-id (echo-util/get-or-create-group (system/context) "admin-update-group")
@@ -162,7 +265,7 @@
 
 (def sample-aggregation-csv
   "Sample CSV to test aggregation of access counts in different CSV entries with the same short-name
-   and version"
+ and version"
   "Product,Version,Hosts\nAMSR-L1A,3,4\nAMSR-L1A,3,6\nAMSR-L1A,N/A,87\nAMSR-L1A,N/A,10\nMAPSS_MOD04_L2,4,12")
 
 (def sample-aggregation-data

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -265,7 +265,7 @@
 
 (def sample-aggregation-csv
   "Sample CSV to test aggregation of access counts in different CSV entries with the same short-name
- and version"
+   and version"
   "Product,Version,Hosts\nAMSR-L1A,3,4\nAMSR-L1A,3,6\nAMSR-L1A,N/A,87\nAMSR-L1A,N/A,10\nMAPSS_MOD04_L2,4,12")
 
 (def sample-aggregation-data


### PR DESCRIPTION
This PR attempts to aggregate the varied values found in the community metrics humanizer.  There are entries where the Product value can be either a collections ShortName, EntryTitle or "ProductId" which is just EntryTitle + version, but they should all be under ShortName.  Version and Provider columns also have inaccurate values so the only column used to try to identify collections will be the Product column.  Introduces new parameter to either do the lookup on every entry, or to try and short cut by using ShortNames currently in the humanizer already.