### PR TITLE
CMR-6719: Updated client partner user guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ applications, as well as several libraries and support applications.
 
 ## Further Reading
 
-- CMR Client Partner User Guide: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide
+- CMR Client Partner User Guide: https://wiki.earthdata.nasa.gov/display/ED/CMR+Client+Partner+User+Guide
 - CMR Data Partner User Guide: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Data+Partner+User+Guide
 - CMR Client Developer Forum: https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum
 

--- a/common-app-lib/src/cmr/common_app/site/data.clj
+++ b/common-app-lib/src/cmr/common_app/site/data.clj
@@ -21,7 +21,7 @@
 (def default-partner-guide
   "Data for templates that display a link to Partner Guides. Clients should overrirde these keys
   in their own base static and base page maps if they need to use different values."
-  {:partner-url "https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide"
+  {:partner-url "https://wiki.earthdata.nasa.gov/display/ED/CMR+Client+Partner+User+Guide"
    :partner-text "Client Partner's Guide"})
 
 (defn base-static


### PR DESCRIPTION
A `grep` shows that the old link is contained in many various apps in HTML files, but my gut says that those should be rectified by this change.
* updated partner-url in common-app-lib
* updated main README