### PR TITLE
CMR-6749 updates quartzite library

### DIFF
--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -15,7 +15,7 @@
                  [cheshire "5.8.1"]
                  [clj-time "0.15.1"]
                  [clojail "1.0.6"]
-                 [org.clojars.daniel-zamora/quartzite "2.2.1-SNAPSHOT"]
+                 [gov.nasa.earthdata/quartzite "2.2.1-SNAPSHOT"]
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
                  [com.gfredericks/test.chuck "0.2.9"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -15,7 +15,7 @@
                  [cheshire "5.8.1"]
                  [clj-time "0.15.1"]
                  [clojail "1.0.6"]
-                 [clojurewerkz/quartzite "2.1.0"]
+                 [org.clojars.daniel-zamora/quartzite "2.2.1-SNAPSHOT"]
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
                  [com.gfredericks/test.chuck "0.2.9"]


### PR DESCRIPTION
This PR updates the quartzite library to my own version.  The current release of quartzite uses an older library of quartz, whose version needs updating per CMR-6759.  However, the maintainer of the https://github.com/michaelklishin/quartzite repo has not updated the underlying quartz library and seems to indicate in a response to this issue, https://github.com/michaelklishin/quartzite/issues/26, that he will not in the future.

In order to resolve this, I cloned the repo cited in this PR https://github.com/michaelklishin/quartzite/pull/39, which updates the quartz version to 2.3.1 and fixes any broken code,  to my own project https://github.com/daniel-zamora/quartzite.  I updated to quartz to version 2.3.2 then deployed my own jar to clojars. 

I have asked for the PR, cited above, to be merged into the main repo.  If in the future quartzite updates their quartz version, we can go back to using their jar.