### PR TITLE
CMR-6633: Purge Sub-Notification from Metadata DB after Subscription is tombstoned

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
@@ -48,5 +48,7 @@
 (defmethod concepts/after-save :subscription
   [db provider sub]
   (when (:deleted sub)
-    ;; Cascade deletion to real deletes of granules
+    ;; Cascade deletion to real deletes of subscription notifications. The intended functionality
+    ;; since the subscription_notification row is purged is that, if this subscription were
+    ;; re-ingested (and un-tombstoned), we just look back 24 hours, as if the sub were brand new.
     (sub-notifs/delete-sub-notification db (:concept-id sub))))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
@@ -2,6 +2,7 @@
   "Implements multi-method variations for subscriptions"
   (:require
    [cmr.metadata-db.data.oracle.concepts :as concepts]
+   [cmr.metadata-db.data.oracle.sub-notifications :as sub-notifs]
    [cmr.oracle.connection :as oracle]))
 
 (defn add-last-notified-at-if-present
@@ -43,3 +44,9 @@
 (defmethod concepts/concept->insert-args [:subscription true]
   [concept _]
   (subscription-concept->insert-args concept))
+
+(defmethod concepts/after-save :subscription
+  [db provider sub]
+  (when (:deleted sub)
+    ;; Cascade deletion to real deletes of granules
+    (sub-notifs/delete-sub-notification db (:concept-id sub))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
@@ -118,7 +118,6 @@
        (ingest/delete-concept subscription-concept)
        (subscription-util/ingest-subscription subscription-concept
                                               {:token "mock-echo-system-token"})
-       
        (is (= 2
              (->> (trigger-process-subscriptions)
                   (map #(nth % 1))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
@@ -113,8 +113,8 @@
          (is (= [(:concept-id gran2)] response))))
 
      (testing "Deleting the subscription purges the suscription notification entry"
-       ;;delete and reingest the subscription. If the sub-notification was purged, then it
-       ;;should look back 24 hours, as if the subscription were new
+       ;; Delete and reingest the subscription. If the sub-notification was purged, then it
+       ;; should look back 24 hours, as if the subscription were new.
        (ingest/delete-concept subscription-concept)
        (subscription-util/ingest-subscription subscription-concept
                                               {:token "mock-echo-system-token"})
@@ -123,4 +123,4 @@
                   (map #(nth % 1))
                   flatten
                   (map :concept-id)
-                  (count))))))))
+                  count)))))))


### PR DESCRIPTION
* Added after-save function to check if the subscription was just tombstoned, and deleted the sub-notification if so
* Added test case for this functionality