### PR TITLE
CMR-7030: Tried to further improve the service ingest performance

### DIFF
--- a/indexer-app/src/cmr/indexer/services/event_handler.clj
+++ b/indexer-app/src/cmr/indexer/services/event_handler.clj
@@ -52,12 +52,15 @@
   [_ _ _])
 
 (defmethod handle-ingest-event :concept-update
-  [context all-revisions-index? {:keys [concept-id revision-id]}]
-  (if (= :humanizer (cc/concept-id->type concept-id))
-    (indexer/update-humanizers context)
-    (indexer/index-concept-by-concept-id-revision-id
-     context concept-id revision-id {:ignore-conflict? true
-                                     :all-revisions-index? all-revisions-index?})))
+  [context all-revisions-index? {:keys [concept-id revision-id more-concepts]}]
+  ;; combine concept-id revision-id with more-concepts
+  (let [all-concepts (conj more-concepts {:concept-id concept-id :revision-id revision-id})]
+    (doseq [{:keys [concept-id revision-id]} all-concepts]
+      (if (= :humanizer (cc/concept-id->type concept-id))
+        (indexer/update-humanizers context)
+        (indexer/index-concept-by-concept-id-revision-id
+         context concept-id revision-id {:ignore-conflict? true
+                                         :all-revisions-index? all-revisions-index?})))))
 
 (defmethod handle-ingest-event :concept-delete
   [context all-revisions-index? {:keys [concept-id revision-id]}]

--- a/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/ingest_events.clj
@@ -19,6 +19,17 @@
         (when queue-broker
           (queue/publish-message queue-broker (exchange-name-fn) msg))))))
 
+(defn associations-update-event
+  "Create an event representing a list of associations being updated or created."
+  [associations]
+  {:action :concept-update
+   :concept-id (:concept-id (first associations))
+   :revision-id (:revision-id (first associations))
+   :more-concepts (when (> (count associations) 1)
+                    (for [association (drop 1 associations)]
+                      {:concept-id (:concept-id association)
+                       :revision-id (:revision-id association)}))})
+
 (defmulti concept-update-event
   "Creates an event representing a concept being updated or created."
   (fn [concept]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -73,7 +73,6 @@
   (fn [concept-type table fields params]
     (condp = concept-type
       :granule :granule-search
-      :service-association :service-association-search
       concept-type)))
 
 ;; special case added to address OB_DAAC granule search not using existing index problem
@@ -83,14 +82,6 @@
   (let [stmt (gen-find-concepts-in-table-sql :dummy table fields params)]
     ;; add index hint to the generated sql statement
     (update-in stmt [0] #(string/replace % #"SELECT" (format "SELECT /*+ INDEX(%s) */" table)))))
-
-(defmethod gen-find-concepts-in-table-sql :service-association-search
-  [concept-type table fields params]
-  (let [params (dissoc params :include-all)]
-    (su/build (select (vec fields)
-                      (from table)
-                      (when-not (empty? params)
-                        (where (sh/find-params->sql-clause params)))))))
 
 (defmethod gen-find-concepts-in-table-sql :default
   [concept-type table fields params]


### PR DESCRIPTION
1.  Publishing all associations in one event, rather than one event for each association.
2. Got rid of the nested query when searching for service associations. (backed it out because not enough testing time in UAT to conclude it's faster even though it's supposed to be)
3. The code is done in a way that could make use of the existing publishing code with minimal code change. i.e. still use the :action, :concept-id and :revision-id in the event, which is used by a lot of places during publishing, and put the rest of the associations in :more-concepts which don't need to be touched until the event handler handles it.
4. Existing tests already covered the functionality in collection_service_search_test.clj. If the associations are not published correctly, the tests will fail.