### PR TITLE
CMR-6751 Updating preview gem commit ref

### DIFF
--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -10,9 +10,9 @@
    the hardcoded commit id during dev integration with cmr_metadata_preview project.
    The hardcoded commit id should be updated when MMT releases a new version of the gem."
   {:repo "https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git"
-   :version "cmr_metadata_preview-0.2.4"
+   :version "cmr_metadata_preview-0.2.5"
    :commit-id (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-                  "1aaef8d08e9636968e84dead10d52c7c1aae09c7")})
+                  "e8323939630270416b7ddc1f41a12f0558598324")})
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."

--- a/collection-renderer-lib/project.clj
+++ b/collection-renderer-lib/project.clj
@@ -12,7 +12,7 @@
   {:repo "https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git"
    :version "cmr_metadata_preview-0.2.5"
    :commit-id (or (System/getenv "CMR_METADATA_PREVIEW_COMMIT")
-                  "e8323939630270416b7ddc1f41a12f0558598324")})
+                  "40320c299336c68047b27110ef1e5dae5a20a24f")})
 
 (def gem-install-path
   "The directory within this library where Ruby gems are installed."


### PR DESCRIPTION
Includes changes to the service tab in how it renders service urls from the metadata
Includes changes to how the JS is compiled from MMT.  

Erich ran the changes in his build plan in Bamboo (green).
Verified the preview gem behaviors in local CMR repl.