### PR TITLE
CMR-6747 Fixes product ids csv lines in usage metrics

### DIFF
--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -37,7 +37,8 @@
   "Query elastic for a collection with a given entry-title, returns short-name"
   [context entry-title]
   (when (seq entry-title)
-    (let [condition (qm/string-condition :entry-title (str entry-title "*") false true)
+    (let [entry-title (first (str/split entry-title #":"))
+          condition (qm/string-condition :entry-title entry-title false false)
           query (qm/query {:concept-type :collection
                            :condition condition
                            :page-size 1

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -6,6 +6,7 @@
    [clojure.data.csv :as csv]
    [clojure.string :as str]
    [cmr.common-app.services.search.parameter-validation :as cpv]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
    [cmr.common-app.services.search.query-execution :as qe]
    [cmr.common-app.services.search.query-model :as qm]
    [cmr.common.log :as log :refer (debug info warn error)]
@@ -33,52 +34,38 @@
   (when (>= col 0)
     (nth csv-line col)))
 
-(defn- get-short-name-by-entry-title
-  "Query elastic for a collection with a given entry-title, returns short-name"
-  [context entry-title]
-  (when (seq entry-title)
-    (let [entry-title (first (str/split entry-title #":"))
-          condition (qm/string-condition :entry-title entry-title false false)
-          query (qm/query {:concept-type :collection
-                           :condition condition
-                           :page-size 1
-                           :all-revisions? true
-                           :result-format :query-specified
-                           :result-fields [:short-name]})
-          results (qe/execute-query context query)
-          short-name (first (map :short-name (:items results)))]
-      short-name)))
-
-(defn- get-collection-by-short-name
-  "Query elastic for collection with a given short-name, returns short-name"
-  [context short-name]
-  (when (seq short-name)
-    (let [condition (qm/string-condition :short-name short-name)
-          query (qm/query {:concept-type :collection
-                           :condition condition
-                           :page-size 1
-                           :all-revisions? true
-                           :result-format :query-specified
-                           :result-fields [:short-name]})
-          results (qe/execute-query context query)
-          short-name (first (map :short-name (:items results)))]
-      short-name)))
+(defn- get-collection-by-product-id
+  "Query elastic for a collection with a given product-id, parses out the value before the last : and
+   checks that value against both entry-title or short-name. Also checks the non-parsed value against
+   short-name."
+  [context product-id]
+  (when (seq product-id)
+    (when-let [parsed-product-id (as-> (re-find #"(^.+):|(^.+)" product-id) matches
+                                       (remove nil? matches)
+                                       (last matches))]
+      (let [condition (gc/or (qm/string-condition :entry-title parsed-product-id false false)
+                             (qm/string-condition :short-name parsed-product-id false false)
+                             (qm/string-condition :short-name product-id false false))
+            query (qm/query {:concept-type :collection
+                             :condition condition
+                             :page-size 1
+                             :result-format :query-specified
+                             :result-fields [:short-name]})
+            results (qe/execute-query context query)]
+        (:short-name (first (:items results)))))))
 
 (defn- comprehensive-collection-short-name-search
-  "This function checks CMR for a collection with given short-name, if it can't find it
-   Then it will check for a collection with that entry-title and return its short-name.
-   Currently there are providers who are supplying non-short-name values in short-name, which breaks usage
-   metrics.  This is a short term solution to this problem, the long term solution is correcting the
-   EMS data which may take a long time to happen."
+  "This function will check for a collection with the given product value against short-name and entry-title
+   and return its short-name.  Currently there are providers who are supplying non-short-name values
+   in short-name, which breaks usage metrics.  This is a short term solution to this problem,
+   the long term solution is correcting the EMS data which may take a long time to happen."
   [context short-name]
-  (if (get-collection-by-short-name context short-name)
-    short-name
-    (get-short-name-by-entry-title context short-name)))
+  (get-collection-by-product-id context short-name))
 
 (defn- efficient-collection-short-name-search
   "This function will check the current community-usage-metrics humanizer to see if this shortname exists,
    if it does, then it will return that short-name, otherwise it will try looking up the short-name via
-   entry-title."
+   product-id."
   [context short-name current-metrics]
   (if (get current-metrics short-name)
     short-name

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -91,26 +91,28 @@
 
 (def comprehensive-usage-test-csv
  "Provider,Product,ProductVersion,Hosts
-  PROV1,SHORTNAME1,N/A,1
-  PROV1,ENTRYTITLE2,N/A,2
-  PROV1,ENTRYTITLE2:1,N/A,3
-  PROV1,SHORTNAME2,N/A,5
-  PROV1,NONEXISTENTCOL1,N/A,6
-  PROV2,SHORTNAME1,N/A,7
-  PROV2,ENTRYTITLE2,N/A,8
-  PROV2,ENTRYTITLE2:1,N/A,9
-  PROV2,SHORTNAME2,N/A,11
-  PROV2,NONEXISTENTCOL2,N/A,12
-  PROV1,NONEXISTENTCOL1:1,N/A,13
-  PROV2,NONEXISTENTCOL2:1,N/A,14")
+  PROV1,SHORTNAME1,N/A,100
+  PROV1,ENTRYTITLE2,N/A,100
+  PROV1,ENTRYTITLE2:1,N/A,100
+  PROV1,ENTRY:TITLE3:1,N/A,100
+  PROV1,SHORTNAME2,N/A,10
+  PROV1,NONEXISTENTCOL1,N/A,1
+  PROV1,NONEXISTENTCOL1:1,N/A,1
+  PROV2,SHORTNAME1,N/A,100
+  PROV2,ENTRYTITLE2,N/A,100
+  PROV2,ENTRYTITLE2:1,N/A,100
+  PROV2,ENTRY:TITLE3:1,N/A,100
+  PROV2,SHORTNAME2,N/A,10
+  PROV2,NONEXISTENTCOL2,N/A,1
+  PROV2,NONEXISTENTCOL2:1,N/A,1")
 
 (def comprehensive-usage-test-result
- [{:short-name "SHORTNAME1" :access-count 30}
-  {:short-name "SHORTNAME2" :access-count 16}
-  {:short-name "NONEXISTENTCOL1" :access-count 6}
-  {:short-name "NONEXISTENTCOL2" :access-count 12}
-  {:short-name "NONEXISTENTCOL1:1" :access-count 13}
-  {:short-name "NONEXISTENTCOL2:1" :access-count 14}])
+ [{:short-name "SHORTNAME1" :access-count 800}
+  {:short-name "SHORTNAME2" :access-count 20}
+  {:short-name "NONEXISTENTCOL1" :access-count 1}
+  {:short-name "NONEXISTENTCOL1:1" :access-count 1}
+  {:short-name "NONEXISTENTCOL2" :access-count 1}
+  {:short-name "NONEXISTENTCOL2:1" :access-count 1}])
 
 (deftest update-community-metrics-test-with-comprehensive
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
@@ -125,11 +127,11 @@
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
                                           3
                                           {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE2.1"})
+                                           :EntryTitle "ENTRY:TITLE3"})
                                  {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
                                           {:ShortName "SHORTNAME2"
-                                           :EntryTitle "ENTRYTITLE3"})
+                                           :EntryTitle "ENTRYTITLE4"})
                                  {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
                                           {:ShortName "SHORTNAME1"
@@ -143,11 +145,11 @@
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
                                           5
                                           {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE2.1"})
+                                           :EntryTitle "ENTRY:TITLE3"})
                                  {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
                                           {:ShortName "SHORTNAME2"
-                                           :EntryTitle "ENTRYTITLE4"})
+                                           :EntryTitle "ENTRYTITLE5"})
                                  {:token "mock-echo-system-token"})
   (index/wait-until-indexed)
   (testing "Create community usage with invalid comprehensive param"

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -93,20 +93,24 @@
  "Provider,Product,ProductVersion,Hosts
   PROV1,SHORTNAME1,N/A,1
   PROV1,ENTRYTITLE2,N/A,2
-  PROV1,ENTRYTITLE2.1,N/A,3
+  PROV1,ENTRYTITLE2:1,N/A,3
   PROV1,SHORTNAME2,N/A,5
   PROV1,NONEXISTENTCOL1,N/A,6
   PROV2,SHORTNAME1,N/A,7
   PROV2,ENTRYTITLE2,N/A,8
-  PROV2,ENTRYTITLE2.1,N/A,9
+  PROV2,ENTRYTITLE2:1,N/A,9
   PROV2,SHORTNAME2,N/A,11
-  PROV2,NONEXISTENTCOL2,N/A,12")
+  PROV2,NONEXISTENTCOL2,N/A,12
+  PROV1,NONEXISTENTCOL1:1,N/A,13
+  PROV2,NONEXISTENTCOL2:1,N/A,14")
 
 (def comprehensive-usage-test-result
  [{:short-name "SHORTNAME1" :access-count 30}
   {:short-name "SHORTNAME2" :access-count 16}
   {:short-name "NONEXISTENTCOL1" :access-count 6}
-  {:short-name "NONEXISTENTCOL2" :access-count 12}])
+  {:short-name "NONEXISTENTCOL2" :access-count 12}
+  {:short-name "NONEXISTENTCOL1:1" :access-count 13}
+  {:short-name "NONEXISTENTCOL2:1" :access-count 14}])
 
 (deftest update-community-metrics-test-with-comprehensive
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection


### PR DESCRIPTION
this PR attempts to address some product ids that weren't being processed in the csv file properly.  Some lines have values that take the form entry-title:version-id, so we split on : and take the entry-title for searching.