### PR TITLE
CMR-6965

### DIFF
--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -48,7 +48,7 @@
   "Create nested elements for the nested maps."
   [m]
   (reduce-kv (fn [memo k v]
-                 (conj memo (xml/element (keyword k) {} (if (map? v) 
+                 (conj memo (xml/element (keyword k) {} (if (map? v)
                                                           (create-nested-elements v)
                                                           v))))
              []
@@ -185,7 +185,7 @@
   [context headers]
   (if-let [user-id (get headers transmit-config/user-id-header)]
     user-id
-    (when-let [token (get headers transmit-config/token-header)]
+    (when-let [token (:token context)]
       (cache/get-value (cache/context->cache context user-id-cache-key)
                        token
                        (partial tokens/get-user-id context token)))))

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -180,15 +180,20 @@
     {}
     {:threshold 1000}))
 
+(defn get-user-id-from-token
+  "Get user id based on token in request context"
+  [context]
+  (when-let [token (:token context)]
+    (cache/get-value (cache/context->cache context user-id-cache-key)
+                     token
+                     (partial tokens/get-user-id context token))))
+
 (defn get-user-id
   "Get user id based on context and headers"
   [context headers]
   (if-let [user-id (get headers transmit-config/user-id-header)]
     user-id
-    (when-let [token (:token context)]
-      (cache/get-value (cache/context->cache context user-id-cache-key)
-                       token
-                       (partial tokens/get-user-id context token)))))
+    (get-user-id-from-token context)))
 
 (defn set-user-id
   "Associate user id to concept."

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -68,7 +68,7 @@
 
 (defn- check-subscription-ingest-permission
   "All the checks needed before starting to process an ingest of subscriptions"
-  [request-context concept headers provider-id]
+  [request-context concept provider-id]
   (let [old-concept-subscriber (-> (mdb/find-concepts request-context
                                                       {:provider-id provider-id
                                                        :native-id (:native-id concept)
@@ -81,7 +81,7 @@
         subscription-user (if old-concept-subscriber
                             old-concept-subscriber
                             (:SubscriberId (json/decode (:metadata concept) true)))
-        token-user (api-core/get-user-id request-context headers)]
+        token-user (api-core/get-user-id-from-token request-context)]
     (if (and token-user
              (= token-user subscription-user))
       (warn (format (str "ACLs were bypassed because the token account '%s' "
@@ -108,7 +108,7 @@
     (common-ingest-checks request-context provider-id)
     (let [concept (api-core/body->concept!
                     :subscription provider-id native-id body content-type headers)]
-      (check-subscription-ingest-permission request-context concept headers provider-id)
+      (check-subscription-ingest-permission request-context concept provider-id)
       (perform-subscription-ingest request-context concept headers))))
 
 (defn delete-subscription
@@ -123,7 +123,7 @@
                                            :exclude-metadata false
                                            :latest true}
                                           concept-type))]
-    (check-subscription-ingest-permission request-context concept headers provider-id)
+    (check-subscription-ingest-permission request-context concept provider-id)
     (let [concept-attribs (-> {:provider-id provider-id
                                :native-id native-id
                                :concept-type concept-type}


### PR DESCRIPTION
CMR subscription ingest user-id check should include Authorization header as well.

We don't have a platform set up to test with an Authorization token. We may want to file a ticket to add that to our test suite, but the test would be based on mock and doesn't offer a whole lot of value. This fix is trivial and I need to merge it today for EDSC's demo tomorrow. Thus no tests.