### PR TITLE
CMR-6873: Removed tool's has-formats impact.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -157,7 +157,7 @@
         service-docs (service/service-associations->elastic-doc context service-associations)
         tool-docs (tool/tool-associations->elastic-doc context tool-associations)
         has-variables (or (:has-variables variable-docs) (:has-variables service-docs))
-        has-formats (or (:has-formats service-docs) (:has-formats tool-docs))]
+        has-formats (:has-formats service-docs)]
     (merge variable-docs service-docs tool-docs
            {:has-variables has-variables} {:has-formats has-formats})))
 

--- a/system-int-test/test/cmr/system_int_test/search/tool/collection_tool_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tool/collection_tool_search_test.clj
@@ -164,12 +164,12 @@
     (au/associate-by-concept-ids token tool2-concept-id [{:concept-id (:concept-id coll2)}])
     (index/wait-until-indexed)
 
-    ;; verify search result on coll1 contains associations with both tool1 and tool2, and has-formats being true
-    ;; because tool1 has more than one distinctive supported formats.
+    ;; verify search result on coll1 contains associations with both tool1 and tool2, and has-formats being false
+    ;; because tools have no effect on the has-formats flag
     (tool-util/assert-collection-search-result
-     coll1 {:has-formats true} [tool1-concept-id tool2-concept-id])
+     coll1 {:has-formats false} [tool1-concept-id tool2-concept-id])
 
     ;; verify search result on coll1 contains associations with tool2, and has-formats being false
-    ;; because tool2 doesn't have more than one distinctive supported formats.
+    ;; because tools have no effect on has-formats flag.
     (tool-util/assert-collection-search-result
      coll2 {:has-formats false} [tool2-concept-id])))


### PR DESCRIPTION
Collection's has-formats flag should only be used  to specify if the associated services can do re formatting. 