### PR TITLE
CMR-6623 - bypassing ACLs

### DIFF
--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.api.subscriptions
   "Subscription ingest functions in support of the ingest API."
   (:require
+   [cheshire.core :as json]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
@@ -18,6 +19,13 @@
     (v/validate-concept-metadata concept)
     concept))
 
+(defn subscription-user-matches-token?
+  "Check to see if the user for the supplied token matches the user in the subscription request"
+  [concept request-context headers]
+  (let [token-user (api-core/get-user-id request-context headers)
+        subscriber (get (json/decode (:metadata concept)) "SubscriberId")]
+        (= subscriber token-user)))
+
 (defn ingest-subscription
   "Processes a request to create or update a subscription."
   [provider-id native-id request]
@@ -26,10 +34,18 @@
                  :subscription provider-id native-id body content-type headers)
         _ (lt-validation/validate-launchpad-token request-context)
         _ (api-core/verify-provider-exists request-context provider-id)
-        _ (acl/verify-ingest-management-permission
-            request-context :update :provider-object provider-id)
-        _ (acl/verify-subscription-management-permission
-            request-context :update :provider-object provider-id)
+        subscription-user (get (json/decode (:metadata concept)) "SubscriberId")
+        token-user (api-core/get-user-id request-context headers)
+        bypass-acls (subscription-user-matches-token? concept request-context headers)
+        _ (when-not bypass-acls
+                    (info "ACLs were checked because the token user"
+                          token-user
+                          "is not the same as the subscription user"
+                          subscription-user)
+                    (acl/verify-ingest-management-permission
+                      request-context :update :provider-object provider-id)
+                    (acl/verify-subscription-management-permission
+                      request-context :update :provider-object provider-id))
         _ (common-enabled/validate-write-enabled request-context "ingest")
         concept (validate-and-prepare-subscription-concept concept)
         concept-with-user-id (api-core/set-user-id concept request-context headers)
@@ -39,6 +55,13 @@
                         (:client-id request-context)))
         save-subscription-result (ingest/save-subscription request-context concept-with-user-id)]
     ;; Log the successful ingest, with the metadata size in bytes.
+
+    ; there is a worry that subscriptions could be created neferiusly, log the
+    ; action. When no longer needed (log) also remove the variables from the let.
+    (when bypass-acls
+      (warn "ACLs were bypassed because the requesting account" token-user
+        "matched the subscription user" subscription-user ""))
+
     (api-core/log-concept-with-metadata-size concept-with-user-id request-context)
     (api-core/generate-ingest-response headers save-subscription-result)))
 

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -50,11 +50,12 @@
                                            body
                                            content-type
                                            headers)
-          subscription-user (:SubscriberId (json/decode (:medata concept) true))
+          subscription-user (:SubscriberId (json/decode (:metadata concept) true))
           token-user (api-core/get-user-id request-context headers)]
-      (if (= token-user subscription-user)
-        (warn (format (str "ACLs were bypassed because the token account %s "
-                      "matched the subscription user %s in the metadata.")
+      (if (and token-user ;; don't allow a bypass of ACLs just because of nil values
+               (= token-user subscription-user))
+        (warn (format (str "ACLs were bypassed because the token account '%s' "
+                      "matched the subscription user '%s' in the metadata.")
                       token-user
                       subscription-user))
         (do

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.test :refer :all]
    [clj-time.core :as t]
-   [cmr.access-control.test.util :as ac-util]))
+   [cmr.access-control.test.util :as ac-util]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.util :refer [are3]]
    [cmr.ingest.services.jobs :as jobs]

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -386,18 +386,16 @@
   Use cases coming from EarthData Search wanting to allow their users to create
   subscriptions without the need to have any acls
   """
-  (let [acls (ac-util/search-for-acls
-                (transmit-config/echo-system-token)
-                {:identity-type "provider"
-                 :provider "PROV1"
-                 :target "INGEST_MANAGEMENT_ACL"})
+  (let [acls (ac-util/search-for-acls (transmit-config/echo-system-token)
+                                      {:identity-type "provider"
+                                       :provider "PROV1"
+                                       :target "INGEST_MANAGEMENT_ACL"})
         _ (echo-util/ungrant (system/context) (:concept_id (first (:items acls))))
         supplied-concept-id "SUB1000-PROV1"
         user1-token (echo-util/login (system/context) "user1")
-        concept (subscription-util/make-subscription-concept
-                        {:concept-id supplied-concept-id
-                         :SubscriberId "user1"
-                         :native-id "Atlantic-1"})]
+        concept (subscription-util/make-subscription-concept {:concept-id supplied-concept-id
+                                                              :SubscriberId "user1"
+                                                              :native-id "Atlantic-1"})]
 
   ;; caes 1 test against guest token - no subscription
   (testing "guest token - guests can not create subscriptions - passes"
@@ -427,10 +425,9 @@
     (let [user2-token (echo-util/login (system/context) "user2")
           supplied-concept-id "SUB1000-PROV1"
           user1-token (echo-util/login (system/context) "user2")
-          concept (subscription-util/make-subscription-concept
-                    {:concept-id supplied-concept-id
-                     :SubscriberId "user1"
-                     :native-id "Atlantic-1"})
+          concept (subscription-util/make-subscription-concept {:concept-id supplied-concept-id
+                                                                :SubscriberId "user1"
+                                                                :native-id "Atlantic-1"})
           {:keys [status errors]} (ingest/ingest-concept concept {:token user2-token})]
       (is (= 201 status))
       (is (nil? errors)))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -396,28 +396,27 @@
         concept (subscription-util/make-subscription-concept {:concept-id supplied-concept-id
                                                               :SubscriberId "user1"
                                                               :native-id "Atlantic-1"})]
-
-  ;; caes 1 test against guest token - no subscription
-  (testing "guest token - guests can not create subscriptions - passes"
-    (let [{:keys [status errors]} (ingest/ingest-concept concept)]
-      (is (= 401 status))
-      (is (= ["You do not have permission to perform that action."] errors))))
-  ;; case 2 test on system token (ECHO token) - should pass
-  (testing "system token - admins can create subscriptions - passes"
-    (let [{:keys [status errors]} (ingest/ingest-concept concept {:token (transmit-config/echo-system-token)})]
-      (is (or (= 200 status) (= 201 status)))
-      (is (nil? errors))))
-  ;; case 3 test account 1 which matches metadata data user - should pass
-  (testing "use an account which matches the metadata and does not have ACL - passes"
-    (let [{:keys [status errors]} (ingest/ingest-concept concept {:token user1-token})]
-      (is (= 200 status))
-      (is (nil? errors))))
-  ;; case 4 test account 3 which does NOT match metadata user and account does not have prems
-  (testing "use an account which does not matches the metadata and does not have ACL - fails"
-    (let [user3-token (echo-util/login (system/context) "user3")
-          {:keys [status errors]} (ingest/ingest-concept concept {:token user3-token})]
-      (is (= 401 status))
-      (is (= ["You do not have permission to perform that action."] errors))))))
+    ;; caes 1 test against guest token - no subscription
+    (testing "guest token - guests can not create subscriptions - passes"
+      (let [{:keys [status errors]} (ingest/ingest-concept concept)]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+    ;; case 2 test on system token (ECHO token) - should pass
+    (testing "system token - admins can create subscriptions - passes"
+      (let [{:keys [status errors]} (ingest/ingest-concept concept {:token (transmit-config/echo-system-token)})]
+        (is (or (= 200 status) (= 201 status)))
+        (is (nil? errors))))
+    ;; case 3 test account 1 which matches metadata data user - should pass
+    (testing "use an account which matches the metadata and does not have ACL - passes"
+      (let [{:keys [status errors]} (ingest/ingest-concept concept {:token user1-token})]
+        (is (= 200 status))
+        (is (nil? errors))))
+    ;; case 4 test account 3 which does NOT match metadata user and account does not have prems
+    (testing "use an account which does not matches the metadata and does not have ACL - fails"
+      (let [user3-token (echo-util/login (system/context) "user3")
+            {:keys [status errors]} (ingest/ingest-concept concept {:token user3-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))))
 
 ;; case 5 test account 2 which does NOT match metadata user and account has prems ; this should be MMT's use case
 (deftest roll-your-own-subscription-and-have-acls-tests-with-acls

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -423,7 +423,6 @@
   (testing "Use an account which does not match matches the metadata and DOES have an ACL"
     (let [user2-token (echo-util/login (system/context) "user2")
           supplied-concept-id "SUB1000-PROV1"
-          user1-token (echo-util/login (system/context) "user2")
           concept (subscription-util/make-subscription-concept {:concept-id supplied-concept-id
                                                                 :SubscriberId "user1"
                                                                 :native-id "Atlantic-1"})

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -3,6 +3,8 @@
   For subscription permissions tests, see `provider-ingest-permissions-test`."
   (:require
    [clojure.test :refer :all]
+   [clj-time.core :as t]
+   [cmr.access-control.test.util :as ac-util]))
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.util :refer [are3]]
    [cmr.ingest.services.jobs :as jobs]
@@ -17,7 +19,7 @@
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
    [cmr.system-int-test.utils.subscription-util :as subscription-util]
    [cmr.transmit.access-control :as access-control]
-   [clj-time.core :as t]
+   [cmr.transmit.config :as transmit-config]
    [cmr.transmit.metadata-db :as mdb2]))
 
 (use-fixtures :each
@@ -378,3 +380,57 @@
                        flatten
                        (map :concept-id))]
        (is (= expected actual))))))
+
+(deftest roll-your-own-subscription-tests
+  """
+  Use cases coming from EarthData Search wanting to allow their users to create
+  subscriptions without the need to have any acls
+  """
+  (let [acls (ac-util/search-for-acls
+                (transmit-config/echo-system-token)
+                {:identity-type "provider"
+                 :provider "PROV1"
+                 :target "INGEST_MANAGEMENT_ACL"})
+        _ (echo-util/ungrant (system/context) (:concept_id (first (:items acls))))
+        supplied-concept-id "SUB1000-PROV1"
+        user1-token (echo-util/login (system/context) "user1")
+        concept (subscription-util/make-subscription-concept
+                        {:concept-id supplied-concept-id
+                         :SubscriberId "user1"
+                         :native-id "Atlantic-1"})]
+
+  ;1 test against guest token - no subscription (nil?)
+  (testing "guest token - guests can not create subscriptions - passes"
+    (let [{:keys [status errors]} (ingest/ingest-concept concept)]
+      (is (= 401 status))
+      (is (= ["You do not have permission to perform that action."] errors))))
+  ;2 test on system token (ECHO token) - should pass
+  (testing "system token - admins can create subscriptions - passes"
+    (let [{:keys [status errors]} (ingest/ingest-concept concept {:token (transmit-config/echo-system-token)})]
+      (is (= 201 status))
+      (is (nil? errors))))
+  ;3 test account 1 which matches metadata data user - should pass
+  (testing "use an account which matches the metadata and does not have ACL - passes"
+    (let [{:keys [status errors]} (ingest/ingest-concept concept {:token user1-token})]
+      (is (= 200 status))
+      (is (nil? errors))))
+  ;4 test account 3 which does NOT match metadata user and account does not have prems
+  (testing "use an account which does not matches the metadata and does not have ACL - fails"
+    (let [user3-token (echo-util/login (system/context) "user3")
+          {:keys [status errors]} (ingest/ingest-concept concept {:token user3-token})]
+      (is (= 401 status))
+      (is (= ["You do not have permission to perform that action."] errors))))))
+
+;5 test account 2 which does NOT match metadata user and account has prems ; this should be MMT's use case
+(deftest roll-your-own-subscription-tests-with-acls
+  (testing "Use an account which does not match matches the metadata and DOES have an ACL"
+    (let [user2-token (echo-util/login (system/context) "user2")
+          supplied-concept-id "SUB1000-PROV1"
+          user1-token (echo-util/login (system/context) "user2")
+          concept (subscription-util/make-subscription-concept
+                    {:concept-id supplied-concept-id
+                     :SubscriberId "user1"
+                     :native-id "Atlantic-1"})
+          {:keys [status errors]} (ingest/ingest-concept concept {:token user2-token})]
+      (is (= 201 status))
+      (is (nil? errors)))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -399,30 +399,30 @@
                          :SubscriberId "user1"
                          :native-id "Atlantic-1"})]
 
-  ;1 test against guest token - no subscription (nil?)
+  ;; caes 1 test against guest token - no subscription
   (testing "guest token - guests can not create subscriptions - passes"
     (let [{:keys [status errors]} (ingest/ingest-concept concept)]
       (is (= 401 status))
       (is (= ["You do not have permission to perform that action."] errors))))
-  ;2 test on system token (ECHO token) - should pass
+  ;; case 2 test on system token (ECHO token) - should pass
   (testing "system token - admins can create subscriptions - passes"
     (let [{:keys [status errors]} (ingest/ingest-concept concept {:token (transmit-config/echo-system-token)})]
       (is (= 201 status))
       (is (nil? errors))))
-  ;3 test account 1 which matches metadata data user - should pass
+  ;; case 3 test account 1 which matches metadata data user - should pass
   (testing "use an account which matches the metadata and does not have ACL - passes"
     (let [{:keys [status errors]} (ingest/ingest-concept concept {:token user1-token})]
       (is (= 200 status))
       (is (nil? errors))))
-  ;4 test account 3 which does NOT match metadata user and account does not have prems
+  ;; case 4 test account 3 which does NOT match metadata user and account does not have prems
   (testing "use an account which does not matches the metadata and does not have ACL - fails"
     (let [user3-token (echo-util/login (system/context) "user3")
           {:keys [status errors]} (ingest/ingest-concept concept {:token user3-token})]
       (is (= 401 status))
       (is (= ["You do not have permission to perform that action."] errors))))))
 
-;5 test account 2 which does NOT match metadata user and account has prems ; this should be MMT's use case
-(deftest roll-your-own-subscription-tests-with-acls
+;; case 5 test account 2 which does NOT match metadata user and account has prems ; this should be MMT's use case
+(deftest roll-your-own-subscription-and-have-acls-tests-with-acls
   (testing "Use an account which does not match matches the metadata and DOES have an ACL"
     (let [user2-token (echo-util/login (system/context) "user2")
           supplied-concept-id "SUB1000-PROV1"

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -407,7 +407,7 @@
   ;; case 2 test on system token (ECHO token) - should pass
   (testing "system token - admins can create subscriptions - passes"
     (let [{:keys [status errors]} (ingest/ingest-concept concept {:token (transmit-config/echo-system-token)})]
-      (is (= 201 status))
+      (is (or (= 200 status) (= 201 status)))
       (is (nil? errors))))
   ;; case 3 test account 1 which matches metadata data user - should pass
   (testing "use an account which matches the metadata and does not have ACL - passes"


### PR DESCRIPTION
Bypass ACLs if the requesting user is the same as the one the subscription is for