### PR TITLE
Bug - CMR-7071 - URL encoded subscription queries fail to run

### DIFF
--- a/ingest-app/test/cmr/ingest/api/subscriptions_test.clj
+++ b/ingest-app/test/cmr/ingest/api/subscriptions_test.clj
@@ -1,9 +1,30 @@
 (ns cmr.ingest.api.subscriptions-test
   (:require
+   [cheshire.core :as json]
    [clojure.string :as string]
    [clojure.test :refer :all]
    [cmr.ingest.api.core :as api-core]
    [cmr.ingest.api.subscriptions :as subscriptions]))
+
+(defn- concept->query
+  "extract just the Query out of a result from process-result->hash"
+  [result]
+  (let  [meta-raw (:metadata result)
+         meta-json (json/parse-string meta-raw)]
+    (get meta-json "Query")))
+
+(defn- create-concept
+  "Helper method to create a basic subscription concept"
+  [query]
+  {:metadata (str "{\"Name\":\"the beginning\","
+                  "\"SubscriberId\":\"post-user\","
+                  "\"EmailAddress\":\"someEmail@gmail.com\","
+                  "\"CollectionConceptId\":\"C1200000018-PROV1\","
+                  "\"Query\":\"" query "\"}")
+   :format "application/vnd.nasa.cmr.umm+json;version=1.0"
+   :native-id nil
+   :concept-type :subscription
+   :provider-id "PROV1"})
 
 (deftest ingest-subscription-test
   (testing "creating a subscription"
@@ -15,7 +36,7 @@
                                                                 :metadata " {\"Name\": \"some name\"}"})
                          #'subscriptions/check-subscription-ingest-permission (fn [request-context concept provider-id]
                                                                                 (is (= "given-native-id" (:native-id concept))))}
-          #(subscriptions/ingest-subscription "test-provider" "given-native-id" subscription)))
+                        #(subscriptions/ingest-subscription "test-provider" "given-native-id" subscription)))
 
       (testing "with native-id not provided generates a native-id"
         (with-redefs-fn {#'subscriptions/perform-subscription-ingest (constantly nil)
@@ -25,17 +46,40 @@
                          #'subscriptions/check-subscription-ingest-permission
                          (fn [request-context concept provider-id]
                            (is (string/starts-with? (:native-id concept) "some_name")))}
-          #(subscriptions/ingest-subscription "test-provider" nil subscription))))))
+                        #(subscriptions/ingest-subscription "test-provider" nil subscription))))))
 
 (deftest generate-native-id-test
-  (let [concept {:metadata
-                 "{\"Name\":\"the beginning\",\"SubscriberId\":\"post-user\",\"EmailAddress\":\"someEmail@gmail.com\",\"CollectionConceptId\":\"C1200000018-PROV1\",\"Query\":\"polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78\"}"
-                 :format "application/vnd.nasa.cmr.umm+json;version=1.0"
-                 :native-id nil
-                 :concept-type :subscription
-                 :provider-id "PROV1"}
+  (let [concept (create-concept "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78")
         native-id (subscriptions/generate-native-id concept)]
     (is (string? native-id))
 
     (testing "name is used as the prefix"
       (is (string/starts-with? native-id "the_beginning")))))
+
+(deftest encoded-query-test
+  "Queries can be URL encoded and ingest needs to be able to properly decode them"
+  (testing
+   "Test that a common parameter is not broken"
+    (let [expected "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+          concept-raw (create-concept expected)
+          concept-clean (#'subscriptions/decode-query-in-concept concept-raw)
+          query (concept->query concept-clean)]
+      (is (= expected query))))
+
+  (testing
+    "Test that a complicated query will be decoded correctly."
+    (let [expected "provider=PROV1&options[spatial][or]=true"]
+      (testing
+        "Test that a complicated unencoded query is used."
+       (let [concept-raw (create-concept expected)
+             concept-clean (#'subscriptions/decode-query-in-concept concept-raw)
+             query (concept->query concept-clean)]
+         (is (= expected query))))
+
+      (testing
+       "Test that a complicated encoded query is fixed"
+        (let [provided "provider=PROV1&options%5bspatial%5d%5bor%5d=true"
+              concept-raw (create-concept provided)
+              concept-clean (#'subscriptions/decode-query-in-concept concept-raw)
+              query (concept->query concept-clean)]
+          (is (= expected query)))))))

--- a/ingest-app/test/cmr/ingest/test/services/jobs.clj
+++ b/ingest-app/test/cmr/ingest/test/services/jobs.clj
@@ -1,9 +1,10 @@
 (ns cmr.ingest.test.services.jobs
   "This tests some of the more complicated functions of cmr.ingest.services.jobs"
   (:require
-    [clojure.test :refer :all]
-    [cmr.common.util :as u :refer [are3]]
-    [cmr.ingest.services.jobs :as jobs]))
+   [clj-time.core :as t]
+   [clojure.test :refer :all]
+   [cmr.common.util :as u :refer [are3]]
+   [cmr.ingest.services.jobs :as jobs]))
 
 (deftest create-query-params
   (is (= {"polygon" "-78,-18,-77,-22,-73,-16,-74,-13,-78,-18"
@@ -11,41 +12,85 @@
          (#'jobs/create-query-params "polygon=-78,-18,-77,-22,-73,-16,-74,-13,-78,-18&concept-id=G123-PROV1"))))
 
 (deftest email-granule-url-list-test
- "This tests the utility function that unpacts a list of urls and turns it into markdown"
- (let [actual (jobs/email-granule-url-list '("https://cmr.link/g1"
-                                             "https://cmr.link/g2"
-                                             "https://cmr.link/g3"))
-       expected (str "* [https://cmr.link/g1](https://cmr.link/g1)\n"
-                     "* [https://cmr.link/g2](https://cmr.link/g2)\n"
-                     "* [https://cmr.link/g3](https://cmr.link/g3)")]
-  (is (= expected actual))))
+  "This tests the utility function that unpacts a list of urls and turns it into markdown"
+  (let [actual (jobs/email-granule-url-list '("https://cmr.link/g1"
+                                              "https://cmr.link/g2"
+                                              "https://cmr.link/g3"))
+        expected (str "* [https://cmr.link/g1](https://cmr.link/g1)\n"
+                      "* [https://cmr.link/g2](https://cmr.link/g2)\n"
+                      "* [https://cmr.link/g3](https://cmr.link/g3)")]
+    (is (= expected actual))))
 
 (deftest create-email-test
- "This tests the HTML output of the email generation"
- (let [actual (jobs/create-email-content
-               "cmr-support@earthdata.nasa.gov"
-               "someone@gmail.com"
-               '("https://cmr.link/g1" "https://cmr.link/g2" "https://cmr.link/g3")
-               {:extra-fields {:collection-concept-id "C1200370131-EDF_DEV06"}
-                :metadata "{\"Name\": \"valid1\",
+  "This tests the HTML output of the email generation"
+  (let [actual (jobs/create-email-content
+                "cmr-support@earthdata.nasa.gov"
+                "someone@gmail.com"
+                '("https://cmr.link/g1" "https://cmr.link/g2" "https://cmr.link/g3")
+                {:extra-fields {:collection-concept-id "C1200370131-EDF_DEV06"}
+                 :metadata "{\"Name\": \"valid1\",
                             \"CollectionConceptId\": \"C1200370131-EDF_DEV06\",
                             \"Query\": \"updated_since[]=2020-05-04T12:51:36Z\",
                             \"SubscriberId\": \"someone1\",
                             \"EmailAddress\": \"someone@gmail.com\"}"
-                :start-time "2020-05-04T12:51:36Z"
-                :end-time "2020-05-05T12:51:36Z"})]
-  (is (= "someone@gmail.com" (:to actual)))
-  (is (= "Email Subscription Notification" (:subject actual)))
-  (is (= "text/html" (:type (first (:body actual)))))
-  (is (= (str "<p>You have subscribed to receive notifications when data is added to the following query:</p>"
-              "<p><code>C1200370131-EDF&#95;DEV06</code></p>"
-              "<p><code>updated&#95;since&#91;&#93;=2020-05-04T12:51:36Z</code></p>"
-              "<p>Since this query was last run at 2020-05-04T12:51:36Z, the following granules have been "
-              "added or updated:</p>"
-              "<ul><li><a href='https://cmr.link/g1'>https://cmr.link/g1</a></li><li>"
-              "<a href='https://cmr.link/g2'>https://cmr.link/g2</a></li><li>"
-              "<a href='https://cmr.link/g3'>https://cmr.link/g3</a></li></ul>"
-              "<p>To unsubscribe from these notifications, or if you have any questions, "
-              "please contact us at <a href='mailto:cmr-support@earthdata.nasa.gov'>"
-              "cmr-support@earthdata.nasa.gov</a>.</p>")
-         (:content (first (:body actual)))))))
+                 :start-time "2020-05-04T12:51:36Z"
+                 :end-time "2020-05-05T12:51:36Z"})]
+    (is (= "someone@gmail.com" (:to actual)))
+    (is (= "Email Subscription Notification" (:subject actual)))
+    (is (= "text/html" (:type (first (:body actual)))))
+    (is (= (str "<p>You have subscribed to receive notifications when data is added to the following query:</p>"
+                "<p><code>C1200370131-EDF&#95;DEV06</code></p>"
+                "<p><code>updated&#95;since&#91;&#93;=2020-05-04T12:51:36Z</code></p>"
+                "<p>Since this query was last run at 2020-05-04T12:51:36Z, the following granules have been "
+                "added or updated:</p>"
+                "<ul><li><a href='https://cmr.link/g1'>https://cmr.link/g1</a></li><li>"
+                "<a href='https://cmr.link/g2'>https://cmr.link/g2</a></li><li>"
+                "<a href='https://cmr.link/g3'>https://cmr.link/g3</a></li></ul>"
+                "<p>To unsubscribe from these notifications, or if you have any questions, "
+                "please contact us at <a href='mailto:cmr-support@earthdata.nasa.gov'>"
+                "cmr-support@earthdata.nasa.gov</a>.</p>")
+           (:content (first (:body actual)))))))
+
+(deftest subscription->time-constraint-test
+  "Test the subscription->time-constraint function as it is criticle for internal
+                      use. Test for when there is and is not a last-notified-at date and when there
+                      is no date, test that the code will look back with a specified number of seconds"
+  (let [now (t/now)
+        one-hour-back (t/minus now (t/seconds 3600))
+        two-hours-back (t/minus now (t/seconds 7200))]
+    (testing
+     "Usecase one: no last-notified-at date, so start an hour ago and end now"
+      (let [data {:extra-fields {}}
+            expected (str one-hour-back "," now)
+            actual (#'jobs/subscription->time-constraint data now 3600)]
+        (is (= expected actual))))
+    (testing
+     "Usecase one: no last-notified-at date, it's explicitly set to nil, so
+                         start an hour ago and end now"
+      (let [data {:extra-fields {:last-notified-at nil}}
+            expected (str one-hour-back "," now)
+            actual (#'jobs/subscription->time-constraint data now 3600)]
+        (is (= expected actual))))
+    (testing
+     "Usecase one: no last-notified-at date, it's explicitly set to nil, so start
+                         two hours ago and end now ; test that look back is not hardcoded"
+      (let [data {:extra-fields {:last-notified-at nil}}
+            expected (str two-hours-back "," now)
+            actual (#'jobs/subscription->time-constraint data now 7200)]
+        (is (= expected actual))))
+
+    (testing
+     "Use case two: last-notified-at date is specified, start then and end now"
+      (let [start "2012-01-10T08:00:00.000Z"
+            data {:extra-fields {:last-notified-at start}}
+            expected (str start "," now)
+            actual (#'jobs/subscription->time-constraint data now 3600)]
+        (is (= expected actual))))
+    (testing
+     "Use case two: last-notified-at date is specified, start then and end now,
+                             look back seconds is ignored and can even be crazy"
+      (let [start "2012-01-10T08:00:00.000Z"
+            data {:extra-fields {:last-notified-at start}}
+            expected (str start "," now)
+            actual (#'jobs/subscription->time-constraint data now -1234)]
+        (is (= expected actual))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
@@ -1,18 +1,24 @@
 (ns cmr.system-int-test.ingest.subscription-processing-test
   "CMR subscription processing tests."
   (:require
+   [cheshire.core :as json]
+   [clj-time.core :as t]
    [clojure.test :refer :all]
    [cmr.ingest.services.jobs :as jobs]
    [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.access-control.test.util :as ac-util]
+   [cmr.common.time-keeper :as tk]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.data2.granule :as data-granule]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.dev-system-util :as dev-system]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.subscription-util :as subscription-util]
    [cmr.transmit.access-control :as access-control]
-   [cmr.transmit.metadata-db :as mdb2]))
+   [cmr.transmit.metadata-db :as mdb2]
+   [ring.util.codec :as codec]))
 
 (use-fixtures :each
   (join-fixtures
@@ -24,7 +30,28 @@
      [:read :update])
     (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
                                                       [:read]
-                                                      [:read :update])]))
+                                                      [:read :update])
+    (dev-system/freeze-resume-time-fixture)]))
+
+(defn- result->query
+  "extract just the Query out of a result from process-result->hash"
+  [result]
+  (let  [meta-raw (get-in result [:subscription :metadata])
+         meta-json (json/parse-string meta-raw)]
+    (get meta-json "Query")))
+
+(defn- process-result->hash
+  "Deconstruct a subscription process response from the function
+       trigger-process-subscriptions into a hash table so that tests can references
+       each value by name and not have to use (nth x #). The order is defined in
+       email_processing.clj"
+  [response]
+  (map (fn [x]
+         (let [[sub-id subscriber-filtered-gran-refs email-address subscription] x]
+           {:sub-id sub-id
+            :subscriber-filtered-gran-refs subscriber-filtered-gran-refs
+            :email-address email-address
+            :subscription subscription})) response))
 
 (defn- trigger-process-subscriptions
   "Sets up process-subscriptions arguments. Calls process-subscriptions, returns granule concept-ids."
@@ -57,7 +84,7 @@
                              :granule_applicable true
                              :granule_identifier {:access_value {:include_undefined_value true
                                                                  :min_value 1 :max_value 50}}})
-
+         _ (ac-util/wait-until-indexed)
          ;; Setup collection
          coll1 (data-core/ingest-umm-spec-collection "PROV1"
                                                      (data-umm-c/collection {:ShortName "coll1"
@@ -90,10 +117,9 @@
          (is (= (:concept-id gran1)
                 (first results)))))
 
-     ;; force eval of lazy seq
-     (is (not= nil (count (trigger-process-subscriptions))))
+     (dev-system/advance-time! 10)
 
-     (testing "Second run finds only collections created since the last notification"
+     (testing "Second run finds only granules created since the last notification"
        (let [gran2 (data-core/ingest "PROV1"
                                      (data-granule/granule-with-umm-spec-collection coll1
                                                                                     (:concept-id coll1)
@@ -101,10 +127,76 @@
                                                                                      :access-value 1})
                                      {:token "mock-echo-system-token"})
              _ (index/wait-until-indexed)
-             response (->> (trigger-process-subscriptions)
+             result (trigger-process-subscriptions)
+             response (->> result
                            (map #(nth % 1))
                            flatten
                            (map :concept-id))]
+         (is (= [(:concept-id gran2)] response)))))))
 
-         (is (= [(:concept-id gran2)]
-                response)))))))
+(deftest ^:oracle subscription-query-ingest-test
+  (system/only-with-real-database
+   (testing
+    "Test subscriptions which uses a query containing 'options'. These options
+     may or may not be URL encoded and the ingest needs to take this into account
+     before processing the subscriptions. See CMR-7071."
+     (let [user2-group-id (echo-util/get-or-create-group (system/context) "group2")
+           _user2-token (echo-util/login (system/context) "user2" [user2-group-id])
+           _ (echo-util/ungrant (system/context)
+                                (-> (access-control/search-for-acls (system/context)
+                                                                    {:provider "PROV1"
+                                                                     :identity-type "catalog_item"}
+                                                                    {:token "mock-echo-system-token"})
+                                    :items
+                                    first
+                                    :concept_id))
+           _ (echo-util/grant (system/context)
+                              [{:group_id user2-group-id :permissions [:read]}]
+                              :catalog_item_identity
+                              {:provider_id "PROV1"
+                               :name "Provider collection/granule ACL- test query encodings"
+                               :collection_applicable true
+                               :granule_applicable true
+                               :granule_identifier {:access_value {:include_undefined_value true
+                                                                   :min_value 1 :max_value 50}}})
+           _ (ac-util/wait-until-indexed)
+           _ (trigger-process-subscriptions)
+           expected "provider=PROV1&options[spatial][or]=true"
+           coll1 (data-core/ingest-umm-spec-collection "PROV1"
+                                                       (data-umm-c/collection {:ShortName "coll1"
+                                                                               :EntryTitle "entry-title1"})
+                                                       {:token "mock-echo-system-token"})
+
+           _ (index/wait-until-indexed)
+           sub2 (subscription-util/ingest-subscription (subscription-util/make-subscription-concept
+                                                        {:Name "test_sub_prov1-encoded-option"
+                                                         :SubscriberId "user2"
+                                                         :CollectionConceptId (:concept-id coll1)
+                                                         :Query expected})
+                                                       {:token "mock-echo-system-token"})
+           sub3 (subscription-util/ingest-subscription (subscription-util/make-subscription-concept
+                                                        {:Name "test_sub_prov1-raw-option"
+                                                         :SubscriberId "user2"
+                                                         :CollectionConceptId (:concept-id coll1)
+                                                         :Query "provider=PROV1&options%5bspatial%5d%5bor%5d=true"})
+                                                       {:token "mock-echo-system-token"})
+           _ (index/wait-until-indexed)
+
+           gran3 (data-core/ingest "PROV1"
+                                   (data-granule/granule-with-umm-spec-collection coll1
+                                                                                  (:concept-id coll1)
+                                                                                  {:granule-ur "Granule3"
+                                                                                   :access-value 1})
+                                   {:token "mock-echo-system-token"})
+           _ (index/wait-until-indexed)
+           gran3-concept-id (:concept-id gran3)
+           response (trigger-process-subscriptions)
+           results-as-hash (process-result->hash response)
+           result-1 (first results-as-hash)
+           result-2 (second results-as-hash)
+           ]
+       ;; Was the query decoded and stored correctly and was the granule found
+       (is (= (:concept-id gran3) (-> result-1 :subscriber-filtered-gran-refs first :concept-id)))
+       (is (= (:concept-id gran3) (-> result-2 :subscriber-filtered-gran-refs first :concept-id)))
+       (is (= expected (-> result-1 result->query)))
+       (is (= expected (-> result-2 result->query)))))))


### PR DESCRIPTION
It looks like the ingest of subscription was not decoding queries, this was causing the processing code to try to run the raw subscription, which it also encoded before sending over the wire. My approach was to assume "garbage in" and clean on ingest to allow for all downstream users of the data to operate as they have.

Also in this change request are some formatting changes caused by Beautify (blame it not me) and some fixes to tests discovered in the now defunct CMR-6658, such as an unreliable use of forcing a lazy seq was converted to an advance-time in subscription_processing_test.clj, also added a test for the subscription->time-constraint function because its operation is very important to the success of subscriptions query time constraints and having the test makes me feel more confident that the code is working.