### PR TITLE
CMR-6257 - NGDA Tags

### DIFF
--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -245,13 +245,13 @@
     {:name (or archive-center umm-spec-util/not-provided)
      :subOrganizationOf hierarchy}))
 
-(defn check_for_modis_aster
+(defn modis-aster
   "Logic to test for collections that use the MODIS or ASTER instruments as
   these are the only ones that should be included in the data.gov output as
   defined by The Data Curation for Discovery (DCD) team at Marshall Space Flight
   Center (MSFC)"
-  [x]
-  (let [short-name (:short-name x)]
+  [metadata]
+  (let [{:keys [short-name]} metadata]
     (or (= "MODIS" short-name) (= "ASTER" short-name))))
 
 (defn keywords
@@ -260,7 +260,7 @@
   conditions. Takes the science keywords as a flat list rather than hierarchical
   and the current item needed for finding conditions."
   [science-keywords-flat item]
-  (if (some check_for_modis_aster (:instruments item))
+  (if (some modis-aster (:instruments item))
     (conj science-keywords-flat "NGDA" "National Geospatial Data Asset")
     science-keywords-flat))
 

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -245,7 +245,7 @@
     {:name (or archive-center umm-spec-util/not-provided)
      :subOrganizationOf hierarchy}))
 
-(defn modis-aster
+(defn modis-aster?
   "Logic to test for collections that use the MODIS or ASTER instruments as
   these are the only ones that should be included in the data.gov output as
   defined by The Data Curation for Discovery (DCD) team at Marshall Space Flight
@@ -260,7 +260,7 @@
   conditions. Takes the science keywords as a flat list rather than hierarchical
   and the current item needed for finding conditions."
   [science-keywords-flat item]
-  (if (some modis-aster (:instruments item))
+  (if (some modis-aster? (:instruments item))
     (conj science-keywords-flat "NGDA" "National Geospatial Data Asset")
     science-keywords-flat))
 

--- a/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/opendata_results_handler.clj
@@ -451,11 +451,7 @@
 
 (defmethod qs/search-results->response [:collection :opendata]
   [context query results]
-  ;(println (:short-name (first (:instruments (last (:items results))))))
-  ;(println query)
   (let [{:keys [concept-type result-features]} query
         response-results (results->opendata
                            context concept-type results)]
-    ;(println "here in the function - tcherry")
-    ;(/ 0 0)
     (json/generate-string response-results)))

--- a/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/opendata_results_handler.clj
@@ -97,6 +97,24 @@
   (testing "graphic-preview-type retrieval"
     (is (= "image/gif" (opendata-results-handler/graphic-preview-type {:get-data-mime-type "image/gif"})))))
 
+(deftest ngda-keywords
+  (let [keywords ["Science Keyword"]]
+    (testing "Check that the NGDA tag is not added for records that make no mention of instruments"
+      (is (= ["Science Keyword"]
+             (opendata-results-handler/keywords keywords {}))))
+    (testing "Check that the NGDA tags are not added to unrelated instruments"
+      (is (= ["Science Keyword"]
+             (opendata-results-handler/keywords keywords {:instruments [{:short-name "unrelated"}]}))))
+    (testing "Check that NGDA tags _are_ added for records that use MODIS"
+      (is (= ["Science Keyword" "NGDA" "National Geospatial Data Asset"]
+             (opendata-results-handler/keywords keywords {:instruments [{:short-name "MODIS"}]}))))
+    (testing "Check that NGDA tags _are_ added for records that use ASTER"
+      (is (= ["Science Keyword" "NGDA" "National Geospatial Data Asset"]
+             (opendata-results-handler/keywords keywords {:instruments [{:short-name "ASTER"}]}))))
+    (testing "Check that NGDA tags _are_ added for records that use both MODIS and ASTER"
+      (is (= ["Science Keyword" "NGDA" "National Geospatial Data Asset"]
+             (opendata-results-handler/keywords keywords {:instruments [{:short-name "MODIS"} {:short-name "ASTER"}]}))))))
+
 (deftest get-best-browse-image
  (let [all-browse-fields {:url "http://example.com"
                           :get-data-mime-type "image/gif"


### PR DESCRIPTION
Changed the rules on how NGDA tags are added to the opendata output. This change adds instrument data to the metadata used by the open data results handler. These values are then used to drive the inclusion of the NGDA tags. Instruments are not included in the opendata output.