### PR TITLE
CMR-6603: Fix tests using old variable(association) endpoints part 1.

### DIFF
--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/concept_delete_spec.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/concept_delete_spec.clj
@@ -1,10 +1,12 @@
 (ns cmr.metadata-db.int-test.concepts.concept-delete-spec
   "Defines a common set of tests for deleting concepts."
-  (:require [clojure.test :refer :all]
-            [clj-time.core :as t]
-            [cmr.common.concepts :as cc]
-            [cmr.metadata-db.int-test.utility :as util]
-            [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]))
+  (:require
+   [clojure.test :refer :all]
+   [clj-time.core :as t]
+   [cmr.common.concepts :as cc]
+   [cmr.metadata-db.int-test.concepts.concept-save-spec :as c-spec]
+   [cmr.metadata-db.int-test.concepts.utils.interface :as concepts]
+   [cmr.metadata-db.int-test.utility :as util]))
 
 (defn general-delete-test
   "Delete tests that all concepts should pass"
@@ -98,6 +100,130 @@
         ;; Other data left in database
         (util/verify-concept-was-saved
           (assoc concept2 :concept-id concept-id2 :revision-id revision-id2))))))
+
+(defn general-delete-variable-and-association-test
+  "Delete tests that all concepts should pass"
+  [provider-ids]
+  (doseq [provider-id provider-ids]
+    (testing "with delete endpoint"
+      (let [coll (concepts/create-and-save-concept :collection provider-id 1)
+            coll-concept-id (:concept-id coll)
+            concept1 (c-spec/gen-concept :variable provider-id 1 {:coll-concept-id coll-concept-id})
+            concept2 (c-spec/gen-concept :variable provider-id 2 {:coll-concept-id coll-concept-id})
+            {:keys [concept-id] :as saved-concept1} (util/save-concept concept1 3)
+            {concept-id2 :concept-id revision-id2 :revision-id} (util/save-concept concept2)
+            {:keys [status revision-id] :as tombstone} (util/delete-concept concept-id)
+            deleted-concept1 (:concept (util/get-concept-by-id-and-revision concept-id revision-id))
+            saved-concept1 (:concept (util/get-concept-by-id-and-revision concept-id (dec revision-id)))
+            concept2 (assoc concept2 :concept-id concept-id2 :revision-id revision-id2)]
+        (is (= {:status 201 :revision-id 4}
+               {:status status :revision-id revision-id}))
+
+        (is (= (dissoc (assoc saved-concept1
+                              :deleted true
+                              :metadata ""
+                              :revision-id revision-id
+                              :user-id nil)
+                       :revision-date :user-id :transaction-id)
+               (dissoc deleted-concept1 :revision-date :user-id :transaction-id)))
+
+        ;; Make sure that a deleted concept gets it's own unique revision date
+        (is (t/after? (:revision-date deleted-concept1) (:revision-date saved-concept1))
+            "The deleted concept revision date should be after the previous revisions revision date.")
+
+        ;; Make sure transaction-ids increment
+        (is (> (:transaction-id deleted-concept1) (:transaction-id saved-concept1)))
+
+        (is (= (util/delete-concept concept-id)
+               (util/delete-concept concept-id)
+               (util/delete-concept concept-id)))
+
+        ;; Other data left in database
+        (util/verify-concept-was-saved concept2)))
+
+    (testing "delete with valid revision"
+      (let [coll (concepts/create-and-save-concept :collection provider-id 1)
+            coll-concept-id (:concept-id coll)
+            concept (c-spec/gen-concept :variable provider-id 3 {:coll-concept-id coll-concept-id})
+            {:keys [concept-id] :as saved-concept} (util/save-concept concept)
+            va (:variable-association saved-concept)
+            va-concept-id (:concept-id va)
+            {:keys [status revision-id]} (util/delete-concept concept-id 4)
+            {va-status :status va-revision-id :revision-id} (util/delete-concept va-concept-id 4)]
+        (is (= {:status 201
+                :revision-id 4}
+               {:status status
+                :revision-id revision-id}))
+        (is (= {:status 201
+                :revision-id 4}
+               {:status va-status
+                :revision-id va-revision-id}))))
+
+    (testing "delete with skipped revision"
+      (let [coll (concepts/create-and-save-concept :collection provider-id 1)
+            coll-concept-id (:concept-id coll)
+            concept (c-spec/gen-concept :variable provider-id 4 {:coll-concept-id coll-concept-id})
+            {:keys [concept-id] :as saved-concept} (util/save-concept concept)
+            va (:variable-association saved-concept)
+            va-concept-id (:concept-id va)
+            {:keys [status revision-id]} (util/delete-concept concept-id 100)
+            {va-status :status va-revision-id :revision-id} (util/delete-concept va-concept-id 100)]
+        (is (= {:status 201
+                :revision-id 100}
+               {:status status
+                :revision-id revision-id}))
+        (is (= {:status 201
+                :revision-id 100}
+               {:status va-status
+                :revision-id va-revision-id}))))
+
+    (testing "delete with new revision"
+      (let [coll (concepts/create-and-save-concept :collection provider-id 1)
+            coll-concept-id (:concept-id coll)
+            concept (c-spec/gen-concept :variable provider-id 5 {:coll-concept-id coll-concept-id})
+            {:keys [concept-id] :as saved-concept} (util/save-concept concept)
+            va (:variable-association saved-concept)
+            va-concept-id (:concept-id va)
+            {status1 :status revision-id1 :revision-id} (util/delete-concept concept-id 5)
+            {status2 :status revision-id2 :revision-id} (util/delete-concept concept-id 7)
+            {va-status1 :status va-revision-id1 :revision-id} (util/delete-concept va-concept-id 5)
+            {va-status2 :status va-revision-id2 :revision-id} (util/delete-concept va-concept-id 7)]
+        (is (= 201 status1 status2 va-status1 va-status2))
+        (is (= 5 revision-id1))
+        (is (= 5 va-revision-id1))
+        (is (= 7 revision-id2))
+        (is (= 7 va-revision-id2))))
+
+    (testing "save tombstone"
+      (let [coll (concepts/create-and-save-concept :collection provider-id 1)
+            coll-concept-id (:concept-id coll)
+            concept1 (c-spec/gen-concept :variable provider-id 6 {:coll-concept-id coll-concept-id})
+            concept2 (c-spec/gen-concept :variable provider-id 7 {:coll-concept-id coll-concept-id})
+            {concept-id1 :concept-id revision-id1 :revision-id} (util/save-concept concept1 3)
+            {concept-id2 :concept-id revision-id2 :revision-id} (util/save-concept concept2)
+
+            {:keys [status revision-id]} (util/save-concept {:concept-id concept-id1
+                                                             :deleted true})
+            {transaction-id1 :transaction-id} (:concept (util/get-concept-by-id-and-revision
+                                                          concept-id1 revision-id1))
+            {transaction-id2 :transaction-id} (:concept (util/get-concept-by-id-and-revision
+                                                          concept-id2 revision-id2))
+            stored-concept1 (:concept (util/get-concept-by-id-and-revision concept-id1 revision-id))
+            concept2 (assoc concept2 :concept-id concept-id2 :revision-id revision-id2)]
+        (is (= {:status 201
+                :revision-id 4
+                :deleted true
+                :metadata ""}
+               {:status status
+                :revision-id revision-id
+                :deleted (:deleted stored-concept1)
+                :metadata (:metadata stored-concept1)}))
+
+        ;; Make sure transaction-ids increment
+        (is (> (:transaction-id stored-concept1) transaction-id2 transaction-id1))
+
+        ;; Other data left in database
+       (util/verify-concept-was-saved concept2)))))
 
 (defn general-force-delete-test
   "Force delete tests that all concepts should pass"

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
@@ -139,11 +139,10 @@
 (deftest force-delete-variable-with-associations
   (let [coll (concepts/create-and-save-concept :collection "REG_PROV" 1)
         coll-concept-id (:concept-id coll)
-        var-concept (concepts/create-and-save-concept :variable "REG_PROV" 1 3)
+        var-concept (concepts/create-and-save-concept :variable "REG_PROV" 1 3 {:coll-concept-id coll-concept-id})
         var-concept-id (:concept-id var-concept)
-        var-assn (concepts/create-and-save-concept :variable-association
-                  coll var-concept 1)
-        var-assn-concept-id (:concept-id var-assn)]
+        var-assn-concept-id (get-in var-concept [:variable-association :concept-id])
+        var-assn (:concept (util/get-concept-by-id var-assn-concept-id))]
     (testing "initial conditions"
       ;; creation results as expected
       (is (= 3 (:revision-id var-concept)))

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_association_search_test.clj
@@ -17,20 +17,20 @@
                                                           :entry-title "et1"
                                                           :version-id "v1"
                                                           :short-name "s1"}})
+        coll-concept-id (:concept-id coll1)
         coll2 (concepts/create-and-save-concept
                :collection "REG_PROV" 2 1 {:extra-fields {:entry-id "entry-2"
                                                           :entry-title "et2"
                                                           :version-id "v1"
                                                           :short-name "s2"}})
-        associated-variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
-        var-association1 (concepts/create-and-save-concept
-                          :variable-association coll1 associated-variable 1 3)]
+        associated-variable (concepts/create-and-save-concept
+                              :variable "REG_PROV" 1 3 {:coll-concept-id coll-concept-id})
+        var-assn-concept-id (get-in associated-variable [:variable-association :concept-id])
+        var-association1 (:concept (util/get-concept-by-id var-assn-concept-id))]
     (testing "find latest revisions"
       (are3 [variable-associations params]
         (is (= (set variable-associations)
-               (set (->> (util/find-latest-concepts :variable-association params)
-                         :concepts
-                         (map #(dissoc % :provider-id :revision-date :transaction-id))))))
+               (set (:concepts (util/find-latest-concepts :variable-association params)))))
 
         "by associated-concept-id"
         [var-association1]

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_search_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/search/variable_search_test.clj
@@ -10,17 +10,20 @@
                                                  {:provider-id "SMAL_PROV1" :small true}))
 
 (deftest find-variables
-  (let [;; create two variables with the same native-id on different providers with multiple revisions
-         variable1 (concepts/create-and-save-concept :variable "REG_PROV" 1 3)
-         variable2 (concepts/create-and-save-concept :variable "SMAL_PROV1" 1 2)]
-    (println "Variable1 is:" variable1)
-    (println "Variable2 is:" variable2)
+  (let [coll1 (concepts/create-and-save-concept :collection "REG_PROV" 1 1)
+        coll1-concept-id (:concept-id coll1)
+        coll2 (concepts/create-and-save-concept :collection "SMAL_PROV1" 1 1)
+        coll2-concept-id (:concept-id coll2)
+        ;; create two variables with the same native-id on different providers with multiple revisions
+        variable1 (concepts/create-and-save-concept :variable "REG_PROV" 1 3 {:coll-concept-id coll1-concept-id})
+        variable2 (concepts/create-and-save-concept :variable "SMAL_PROV1" 1 2 {:coll-concept-id coll2-concept-id})]
     (testing "find latest revisions"
       (are3 [variables params]
-        (is (= (set variables)
+        (is (= (set (map #(dissoc % :coll-concept-id :variable-association) variables))
                (set (->> (util/find-latest-concepts :variable params)
                          :concepts
-                         util/concepts-for-comparison))))
+                         util/concepts-for-comparison
+                         (map #(dissoc % :coll-concept-id))))))
 
         "with metadata search by provider-id"
         [variable1] {:provider-id "REG_PROV"}

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/utils/interface.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/utils/interface.clj
@@ -111,5 +111,7 @@
         concept (apply create-concept concept-type parsed-args)
         _ (dotimes [n (dec num-revisions)]
             (util/assert-no-errors (util/save-concept concept)))
-        {:keys [concept-id revision-id]} (util/save-concept concept)]
-    (assoc concept :concept-id concept-id :revision-id revision-id)))
+        {:keys [concept-id revision-id variable-association]} (util/save-concept concept)]
+    (if (= :variable concept-type)
+      (assoc concept :concept-id concept-id :revision-id revision-id :variable-association variable-association)
+      (assoc concept :concept-id concept-id :revision-id revision-id))))


### PR DESCRIPTION
Given the number of tests that need to be fixed before we retire the old variable and association endpoints, we're dividing up the task into several parts to show incremental progress. 