### PR TITLE
CMR-6808 CMR-6807 CMR-6929

### DIFF
--- a/search-app/src/cmr/search/services/acls/subscription_acls.clj
+++ b/search-app/src/cmr/search/services/acls/subscription_acls.clj
@@ -4,6 +4,7 @@
    [cmr.common-app.services.search.group-query-conditions :as gc]
    [cmr.common-app.services.search.query-execution :as qe]
    [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common.api.context :as context-util]
    [cmr.common.util :as util]
    [cmr.search.services.acls.acl-helper :as acl-helper]
    [cmr.transmit.config :as tc]))
@@ -12,14 +13,19 @@
   [context query]
   ;; return unmodified query if the context has a system token
   ;; otherwise, get the provider-ids from the SUBSCRIPTION_MANAGEMENT ACLs
-  ;; that grant the read permission to the current user, and add provider-id
-  ;; constraint to the query.
+  ;; that grant the read permission to the current user, or if the user is subject
+  ;; of the subcription
   (if (tc/echo-system-token? context)
     query
     (let [;; sm-acls that grant read permission to the current user
           sm-acls (acl-helper/get-sm-acls-applicable-to-token context)
+          subscriber-cond (if (:token context)
+                            (qm/string-condition :subscriber-id
+                                                 (context-util/context->user-id context))
+                            qm/match-none)
           provider-ids (if (seq sm-acls)
                          (map #(get-in % [:provider-identity :provider-id]) sm-acls)
                          ["non-existing-provider-id"])
-          acl-cond (qm/string-conditions :provider-id provider-ids true)]
+          acl-cond (gc/or-conds [(qm/string-conditions :provider-id provider-ids true)
+                                 subscriber-cond])]
       (update-in query [:condition] #(gc/and-conds [acl-cond %])))))

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -190,7 +190,9 @@
   ([concept-id revision-id] (retrieve-concept concept-id revision-id {}))
   ([concept-id revision-id options]
    (let [url-extension (get options :url-extension)
-         concept-type (cs/concept-prefix->concept-type (subs concept-id 0 1))
+         concept-type (cs/concept-prefix->concept-type (if (= (subs concept-id 0 3) "SUB")
+                                                         "SUB"
+                                                         (subs concept-id 0 1)))
          format-mime-type (or (:accept options) mime-types/echo10)
          url (url/retrieve-concept-url concept-type concept-id revision-id)
          url (if url-extension

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -429,3 +429,56 @@
           {:keys [status errors]} (ingest/ingest-concept concept {:token user2-token})]
       (is (= 201 status))
       (is (nil? errors)))))
+
+(deftest ingest-update-and-delete-subscription-as-subscriber
+  (testing "Tests updating and deleting subscriptions as subscriber"
+    (doseq [acl (:items
+                 (ac-util/search-for-acls (system/context)
+                                          {:provider "PROV1"
+                                           :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]}
+                                          {:token "mock-echo-system-token"}))
+            :let [concept-id (:concept_id acl)]]
+      (echo-util/ungrant (system/context) concept-id))
+    (index/wait-until-indexed)
+    (let [admin-group (echo-util/get-or-create-group (system/context) "admin-group")
+          admin-user-token (echo-util/login (system/context) "admin-user" [admin-group])]
+      (echo-util/grant-all-subscription-group-sm (system/context)
+                                                 "PROV1"
+                                                 admin-group
+                                                 [:read :update])
+      (echo-util/grant-groups-ingest (system/context)
+                                     "PROV1"
+                                     [admin-group])
+      (index/wait-until-indexed)
+      (let [user1-token (echo-util/login (system/context) "user1")
+            user2-token (echo-util/login (system/context) "user2")
+            concept (subscription-util/make-subscription-concept {:SubscriberId "user1"})
+            concept2 (subscription-util/make-subscription-concept {:SubscriberId "user1" :native-id "new-concept"})
+            {:keys [concept-id revision-id status]} (ingest/ingest-concept concept {:token user1-token})
+            concept (merge {:concept-id concept-id} concept)]
+        (is (= 201 status))
+        (are3 [ingest-api-call args expected-status expected-errors]
+          (let [{:keys [status errors]} (apply ingest-api-call args)]
+            (is (= expected-status status))
+            (is (= expected-errors errors)))
+
+          "Attempt to update subscription as user2"
+          ingest/ingest-concept [concept {:token user2-token}] 401 ["You do not have permission to perform that action."]
+
+          "Attempt to delete subscription as user2"
+          ingest/delete-concept [concept {:token user2-token}] 401 ["You do not have permission to perform that action."]
+
+          "Update subscription as user1"
+          ingest/ingest-concept [concept {:token user1-token}] 200 nil
+
+          "Delete subscription as user1"
+          ingest/delete-concept [concept {:token user1-token}] 200 nil
+
+          "Ingest subscription as admin"
+          ingest/ingest-concept [concept2 {:token admin-user-token}] 201 nil
+
+          "Update subscription as admin"
+          ingest/ingest-concept [concept2 {:token admin-user-token}] 200 nil
+
+          "Delete subscription as admin"
+          ingest/delete-concept [concept2 {:token admin-user-token}] 200 nil)))))

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
@@ -2,6 +2,7 @@
   "This tests searching subscriptions."
   (:require
    [clojure.test :refer :all]
+   [cmr.access-control.test.util :as ac-util]
    [cmr.common.mime-types :as mime-types]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as echo-util]
@@ -14,8 +15,8 @@
 
 (use-fixtures :each
               (join-fixtures
-               [(ingest/reset-fixture {"provguid1" "PROV1" 
-                                       "provguid2" "PROV2" 
+               [(ingest/reset-fixture {"provguid1" "PROV1"
+                                       "provguid2" "PROV2"
                                        "provguid3" "PROV3"
                                        "provguid4" "PROV4"})
                 (subscriptions/grant-all-subscription-fixture
@@ -26,6 +27,45 @@
                 ;; No read permission granted for any user_types for PROV4.
                 (subscriptions/grant-all-subscription-fixture
                   {"provguid4" "PROV4"} [:update] [:update])]))
+
+(deftest search-for-subscriptions-test-with-subscriber
+  (doseq [acl (:items
+               (ac-util/search-for-acls (system/context)
+                                        {:provider "PROV1"
+                                         :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]}
+                                        {:token "mock-echo-system-token"}))
+          :let [concept-id (:concept_id acl)]]
+    (echo-util/ungrant (system/context) concept-id))
+  (index/wait-until-indexed)
+  (let [subscriber-token (echo-util/login (system/context) "subscriber")
+        guest-token (echo-util/login-guest (system/context))
+        subscription (subscriptions/ingest-subscription (subscriptions/make-subscription-concept
+                                                         {:Name "test subscription"
+                                                          :SubscriberId "subscriber"
+                                                          :native-id "test-subscription-native-id"})
+                                                        {:token "mock-echo-system-token"})]
+    (index/wait-until-indexed)
+    (is (= 201 (:status subscription)))
+    (are3 [expected-subscriptions query]
+      (do
+        (testing "XML references format"
+          (data2-core/assert-refs-match expected-subscriptions (subscriptions/search-refs query)))
+        (testing "JSON format"
+          (subscriptions/assert-subscription-search expected-subscriptions (subscriptions/search-json query))))
+
+      "Find all returns nothing for guest"
+      [] {:token guest-token}
+
+      "Find all returns all for subscriber"
+      [subscription] {:token subscriber-token}
+
+      ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+      ;; name Param
+      "By name case sensitive - exact match returns nothing for guest"
+      [] {:name "test subscription" :token guest-token}
+
+      "By name case sensitive - exact match returns the right subscription for registered user"
+      [subscription] {:name "test subscription" :token subscriber-token})))
 
 (deftest search-for-subscriptions-user-read-permission-test
   ;; SUBSCRIPTION_MANAGEMENT ACL grants only update permission for guest on PROV3,
@@ -59,7 +99,7 @@
       [] {:name "Subscription3" :token guest-token}
 
       "By name case sensitive - exact match returns the right subscription for registered user"
-      [subscription3] {:name "Subscription3" :token user1-token} )))
+      [subscription3] {:name "Subscription3" :token user1-token})))
 
 (deftest search-for-subscriptions-group-read-permission-test
   (let [subscription4 (subscriptions/ingest-subscription-with-attrs {:native-id "Sub4"
@@ -77,7 +117,7 @@
 
     ;; grant one group read permission
     (echo-util/grant-all-subscription-group-sm (system/context) "PROV4" group1-concept-id [:read])
-    
+
     (is (= 201 (:status subscription4)))
     (are3 [expected-subscriptions query]
       (do
@@ -98,7 +138,7 @@
       [] {:name "Subscription4" :token user2g-token}
 
       "By name case sensitive - exact match returns the right subscription for user1g"
-      [subscription4] {:name "Subscription4" :token user1g-token} )))
+      [subscription4] {:name "Subscription4" :token user1g-token})))
 
 (deftest search-for-subscriptions-validation-test
   (testing "Unrecognized parameters"


### PR DESCRIPTION
This PR adds the subscriber permission ACL bypass updating and deleting subscriptions, it also fixes oversight with searching subscriptions, should now be fully searchable by the subscriber.