### PR TITLE
CMR-6603: Modified more tests from using old variable endpoint to new endpoint

### DIFF
--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/force_delete_test.clj
@@ -19,10 +19,6 @@
   [_ provider-id uniq-num attributes]
   (concepts/create-concept :service provider-id uniq-num attributes))
 
-(defmethod cs-spec/gen-concept :variable
-  [_ provider-id uniq-num attributes]
-  (concepts/create-concept :variable provider-id uniq-num attributes))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_association_save_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/variable_association_save_test.clj
@@ -9,29 +9,12 @@
 
 (use-fixtures :each (util/reset-database-fixture {:provider-id "REG_PROV" :small false}))
 
-(defmethod c-spec/gen-concept :variable-association
-  [_ provider-id uniq-num attributes]
-  (let [provider-id (if (= "CMR" provider-id)
-                      "REG_PROV"
-                      provider-id)
-        concept-attributes (or (:concept-attributes attributes) {})
-        concept (concepts/create-and-save-concept :collection provider-id uniq-num 1
-                                                  concept-attributes)
-        variable-attributes (or (:variable-attributes attributes) {})
-        variable (concepts/create-and-save-concept :variable provider-id uniq-num 1
-                                                   variable-attributes)
-        attributes (dissoc attributes :concept-attributes :variable-attributes)]
-    (concepts/create-concept :variable-association concept variable uniq-num attributes)))
-
 ;; tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(deftest save-variable-association-test
-  (c-spec/general-save-concept-test :variable-association ["CMR"]))
-
 (deftest save-variable-association-failure-test
   (testing "saving new variable associations on non system-level provider"
     (let [coll (concepts/create-and-save-concept :collection "REG_PROV" 1)
-          variable (concepts/create-and-save-concept :variable "REG_PROV" 1)
+          variable (concepts/create-and-save-concept :variable "REG_PROV" 1 1 {:coll-concept-id (:concept-id coll)})
           variable-association (-> (concepts/create-concept :variable-association coll variable 2)
                                    (assoc :provider-id "REG_PROV"))
           {:keys [status errors]} (util/save-concept variable-association)]

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/utility.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/utility.clj
@@ -341,7 +341,7 @@
         stored-concept (:concept (get-concept-by-id-and-revision concept-id revision-id))]
     (if (= :variable (:concept-type concept))
       ;; We added :coll-concept-id in the attribute in the tests, it'll appear in both concept and
-      ;; stored-concept in memory db, but not in the stored-concept in real db. This is the cas
+      ;; stored-concept in memory db, but not in the stored-concept in real db. This is the case
       ;; for all the concept types when you add new attributes in the test. So, we want to remove
       ;; :coll-concept-id from both.
       (is (= (dissoc (expected-concept concept) :coll-concept-id)


### PR DESCRIPTION
This PR fixed more tests(from using old endpoint to using new endpoint) in CMR-6603, which will be closed. The remaining tests will be fixed as maintenance task through new tickets.