### PR TITLE
CMR-6657

### DIFF
--- a/common-lib/src/cmr/common/api/errors.clj
+++ b/common-lib/src/cmr/common/api/errors.clj
@@ -11,6 +11,7 @@
 (def type->http-status-code
   {:bad-request 400
    :unauthorized 401
+   :forbidden 403
    :not-found 404
    :conflict 409
    :invalid-content-type 415

--- a/common-lib/src/cmr/common/api/errors.clj
+++ b/common-lib/src/cmr/common/api/errors.clj
@@ -11,7 +11,6 @@
 (def type->http-status-code
   {:bad-request 400
    :unauthorized 401
-   :forbidden 403
    :not-found 404
    :conflict 409
    :invalid-content-type 415

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -250,7 +250,7 @@
                                     {:token token}))
            :let [concept-id (:concept_id acl)]
            :when concept-id]
-    (ungrant context concept-id))))
+     (ungrant context concept-id))))
 
 (defn get-acls-by-type-and-target
   "Get the GROUP ACLs set up for providers in fixtures.  Return in format used for test assertions"

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -239,6 +239,19 @@
   (ac/delete-acl context acl {:raw? true :token (config/echo-system-token)})
   (echo-client/delete-acl context acl))
 
+(defn ungrant-by-search
+  "Takes acl search parameters and removes all acls found."
+  ([context params]
+   (ungrant-by-search context params (config/echo-system-token)))
+  ([context params token]
+   (doseq [acl (:items
+                (ac/search-for-acls context
+                                    params
+                                    {:token token}))
+           :let [concept-id (:concept_id acl)]
+           :when concept-id]
+    (ungrant context concept-id))))
+
 (defn get-acls-by-type-and-target
   "Get the GROUP ACLs set up for providers in fixtures.  Return in format used for test assertions"
   ([context type target]

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
@@ -138,7 +138,8 @@
 
 (deftest delete-provider-test
   (testing "delete provider"
-    (let [token (e/login-guest (cmr.system-int-test.system/context))
+    (let [token (e/login-guest (s/context))
+          user1 (e/login (s/context) "user1")
           coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
                                                                               :ShortName "S1"
                                                                               :Version "V1"}))
@@ -175,9 +176,13 @@
                                                :Name "tool2"
                                                :provider-id "PROV2"})
           sub1 (subscriptions/ingest-subscription-with-attrs {:native-id "sub1"
-                                                              :Name "sub1"})
+                                                              :Name "sub1"
+                                                              :SubscriberId "user1"
+                                                              :CollectionConceptId (:concept-id coll1)})
           sub2 (subscriptions/ingest-subscription-with-attrs {:native-id "sub2"
                                                               :Name "sub2"
+                                                              :SubscriberId "user1"
+                                                              :CollectionConceptId (:concept-id coll1)
                                                               :provider-id "PROV2"})
           _ (index/wait-until-indexed)
           svc-association1 (au/make-service-association
@@ -185,9 +190,9 @@
           svc-association2 (au/make-service-association
                             token (:concept-id service2) [{:concept-id (:concept-id coll3)}])
           tool-association1 (au/make-tool-association
-                            token (:concept-id tool1) [{:concept-id (:concept-id coll1)}])
+                             token (:concept-id tool1) [{:concept-id (:concept-id coll1)}])
           tool-association2 (au/make-tool-association
-                            token (:concept-id tool2) [{:concept-id (:concept-id coll3)}])
+                             token (:concept-id tool2) [{:concept-id (:concept-id coll3)}])
           ;; create an access group to test cascading deletes
           access-group (u/map-keys->kebab-case
                         (access-control/create-group
@@ -221,34 +226,35 @@
                 :revision-id 1}]
       (index/wait-until-indexed)
 
-      (is (= 2 (count (:refs (search/find-refs :collection {:provider-id "PROV1"})))))
-      (is (= 3 (count (:refs (search/find-refs :granule {:provider-id "PROV1"})))))
-      (d/refs-match? [variable1] (search/find-refs :variable {:name "Variable1"}))
-      (d/refs-match? [variable2] (search/find-refs :variable {:name "Variable2"}))
-      (d/refs-match? [service1] (search/find-refs :service {:name "service1"}))
-      (d/refs-match? [service2] (search/find-refs :service {:name "service2"}))
-      (d/refs-match? [tool1] (search/find-refs :tool {:name "tool1"}))
-      (d/refs-match? [tool2] (search/find-refs :tool {:name "tool2"}))
-      (d/refs-match? [sub1] (search/find-refs :subscription {:name "sub1"}))
-      (d/refs-match? [sub2] (search/find-refs :subscription {:name "sub2"}))
+      (testing "concepts still exist"
+        (is (= 2 (count (:refs (search/find-refs :collection {:provider-id "PROV1"})))))
+        (is (= 3 (count (:refs (search/find-refs :granule {:provider-id "PROV1"})))))
+        (d/refs-match? [variable1] (search/find-refs :variable {:name "Variable1"}))
+        (d/refs-match? [variable2] (search/find-refs :variable {:name "Variable2"}))
+        (d/refs-match? [service1] (search/find-refs :service {:name "service1"}))
+        (d/refs-match? [service2] (search/find-refs :service {:name "service2"}))
+        (d/refs-match? [tool1] (search/find-refs :tool {:name "tool1"}))
+        (d/refs-match? [tool2] (search/find-refs :tool {:name "tool2"}))
+        (d/refs-match? [sub1] (search/find-refs :subscription {:name "sub1"}))
+        (d/refs-match? [sub2] (search/find-refs :subscription {:name "sub2"})))
 
-      ;; ensure PROV1 group is indexed
-      (is (= [(:concept-id access-group)]
-             (map :concept_id
-                  (:items
-                   (access-control/search-for-groups (transmit-config/echo-system-token)
-                                                     {:provider "PROV1"})))))
-      ;; PROV1 ACLs are indexed
-      (is (set/subset? (set [(:concept-id acl1) (:concept-id acl2) (:concept-id acl3)])
-                       (set (map :concept_id
-                                 (:items
-                                  (access-control/search-for-acls (transmit-config/echo-system-token) {:provider "PROV1"}))))))
+      (testing "PROV1 group is indexed"
+        (is (= [(:concept-id access-group)]
+               (map :concept_id
+                    (:items
+                     (access-control/search-for-groups (transmit-config/echo-system-token)
+                                                       {:provider "PROV1"}))))))
+      (testing "PROV1 ACLs are indexed"
+        (is (set/subset? (set [(:concept-id acl1) (:concept-id acl2) (:concept-id acl3)])
+                         (set (map :concept_id
+                                   (:items
+                                    (access-control/search-for-acls (transmit-config/echo-system-token) {:provider "PROV1"})))))))
 
-      ;; delete provider PROV1, fails because collections exist
-      (let [{:keys [status errors]} (ingest/delete-ingest-provider "PROV1")]
-        (is (= 401 status))
-        (is (= ["You cannot perform this action on a provider that has collections."]
-               errors)))
+      (testing "delete provider PROV1, fails because collections exist"
+        (let [{:keys [status errors]} (ingest/delete-ingest-provider "PROV1")]
+          (is (= 401 status))
+          (is (= ["You cannot perform this action on a provider that has collections."]
+                 errors))))
 
       (ingest/delete-concept (d/umm-c-collection->concept coll1 :echo10) {:accept-format :json
                                                                           :raw? true})
@@ -256,80 +262,81 @@
                                                                           :raw? true})
       (index/wait-until-indexed)
 
-      ;; delete provider PROV1
-      (let [{:keys [status content-length]} (ingest/delete-ingest-provider "PROV1")]
-        (is (= 204 status))
-        (is (nil? content-length)))
-      (index/wait-until-indexed)
+      (testing "delete provider PROV1"
+        (let [{:keys [status content-length]} (ingest/delete-ingest-provider "PROV1")]
+          (is (= 204 status))
+          (is (nil? content-length)))
+        (index/wait-until-indexed))
 
-      ;; PROV1 concepts are not in metadata-db
-      (are [concept]
-        (not (mdb/concept-exists-in-mdb? (:concept-id concept) (:revision-id concept)))
-        coll1
-        coll2
-        gran1
-        gran2
-        gran3
-        variable1
-        service1
-        tool1
-        sub1
-        svc-association1
-        tool-association1
-        access-group
-        acl1
-        acl2)
+      (testing "PROV1 concepts are not in metadata-db"
+        (are [concept]
+          (not (mdb/concept-exists-in-mdb? (:concept-id concept) (:revision-id concept)))
+          coll1
+          coll2
+          gran1
+          gran2
+          gran3
+          variable1
+          service1
+          tool1
+          sub1
+          svc-association1
+          tool-association1
+          access-group
+          acl1
+          acl2))
 
-      ;; PROV1 access group is unindexed
-      (is (= 0 (:hits
-                (access-control/search-for-groups (transmit-config/echo-system-token)
-                                                  {:provider "PROV1"}))))
+      (testing "PROV1 access group is unindexed"
+        (is (= 0 (:hits
+                  (access-control/search-for-groups (transmit-config/echo-system-token)
+                                                    {:provider "PROV1"})))))
 
-      ;; PROV1 ACLs are no longer indexed
-      (is (= 0 (:hits
-                (access-control/search-for-acls token {:provider "PROV1"}))))
-      ;; PROV2 concepts are in metadata-db
-      (are [concept]
-        (mdb/concept-exists-in-mdb? (:concept-id concept) (:revision-id concept))
-        coll3
-        gran4
-        variable2
-        service2
-        tool2
-        sub2
-        svc-association2
-        tool-association2)
+      (testing "PROV1 ACLs are no longer indexed"
+        (is (= 0 (:hits
+                  (access-control/search-for-acls token {:provider "PROV1"})))))
 
-      ;; search on PROV1 finds nothing
-      (is (d/refs-match?
-           []
-           (search/find-refs :collection {:provider-id "PROV1"})))
-      (is (d/refs-match?
-           []
-           (search/find-refs :granule {:provider-id "PROV1"})))
+      (testing "PROV2 concepts are in metadata-db"
+        (are [concept]
+          (mdb/concept-exists-in-mdb? (:concept-id concept) (:revision-id concept))
+          coll3
+          gran4
+          variable2
+          service2
+          tool2
+          sub2
+          svc-association2
+          tool-association2))
 
-      ;; search on PROV2 finds the concepts
+      (testing "search on PROV1 finds nothing"
+        (is (d/refs-match?
+             []
+             (search/find-refs :collection {:provider-id "PROV1"})))
+        (is (d/refs-match?
+             []
+             (search/find-refs :granule {:provider-id "PROV1"}))))
+
+      (testing "search on PROV2 finds the concepts")
       (is (d/refs-match?
            [coll3]
            (search/find-refs :collection {:provider-id "PROV2"})))
       (is (d/refs-match?
            [gran4]
            (search/find-refs :granule {:provider-id "PROV2"})))
-      ;; Variable on PROV1 is not found in search
+      (testing "Variable on PROV1 is not found in search")
       (d/refs-match? [] (search/find-refs :variable {:name "Variable1"}))
-      ;; Variable on PROV2 is still found in search
+      (testing "Variable on PROV2 is still found in search")
       (d/refs-match? [variable2] (search/find-refs :variable {:name "Variable2"}))
-      ;; Tool on PROV1 is not found in search
+      (testing "Tool on PROV1 is not found in search")
       (d/refs-match? [] (search/find-refs :tool {:name "tool1"}))
-      ;; Tool on PROV2 is still found in search
+      (testing "Tool on PROV2 is still found in search")
       (d/refs-match? [tool2] (search/find-refs :tool {:name "tool2"}))
-      ;; Subscription on PROV1 is not found in search
+      (testing "Subscription on PROV1 is not found in search")
       (d/refs-match? [] (search/find-refs :subscription {:name "sub1"}))
-      ;; Subscription on PROV2 is still found in search
+      (testing "Subscription on PROV2 is still found in search")
       (d/refs-match? [sub2] (search/find-refs :subscription {:name "sub2"}))
-      ;; Service on PROV1 is not found in search
+      (testing "Service on PROV1 is not found in search")
       (d/refs-match? [] (search/find-refs :service {:name "service1"}))
-      ;; Service on PROV2 is still found in search
+      (testing "Service on PROV2 is still found in search")
       (d/refs-match? [service2] (search/find-refs :service {:name "service2"}))))
 
   (testing "delete non-existent provider"
@@ -364,6 +371,6 @@
       (is (mdb/concept-exists-in-mdb? (:concept-id access-group) (:revision-id access-group)))
       (ingest/delete-ingest-provider (:provider-id provider))
       (is (not (mdb/concept-exists-in-mdb? (:concept-id access-group) (:revision-id access-group))))
-      ;; re-create the provider to ensure nothing has stuck around in the DB
+      ;; re-create the provider to ensure nothing has stuck around in the DB)
       (ingest/create-ingest-provider provider)
       (is (not (mdb/concept-exists-in-mdb? (:concept-id access-group) (:revision-id access-group)))))))

--- a/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
@@ -221,13 +221,9 @@
                 unsupported-mt)))))
 
 (deftest retrieve-subscription-by-concept-id-with-subscriber
-  (doseq [acl (:items
-               (ac-util/search-for-acls (s/context)
-                                        {:provider "PROV1"
-                                         :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]}
-                                        {:token "mock-echo-system-token"}))
-          :let [concept-id (:concept_id acl)]]
-    (e/ungrant (s/context) concept-id))
+  (e/ungrant-by-search (s/context)
+                       {:provider "PROV1"
+                        :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]})
   (ac-util/wait-until-indexed)
   (doseq [accept-format [mt/umm-json]]
     (let [suffix (if accept-format

--- a/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
@@ -9,6 +9,8 @@
    [cmr.access-control.test.util :as ac-util]
    [cmr.common.mime-types :as mt]
    [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
@@ -114,104 +116,118 @@
 
 (deftest retrieve-subscription-by-concept-id-various-read-permission
   ;; We support UMM JSON format; No format and any format are also accepted.
-  (doseq [accept-format [mt/umm-json]];; nil mt/any]]
-    (let [suffix (if accept-format
-                   (mt/mime-type->format accept-format)
-                   "nil")
-          ;; append result format to subscription name to make it unique
-          ;; for different formats so that the test can be run for multiple formats
-          sub1-r1-name (str "s1-r1" suffix)
-          sub1-r2-name (str "s1-r2" suffix)
-          native-id (str "subscription1" suffix)
-          sub1-r1 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
-                                                                :Name  sub1-r1-name
-                                                                :native-id native-id})
-          sub1-r2 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
-                                                                :Name sub1-r2-name
-                                                                :native-id native-id})
-          concept-id (:concept-id sub1-r1)]
-      (index/wait-until-indexed)
-      (testing "Sanity check that the test subscription got updated and its revision id was incremented"
-        (is (= concept-id (:concept-id sub1-r2)))
-        (is (= 1 (:revision-id sub1-r1)))
-        (is (= 2 (:revision-id sub1-r2))))
-
-      ;; no read permission granted for guest on provider "PROV2" so, no subscription could be found.
-      (testing "retrieval by subscription concept-id and revision id returns error"
-        (assert-retrieved-concept-error concept-id 1 accept-format 404
-          (format "Concept with concept-id [%s] and revision-id [1] could not be found." concept-id))
-        (assert-retrieved-concept-error concept-id 2 accept-format 404
-          (format "Concept with concept-id [%s] and revision-id [2] could not be found." concept-id)))
-
-      (testing "retrieval by only subscription concept-id returns error"
-        (assert-retrieved-concept-error concept-id nil accept-format 404
-          (format "Concept with concept-id [%s] could not be found." concept-id)))
-
-      ;; read permission is granted for registered user, subscriptions will be found
-      (testing "retrieval by subscription concept-id and revision id returns the specified revision"
-        (assert-retrieved-concept-with-registered-user concept-id 1 accept-format sub1-r1-name)
-        (assert-retrieved-concept-with-registered-user concept-id 2 accept-format sub1-r2-name))
-
-      (testing "retrieval by only subscription concept-id returns the latest revision"
-        (assert-retrieved-concept-with-registered-user concept-id nil accept-format sub1-r2-name)))))
-
-(deftest retrieve-subscription-by-concept-id
-  ;; We support UMM JSON format; No format and any format are also accepted.
-  (doseq [accept-format [mt/umm-json]];; nil mt/any]]
-    (let [suffix (if accept-format
-                   (mt/mime-type->format accept-format)
-                   "nil")
-          ;; append result format to subscription name to make it unique
-          ;; for different formats so that the test can be run for multiple formats
-          sub1-r1-name (str "s1-r1" suffix)
-          sub1-r2-name (str "s1-r2" suffix)
-          native-id (str "subscription1" suffix)
-          sub1-r1 (subscription/ingest-subscription-with-attrs {:Name  sub1-r1-name
-                                                                :native-id native-id})
-          sub1-r2 (subscription/ingest-subscription-with-attrs {:Name sub1-r2-name
-                                                                :native-id native-id})
-          concept-id (:concept-id sub1-r1)
-          sub1-concept (mdb/get-concept concept-id)]
-      (index/wait-until-indexed)
-
-      (testing "Sanity check that the test subscription got updated and its revision id was incremented"
-        (is (= concept-id (:concept-id sub1-r2)))
-        (is (= 1 (:revision-id sub1-r1)))
-        (is (= 2 (:revision-id sub1-r2))))
-
-      (testing "retrieval by subscription concept-id and revision id returns the specified revision"
-        (assert-retrieved-concept concept-id 1 accept-format sub1-r1-name)
-        (assert-retrieved-concept concept-id 2 accept-format sub1-r2-name))
-
-      (testing "retrieval by only subscription concept-id returns the latest revision"
-        (assert-retrieved-concept concept-id nil accept-format sub1-r2-name))
-
-      (testing "retrieval by non-existent revision returns error"
-        (assert-retrieved-concept-error concept-id 3 accept-format 404
-          (format "Concept with concept-id [%s] and revision-id [3] does not exist." concept-id)))
-
-      (testing "retrieval by non-existent concept-id returns error"
-        (assert-retrieved-concept-error "SUB404404404-PROV1" nil accept-format 404
-          "Concept with concept-id [SUB404404404-PROV1] could not be found."))
-
-      (testing "retrieval by non-existent concept-id and revision-id returns error"
-        (assert-retrieved-concept-error "SUB404404404-PROV1" 1 accept-format 404
-          "Concept with concept-id [SUB404404404-PROV1] and revision-id [1] does not exist."))
-
-      (testing "retrieval of deleted concept"
-        ;; delete the subscription concept
-        (ingest/delete-concept sub1-concept (subscription/token-opts (e/login (s/context) "user1")))
+  (let [coll1 (data-core/ingest-umm-spec-collection "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})]
+    (doseq [accept-format [mt/umm-json]];; nil mt/any]]
+      (let [suffix (if accept-format
+                     (mt/mime-type->format accept-format)
+                     "nil")
+            ;; append result format to subscription name to make it unique
+            ;; for different formats so that the test can be run for multiple formats
+            sub1-r1-name (str "s1-r1" suffix)
+            sub1-r2-name (str "s1-r2" suffix)
+            native-id (str "subscription1" suffix)
+            sub1-r1 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
+                                                                  :Name  sub1-r1-name
+                                                                  :CollectionConceptId (:concept-id coll1)
+                                                                  :native-id native-id})
+            sub1-r2 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
+                                                                  :Name sub1-r2-name
+                                                                  :CollectionConceptId (:concept-id coll1)
+                                                                  :native-id native-id})
+            concept-id (:concept-id sub1-r1)]
         (index/wait-until-indexed)
+        (testing "Sanity check that the test subscription got updated and its revision id was incremented"
+          (is (= concept-id (:concept-id sub1-r2)))
+          (is (= 1 (:revision-id sub1-r1)))
+          (is (= 2 (:revision-id sub1-r2))))
 
-        (testing "retrieval of deleted concept without revision id results in error"
+        ;; no read permission granted for guest on provider "PROV2" so, no subscription could be found.
+        (testing "retrieval by subscription concept-id and revision id returns error"
+          (assert-retrieved-concept-error concept-id 1 accept-format 404
+            (format "Concept with concept-id [%s] and revision-id [1] could not be found." concept-id))
+          (assert-retrieved-concept-error concept-id 2 accept-format 404
+            (format "Concept with concept-id [%s] and revision-id [2] could not be found." concept-id)))
+
+        (testing "retrieval by only subscription concept-id returns error"
           (assert-retrieved-concept-error concept-id nil accept-format 404
             (format "Concept with concept-id [%s] could not be found." concept-id)))
 
-        (testing "retrieval of deleted concept with revision id returns a 400 error"
-          (assert-retrieved-concept-error concept-id 3 accept-format 400
-            (format (str "The revision [3] of concept [%s] represents "
-                         "a deleted concept and does not contain metadata.")
-                    concept-id)))))))
+        ;; read permission is granted for registered user, subscriptions will be found
+        (testing "retrieval by subscription concept-id and revision id returns the specified revision"
+          (assert-retrieved-concept-with-registered-user concept-id 1 accept-format sub1-r1-name)
+          (assert-retrieved-concept-with-registered-user concept-id 2 accept-format sub1-r2-name))
+
+        (testing "retrieval by only subscription concept-id returns the latest revision"
+          (assert-retrieved-concept-with-registered-user concept-id nil accept-format sub1-r2-name))))))
+
+(deftest retrieve-subscription-by-concept-id
+  ;; We support UMM JSON format; No format and any format are also accepted.
+  (let [coll1 (data-core/ingest-umm-spec-collection "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})]
+    (doseq [accept-format [mt/umm-json]];; nil mt/any]]
+      (let [suffix (if accept-format
+                     (mt/mime-type->format accept-format)
+                     "nil")
+            ;; append result format to subscription name to make it unique
+            ;; for different formats so that the test can be run for multiple formats
+            sub1-r1-name (str "s1-r1" suffix)
+            sub1-r2-name (str "s1-r2" suffix)
+            native-id (str "subscription1" suffix)
+            sub1-r1 (subscription/ingest-subscription-with-attrs {:Name  sub1-r1-name
+                                                                  :CollectionConceptId (:concept-id coll1)
+                                                                  :native-id native-id})
+            sub1-r2 (subscription/ingest-subscription-with-attrs {:Name sub1-r2-name
+                                                                  :CollectionConceptId (:concept-id coll1)
+                                                                  :native-id native-id})
+            concept-id (:concept-id sub1-r1)
+            sub1-concept (mdb/get-concept concept-id)]
+        (index/wait-until-indexed)
+
+        (testing "Sanity check that the test subscription got updated and its revision id was incremented"
+          (is (= concept-id (:concept-id sub1-r2)))
+          (is (= 1 (:revision-id sub1-r1)))
+          (is (= 2 (:revision-id sub1-r2))))
+
+        (testing "retrieval by subscription concept-id and revision id returns the specified revision"
+          (assert-retrieved-concept concept-id 1 accept-format sub1-r1-name)
+          (assert-retrieved-concept concept-id 2 accept-format sub1-r2-name))
+
+        (testing "retrieval by only subscription concept-id returns the latest revision"
+          (assert-retrieved-concept concept-id nil accept-format sub1-r2-name))
+
+        (testing "retrieval by non-existent revision returns error"
+          (assert-retrieved-concept-error concept-id 3 accept-format 404
+            (format "Concept with concept-id [%s] and revision-id [3] does not exist." concept-id)))
+
+        (testing "retrieval by non-existent concept-id returns error"
+          (assert-retrieved-concept-error "SUB404404404-PROV1" nil accept-format 404
+            "Concept with concept-id [SUB404404404-PROV1] could not be found."))
+
+        (testing "retrieval by non-existent concept-id and revision-id returns error"
+          (assert-retrieved-concept-error "SUB404404404-PROV1" 1 accept-format 404
+            "Concept with concept-id [SUB404404404-PROV1] and revision-id [1] does not exist."))
+
+        (testing "retrieval of deleted concept"
+          ;; delete the subscription concept
+          (ingest/delete-concept sub1-concept (subscription/token-opts (e/login (s/context) "user1")))
+          (index/wait-until-indexed)
+
+          (testing "retrieval of deleted concept without revision id results in error"
+            (assert-retrieved-concept-error concept-id nil accept-format 404
+              (format "Concept with concept-id [%s] could not be found." concept-id)))
+
+          (testing "retrieval of deleted concept with revision id returns a 400 error"
+            (assert-retrieved-concept-error concept-id 3 accept-format 400
+              (format (str "The revision [3] of concept [%s] represents "
+                           "a deleted concept and does not contain metadata.")
+                      concept-id))))))))
 
 (deftest retrieve-subscription-with-invalid-format
   (testing "unsupported accept header results in error"
@@ -225,51 +241,57 @@
                        {:provider "PROV1"
                         :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]})
   (ac-util/wait-until-indexed)
-  (doseq [accept-format [mt/umm-json]]
-    (let [suffix (if accept-format
-                   (mt/mime-type->format accept-format)
-                   "nil")
-          subscriber-token (e/login (s/context) "subscriber")
-          sub1-r1-name (str "s1-r1" suffix)
-          native-id (str "subscription1" suffix)
-          sub1-r1 (subscription/ingest-subscription (subscription/make-subscription-concept
-                                                      {:Name sub1-r1-name
-                                                       :SubscriberId "subscriber"
-                                                       :native-id native-id})
-                                                    {:token "mock-echo-system-token"})
-          concept-id (:concept-id sub1-r1)
-          sub1-concept (mdb/get-concept concept-id)]
-      (index/wait-until-indexed)
-
-      (testing "retrieval by subscription concept-id and revision id returns the specified revision"
-        (assert-retrieved-concept-as-subscriber concept-id 1 accept-format sub1-r1-name subscriber-token))
-
-      (testing "retrieval by only subscription concept-id returns the latest revision"
-        (assert-retrieved-concept-as-subscriber concept-id nil accept-format sub1-r1-name subscriber-token))
-
-      (testing "retrieval by non-existent revision returns error"
-        (assert-retrieved-concept-as-subscriber-recieved-error concept-id 3 accept-format 404 subscriber-token
-          (format "Concept with concept-id [%s] and revision-id [3] does not exist." concept-id)))
-
-      (testing "retrieval by non-existent concept-id returns error"
-        (assert-retrieved-concept-as-subscriber-recieved-error "SUB404404404-PROV1" nil accept-format 404 subscriber-token
-          "Concept with concept-id [SUB404404404-PROV1] could not be found."))
-
-      (testing "retrieval by non-existent concept-id and revision-id returns error"
-        (assert-retrieved-concept-as-subscriber-recieved-error "SUB404404404-PROV1" 1 accept-format 404 subscriber-token
-          "Concept with concept-id [SUB404404404-PROV1] and revision-id [1] does not exist."))
-
-      (testing "retrieval of deleted concept"
-        ;; delete the subscription concept
-        (ingest/delete-concept sub1-concept (subscription/token-opts "mock-echo-system-token"))
+  (let [coll1 (data-core/ingest-umm-spec-collection "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})]
+    (doseq [accept-format [mt/umm-json]]
+      (let [suffix (if accept-format
+                     (mt/mime-type->format accept-format)
+                     "nil")
+            subscriber-token (e/login (s/context) "subscriber")
+            sub1-r1-name (str "s1-r1" suffix)
+            native-id (str "subscription1" suffix)
+            sub1-r1 (subscription/ingest-subscription (subscription/make-subscription-concept
+                                                        {:Name sub1-r1-name
+                                                         :CollectionConceptId (:concept-id coll1)
+                                                         :SubscriberId "subscriber"
+                                                         :native-id native-id})
+                                                      {:token "mock-echo-system-token"})
+            concept-id (:concept-id sub1-r1)
+            sub1-concept (mdb/get-concept concept-id)]
         (index/wait-until-indexed)
 
-        (testing "retrieval of deleted concept without revision id results in error"
-          (assert-retrieved-concept-as-subscriber-recieved-error concept-id nil accept-format 404 subscriber-token
-            (format "Concept with concept-id [%s] could not be found." concept-id)))
+        (testing "retrieval by subscription concept-id and revision id returns the specified revision"
+          (assert-retrieved-concept-as-subscriber concept-id 1 accept-format sub1-r1-name subscriber-token))
 
-        (testing "retrieval of deleted concept with revision id returns a 400 error"
-          (assert-retrieved-concept-as-subscriber-recieved-error concept-id 2 accept-format 400 subscriber-token
-            (format (str "The revision [2] of concept [%s] represents "
-                         "a deleted concept and does not contain metadata.")
-                    concept-id)))))))
+        (testing "retrieval by only subscription concept-id returns the latest revision"
+          (assert-retrieved-concept-as-subscriber concept-id nil accept-format sub1-r1-name subscriber-token))
+
+        (testing "retrieval by non-existent revision returns error"
+          (assert-retrieved-concept-as-subscriber-recieved-error concept-id 3 accept-format 404 subscriber-token
+            (format "Concept with concept-id [%s] and revision-id [3] does not exist." concept-id)))
+
+        (testing "retrieval by non-existent concept-id returns error"
+          (assert-retrieved-concept-as-subscriber-recieved-error "SUB404404404-PROV1" nil accept-format 404 subscriber-token
+            "Concept with concept-id [SUB404404404-PROV1] could not be found."))
+
+        (testing "retrieval by non-existent concept-id and revision-id returns error"
+          (assert-retrieved-concept-as-subscriber-recieved-error "SUB404404404-PROV1" 1 accept-format 404 subscriber-token
+            "Concept with concept-id [SUB404404404-PROV1] and revision-id [1] does not exist."))
+
+        (testing "retrieval of deleted concept"
+          ;; delete the subscription concept
+          (ingest/delete-concept sub1-concept (subscription/token-opts "mock-echo-system-token"))
+          (index/wait-until-indexed)
+
+          (testing "retrieval of deleted concept without revision id results in error"
+            (assert-retrieved-concept-as-subscriber-recieved-error concept-id nil accept-format 404 subscriber-token
+              (format "Concept with concept-id [%s] could not be found." concept-id)))
+
+          (testing "retrieval of deleted concept with revision id returns a 400 error"
+            (assert-retrieved-concept-as-subscriber-recieved-error concept-id 2 accept-format 400 subscriber-token
+              (format (str "The revision [2] of concept [%s] represents "
+                           "a deleted concept and does not contain metadata.")
+                      concept-id))))))))

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
@@ -6,6 +6,7 @@
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.umm-json :as du]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
@@ -21,18 +22,26 @@
                   {"provguid1" "PROV1" "provguid2" "PROV2"} [:read :update] [:read :update])]))
 
 (deftest search-subscription-all-revisions-after-cleanup
-  (let [subscription1 {:native-id "SUB1"
+  (let [coll1 (d/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})
+        subscription1 {:native-id "SUB1"
                        :Name "Sub1"
+                       :CollectionConceptId (:concept-id coll1)
                        :provider-id "PROV1"}
         subscription2 {:native-id "SUB2"
+                       :CollectionConceptId (:concept-id coll1)
                        :Name "Sub2"
                        :provider-id "PROV2"}
         subscription1s (doall (for [n (range 2)]
-                        (subscription/ingest-subscription
-                          (subscription/make-subscription-concept subscription1))))
+                               (subscription/ingest-subscription
+                                 (subscription/make-subscription-concept subscription1))))
         subscription2s (doall (for [n (range 1)]
-                        (subscription/ingest-subscription
-                          (subscription/make-subscription-concept subscription2))))
+                               (subscription/ingest-subscription
+                                 (subscription/make-subscription-concept subscription2))))
         all-subscriptions-after-cleanup (concat (drop 1 subscription1s) subscription2s)]
     (index/wait-until-indexed)
 
@@ -48,22 +57,32 @@
     (d/assert-refs-match
       all-subscriptions-after-cleanup
       (search/find-refs :subscription {:all-revisions true
-                               :page-size 20}))))
+                                       :page-size 20}))))
 
 (deftest search-subscription-all-revisions
   (let [token (e/login (s/context) "user1")
+        coll1 (d/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})
         sub1-concept (subscription/make-subscription-concept {:native-id "SUB1"
-                                                    :Name "Subscription1"
-                                                    :provider-id "PROV1"})
+                                                              :CollectionConceptId (:concept-id coll1)
+                                                              :Name "Subscription1"
+                                                              :provider-id "PROV1"})
         sub2-concept (subscription/make-subscription-concept {:native-id "SUB2"
-                                                    :Name "Subscription2"
-                                                    :provider-id "PROV1"})
+                                                              :CollectionConceptId (:concept-id coll1)
+                                                              :Name "Subscription2"
+                                                              :provider-id "PROV1"})
         sub2-2-concept (subscription/make-subscription-concept {:native-id "SUB2"
-                                                      :Name "Subscription2-2"
-                                                      :provider-id "PROV1"})
+                                                                :CollectionConceptId (:concept-id coll1)
+                                                                :Name "Subscription2-2"
+                                                                :provider-id "PROV1"})
         sub3-concept (subscription/make-subscription-concept {:native-id "SUB3"
-                                                    :Name "Subscription1"
-                                                    :provider-id "PROV2"})
+                                                              :CollectionConceptId (:concept-id coll1)
+                                                              :Name "Subscription1"
+                                                              :provider-id "PROV2"})
         sub1-1 (subscription/ingest-subscription sub1-concept)
         sub1-2-tombstone (merge (ingest/delete-concept
                                  sub1-concept (subscription/token-opts token))

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
@@ -29,13 +29,9 @@
                   {"provguid4" "PROV4"} [:update] [:update])]))
 
 (deftest search-for-subscriptions-test-with-subscriber
-  (doseq [acl (:items
-               (ac-util/search-for-acls (system/context)
-                                        {:provider "PROV1"
-                                         :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]}
-                                        {:token "mock-echo-system-token"}))
-          :let [concept-id (:concept_id acl)]]
-    (echo-util/ungrant (system/context) concept-id))
+  (echo-util/ungrant-by-search (system/context)
+                               {:provider "PROV1"
+                                :target ["SUBSCRIPTION_MANAGEMENT" "INGEST_MANAGEMENT_ACL"]})
   (ac-util/wait-until-indexed)
   (let [subscriber-token (echo-util/login (system/context) "subscriber")
         guest-token (echo-util/login-guest (system/context))


### PR DESCRIPTION
This PR prevents subscription ingest for a user who doesn't have the appropriate ACL to view the collection.  Primary use is through MMT, preventing admin users from accidentally subscribing users without collection access, to a collection.