### PR TITLE
CMR-6754 updates com.fasterxml.jackson.core:jackson-databind

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -21,7 +21,7 @@
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.10.4"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.6"]
                  [commons-logging "1.2"]

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -12,7 +12,7 @@
   :dependencies [[cheshire "5.8.1"]
                  [clj-time "0.15.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.9.8"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.10.4"]
                  [compojure "1.6.1"]
                  [drift "1.5.3"]
                  [inflections "0.13.0"]


### PR DESCRIPTION
I tried updating to the latest version after updating to the minimum version of 2.9.10.4 to see what would happen.  The latest version has test failures, and will require some coding.  I can do that if necessary but the AC only required the snyk issue be resolved, and this version does that.