### PR TITLE
CMR-6901: Fixed the 500 error when GetData component is missing in RelatedUrl

### DIFF
--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -86,8 +86,9 @@
   match."
   [kms-index msg-fn]
   (fn [field-path value]
-    (when-not (kms-lookup/lookup-by-umm-c-keyword kms-index :granule-data-format value)
-      {field-path [(msg-fn value)]})))
+    (when value
+      (when-not (kms-lookup/lookup-by-umm-c-keyword kms-index :granule-data-format value)
+        {field-path [(msg-fn value)]}))))
 
 (defn keyword-validations
   "Creates validations that check various collection fields to see if they match KMS keywords."

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_keyword_validation_test.clj
@@ -90,7 +90,11 @@
                       :GetData {:Format "8-track tape"
                                 :Size 10.0
                                 :Unit "MB"
-                                :Fees "fees"}}]}
+                                :Fees "fees"}}
+                     {:Description "Related url description"
+                      :URL "www.foobarbazquxquux.com"
+                      :URLContentType "DistributionURL"
+                      :Type "GET DATA"}]}
                   :umm-json)
           response (ingest/validate-concept format {:validate-keywords true})]
 


### PR DESCRIPTION
When GetData is missing from RelatedUrl, common-app lib couldn't handle the nil case when lookup kms keyword. Fixed the 500 error by making sure we don't pass a nil value to the common-app normalize-for-lookup function. 