### PR TITLE
CMR-6764: Fixed DC namespace to accurately reflect CEOS best practices

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -418,7 +418,7 @@ __Example__
 <feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
       xmlns:georss="http://www.georss.org/georss/10"
       xmlns="http://www.w3.org/2005/Atom"
-      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:dc="http://purl.org/dc/elements/"
       xmlns:echo="http://www.echo.nasa.gov/esip"
       xmlns:esipdiscovery="http://commons.esipfed.org/ns/discovery/1.2/"
       xmlns:gml="http://www.opengis.net/gml"

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -418,7 +418,7 @@ __Example__
 <feed xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
       xmlns:georss="http://www.georss.org/georss/10"
       xmlns="http://www.w3.org/2005/Atom"
-      xmlns:dc="http://purl.org/dc/elements/"
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:echo="http://www.echo.nasa.gov/esip"
       xmlns:esipdiscovery="http://commons.esipfed.org/ns/discovery/1.2/"
       xmlns:gml="http://www.opengis.net/gml"

--- a/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
@@ -294,7 +294,7 @@
 (def ATOM_HEADER_ATTRIBUTES
   "The set of attributes that go on the ATOM root element"
   {:xmlns "http://www.w3.org/2005/Atom"
-   :xmlns:dc "http://purl.org/dc/terms/"
+   :xmlns:dc "http://purl.org/dc/elements/"
    :xmlns:georss "http://www.georss.org/georss/10"
    :xmlns:time "http://a9.com/-/opensearch/extensions/time/1.0/"
    :xmlns:echo "https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#atom"

--- a/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
@@ -294,7 +294,7 @@
 (def ATOM_HEADER_ATTRIBUTES
   "The set of attributes that go on the ATOM root element"
   {:xmlns "http://www.w3.org/2005/Atom"
-   :xmlns:dc "http://purl.org/dc/elements/"
+   :xmlns:dc "http://purl.org/dc/elements/1.1/"
    :xmlns:georss "http://www.georss.org/georss/10"
    :xmlns:time "http://a9.com/-/opensearch/extensions/time/1.0/"
    :xmlns:echo "https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#atom"


### PR DESCRIPTION
It was updated to http://purl.org/dc/elements/, but should have been updated to http://purl.org/dc/elements/1.1