### PR TITLE
CMR-7042 Generate codecov reports

### DIFF
--- a/access-control-app/tests.edn
+++ b/access-control-app/tests.edn
@@ -18,10 +18,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/acl-lib/tests.edn
+++ b/acl-lib/tests.edn
@@ -22,4 +22,4 @@
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3
- :kaocha.plugin.profiling/profiling? true }
+ :kaocha.plugin.profiling/profiling? true}

--- a/acl-lib/tests.edn
+++ b/acl-lib/tests.edn
@@ -13,11 +13,13 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
 
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
+
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3
- :kaocha.plugin.profiling/profiling? true}
+ :kaocha.plugin.profiling/profiling? true }

--- a/bootstrap-app/tests.edn
+++ b/bootstrap-app/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/collection-renderer-lib/tests.edn
+++ b/collection-renderer-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/common-app-lib/tests.edn
+++ b/common-app-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/common-lib/tests.edn
+++ b/common-lib/tests.edn
@@ -14,11 +14,13 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
 
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
+
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3
- :kaocha.plugin.profiling/profiling? true}
+ :kaocha.plugin.profiling/profiling? true }

--- a/common-lib/tests.edn
+++ b/common-lib/tests.edn
@@ -23,4 +23,4 @@
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3
- :kaocha.plugin.profiling/profiling? true }
+ :kaocha.plugin.profiling/profiling? true}

--- a/dev-system/tests.edn
+++ b/dev-system/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/elastic-utils-lib/tests.edn
+++ b/elastic-utils-lib/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/es-spatial-plugin/tests.edn
+++ b/es-spatial-plugin/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/indexer-app/tests.edn
+++ b/indexer-app/tests.edn
@@ -18,10 +18,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/ingest-app/tests.edn
+++ b/ingest-app/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/message-queue-lib/tests.edn
+++ b/message-queue-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/metadata-db-app/tests.edn
+++ b/metadata-db-app/tests.edn
@@ -18,10 +18,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/mock-echo-app/tests.edn
+++ b/mock-echo-app/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/oracle-lib/tests.edn
+++ b/oracle-lib/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/orbits-lib/tests.edn
+++ b/orbits-lib/tests.edn
@@ -13,10 +13,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/redis-utils-lib/tests.edn
+++ b/redis-utils-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/schema-validation-lib/tests.edn
+++ b/schema-validation-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/search-app/tests.edn
+++ b/search-app/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/search-relevancy-test/tests.edn
+++ b/search-relevancy-test/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/spatial-lib/tests.edn
+++ b/spatial-lib/tests.edn
@@ -4,6 +4,7 @@
 
  :plugins [:kaocha.plugin.alpha/info
            ;; TODO: modify testing to let cloverage work
+           ;; the primitive-math library interferes with cloverage
            ;; :kaocha.plugin/cloverage
            :capture-output
            :junit-xml

--- a/spatial-lib/tests.edn
+++ b/spatial-lib/tests.edn
@@ -15,10 +15,13 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ ;; re-enable when cloverage is functional for this module
+ ;; :cloverage/opts {:codecov? #profile {:default false :ci true}
+ ;;                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/system-int-test/tests.edn
+++ b/system-int-test/tests.edn
@@ -16,11 +16,9 @@
  :color? #profile {:default true
                    :ci false}
 
- :fail-fast? #profile {:default true
-                       :ci false}
+ :fail-fast? false
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.randomize/randomize? false
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"}

--- a/transmit-lib/tests.edn
+++ b/transmit-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/umm-lib/tests.edn
+++ b/umm-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/umm-spec-lib/tests.edn
+++ b/umm-spec-lib/tests.edn
@@ -14,10 +14,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3

--- a/virtual-product-app/tests.edn
+++ b/virtual-product-app/tests.edn
@@ -17,10 +17,12 @@
  :color? #profile {:default true
                    :ci false}
 
- :reporter #profile {:default kaocha.report.progress/report
-                     :ci kaocha.report/documentation}
+ :reporter kaocha.report/documentation
 
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  ;; 3 slowest tests shown
  :kaocha.plugin.profiling/count 3


### PR DESCRIPTION
Generate codecov.json reports to use with CI buidls instead of HTML reports during CI builds.

Also set reporter to be documentation for all builds for consistency.