### PR TITLE
CMR-6657 

### DIFF
--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -26,9 +26,9 @@
   [subscriber-id concept-id]
   (errors/throw-service-error
    :unauthorized
-   (format "Subscriber-id [%s] does not have permission to view collection [%s]."
-           subscriber-id
-           concept-id)))
+   (format "Collection with concept id [%s] does not exist or subscriber-id [%s] does not have permission to view the collection."
+           concept-id
+           subscriber-id)))
 
 (defn- check-subscriber-collection-permission
   "Checks that the subscriber-id can read the collection supplied in the subscription metadata"

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -596,7 +596,7 @@
       (testing "non-existent collection concept-id"
         (let [{:keys [status errors]} (ingest/ingest-concept fake-concept {:token "mock-echo-system-token"})]
           (is (= 401 status))
-          (is (= [(format "Subscriber-id [user1] does not have permission to view collection [FAKE].")]
+          (is (= [(format "Collection with concept id [FAKE] does not exist or subscriber-id [user1] does not have permission to view the collection.")]
                  errors))))
 
       (testing "user doesn't have permission to view collection"
@@ -606,10 +606,10 @@
                 (is (= expected-errors errors)))
 
               "Attempt to ingest subscription as user1"
-              ingest/ingest-concept [concept {:token user-token}] 401 [(format "Subscriber-id [user1] does not have permission to view collection [%s]." (:concept-id coll1))]
+              ingest/ingest-concept [concept {:token user-token}] 401 [(format "Collection with concept id [%s] does not exist or subscriber-id [user1] does not have permission to view the collection." (:concept-id coll1))]
 
               "Attempt to ingest subscription as admin-user"
-              ingest/ingest-concept [concept {:token admin-user-token}] 401 [(format "Subscriber-id [user1] does not have permission to view collection [%s]." (:concept-id coll1))]))
+              ingest/ingest-concept [concept {:token admin-user-token}] 401 [(format "Collection with concept id [%s] does not exist or subscriber-id [user1] does not have permission to view the collection." (:concept-id coll1))]))
 
       (echo-util/ungrant-by-search (system/context)
                                    {:provider "PROV1"
@@ -674,6 +674,6 @@
 
               "Update subscription as user1"
               ingest/ingest-concept [concept {:token user-token}] 200 nil
-      
+
               "Delete subscription as user1"
               ingest/delete-concept [concept {:token user-token}] 200 nil)))))


### PR DESCRIPTION
This PR fixes 500 error when concept-id is malformed or non-existent on subscription ingest.