### PR TITLE
Cmr-7050 Provider Holding Dir - Display just online_only granule count

### DIFF
--- a/search-app/src/cmr/search/services/query_execution/granule_counts_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/granule_counts_results_feature.clj
@@ -144,7 +144,7 @@
                                               :collection-concept-id :granule)
                                       :size (count collection-ids)}}}})))
 
-(defn- search-results->granule-counts
+(defn search-results->granule-counts
   "Extracts the granule counts per collection id in a map from the search results from ElasticSearch"
   [elastic-results]
   (let [aggs (get-in elastic-results [:aggregations :granule-counts-by-collection-id :buckets])]

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -113,8 +113,8 @@
         {:keys [items granule-counts-map]} result]
     (sort-by :entry-title
             (map #(assoc % :granule-count 
-                         (let [count (get-granule-count context (:concept-id %) {:downloadable true})] 
-                           (if (= 0 count) nil count))) items))))
+                         (let [gran-count (get-granule-count context (:concept-id %) {:downloadable true})] 
+                           (if (= 0 gran-count) nil gran-count))) items))))
 
 (defmethod collection-data :default
   [context tag provider-id]

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -101,9 +101,9 @@
                                                    :version-id]})
          result (query-exec/execute-query context query)
          collection-concept-ids (vec (map :concept-id (:items result)))
-         my-condition (gc/and-conds (concat granule-conditions [(query-model/string-conditions :collection-concept-id collection-concept-ids true)]))
+         gran-agg-condition (gc/and-conds (concat granule-conditions [(query-model/string-conditions :collection-concept-id collection-concept-ids true)]))
          granule-query (query-model/query {:concept-type :granule
-                                           :condition my-condition
+                                           :condition gran-agg-condition
                                            :page-size 0
                                            :result-format :query-specified
                                            :result-fields []

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -101,7 +101,7 @@
                                                    :version-id]})
          result (query-exec/execute-query context query)
          collection-concept-ids (vec (map :concept-id (:items result)))
-         my-condition (gc/and-conds (into [] (concat granule-conditions [(query-model/string-conditions :collection-concept-id collection-concept-ids true)])))
+         my-condition (gc/and-conds (concat granule-conditions [(query-model/string-conditions :collection-concept-id collection-concept-ids true)]))
          granule-query (query-model/query {:concept-type :granule
                                            :condition my-condition
                                            :page-size 0
@@ -120,7 +120,7 @@
 
 (defmethod collection-data :default
   ([context tag provider-id]
-   (get-collection-data context tag provider-id []))
+   (get-collection-data context tag provider-id))
   ([context tag provider-id granule-conditions]
    (get-collection-data context tag provider-id granule-conditions)))
 

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -84,10 +84,10 @@
                                                             context
                                                             :granule
                                                             (merge {:collection-concept-id collection-concept-id} query-params)))
-                                  :page-size :unlimited
+                                  :page-size 0
                                   :result-format :query-specified
                                   :result-fields [:collection-concept-id]})]
-    (count (:items (query-exec/execute-query context query)))))
+    (:hits (query-exec/execute-query context query))))
 
 (defn-timed get-collection-data
   "Get the collection data from elastic by provider id and tag. Sort results

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -84,7 +84,7 @@
                                                             context
                                                             :granule
                                                             (merge {:collection-concept-id collection-concept-id} query-params)))
-                                  :page-size 0
+                                  :page-size :unlimited
                                   :result-format :query-specified
                                   :result-fields [:collection-concept-id]})]
     (count (:items (query-exec/execute-query context query)))))

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -84,7 +84,7 @@
                                                             context
                                                             :granule
                                                             (merge {:collection-concept-id collection-concept-id} query-params)))
-                                  :page-size :unlimited
+                                  :page-size :0
                                   :result-format :query-specified
                                   :result-fields [:collection-concept-id]})]
     (count (:items (query-exec/execute-query context query)))))

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -100,7 +100,7 @@
                                                    :short-name
                                                    :version-id]})
          result (query-exec/execute-query context query)
-         collection-concept-ids (into [] (map (fn [item] (:concept-id item)) (:items result)))
+         collection-concept-ids (vec (map :concept-id (:items result)))
          my-condition (gc/and-conds (into [] (concat granule-conditions [(query-model/string-conditions :collection-concept-id collection-concept-ids true)])))
          granule-query (query-model/query {:concept-type :granule
                                            :condition my-condition

--- a/search-app/src/cmr/search/site/data.clj
+++ b/search-app/src/cmr/search/site/data.clj
@@ -84,7 +84,7 @@
                                                             context
                                                             :granule
                                                             (merge {:collection-concept-id collection-concept-id} query-params)))
-                                  :page-size :0
+                                  :page-size 0
                                   :result-format :query-specified
                                   :result-fields [:collection-concept-id]})]
     (count (:items (query-exec/execute-query context query)))))
@@ -114,7 +114,7 @@
     (sort-by :entry-title
             (map #(assoc % :granule-count 
                          (let [gran-count (get-granule-count context (:concept-id %) {:downloadable true})] 
-                           (if (= 0 gran-count) nil gran-count))) items))))
+                           (when-not (zero? gran-count) gran-count))) items))))
 
 (defmethod collection-data :default
   [context tag provider-id]

--- a/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
+++ b/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
@@ -5,7 +5,7 @@
    [clojure.string :refer [trim]]
    [cmr.mock-echo.client.echo-util :as echo]
    [cmr.system-int-test.data2.core :as data]
-   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.granule :as data-granule]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
    [cmr.system-int-test.system :as system]
@@ -66,28 +66,28 @@
                            :ShortName "granule-less collection"}))
         _ (index/wait-until-indexed)
 
-        _g1 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+        _g1 (data/ingest "PROV1" (data-granule/granule-with-umm-spec-collection
                                    coll1 (:concept-id coll1)
                                    {:granule-ur "Granule1"
                                     :beginning-date-time "1970-06-02T12:00:00Z"
                                     :ending-date-time "1975-02-02T12:00:00Z"}))
         
-        _g1-online-1 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+        _g1-online-1 (data/ingest "PROV1" (data-granule/granule-with-umm-spec-collection
                                   coll1 (:concept-id coll1)
-                                  {:related-urls [(dg/related-url {:type "GET DATA"})]
+                                  {:related-urls [(data-granule/related-url {:type "GET DATA"})]
                                    :beginning-date-time "1970-06-02T12:00:00Z"
                                    :ending-date-time "1975-02-02T12:00:00Z"}))
         
-        _g1-online-2 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+        _g1-online-2 (data/ingest "PROV1" (data-granule/granule-with-umm-spec-collection
                                            coll1 (:concept-id coll1)
-                                           {:related-urls [(dg/related-url {:type "GET DATA"})]
+                                           {:related-urls [(data-granule/related-url {:type "GET DATA"})]
                                             :beginning-date-time "1970-06-02T12:00:00Z"
                                             :ending-date-time "1975-02-02T12:00:00Z"}))
 
         _g2 (data/ingest "PROV1"
-                         (dg/granule-with-umm-spec-collection
+                         (data-granule/granule-with-umm-spec-collection
                            coll2 (:concept-id coll2)
-                           {:spatial-coverage (dg/spatial-with-track
+                           {:spatial-coverage (data-granule/spatial-with-track
                                                 {:cycle 1
                                                  :passes [{:pass 1}]})
                             :beginning-date-time "2012-01-01T00:00:00.000Z"
@@ -95,9 +95,9 @@
                          {:format :umm-json})
 
         _g3 (data/ingest "PROV1"
-                         (dg/granule-with-umm-spec-collection
+                         (data-granule/granule-with-umm-spec-collection
                            coll2 (:concept-id coll2)
-                           {:spatial-coverage (dg/spatial-with-track
+                           {:spatial-coverage (data-granule/spatial-with-track
                                                 {:cycle 2
                                                  :passes [{:pass 3}
                                                           {:pass 4}]})
@@ -106,14 +106,14 @@
                          {:format :umm-json})
         
         _g3-online (data/ingest "PROV1"
-                         (dg/granule-with-umm-spec-collection
+                         (data-granule/granule-with-umm-spec-collection
                           coll2 (:concept-id coll2)
-                          {:spatial-coverage (dg/spatial-with-track
+                          {:spatial-coverage (data-granule/spatial-with-track
                                               {:cycle 2
                                                :passes [{:pass 3}
                                                         {:pass 4}]})
-                           :related-urls [(dg/related-url {:type "GET DATA"})
-                                          (dg/related-url)]
+                           :related-urls [(data-granule/related-url {:type "GET DATA"})
+                                          (data-granule/related-url)]
                            :beginning-date-time "2012-01-01T00:00:00.000Z"
                            :ending-date-time "2012-01-01T00:00:00.000Z"})
                          {:format :umm-json})

--- a/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
+++ b/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
@@ -71,6 +71,18 @@
                                    {:granule-ur "Granule1"
                                     :beginning-date-time "1970-06-02T12:00:00Z"
                                     :ending-date-time "1975-02-02T12:00:00Z"}))
+        
+        _g1-online_1 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+                                  coll1 (:concept-id coll1)
+                                  {:related-urls [(dg/related-url {:type "GET DATA"})]
+                                   :beginning-date-time "1970-06-02T12:00:00Z"
+                                   :ending-date-time "1975-02-02T12:00:00Z"}))
+        
+        _g1-online_2 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+                                           coll1 (:concept-id coll1)
+                                           {:related-urls [(dg/related-url {:type "GET DATA"})]
+                                            :beginning-date-time "1970-06-02T12:00:00Z"
+                                            :ending-date-time "1975-02-02T12:00:00Z"}))
 
         _g2 (data/ingest "PROV1"
                          (dg/granule-with-umm-spec-collection
@@ -92,6 +104,19 @@
                             :beginning-date-time "2012-01-01T00:00:00.000Z"
                             :ending-date-time "2012-01-01T00:00:00.000Z"})
                          {:format :umm-json})
+        
+        _g3-online (data/ingest "PROV1"
+                         (dg/granule-with-umm-spec-collection
+                          coll2 (:concept-id coll2)
+                          {:spatial-coverage (dg/spatial-with-track
+                                              {:cycle 2
+                                               :passes [{:pass 3}
+                                                        {:pass 4}]})
+                           :related-urls [(dg/related-url {:type "GET DATA"})
+                                          (dg/related-url)]
+                           :beginning-date-time "2012-01-01T00:00:00.000Z"
+                           :ending-date-time "2012-01-01T00:00:00.000Z"})
+                         {:format :umm-json})
 
         _ (index/wait-until-indexed)
         user1-token (echo/login (system/context) "user1")
@@ -108,7 +133,7 @@
       (let [page-data (html/parse (format "%sPROV1/tag1"
                                           (url/search-site-providers-holdings-url)))]
         (is (not= nil page-data))
-        
+
         (testing "Virtual directory links exist for each collection."
           (is (= 2
                  (->> page-data
@@ -118,20 +143,20 @@
                       count))))
 
         (testing "Collection granule counts and pluralizations are correct."
-          (is (= "Browse 2 Granules"
+          (is (= "Browse 1 Granule"
                  (->> page-data
                       (find-element-by-id "C2-PROV1-virtual-directory-link")
                       :content
                       first
                       trim)))
-          
-          (is (= "Browse 1 Granule"
+
+          (is (= "Browse 2 Granules"
                  (->> page-data
                       (find-element-by-id "C1-PROV1-virtual-directory-link")
                       :content
                       first
                       trim))))
-        
+
         (testing "Collections with no granules do not have link"
           (is (= nil (find-element-by-id "C3-PROV1-virtual-directory-link" page-data)))
           (is (= "No Granules"

--- a/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
+++ b/system-int-test/test/cmr/system_int_test/site/holdings_provider_test.clj
@@ -72,13 +72,13 @@
                                     :beginning-date-time "1970-06-02T12:00:00Z"
                                     :ending-date-time "1975-02-02T12:00:00Z"}))
         
-        _g1-online_1 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+        _g1-online-1 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                   coll1 (:concept-id coll1)
                                   {:related-urls [(dg/related-url {:type "GET DATA"})]
                                    :beginning-date-time "1970-06-02T12:00:00Z"
                                    :ending-date-time "1975-02-02T12:00:00Z"}))
         
-        _g1-online_2 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
+        _g1-online-2 (data/ingest "PROV1" (dg/granule-with-umm-spec-collection
                                            coll1 (:concept-id coll1)
                                            {:related-urls [(dg/related-url {:type "GET DATA"})]
                                             :beginning-date-time "1970-06-02T12:00:00Z"


### PR DESCRIPTION
Here are changes from both Yiduo (mostly her actually) and some changes by me to get two tests to pass. If you reviewed the pull request from her github fork, what is different here is at line 103 in the file search-app/src/cmr/search/site/data.clj where changes were made to handle the flow when no collections are found. A corresponding changes is at line 140 of the same file. Together these changes allowed existing changes to pass.