### PR TITLE
CMR-6731, CMR-6732

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -234,7 +234,12 @@
                                                                          (:db-batch-size system))]
                           concept-batch)
         total (index/bulk-index {:system (helper/get-indexer system)} concept-batches)]
-    (index/bulk-index {:system (helper/get-indexer system)} concept-batches {:all-revisions-index? true})
+
+    ;; for concept types that have all revisions index, also index the all revisions index
+    (when-not (#{:tag :granule} concept-type)
+      (index/bulk-index
+       {:system (helper/get-indexer system)} concept-batches {:all-revisions-index? true}))
+
     (info "Indexed " total " concepts.")
     total))
 

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -52,14 +52,16 @@
     (get-in query-field->elastic-doc-values-fields [concept-type field] field)
     field))
 
-(defn filter-expired-concepts
+(defn- filter-expired-concepts
   "Remove concepts that have an expired delete-time."
   [batch]
   (filter (fn [concept]
             (let [delete-time-str (get-in concept [:extra-fields :delete-time])
                   delete-time (when delete-time-str
                                 (date/parse-datetime delete-time-str))]
-              (or (nil? delete-time)
+              ;; do not filter out the concept if it is deleted (see CMR-6731)
+              (or (:deleted concept)
+                  (nil? delete-time)
                   (t/after? delete-time (tk/now)))))
           batch))
 


### PR DESCRIPTION
Fixed bulk indexing of deleted granules that are also expired.
Fixed bulk indexing of granules/tags to not try to index into all revisions index.