### PR TITLE
CMR-6792 updated library to address docker breaking change

### DIFF
--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -15,7 +15,7 @@
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [org.elasticsearch/elasticsearch "7.5.2"]
-                 [org.testcontainers/testcontainers "1.14.1"]
+                 [org.testcontainers/testcontainers "1.15.0-rc2"]
                  [potemkin "0.4.5"]]
   :plugins [[lein-shell "0.5.0"]
             [test2junit "1.3.3"]]

--- a/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
@@ -8,7 +8,7 @@
   (:import
    (java.time Duration)
    (org.testcontainers.containers FixedHostPortGenericContainer Network)
-   (org.testcontainers.containers.wait Wait)
+   (org.testcontainers.containers.wait.strategy Wait)
    (org.testcontainers.images.builder ImageFromDockerfile)))
 
 (def ^:private elasticsearch-official-docker-image


### PR DESCRIPTION
Updated library version to use fix contained in https://github.com/testcontainers/testcontainers-java/pull/3159