### PR TITLE
CMR-6444: Uncommented out the 2 RevisionDate sort tests.

### DIFF
--- a/system-int-test/test/cmr/system_int_test/search/tool/tool_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/tool/tool_search_test.clj
@@ -495,16 +495,13 @@
       "-provider"
       [tool1 tool2 tool3 tool4]
 
-      ;;The following two tests failed when running test suite locally,
-      ;;but succeeded in bamboo and locally when running tool_search_test.clj by itself.
-      ;;Filed CMR-6444 to investigate.
-      ;;"Sort by revision-date"
-      ;;"revision_date"
-      ;;[tool1 tool2 tool3 tool4]
+      "Sort by revision-date"
+      "revision_date"
+      [tool1 tool2 tool3 tool4]
 
-      ;;"Sort by revision-date descending order"
-      ;;"-revision_date"
-      ;;[tool4 tool3 tool2 tool1]
+      "Sort by revision-date descending order"
+      "-revision_date"
+      [tool4 tool3 tool2 tool1]
 
       "Sort by long-name"
       "long_name"


### PR DESCRIPTION
The two RevisionDate sorting tests used to fail ONLY when running them locally in the test suites. Now the failures can no longer be reproduced.  So the two tests are uncommented out. If it fails again locally in the future, we might want to introduce some delays in between the Tool ingests so that their RevisionDate can be more distinguished. 