### PR TITLE
CMR-6839

### DIFF
--- a/common-app-lib/src/cmr/common_app/static.clj
+++ b/common-app-lib/src/cmr/common_app/static.clj
@@ -215,6 +215,7 @@
                  site-example-provider (get site-provider-map (headers "host") "PROV1")
                  cmr-example-collection-id (str "C1234567-" site-example-provider)]
              {:status 200
+              :headers {"Content-Type" "text/html; charset=utf-8"}
               :body (-> resource
                         slurp
                         (string/replace "%CMR-ENDPOINT%" cmr-root)


### PR DESCRIPTION
Fixed CMR API documentation pages to work with "X-Content-Type-Options: nosniff" header.

This problem is identified after the NGAP deployment yesterday. We need to get this backported to UAT and PROD.