### PR TITLE
CMR-6890 moved a test up.

### DIFF
--- a/search-app/test/cmr/search/test/services/humanizers/humanizer_range_facet_service.clj
+++ b/search-app/test/cmr/search/test/services/humanizers/humanizer_range_facet_service.clj
@@ -49,6 +49,24 @@
      :reportable false,
      :order 0}))
 
+(deftest get-range-facets-cache-empty-test
+  "Testing converting the humanizers to search facets when the cache is empty."
+  (let [context {:system {:caches  {hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}}}]
+    (is (= [{:key "0 to 1 meter", :from 0.0, :to (+ 1.0 hrfs/addition-factor)}
+            {:key "1 to 30 meters", :from 1.0, :to (+ 30.0 hrfs/addition-factor)}
+            {:key "30 to 100 meters", :from 30.0, :to (+ 100.0 hrfs/addition-factor)}
+            {:key "100 to 250 meters", :from 100.0, :to (+ 250.0 hrfs/addition-factor)}
+            {:key "250 to 500 meters", :from 250.0, :to (+ 500.0 hrfs/addition-factor)}
+            {:key "500 to 1000 meters", :from 500.0, :to (+ 1000.0 hrfs/addition-factor)}
+            {:key "1 to 10 km", :from 1000.0, :to (+ 10000.0 hrfs/addition-factor)}
+            {:key "10 to 50 km", :from 10000.0, :to (+ 50000.0 hrfs/addition-factor)}
+            {:key "50 to 100 km", :from 50000.0, :to (+ 100000.0 hrfs/addition-factor)}
+            {:key "100 to 250 km", :from 100000.0, :to (+ 250000.0 hrfs/addition-factor)}
+            {:key "250 to 500 km", :from 250000.0, :to (+ 500000.0 hrfs/addition-factor)}
+            {:key "500 to 1000 km", :from 500000.0, :to (+ 1000000.0 hrfs/addition-factor)}
+            {:key "1000 km & beyond", :from 1000000.0 :to (Float/MAX_VALUE)}]
+           (hrfs/get-range-facets context)))))
+
 (defn- get-sample-range-facet-humanizers
   "Get the sample humanizers that work for range facets."
   []
@@ -74,22 +92,4 @@
             {:key "250 to 500 km", :from 250000.0, :to (+ 500000.0 hrfs/addition-factor)}
             {:key "500 to 1000 km", :from 500000.0, :to (+ 1000000.0 hrfs/addition-factor)}
             {:key "1000 km & above", :from 1000000.0 :to (Float/MAX_VALUE)}]
-           (hrfs/get-range-facets context)))))
-
-(deftest get-range-facets-cache-empty-test
-  "Testing converting the humanizers to search facets when the cache is empty."
-  (let [context {:system {:caches  {hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}}}]
-    (is (= [{:key "0 to 1 meter", :from 0.0, :to (+ 1.0 hrfs/addition-factor)}
-            {:key "1 to 30 meters", :from 1.0, :to (+ 30.0 hrfs/addition-factor)}
-            {:key "30 to 100 meters", :from 30.0, :to (+ 100.0 hrfs/addition-factor)}
-            {:key "100 to 250 meters", :from 100.0, :to (+ 250.0 hrfs/addition-factor)}
-            {:key "250 to 500 meters", :from 250.0, :to (+ 500.0 hrfs/addition-factor)}
-            {:key "500 to 1000 meters", :from 500.0, :to (+ 1000.0 hrfs/addition-factor)}
-            {:key "1 to 10 km", :from 1000.0, :to (+ 10000.0 hrfs/addition-factor)}
-            {:key "10 to 50 km", :from 10000.0, :to (+ 50000.0 hrfs/addition-factor)}
-            {:key "50 to 100 km", :from 50000.0, :to (+ 100000.0 hrfs/addition-factor)}
-            {:key "100 to 250 km", :from 100000.0, :to (+ 250000.0 hrfs/addition-factor)}
-            {:key "250 to 500 km", :from 250000.0, :to (+ 500000.0 hrfs/addition-factor)}
-            {:key "500 to 1000 km", :from 500000.0, :to (+ 1000000.0 hrfs/addition-factor)}
-            {:key "1000 km & beyond", :from 1000000.0 :to (Float/MAX_VALUE)}]
            (hrfs/get-range-facets context)))))

--- a/search-app/test/cmr/search/test/services/humanizers/humanizer_range_facet_service.clj
+++ b/search-app/test/cmr/search/test/services/humanizers/humanizer_range_facet_service.clj
@@ -76,20 +76,20 @@
             {:key "1000 km & above", :from 1000000.0 :to (Float/MAX_VALUE)}]
            (hrfs/get-range-facets context)))))
 
-; (deftest get-range-facets-cache-empty-test
-;   "Testing converting the humanizers to search facets when the cache is empty."
-;   (let [context {:system {:caches  {hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}}}]
-;     (is (= [{:key "0 to 1 meter", :from 0.0, :to (+ 1.0 hrfs/addition-factor)}
-;             {:key "1 to 30 meters", :from 1.0, :to (+ 30.0 hrfs/addition-factor)}
-;             {:key "30 to 100 meters", :from 30.0, :to (+ 100.0 hrfs/addition-factor)}
-;             {:key "100 to 250 meters", :from 100.0, :to (+ 250.0 hrfs/addition-factor)}
-;             {:key "250 to 500 meters", :from 250.0, :to (+ 500.0 hrfs/addition-factor)}
-;             {:key "500 to 1000 meters", :from 500.0, :to (+ 1000.0 hrfs/addition-factor)}
-;             {:key "1 to 10 km", :from 1000.0, :to (+ 10000.0 hrfs/addition-factor)}
-;             {:key "10 to 50 km", :from 10000.0, :to (+ 50000.0 hrfs/addition-factor)}
-;             {:key "50 to 100 km", :from 50000.0, :to (+ 100000.0 hrfs/addition-factor)}
-;             {:key "100 to 250 km", :from 100000.0, :to (+ 250000.0 hrfs/addition-factor)}
-;             {:key "250 to 500 km", :from 250000.0, :to (+ 500000.0 hrfs/addition-factor)}
-;             {:key "500 to 1000 km", :from 500000.0, :to (+ 1000000.0 hrfs/addition-factor)}
-;             {:key "1000 km & beyond", :from 1000000.0 :to (Float/MAX_VALUE)}]
-;            (hrfs/get-range-facets context)))))
+(deftest get-range-facets-cache-empty-test
+  "Testing converting the humanizers to search facets when the cache is empty."
+  (let [context {:system {:caches  {hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}}}]
+    (is (= [{:key "0 to 1 meter", :from 0.0, :to (+ 1.0 hrfs/addition-factor)}
+            {:key "1 to 30 meters", :from 1.0, :to (+ 30.0 hrfs/addition-factor)}
+            {:key "30 to 100 meters", :from 30.0, :to (+ 100.0 hrfs/addition-factor)}
+            {:key "100 to 250 meters", :from 100.0, :to (+ 250.0 hrfs/addition-factor)}
+            {:key "250 to 500 meters", :from 250.0, :to (+ 500.0 hrfs/addition-factor)}
+            {:key "500 to 1000 meters", :from 500.0, :to (+ 1000.0 hrfs/addition-factor)}
+            {:key "1 to 10 km", :from 1000.0, :to (+ 10000.0 hrfs/addition-factor)}
+            {:key "10 to 50 km", :from 10000.0, :to (+ 50000.0 hrfs/addition-factor)}
+            {:key "50 to 100 km", :from 50000.0, :to (+ 100000.0 hrfs/addition-factor)}
+            {:key "100 to 250 km", :from 100000.0, :to (+ 250000.0 hrfs/addition-factor)}
+            {:key "250 to 500 km", :from 250000.0, :to (+ 500000.0 hrfs/addition-factor)}
+            {:key "500 to 1000 km", :from 500000.0, :to (+ 1000000.0 hrfs/addition-factor)}
+            {:key "1000 km & beyond", :from 1000000.0 :to (Float/MAX_VALUE)}]
+           (hrfs/get-range-facets context)))))


### PR DESCRIPTION
When I merged CMR-6783 a test failed in Bamboo - so I commented it out.  Since then it failed once, but passed twice and I don't know why.  I moved the test up in the file so that it would be run first thinking that maybe its a caching thing in Bamboo.  I am running a full build one more time to see if it will build correctly. The last three additional builds that I did all tests passed. The test itself hasn't changed and it is passing so I want to add it back in.