### PR TITLE
CMR-6931: SubscriberID and EmailAddress are now optional subscription fields

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -707,6 +707,10 @@ Subscription concepts can be created by sending an HTTP POST or PUT with the met
 If a native-id is not provided it will be generated. This is only supported for POST requests.
 POST requests may only be used for creating subscriptions.
 
+If a SubscriberId is not provided, then the user ID associated with the token used to ingest the subscription will be used. 
+
+If an EmailAddress is not provided, then the email address associated with the SubscriberId's Earthdata Login (URS) account will be used.
+
 POST only may be used without a native-id at the following URL.
 `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions`
 

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -707,9 +707,9 @@ Subscription concepts can be created by sending an HTTP POST or PUT with the met
 If a native-id is not provided it will be generated. This is only supported for POST requests.
 POST requests may only be used for creating subscriptions.
 
-If a SubscriberId is not provided, then the user ID associated with the token used to ingest the subscription will be used. 
+If a SubscriberId is not provided, then the user ID associated with the token used to ingest the subscription will be used as the SubscriberId.
 
-If an EmailAddress is not provided, then the email address associated with the SubscriberId's Earthdata Login (URS) account will be used.
+If an EmailAddress is not provided, then the email address associated with the SubscriberId's Earthdata Login (URS) account will be used as the EmailAddress.
 
 POST only may be used without a native-id at the following URL.
 `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions`

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -171,30 +171,9 @@
     (if (:EmailAddress parsed-metadata)
       concept
       (let [token-user-info (urs/get-user-info request-context token-user)
-            generated-metadata (json/generate-string (assoc parsed-metadata :EmailAddress (:email_address token-user-info)))]
+            generated-metadata (json/generate-string (assoc parsed-metadata :EmailAddress
+                                                            (:email_address token-user-info)))]
         (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
-
-
-
-
-(defn ingest-subscription
-  "Processes a request to create or update a subscription. Note, this will allow
-  unlimited subscriptions to be created by users for themselves. Revisit if this
-  Becomes a problem"
-  [provider-id opt-native-id request]
-  (let [{:keys [body content-type headers request-context]} request]
-    (common-ingest-checks request-context provider-id)
-    (let [tmp-concept (api-core/body->concept!
-                       :subscription provider-id (str (UUID/randomUUID)) body content-type headers)
-          native-id (or opt-native-id (generate-native-id tmp-concept))
-          token-user (api-core/get-user-id-from-token request-context)
-          concept (assoc tmp-concept :native-id native-id)
-          concept-with-subscriber-id (check-subscriber-id
-                                      request-context concept provider-id token-user)
-          concept-with-id-and-email (check-subscriber-email
-                                     request-context concept-with-subscriber-id token-user)]
-      (check-subscription-ingest-permission request-context concept-with-id-and-email provider-id token-user)
-      (perform-subscription-ingest request-context concept-with-id-and-email headers))))
 
 (defn create-subscription
   "Processes a request to create a subscription. A native id will be generated."

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -159,8 +159,7 @@
   [request-context concept provider-id token-user]
   (let [parsed-metadata (json/parse-string (:metadata concept) true)]
     (if (:SubscriberId parsed-metadata)
-      (let [_ (check-subscription-ingest-permission request-context concept provider-id token-user)]
-        concept)
+     concept
       (let [generated-metadata (json/generate-string (assoc parsed-metadata :SubscriberId token-user))]
         (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
 
@@ -191,10 +190,10 @@
           token-user (api-core/get-user-id-from-token request-context)
           new-subscription (assoc tmp-subscription :native-id native-id)
           subscriber-id (get-subscriber-id new-subscription)
-          concept-with-subscriber-id (check-subscriber-id
-                                      request-context concept provider-id token-user)
-          concept-with-id-and-email (check-subscriber-email
-                                     request-context concept-with-subscriber-id token-user)]
+          sub-with-subscriber-id (check-subscriber-id
+                                      request-context new-subscription provider-id token-user)
+          sub-with-id-and-email (check-subscriber-email
+                                     request-context sub-with-subscriber-id token-user)]
       (check-ingest-permission request-context provider-id subscriber-id)
       (perform-subscription-ingest request-context new-subscription headers))))
 

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -165,14 +165,14 @@
             (assoc metadata field (value-fn context user))))))
 
 (defn add-subscriber-id-if-missing
-  "If subscriber EmailAddress is provided, use it. Else, use the value supplied by EDL for the user."
+  "If SubscriberId is provided, use it. Else, get it from the token."
   [subscription context token-user]
   (let [metadata (json/parse-string (:metadata subscription) true)]
     (add-subscription-field-if-missing context subscription metadata token-user :SubscriberId
       (constantly token-user))))
 
 (defn add-email-if-missing
-   "If SubscriberId is provided, use it. Else, get it from the token."
+  "If subscriber EmailAddress is provided, use it. Else, use the value supplied by EDL for the user."
   [subscription context]
   (let [metadata (json/parse-string (:metadata subscription) true)
         subscriberId (:SubscriberId metadata)]

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -157,18 +157,16 @@
   [context subscription metadata user field value-fn]
   (if-let [old-value (field metadata)]
     subscription
-    (do
-      (println (value-fn context user))
-      (assoc subscription :metadata
-             (json/generate-string
-              (assoc metadata field (value-fn context user)))))))
+    (assoc subscription :metadata
+           (json/generate-string
+            (assoc metadata field (value-fn context user))))))
 
 (defn add-subscriber-id-if-missing
   "If subscriber EmailAddress is provided, use it. Else, get it from EDL."
   [context subscription token-user]
   (let [metadata (json/parse-string (:metadata subscription) true)]
     (add-if-missing context subscription metadata token-user :SubscriberId
-      (fn [ctx user] user))))
+      (constantly token-user))))
 
 (defn add-email-if-missing
    "If SubscriberId is provided, use it. Else, get it from the token."

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -195,7 +195,7 @@
           sub-with-id-and-email (check-subscriber-email
                                      request-context sub-with-subscriber-id token-user)]
       (check-ingest-permission request-context provider-id subscriber-id)
-      (perform-subscription-ingest request-context new-subscription headers))))
+      (perform-subscription-ingest request-context sub-with-id-and-email headers))))
 
 
 (defn create-subscription-with-native-id

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -153,16 +153,6 @@
         (get-unique-native-id context subscription))
       native-id)))
 
-(defn check-subscriber-id
-  "If subscriber id is provided, checks that token-user has appropriate ACLs.
-  If subscriber id is not provided, then the token-user themself is used"
-  [request-context concept provider-id token-user]
-  (let [parsed-metadata (json/parse-string (:metadata concept) true)]
-    (if (:SubscriberId parsed-metadata)
-      concept
-      (let [generated-metadata (json/generate-string (assoc parsed-metadata :SubscriberId token-user))]
-        (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
-
 (defn add-if-missing
   [context subscription metadata user field value-fn]
   (if-let [old-value (field metadata)]

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -163,27 +163,6 @@
       (let [generated-metadata (json/generate-string (assoc parsed-metadata :SubscriberId token-user))]
         (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
 
-(defn check-subscriber-id
-  "If subscriber id is provided, checks that token-user has appropriate ACLs.
-  If subscriber id is not provided, then the token-user themself is used"
-  [request-context concept provider-id token-user]
-  (let [parsed-metadata (json/parse-string (:metadata concept) true)]
-    (if (:SubscriberId parsed-metadata)
-      concept
-      (let [generated-metadata (json/generate-string (assoc parsed-metadata :SubscriberId token-user))]
-        (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
-
-(defn check-subscriber-email
-  "If subscriber email is provided, use it. Else, get it from EDL."
-  [request-context concept token-user]
-  (let [parsed-metadata (json/parse-string (:metadata concept) true)]
-    (if (:EmailAddress parsed-metadata)
-      concept
-      (let [token-user-info (urs/get-user-info request-context token-user)
-            generated-metadata (json/generate-string (assoc parsed-metadata :EmailAddress
-                                                            (:email_address token-user-info)))]
-        (assoc (dissoc concept :metadata) :metadata generated-metadata)))))
-
 (defn add-if-missing
   [context subscription metadata user field value-fn]
   (if-let [old-value (field metadata)]

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -117,7 +117,7 @@
               :public-conf (public-conf)
               :queue-broker (queue-broker/create-queue-broker (config/queue-config))}]
      (transmit-config/system-with-connections
-       sys [:metadata-db :indexer :access-control :echo-rest :search :kms]))))
+       sys [:metadata-db :indexer :access-control :echo-rest :search :kms :urs]))))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,

--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -143,7 +143,11 @@
       (context "/api/users" []
         (GET "/verify_uid" {:keys [request-context params] :as request}
           (assert-bearer-token request)
-          (get-user request-context (:uid params))))
+          (get-user request-context (:uid params)))
+        ;; While a real URS connection would return more than just the email address,
+        ;; we only need the email address to fill in for the subscription concept.
+        (GET "/:user-id" {{:keys [user-id]} :params}
+          {:status 200 :body {:email_address (str user-id"@google.website")}}))
 
       (context "/users" []
         ;; Create a bunch of users all at once

--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -147,7 +147,7 @@
         ;; While a real URS connection would return more than just the email address,
         ;; we only need the email address to fill in for the subscription concept.
         (GET "/:user-id" {{:keys [user-id]} :params}
-          {:status 200 :body {:email_address (str user-id"@google.website")}}))
+          {:status 200 :body {:email_address (str user-id"@example.com")}}))
 
       (context "/users" []
         ;; Create a bunch of users all at once

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -186,7 +186,7 @@
                     {:accept-format :json
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (is (re-find #"Request content is too short." (first errors)))))
+      (is (re-find #"required key \[Name\] not found" (first errors)))))
   (testing "xml response"
     (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
                                      :metadata "")
@@ -195,7 +195,7 @@
                     {:accept-format :xml
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"Request content is too short." (first errors))))))
+      (is (re-find #"required key \[Name\] not found" (first errors))))))
 
 ;; Verify that user-id is saved from User-Id or token header
 (deftest subscription-ingest-user-id-test

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -186,7 +186,6 @@
                     {:accept-format :json
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (println errors)
       (is (re-find #"required key \[Name\] not found" (first errors)))))
   (testing "xml response"
     (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -54,7 +54,8 @@
     (testing "ingest on PROV1, with no subscriber-id supplied"
       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"
                                                                   :CollectionConceptId (:concept-id coll1)
-                                                                  :SubscriberId nil})
+                                                                  :SubscriberId nil
+                                                                  :EmailAddress "foo"})
             user1-token (echo-util/login (system/context) "user1")
             response (ingest/ingest-concept concept {:token user1-token})
             ingested-concept (mdb/get-concept (:concept-id response))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -78,7 +78,18 @@
             response (ingest/ingest-concept concept {:token user1-token})
             ingested-concept (mdb/get-concept (:concept-id response))
             parsed-metadata (json/parse-string (:metadata ingested-concept) true)]
-       (is (= "user1@example.com" (:EmailAddress parsed-metadata)))))))
+       (is (= "user1@example.com" (:EmailAddress parsed-metadata)))))
+    (testing "ingest on PROV1, admin subscribes for a user with no email provided"
+      (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"
+                                                                  :CollectionConceptId (:concept-id coll1)
+                                                                  :SubscriberId "mark"
+                                                                  :EmailAddress nil})
+
+            response (ingest/ingest-concept concept {:token "mock-echo-system-token"})
+            ingested-concept (mdb/get-concept (:concept-id response))
+            parsed-metadata (json/parse-string (:metadata ingested-concept) true)]
+       (is (= "mark@example.com" (:EmailAddress parsed-metadata)))))))
+
 
 (deftest subscription-ingest-on-prov3-test
   (let [coll1 (data-core/ingest-umm-spec-collection
@@ -783,7 +794,7 @@
           (let [{:keys [status errors]} (ingest/ingest-concept concept {:token token
                                                                         :method :post})]
             (is (= 409 status))
-            (is (= ["Subscription with with provider-id [PROV1] and native-id [another-native-id] already exists."]
+            (is (= ["Subscription with provider-id [PROV1] and native-id [another-native-id] already exists."]
                    errors))))))
 
     (testing "without native-id provided with unicode in the name"

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -186,7 +186,7 @@
                     {:accept-format :json
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (is (re-find #"required key \[Name\] not found" (first errors)))))
+      (is (re-find #"Request content is too short." (first errors)))))
   (testing "xml response"
     (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
                                      :metadata "")
@@ -195,7 +195,7 @@
                     {:accept-format :xml
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"required key \[Name\] not found" (first errors))))))
+      (is (re-find #"Request content is too short." (first errors))))))
 
 ;; Verify that user-id is saved from User-Id or token header
 (deftest subscription-ingest-user-id-test

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -78,7 +78,7 @@
             response (ingest/ingest-concept concept {:token user1-token})
             ingested-concept (mdb/get-concept (:concept-id response))
             parsed-metadata (json/parse-string (:metadata ingested-concept) true)]
-       (is (= "user1@google.website" (:EmailAddress parsed-metadata)))))))
+       (is (= "user1@example.com" (:EmailAddress parsed-metadata)))))))
 
 (deftest subscription-ingest-on-prov3-test
   (let [coll1 (data-core/ingest-umm-spec-collection

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -186,7 +186,8 @@
                     {:accept-format :json
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (is (re-find #"Request content is too short." (first errors)))))
+      (println errors)
+      (is (re-find #"required key \[Name\] not found" (first errors)))))
   (testing "xml response"
     (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
                                      :metadata "")
@@ -195,7 +196,7 @@
                     {:accept-format :xml
                      :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"Request content is too short." (first errors))))))
+      (is (re-find #"required key \[Name\] not found" (first errors))))))
 
 ;; Verify that user-id is saved from User-Id or token header
 (deftest subscription-ingest-user-id-test

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -55,7 +55,7 @@
       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV3"
                                                                   :CollectionConceptId (:concept-id coll1)
                                                                   :SubscriberId nil
-                                                                  :EmailAddress "foo"})
+                                                                  :EmailAddress "foo@example.com"})
             user1-token (echo-util/login (system/context) "user1")
             response (ingest/ingest-concept concept {:token user1-token})
             ingested-concept (mdb/get-concept (:concept-id response))

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -73,7 +73,7 @@
      (errors/internal-error!
       (format "Cannot get info for username [%s] in URS. Failed with status code [%d].
                EDL error message: [%s]"
-              user status (str body))))
+              user status (pr-str body))))
    body))
 
 (defn get-user-email

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -75,6 +75,11 @@
               user status)))
    body))
 
+(defn get-user-email
+  "Returns URS email associated with a username"
+  [context user]
+  (:email_address (get-user-info context user)))
+
 
 (comment
  ;; Use this code to test with URS. Replace XXXX with real values

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -71,8 +71,9 @@
                                                           :raw? true})]
    (when-not (= 200 status)
      (errors/internal-error!
-      (format "Cannot get info for username [%s] in EDL. Failed with status code [%d]."
-              user status)))
+      (format "Cannot get info for username [%s] in URS. Failed with status code [%d].
+               EDL error message: [%s]"
+              user status (str body))))
    body))
 
 (defn get-user-email

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -17,6 +17,10 @@
   [conn]
   (format "%s/oauth/token?grant_type=client_credentials" (conn/root-url conn)))
 
+(defn- user-info-url
+  [conn username]
+  (format "%s/api/users/%s" (conn/root-url conn) username))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Request functions
 
@@ -58,6 +62,19 @@
      (if raw?
        response
        (not (nil? response))))))
+
+(defn get-user-info
+  "Returns URS info associated with a username"
+  [context user]
+  (let [{:keys [status body]} (request-with-auth context {:url-fn #(user-info-url % user)
+                                                          :method :get
+                                                          :raw? true})]
+   (when-not (= 200 status)
+     (errors/internal-error!
+      (format "Cannot get info for username [%s] in EDL. Failed with status code [%d]."
+              user status)))
+   body))
+
 
 (comment
  ;; Use this code to test with URS. Replace XXXX with real values

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.0/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.0/umm-sub-json-schema.json
@@ -26,20 +26,18 @@
       "description": "The collection concept id of the granules subscribed.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 255 
+      "maxLength": 255
     },
     "Query": {
       "description": "The search query for the granules that matches the subscription.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 40000 
+      "maxLength": 40000
     }
   },
   "required": [
     "Name",
-    "SubscriberId",
-    "EmailAddress",
     "CollectionConceptId",
-    "Query" 
+    "Query"
   ]
 }


### PR DESCRIPTION
* SubscriberID is now an optional subscription field
    * If no SubscriberID is supplied, the user associated with the token will be used
* EmailAddress is now an optional subscription field
    * If no EmailAddress is supplied, the email associated with the user in URS (Earthdata Login) will be used
* Added tests for these optional cases