### PR TITLE
CMR-6751 updating commit ref and version for preview gem to update service tab link generation.

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -10,9 +10,9 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   {:repo "https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git"
-   :version "cmr_metadata_preview-0.2.4"
+   :version "cmr_metadata_preview-0.2.5"
    :commit-id (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-                  "1aaef8d08e9636968e84dead10d52c7c1aae09c7")})
+                  "e8323939630270416b7ddc1f41a12f0558598324")})
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
Erich ran the code change as branch CMR-6750 in his repo so that bamboo would build it (I don't have a plan).  Passed in bamboo.  