### PR TITLE
CMR-7091: Add Granule URL Update worker to process OPeNDAP URL update for ECHO10 format

### DIFF
--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -30,6 +30,8 @@
                  [org.apache.httpcomponents/httpclient "4.5.13"]
                  [org.apache.httpcomponents/httpcore "4.4.10"]
                  [org.clojure/clojure "1.10.0"]
+                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.zip "1.0.0"]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.quartz-scheduler/quartz "2.3.1"]
                  [org.slf4j/slf4j-api "1.7.30"]

--- a/ingest-app/resources/CMR-4722/OMSO2.003-granule-opendap-url.xml
+++ b/ingest-app/resources/CMR-4722/OMSO2.003-granule-opendap-url.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Granule>
+   <GranuleUR>OMSO2.003:OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</GranuleUR>
+   <InsertTime>2016-06-17T12:37:02Z</InsertTime>
+   <LastUpdate>2016-06-17T12:37:02Z</LastUpdate>
+   <Collection>
+      <ShortName>OMSO2</ShortName>
+      <VersionId>003</VersionId>
+   </Collection>
+   <DataGranule>
+      <DataGranuleSizeInBytes>39379225</DataGranuleSizeInBytes>
+      <SizeMBDataGranule>39.3792247772217</SizeMBDataGranule>
+      <Checksum>
+         <Value>1234567890</Value>
+         <Algorithm>Fletcher-32</Algorithm>
+      </Checksum>
+      <ProducerGranuleId>OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</ProducerGranuleId>
+      <DayNightFlag>DAY</DayNightFlag>
+      <ProductionDateTime>2016-06-15T19:15:23.000Z</ProductionDateTime>
+   </DataGranule>
+   <PGEVersionClass>
+      <PGEVersion>0.1.7</PGEVersion>
+   </PGEVersionClass>
+   <Temporal>
+      <RangeDateTime>
+         <BeginningDateTime>2004-10-01T23:07:20.000000Z</BeginningDateTime>
+         <EndingDateTime>2004-10-02T00:46:13.000000Z</EndingDateTime>
+      </RangeDateTime>
+   </Temporal>
+   <Spatial>
+      <HorizontalSpatialDomain>
+         <ZoneIdentifier>Text</ZoneIdentifier>
+         <Orbit>
+            <AscendingCrossing>-153.66</AscendingCrossing>
+            <StartLat>-77.975486</StartLat>
+            <StartDirection>D</StartDirection>
+            <EndLat>76.799534</EndLat>
+            <EndDirection>D</EndDirection>
+         </Orbit>
+      </HorizontalSpatialDomain>
+   </Spatial>
+   <OrbitCalculatedSpatialDomains>
+      <OrbitCalculatedSpatialDomain>
+         <OrbitNumber>1146</OrbitNumber>
+         <EquatorCrossingLongitude>-153.66</EquatorCrossingLongitude>
+         <EquatorCrossingDateTime>2004-10-01T23:56:44.000000Z</EquatorCrossingDateTime>
+      </OrbitCalculatedSpatialDomain>
+   </OrbitCalculatedSpatialDomains>
+   <MeasuredParameters>
+      <MeasuredParameter>
+         <ParameterName>Total Column Sulphur Dioxide</ParameterName>
+         <QAStats>
+            <QAPercentMissingData>-999</QAPercentMissingData>
+         </QAStats>
+         <QAFlags>
+            <AutomaticQualityFlag>Passed</AutomaticQualityFlag>
+            <AutomaticQualityFlagExplanation>Set to 'Failed' if processing error occurred,'Passed' otherwise</AutomaticQualityFlagExplanation>
+            <OperationalQualityFlag>Passed</OperationalQualityFlag>
+            <OperationalQualityFlagExplanation>This granule passed operational tests that were administered by the OMI SIPS.  QA metadata was extracted and the file was successfully read using standard HDF-EOS utilities.</OperationalQualityFlagExplanation>
+            <ScienceQualityFlag>Not Investigated</ScienceQualityFlag>
+            <ScienceQualityFlagExplanation>An updated science quality flag and explanation is put in the product .met file when a granule has been evaluated.  The flag value in this file, Not Investigated, is an automatic default that is put into every granule during production.</ScienceQualityFlagExplanation>
+         </QAFlags>
+      </MeasuredParameter>
+   </MeasuredParameters>
+   <OnlineAccessURLs>
+      <OnlineAccessURL>
+         <URL>http://aura.gesdisc.eosdis.nasa.gov/data//Aura_OMI_Level2/OMSO2.003/2004/275/OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</URL>
+      </OnlineAccessURL>
+   </OnlineAccessURLs>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://opendap-url.example.com</URL>
+         <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+   </OnlineResources>
+   <Orderable>false</Orderable>
+   <DataFormat>HDF-EOS5</DataFormat>
+</Granule>

--- a/ingest-app/resources/granule_bulk_update_schema.json
+++ b/ingest-app/resources/granule_bulk_update_schema.json
@@ -1,65 +1,67 @@
 {
-    "definitions": {
-	"OperationEnum": {
-	    "type": "string",
-	    "enum": ["UPDATE_FIELD"]
-	},
-	"UpdateArgumentsType": {
-	    "title": "Items",
-	    "type": "array",
-	    "minItems": 1,
-	    "items":{
-		"title": "Arguments",
-		"type": "string",
-		"default": "",
-		"examples": [
-		    "SL:AB_5DSno.008:30500511"
-		],
-		"pattern": "^.*$"
-	    }
-	}
+  "definitions": {
+    "OperationEnum": {
+      "type": "string",
+      "enum": [
+        "UPDATE_FIELD"
+      ]
     },
-    "$schema": "http://json-schema.org/draft-07/schema#", 
-    "$id": "https://example.com/object1612966828.json", 
-    "title": "Root", 
-    "type": "object",
-    "required": [
-	"operation",
-	"update-field",
-	"updates"
-    ],
-    "properties": {
-	"name": {
-	    "$id": "#root/name", 
-	    "title": "Name", 
-	    "type": "string",
-	    "default": "",
-	    "examples": [
-		"Add opendap links"
-	    ],
-	    "pattern": "^.*$"
-	},
-	"operation": {
-	    "$ref": "#/definitions/OperationEnum"
-	},
-	"update-field": {
-	    "$id": "#root/update-field", 
-	    "title": "Update-field", 
-	    "type": "string",
-	    "default": "",
-	    "examples": [
-		"OPEnDAPLink"
-	    ],
-	    "pattern": "^.*$"
-	},
-	"updates": {
-	    "$id": "#root/updates", 
-	    "title": "Updates", 
-	    "type": "array",
-	    "minItems": 1,
-	    "items":{
-		"$ref" : "#/definitions/UpdateArgumentsType"
-	    }
-	}
+    "UpdateArgumentsType": {
+      "title": "Items",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Arguments",
+        "type": "string",
+        "default": "",
+        "examples": [
+          "SL:AB_5DSno.008:30500511"
+        ],
+        "pattern": "^.*$"
+      }
     }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/object1612966828.json",
+  "title": "Root",
+  "type": "object",
+  "required": [
+    "operation",
+    "update-field",
+    "updates"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#root/name",
+      "title": "Name",
+      "type": "string",
+      "default": "",
+      "examples": [
+        "Add opendap links"
+      ],
+      "pattern": "^.*$"
+    },
+    "operation": {
+      "$ref": "#/definitions/OperationEnum"
+    },
+    "update-field": {
+      "$id": "#root/update-field",
+      "title": "Update-field",
+      "type": "string",
+      "default": "",
+      "examples": [
+        "OPEnDAPLink"
+      ],
+      "pattern": "^.*$"
+    },
+    "updates": {
+      "$id": "#root/updates",
+      "title": "Updates",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/UpdateArgumentsType"
+      }
+    }
+  }
 }

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -31,7 +31,7 @@
 (defn- generate-updated-msg
   "Generate the UPDATED part of the status message."
   [num-failed-collections num-skipped-collections num-total-collections]
-  (let [num-updated-collections (- num-total-collections 
+  (let [num-updated-collections (- num-total-collections
                                    (+ num-failed-collections num-skipped-collections))]
     (when (not= 0 num-updated-collections)
       (if (or (not= 0 num-failed-collections) (not= 0 num-skipped-collections))
@@ -43,13 +43,13 @@
   [num-failed-collections num-skipped-collections num-total-collections]
   (if (and (= 0 num-failed-collections) (= 0 num-skipped-collections))
     "All collection updates completed successfully."
-    (str "Task completed with " 
-         (generate-failed-msg num-failed-collections)  
-         (generate-skipped-msg num-failed-collections num-skipped-collections num-total-collections) 
-         (generate-updated-msg num-failed-collections num-skipped-collections num-total-collections) 
-         " out of " 
-         num-total-collections 
-         " total collection update(s).")))  
+    (str "Task completed with "
+         (generate-failed-msg num-failed-collections)
+         (generate-skipped-msg num-failed-collections num-skipped-collections num-total-collections)
+         (generate-updated-msg num-failed-collections num-skipped-collections num-total-collections)
+         " out of "
+         num-total-collections
+         " total collection update(s).")))
 
 (defprotocol BulkUpdateStore
   "Defines a protocol for getting and storing the bulk update status and task-id
@@ -71,117 +71,116 @@
   cmr.oracle.connection.OracleStore
 
   (get-provider-bulk-update-status
-    [db provider-id]
-    (j/with-db-transaction
-      [conn db]
-      ;; Returns a list of bulk update statuses for the provider
-      (let [stmt (su/build (su/select [:created-at :name :task-id :status :status-message :request-json-body]
-                                      (su/from bulk_update_task_status)
-                                      (su/where `(= :provider-id ~provider-id))))
-            ;; Note: the column selected out of the database is created_at, instead of created-at.
-            statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn)) 
-                                 (su/query conn stmt)))
-            statuses (map util/map-keys->kebab-case statuses)]
-        (map #(update % :request-json-body util/gzip-blob->string)
-             statuses))))
+   [db provider-id]
+   (j/with-db-transaction
+    [conn db]
+    ;; Returns a list of bulk update statuses for the provider
+    (let [stmt (su/build (su/select [:created-at :name :task-id :status :status-message :request-json-body]
+                                    (su/from bulk_update_task_status)
+                                    (su/where `(= :provider-id ~provider-id))))
+          ;; Note: the column selected out of the database is created_at, instead of created-at.
+          statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn))
+                               (su/query conn stmt)))
+          statuses (map util/map-keys->kebab-case statuses)]
+      (map #(update % :request-json-body util/gzip-blob->string)
+           statuses))))
 
   (get-bulk-update-task-status
-    [db task-id provider-id]
-    (j/with-db-transaction
-      [conn db]
-      ;; Returns a status for the particular task
-      (some-> conn 
-              (su/find-one (su/select [:created-at :name :status :status-message :request-json-body]
-                                      (su/from bulk_update_task_status)
-                                      (su/where `(and (= :task-id ~task-id)
-                                                      (= :provider-id ~provider-id)))))
-              util/map-keys->kebab-case
-              (update :request-json-body util/gzip-blob->string)
-              (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
+   [db task-id provider-id]
+   (j/with-db-transaction
+    [conn db]
+    ;; Returns a status for the particular task
+    (some-> conn
+            (su/find-one (su/select [:created-at :name :status :status-message :request-json-body]
+                                    (su/from bulk_update_task_status)
+                                    (su/where `(and (= :task-id ~task-id)
+                                                    (= :provider-id ~provider-id)))))
+            util/map-keys->kebab-case
+            (update :request-json-body util/gzip-blob->string)
+            (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
 
   (get-bulk-update-task-collection-status
-    [db task-id]
-    ;; Get statuses for all collections by task id
-    (map util/map-keys->kebab-case
-         (su/query db (su/build (su/select [:concept-id :status :status-message]
-                                           (su/from "bulk_update_coll_status")
-                                           (su/where `(= :task-id ~task-id)))))))
+   [db task-id]
+   ;; Get statuses for all collections by task id
+   (map util/map-keys->kebab-case
+        (su/query db (su/build (su/select [:concept-id :status :status-message]
+                                          (su/from "bulk_update_coll_status")
+                                          (su/where `(= :task-id ~task-id)))))))
 
   (get-bulk-update-collection-status
-    [db task-id concept-id]
-    ;; Get the status for a particular collection
-    (su/find-one db (su/select [:status :status-message]
-                               (su/from "bulk_update_coll_status")
-                               (su/where `(and (= :task-id ~task-id)
-                                               (= :concept-id ~concept-id))))))
+   [db task-id concept-id]
+   ;; Get the status for a particular collection
+   (su/find-one db (su/select [:status :status-message]
+                              (su/from "bulk_update_coll_status")
+                              (su/where `(and (= :task-id ~task-id)
+                                              (= :concept-id ~concept-id))))))
 
   (create-and-save-bulk-update-status
-    [db provider-id json-body concept-ids]
-    ;; In a transaction, add one row to the task status table and for each concept
-    (j/with-db-transaction
-      [conn db]
-      (let [task-id (:nextval (first (su/query db ["SELECT task_id_seq.NEXTVAL FROM DUAL"])))
-            statement (str "INSERT INTO bulk_update_task_status "
-                           "(task_id, provider_id, name, request_json_body, status)"
-                           "VALUES (?, ?, ?, ?, ?)")
-            name (get (json/parse-string json-body) "name" task-id)
-            values [task-id provider-id name (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
-        (j/db-do-prepared db statement values)
-        ;; Write a row to collection status for each concept id
-        (apply j/insert! conn
-               "bulk_update_coll_status"
-               ["task_id" "concept_id" "status"]
-               ;; set :transaction? false since we are already inside a transaction
-               (concat (map #(vector task-id % "PENDING") concept-ids) [:transaction? false]))
-        task-id)))
+   [db provider-id json-body concept-ids]
+   ;; In a transaction, add one row to the task status table and for each concept
+   (j/with-db-transaction
+    [conn db]
+    (let [task-id (:nextval (first (su/query db ["SELECT task_id_seq.NEXTVAL FROM DUAL"])))
+          statement (str "INSERT INTO bulk_update_task_status "
+                         "(task_id, provider_id, name, request_json_body, status)"
+                         "VALUES (?, ?, ?, ?, ?)")
+          name (get (json/parse-string json-body) "name" task-id)
+          values [task-id provider-id name (util/string->gzip-bytes json-body) "IN_PROGRESS"]]
+      (j/db-do-prepared db statement values)
+      ;; Write a row to collection status for each concept id
+      (apply j/insert! conn
+             "bulk_update_coll_status"
+             ["task_id" "concept_id" "status"]
+             ;; set :transaction? false since we are already inside a transaction
+             (concat (map #(vector task-id % "PENDING") concept-ids) [:transaction? false]))
+      task-id)))
 
   (update-bulk-update-task-status
-    [db task-id status status-message]
-    (try
-      (let [statement (str "UPDATE bulk_update_task_status "
-                           "SET status = ?, status_message = ?"
-                           "WHERE task_id = ?")]
-        (j/db-do-prepared db statement [status status-message task-id]))
-      (catch Exception e
-        (errors/throw-service-error :invalid-data
-                                    [(str "Error creating updating bulk update task status "
-                                          (.getMessage e))]))))
+   [db task-id status status-message]
+   (try
+     (let [statement (str "UPDATE bulk_update_task_status "
+                          "SET status = ?, status_message = ?"
+                          "WHERE task_id = ?")]
+       (j/db-do-prepared db statement [status status-message task-id]))
+     (catch Exception e
+       (errors/throw-service-error :invalid-data
+                                   [(str "Error creating updating bulk update task status "
+                                         (.getMessage e))]))))
 
   (update-bulk-update-collection-status
-    [db task-id concept-id status status-message]
-    (try
-      (j/with-db-transaction
-       [conn db]
-       (let [statement (str "UPDATE bulk_update_coll_status "
-                            "SET status = ?, status_message = ?"
-                            "WHERE task_id = ? AND concept_id = ?")
-             status-message (util/trunc status-message 4000)]
-         (j/db-do-prepared db statement [status status-message task-id concept-id])
-         (let [task-collections (su/query db
-                                          (su/build (su/select
-                                                     [:concept-id :status]
-                                                     (su/from "bulk_update_coll_status")
-                                                     (su/where `(= :task-id ~task-id)))))
-               pending-collections (filter #(= "PENDING" (:status %)) task-collections)
-               failed-collections (filter #(= "FAILED" (:status %)) task-collections)
-               skipped-collections (filter #(= "SKIPPED" (:status %)) task-collections)]
-           (when-not (seq pending-collections)
-             (update-bulk-update-task-status db task-id "COMPLETE"
-                                             (generate-task-status-message
-                                              (count failed-collections)
-                                              (count skipped-collections)
-                                              (count task-collections)))))))
-      (catch Exception e
-        (errors/throw-service-error :invalid-data
-                                    [(str "Error creating updating bulk update collection status "
-                                          (.getMessage e))]))))
+   [db task-id concept-id status status-message]
+   (try
+     (j/with-db-transaction
+      [conn db]
+      (let [statement (str "UPDATE bulk_update_coll_status "
+                           "SET status = ?, status_message = ?"
+                           "WHERE task_id = ? AND concept_id = ?")
+            status-message (util/trunc status-message 4000)]
+        (j/db-do-prepared db statement [status status-message task-id concept-id])
+        (let [task-collections (su/query db
+                                         (su/build (su/select
+                                                    [:concept-id :status]
+                                                    (su/from "bulk_update_coll_status")
+                                                    (su/where `(= :task-id ~task-id)))))
+              pending-collections (filter #(= "PENDING" (:status %)) task-collections)
+              failed-collections (filter #(= "FAILED" (:status %)) task-collections)
+              skipped-collections (filter #(= "SKIPPED" (:status %)) task-collections)]
+          (when-not (seq pending-collections)
+            (update-bulk-update-task-status db task-id "COMPLETE"
+                                            (generate-task-status-message
+                                             (count failed-collections)
+                                             (count skipped-collections)
+                                             (count task-collections)))))))
+     (catch Exception e
+       (errors/throw-service-error :invalid-data
+                                   [(str "Error creating updating bulk update collection status "
+                                         (.getMessage e))]))))
 
   (reset-bulk-update
-    [db]
-    (let [statement "DELETE FROM bulk_update_coll_status"]
-      (j/db-do-prepared db statement []))
-    (let [statement "DELETE FROM bulk_update_task_status"]
-      (j/db-do-prepared db statement []))))
+   [db]
+   (su/run-sql db "DELETE FROM bulk_update_coll_status")
+   (su/run-sql db "DELETE FROM bulk_update_task_status")
+   (su/run-sql db "ALTER SEQUENCE task_id_seq restart start with 1")))
 
 (defn context->db
   [context]

--- a/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
@@ -3,7 +3,6 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
-   [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :refer [defn-timed] :as util]
@@ -48,100 +47,107 @@
                 (generate-updated-msg num-failed-granules num-skipped-granules num-total-granules))
            num-total-granules)))
 
-(defprotocol BulkUpdateStore
- "Defines a protocol for getting and storing the bulk update status and task-id
+(defn- instructions->gran-stats
+  "Return the bulk_update_gran_status insert values in the form of
+   [task_id provider_id granule_ur instruction status] for the given instructions map."
+  [task-id provider-id instructions]
+  ;; create a granule status row for each granule-ur
+  (concat
+   (map #(vector task-id provider-id (:granule-ur %) (json/generate-string %) "PENDING")
+        instructions)
+   ;; set :transaction? false since we are already inside a transaction
+   [:transaction? false]))
+
+(defprotocol GranBulkUpdateStore
+ "Defines a protocol for getting and storing the granule bulk update status and task-id
  information."
  (get-provider-bulk-granule-update-status [db provider-id])
  (get-bulk-granule-update-task-status [db task-id provider-id])
  (get-bulk-update-task-granule-status [db task-id])
  (get-bulk-update-granule-status [db task-id concept-id])
- (create-and-save-bulk-granule-update-status [db provider-id json-body granule-urs])
+ (create-and-save-bulk-granule-update-status [db provider-id user-id request-json-body instructions])
  (update-bulk-granule-update-task-status [db task-id status status-message])
- (update-bulk-update-granule-status [db task-id concept-id status status-message])
+ (update-bulk-update-granule-status [db task-id granule-ur status status-message])
  (reset-bulk-granule-update [db]))
 
 (def bulk_update_task_status
   "bulk_update_gran_status")
 
-;; Extends the BulkUpdateStore to the oracle store so it will work with oracle.
-(extend-protocol BulkUpdateStore
- cmr.oracle.connection.OracleStore
+;; Extends the GranBulkUpdateStore to the oracle store so it will work with oracle.
+(extend-protocol GranBulkUpdateStore
+  cmr.oracle.connection.OracleStore
 
- (get-provider-bulk-update-status
+  (get-provider-bulk-update-status
    [db provider-id]
    (jdbc/with-db-transaction
-     [conn db]
-     ;; Returns a list of bulk update statuses for the provider
-     (let [stmt (sql-utils/build (sql-utils/select [:created-at :name :task-id :status :status-message :instruction]
-                                     (sql-utils/from bulk_update_task_status)
-                                     (sql-utils/where `(= :provider-id ~provider-id))))
-           ;; Note: the column selected out of the database is created_at, instead of created-at.
-           statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn))
-                                (sql-utils/query conn stmt)))
-           statuses (map util/map-keys->kebab-case statuses)]
-       (map #(update % :request-json-body util/gzip-blob->string)
-            statuses))))
+    [conn db]
+    ;; Returns a list of bulk update statuses for the provider
+    (let [stmt (sql-utils/build (sql-utils/select [:created-at :name :task-id :status :status-message :instruction]
+                                                  (sql-utils/from bulk_update_task_status)
+                                                  (sql-utils/where `(= :provider-id ~provider-id))))
+          ;; Note: the column selected out of the database is created_at, instead of created-at.
+          statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn))
+                               (sql-utils/query conn stmt)))
+          statuses (map util/map-keys->kebab-case statuses)]
+      (map #(update % :request-json-body util/gzip-blob->string)
+           statuses))))
 
- (get-bulk-granule-update-task-status
+  (get-bulk-granule-update-task-status
    [db task-id provider-id]
    (jdbc/with-db-transaction
-     [conn db]
-     ;; Returns a status for the particular task
-     (some-> conn
-             (sql-utils/find-one (sql-utils/select [:created-at :name :status :status-message :instruction]
-                                     (sql-utils/from bulk_update_task_status)
-                                     (sql-utils/where `(and (= :task-id ~task-id))
-                                                     (= :provider-id ~provider-id))))
-             util/map-keys->kebab-case
-             (update :request-json-body util/gzip-blob->string)
-             (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
+    [conn db]
+    ;; Returns a status for the particular task
+    (some-> conn
+            (sql-utils/find-one (sql-utils/select [:created-at :name :status :status-message :instruction]
+                                                  (sql-utils/from bulk_update_task_status)
+                                                  (sql-utils/where `(and (= :task-id ~task-id))
+                                                                   (= :provider-id ~provider-id))))
+            util/map-keys->kebab-case
+            (update :request-json-body util/gzip-blob->string)
+            (update :created-at (partial oracle/oracle-timestamp->str-time conn)))))
 
- (get-bulk-update-task-granule-status
+  (get-bulk-update-task-granule-status
    [db task-id]
    ;; Get statuses for all granules by task id
    (map util/map-keys->kebab-case
         (sql-utils/query db (sql-utils/build (sql-utils/select [:granule-ur :status :status-message])
-                                          (sql-utils/from "bulk_update_gran_status")
-                                          (sql-utils/where `(= :task-id ~task-id))))))
+                                             (sql-utils/from "bulk_update_gran_status")
+                                             (sql-utils/where `(= :task-id ~task-id))))))
 
- (get-bulk-update-granule-status
+  (get-bulk-update-granule-status
    [db task-id granule-ur]
    ;; Get the status for a particular granule
    (sql-utils/find-one db (sql-utils/select [:status :status-message]
-                              (sql-utils/from "granule_bulk_update_tasks")
-                              (sql-utils/where `(and (= :task-id ~task-id))
-                                              (= :granule-ur ~granule-ur)))))
+                                            (sql-utils/from "granule_bulk_update_tasks")
+                                            (sql-utils/where `(and (= :task-id ~task-id))
+                                                             (= :granule-ur ~granule-ur)))))
 
- (create-and-save-bulk-granule-update-status
-   [db provider-id request-json-body user-id]
+  (create-and-save-bulk-granule-update-status
+   [db provider-id user-id request-json-body instructions]
    ;; In a transaction, add one row to the task status table and for each concept
    (jdbc/with-db-transaction
-     [conn db]
-     (let [task-id (:nextval (first (sql-utils/query db ["SELECT GRAN_TASK_ID_SEQ.NEXTVAL FROM DUAL"])))
-           statement (str "INSERT INTO granule_bulk_update_tasks "
-                          "(task_id, provider_id, name, request_json_body, status, user_id)"
-                          "VALUES (?, ?, ?, ?, ?, ?)")
-           parsed-json (json/parse-string request-json-body)
-           instruction (get parsed-json "operation")
-           task-name (get parsed-json "name" task-id)
-           unique-task-name (format "%s: %s" task-name task-id)
-           values [task-id provider-id unique-task-name (util/string->gzip-bytes request-json-body) "IN_PROGRESS" user-id]
-           granule-urs (as-> parsed-json json
-                             (get json "updates")
-                             (map first json))]
-       (jdbc/db-do-prepared db statement values)
-       ;; Write a row to granule status for each granule-ur
-       (apply jdbc/insert! conn
-              "bulk_update_gran_status"
-              ["task_id" "granule_ur" "status" "provider_id" "instruction"]
-              ;; set :transaction? false since we are already inside a transaction
-              (concat (map #(vector task-id % provider-id "PENDING" instruction) granule-urs) [:transaction? false]))
-       task-id)))
+    [conn db]
+    (let [task-id (:nextval (first (sql-utils/query db ["SELECT GRAN_TASK_ID_SEQ.NEXTVAL FROM DUAL"])))
+          statement (str "INSERT INTO granule_bulk_update_tasks "
+                         "(task_id, provider_id, name, request_json_body, status, user_id)"
+                         "VALUES (?, ?, ?, ?, ?, ?)")
+          parsed-json (json/parse-string request-json-body true)
+          task-name (get parsed-json :name task-id)
+          unique-task-name (format "%s: %s" task-name task-id)
+          values [task-id provider-id unique-task-name (util/string->gzip-bytes request-json-body)
+                  "IN_PROGRESS" user-id]]
+      (jdbc/db-do-prepared db statement values)
+      ;; Write a row to granule status for each granule-ur
+      (apply jdbc/insert! conn
+             "bulk_update_gran_status"
+             ["task_id" "provider_id" "granule_ur" "instruction" "status"]
+             (instructions->gran-stats task-id provider-id instructions))
+      task-id)))
 
- (update-bulk-granule-update-task-status
+  (update-bulk-granule-update-task-status
    [db task-id status status-message]
    (try
-     (let [statement (str "UPDATE bulk_update_gran_status "
+     (let [statement (str "UPDATE granule_bulk_update_tasks "
                           "SET status = ?, status_message = ?"
                           "WHERE task_id = ?")]
        (jdbc/db-do-prepared db statement [status status-message task-id]))
@@ -150,41 +156,42 @@
                                    [(str "Error updating bulk update task status "
                                          (.getMessage e))]))))
 
- (update-bulk-update-granule-status
+  (update-bulk-update-granule-status
    [db task-id granule-ur status status-message]
    (try
      (jdbc/with-db-transaction
       [conn db]
-      (let [statement (str "UPDATE granule_bulk_update_tasks "
+      (let [statement (str "UPDATE bulk_update_gran_status "
                            "SET status = ?, status_message = ?"
                            "WHERE task_id = ? AND granule_ur = ?")
             status-message (util/trunc status-message 4000)]
         (jdbc/db-do-prepared db statement [status status-message task-id granule-ur])
-        (let [task-granules (sql-utils/query db
-                                         (sql-utils/build (sql-utils/select)
-                                                    [:granule-ur :status]
-                                                    (sql-utils/from "bulk_update_gran_status")
-                                                    (sql-utils/where `(= :task-id ~task-id))))
-              pending-granules (filter #(= "PENDING" (:status %)) task-granules)
-              failed-granules (filter #(= "FAILED" (:status %)) task-granules)
-              skipped-granules (filter #(= "SKIPPED" (:status %)) task-granules)]
+        (let [task-granules (sql-utils/query
+                             db
+                             (sql-utils/build (sql-utils/select
+                                               [:granule-ur :status]
+                                               (sql-utils/from "bulk_update_gran_status")
+                                               (sql-utils/where `(= :task-id ~task-id)))))
+              pending-granules (filter #(= "PENDING" (:status %)) task-granules)]
           (when-not (seq pending-granules)
-            (update-bulk-granule-update-task-status db task-id "COMPLETE"
-                                            (generate-task-status-message
-                                             (count failed-granules)
-                                             (count skipped-granules)
-                                             (count task-granules)))))))
+            (let [failed-granules (filter #(= "FAILED" (:status %)) task-granules)
+                  skipped-granules (filter #(= "SKIPPED" (:status %)) task-granules)]
+              (update-bulk-granule-update-task-status db task-id "COMPLETE"
+                                                      (generate-task-status-message
+                                                       (count failed-granules)
+                                                       (count skipped-granules)
+                                                       (count task-granules))))))))
      (catch Exception e
+       (error "Exception caught in update bulk update granule status: " e)
        (errors/throw-service-error :invalid-data
                                    [(str "Error updating bulk update granule status "
                                          (.getMessage e))]))))
 
- (reset-bulk-update
+  (reset-bulk-granule-update
    [db]
-   (let [statement "DELETE FROM granule_bulk_update_tasks"]
-     (jdbc/db-do-prepared db statement []))
-   (let [statement "DELETE FROM granule_bulk_update_tasks"]
-     (jdbc/db-do-prepared db statement []))))
+   (sql-utils/run-sql db "DELETE FROM bulk_update_gran_status")
+   (sql-utils/run-sql db "DELETE FROM granule_bulk_update_tasks")
+   (sql-utils/run-sql db "ALTER SEQUENCE gran_task_id_seq restart start with 1")))
 
 (defn context->db
   "Return the path to the database from a given context"
@@ -204,37 +211,19 @@
  [context task-id]
  (get-bulk-update-task-granule-status (context->db context) task-id))
 
-(defn-timed create-bulk-update-task
- "Creates all the rows for bulk update status tables - task status and granule
- status. Returns task id"
- [context provider-id user-id request-json-body]
- (create-and-save-bulk-granule-update-status
-  (context->db context)
-  provider-id
-  request-json-body
-  user-id))
-
 (defn-timed create-granule-bulk-update-task
  "Create all rows for granule bulk update status tables - task status and granule status.
  Returns task id."
- [context provider-id instruction updates]
+ [context provider-id user-id request-json-body instructions]
  (create-and-save-bulk-granule-update-status
-  (context->db context)
-  provider-id
-  instruction
-  updates))
-
+  (context->db context) provider-id user-id request-json-body instructions))
 
 (defn-timed update-bulk-update-task-granule-status
  "For the task and concept id, update the granule to the given status with the
  given status message"
  [context task-id granule-ur status status-message]
  (update-bulk-update-granule-status
-  (context->db context)
-  task-id
-  granule-ur
-  status
-  status-message))
+  (context->db context) task-id granule-ur status status-message))
 
 (defn reset-db
  "Clear bulk update db"
@@ -251,7 +240,3 @@
                       (config/bulk-update-cleanup-minimum-age)
                       "' DAY)")]
    (jdbc/db-do-prepared db statement)))
-
-(comment
- (reset-bulk-update (context->db context))
- (def db (context->db context)))

--- a/ingest-app/src/cmr/ingest/data/ingest_events.clj
+++ b/ingest-app/src/cmr/ingest/data/ingest_events.clj
@@ -66,7 +66,8 @@
   {:action :provider-delete
    :provider-id provider-id})
 
-(defn ingest-bulk-update-event
+(defn collections-bulk-event
+  "Creates a collection bulk update event that is for multiple collections."
   [provider-id task-id bulk-update-params user-id]
   {:action :bulk-update
    :provider-id provider-id
@@ -75,6 +76,7 @@
    :user-id user-id})
 
 (defn ingest-collection-bulk-update-event
+  "Creates a single collection bulk update event. This is to update a single collection."
   [provider-id task-id concept-id bulk-update-params user-id]
   {:action :collection-bulk-update
    :provider-id provider-id
@@ -83,12 +85,21 @@
    :bulk-update-params bulk-update-params
    :user-id user-id})
 
-(defn ingest-granule-bulk-update-event
-  "Creates an event representing a bulk granule update task"
-  [provider-id task-id event-type granule-ur value]
-  {:action :granule-bulk-update
-   :task-id task-id
-   :event-type event-type
+(defn granules-bulk-event
+  "Creates a granule bulk update event that is for multiple granules."
+  [provider-id task-id user-id instructions]
+  {:action :granules-bulk
    :provider-id provider-id
-   :granule-ur granule-ur
-   :value value})
+   :task-id task-id
+   :bulk-update-params instructions
+   :user-id user-id})
+
+(defn ingest-granule-bulk-update-event
+  "Creates an event representing bulk update for a single granule.
+   bulk-update-params holds specific info for each update. e.g. event-type, granule-ur, url."
+  [provider-id task-id user-id instruction]
+  {:action :granule-bulk-update
+   :provider-id provider-id
+   :task-id task-id
+   :bulk-update-params instruction
+   :user-id user-id})

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -26,50 +26,50 @@
   acl-hash/AclHashStore
 
   (save-acl-hash
-    [this acl-hash]
-    (reset! (:acl-hash-data-atom this) acl-hash))
+   [this acl-hash]
+   (reset! (:acl-hash-data-atom this) acl-hash))
 
   (get-acl-hash
-    [this]
-    (-> this :acl-hash-data-atom deref))
+   [this]
+   (-> this :acl-hash-data-atom deref))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   data-bulk-update/BulkUpdateStore
 
   (get-provider-bulk-update-status
-    [this provider-id]
-    (some->> @task-status-atom
-             (filter #(= provider-id (:provider-id %)))
-             (map #(select-keys % [:created-at :name :task-id :status :status-message :request-json-body]))))
+   [this provider-id]
+   (some->> @task-status-atom
+            (filter #(= provider-id (:provider-id %)))
+            (map #(select-keys % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-bulk-update-task-status
-    [this task-id provider-id]
-    (let [task-status (some->> @task-status-atom
-                               (some #(when (and (= provider-id (str (:provider-id %)))
-                                                 (= task-id (str (:task-id %))))
-                                            %)))]
-      (select-keys task-status [:created-at :name :task-id :status :status-message :request-json-body])))
+   [this task-id provider-id]
+   (let [task-status (some->> @task-status-atom
+                              (some #(when (and (= provider-id (str (:provider-id %)))
+                                                (= task-id (str (:task-id %))))
+                                       %)))]
+     (select-keys task-status [:created-at :name :task-id :status :status-message :request-json-body])))
 
   (get-bulk-update-task-collection-status
-    [this task-id]
-    (some->> @collection-status-atom
-             (into [])
-             (filter #(= (str task-id) (str (:task-id %))))
-             (map #(select-keys % [:concept-id :status :status-message]))))
+   [this task-id]
+   (some->> @collection-status-atom
+            (into [])
+            (filter #(= (str task-id) (str (:task-id %))))
+            (map #(select-keys % [:concept-id :status :status-message]))))
 
   (get-bulk-update-collection-status
-    [this task-id concept-id]
-    (let [coll-status (some->> @collection-status-atom
-                               (some #(when (and (= concept-id (:concept-id %))
-                                                 (= (str task-id) (:task-id %)))
-                                            %)))]
-      (select-keys coll-status [:concept-id :status :status-message])))
+   [this task-id concept-id]
+   (let [coll-status (some->> @collection-status-atom
+                              (some #(when (and (= concept-id (:concept-id %))
+                                                (= (str task-id) (:task-id %)))
+                                       %)))]
+     (select-keys coll-status [:concept-id :status :status-message])))
 
   (create-and-save-bulk-update-status
-    [this provider-id json-body concept-ids]
-    (swap! task-id-atom inc)
-    (let [task-id (str @task-id-atom)
-          name (get (json/parse-string json-body) "name" task-id)]
+   [this provider-id json-body concept-ids]
+   (swap! task-id-atom inc)
+   (let [task-id (str @task-id-atom)
+         name (get (json/parse-string json-body) "name" task-id)]
      ;; provider-id and name together need to be unique.
      (if (some #(and (= provider-id (:provider-id %))(= name (:name %)))
                @task-status-atom)
@@ -83,181 +83,180 @@
                                      :request-json-body json-body
                                      :status "IN_PROGRESS"}))
      (swap! collection-status-atom concat (map (fn [c]
-                                                {:task-id task-id
-                                                 :concept-id c
-                                                 :status "PENDING"})
+                                                 {:task-id task-id
+                                                  :concept-id c
+                                                  :status "PENDING"})
                                                concept-ids))
      task-id))
 
   (update-bulk-update-task-status
-    [this task-id status status-message]
-    (let [task-statuses @task-status-atom
-          index (first (keep-indexed #(when (= task-id (:task-id %2))
-                                         %1)
-                                     task-statuses))]
-      (swap! (:task-status-atom this) (fn [task-statuses]
+   [this task-id status status-message]
+   (let [task-statuses @task-status-atom
+         index (first (keep-indexed #(when (= task-id (:task-id %2))
+                                       %1)
+                                    task-statuses))]
+     (swap! (:task-status-atom this) (fn [task-statuses]
                                        (-> task-statuses
                                            (assoc-in [index :status] status)
                                            (assoc-in [index :status-message] status-message))))))
 
 
   (update-bulk-update-collection-status
-    [this task-id concept-id status status-message]
-    ;; @collection-status-atom is a lazy seq so force into []
-    (let [coll-statuses (into [] @collection-status-atom)
-          index (first (keep-indexed #(when (and (= concept-id (:concept-id %2))
-                                                 (= task-id (:task-id %2)))
-                                         %1)
-                                     coll-statuses))]
-      (swap! (:collection-status-atom this) (fn [coll-statuses]
-                                              (-> (into [] coll-statuses)
-                                                  (assoc-in [index :status] status)
-                                                  (assoc-in [index :status-message] status-message))))
-      (let [coll-statuses (into [] @collection-status-atom) ; Need to refresh after change
-            task-collections (filter #(= task-id (:task-id %)) coll-statuses)
-            pending-collections (filter #(= "PENDING" (:status %)) task-collections)
-            failed-collections (filter #(= "FAILED" (:status %)) task-collections)
-            skipped-collections (filter #(= "SKIPPED" (:status %)) task-collections)]
-        (when-not (seq pending-collections)
-          (let [task-statuses @task-status-atom
-                index (first (keep-indexed #(when (= task-id (:task-id %2))
-                                               %1)
-                                           task-statuses))]
-            (swap! (:task-status-atom this) (fn [task-statuses]
+   [this task-id concept-id status status-message]
+   ;; @collection-status-atom is a lazy seq so force into []
+   (let [coll-statuses (into [] @collection-status-atom)
+         index (first (keep-indexed #(when (and (= concept-id (:concept-id %2))
+                                                (= task-id (:task-id %2)))
+                                       %1)
+                                    coll-statuses))]
+     (swap! (:collection-status-atom this) (fn [coll-statuses]
+                                             (-> (into [] coll-statuses)
+                                                 (assoc-in [index :status] status)
+                                                 (assoc-in [index :status-message] status-message))))
+     (let [coll-statuses (into [] @collection-status-atom) ; Need to refresh after change
+           task-collections (filter #(= task-id (:task-id %)) coll-statuses)
+           pending-collections (filter #(= "PENDING" (:status %)) task-collections)
+           failed-collections (filter #(= "FAILED" (:status %)) task-collections)
+           skipped-collections (filter #(= "SKIPPED" (:status %)) task-collections)]
+       (when-not (seq pending-collections)
+         (let [task-statuses @task-status-atom
+               index (first (keep-indexed #(when (= task-id (:task-id %2))
+                                             %1)
+                                          task-statuses))]
+           (swap! (:task-status-atom this) (fn [task-statuses]
                                              (-> task-statuses
                                                  (assoc-in [index :status] "COMPLETE")
                                                  (assoc-in [index :status-message]
-                                                   (data-bulk-update/generate-task-status-message
-                                                     (count failed-collections)
-                                                     (count skipped-collections)
-                                                     (count task-collections)))))))))))
+                                                           (data-bulk-update/generate-task-status-message
+                                                            (count failed-collections)
+                                                            (count skipped-collections)
+                                                            (count task-collections)))))))))))
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  granule-data-bulk-update/BulkUpdateStore
-  
+  granule-data-bulk-update/GranBulkUpdateStore
+
   (get-provider-bulk-granule-update-status
-    [this provider-id]
-    (some->> @granule-task-status-atom
-             (filter #(= provider-id (:provider-id %)))
-             (map #(select-keys % [:created-at :name :task-id :status :status-message :instruction]))))
+   [this provider-id]
+   (some->> @granule-task-status-atom
+            (filter #(= provider-id (:provider-id %)))
+            (map #(select-keys % [:created-at :name :task-id :status :status-message :instruction]))))
 
   (get-bulk-granule-update-task-status
-    [this task-id provider-id]
-    (let [task-status (some->> @task-status-atom
-                               (some #(when (and (= provider-id (str (:provider-id %)))
-                                                 (= task-id (str (:task-id %))))
-                                            %)))]
-      (select-keys task-status [:created-at :name :status :status-message :instruction])))
+   [this task-id provider-id]
+   (let [task-status (some->> @granule-task-status-atom
+                              (some #(when (and (= provider-id (str (:provider-id %)))
+                                                (= task-id (str (:task-id %))))
+                                       %)))]
+     (select-keys task-status [:created-at :name :status :status-message :instruction])))
 
   (get-bulk-update-task-granule-status
-    [this task-id]
-    (some->> @granule-status-atom
-             (into [])
-             (filter #(= (str task-id) (str (:task-id %))))
-             (map #(select-keys % [:concept-id :status :status-message]))))
+   [this task-id]
+   (some->> @granule-status-atom
+            (into [])
+            (filter #(= (str task-id) (str (:task-id %))))
+            (map #(select-keys % [:granule-ur :status :status-message]))))
 
   (get-bulk-update-granule-status
-    [this task-id granule-ur]
-    (let [gran-status (some->> @granule-status-atom
-                               (some #(when (and (= granule-ur (:granule-ur %))
-                                                 (= (str task-id) (:task-id %)))
-                                            %)))]
-      (select-keys gran-status [:granule-ur :status :status-message])))
+   [this task-id granule-ur]
+   (let [gran-status (some->> @granule-status-atom
+                              (some #(when (and (= granule-ur (:granule-ur %))
+                                                (= (str task-id) (:task-id %)))
+                                       %)))]
+     (select-keys gran-status [:granule-ur :status :status-message])))
 
   (create-and-save-bulk-granule-update-status
-    [this provider-id json-body user-id]
-    (swap! task-id-atom inc)
-    (let [task-id (str @granule-task-id-atom)
-          parsed-json (json/parse-string json-body)
-          instruction (get parsed-json "operation")
-          task-name (get parsed-json "name" task-id)
-          unique-task-name (format "%s: %s" task-name task-id)
-          granule-urs (as-> parsed-json json
-                            (get json "updates")
-                            (map first json))]
+   [this provider-id user-id request-json-body instructions]
+   (swap! granule-task-id-atom inc)
+   (let [task-id (str @granule-task-id-atom)
+         parsed-json (json/parse-string request-json-body true)
+         task-name (get parsed-json :name task-id)
+         unique-task-name (format "%s: %s" task-name task-id)]
      ;; provider-id and name together need to be unique.
-     (if (some #(and (= provider-id (:provider-id %))(= task-name (:name %)))
+     (if (some #(and (= provider-id (:provider-id %))(= unique-task-name (:name %)))
                @granule-task-status-atom)
        (throw (Exception. (str "ORA-00001: unique constraint "
-                               "(CMR_INGEST.BULK_UPDATE_TASK_STATUS_UK) "
+                               "(CMR_INGEST.GBUT_PN_I) "
                                "violated\n")))
-       (swap! task-status-atom conj {:created-at (str (time-keeper/now))
-                                     :task-id task-id
-                                     :name unique-task-name
-                                     :provider-id provider-id
-                                     :request-json-body json-body
-                                     :status "IN_PROGRESS"
-                                     :user-id user-id}))
-     (swap! granule-status-atom concat (map (fn [granule-ur]
-                                                {:task-id task-id
-                                                 :granule-ur granule-ur
-                                                 :provider-id provider-id
-                                                 :instruction instruction
-                                                 :status "PENDING"}
-                                               granule-urs)))
+       (swap! granule-task-status-atom conj {:created-at (str (time-keeper/now))
+                                             :task-id task-id
+                                             :name unique-task-name
+                                             :provider-id provider-id
+                                             :request-json-body request-json-body
+                                             :status "IN_PROGRESS"
+                                             :user-id user-id}))
+     (swap! granule-status-atom concat (map (fn [instruction]
+                                              {:task-id task-id
+                                               :granule-ur (:granule-ur instruction)
+                                               :provider-id provider-id
+                                               :instruction (json/generate-string instruction)
+                                               :status "PENDING"})
+                                            instructions))
      task-id))
 
   (update-bulk-granule-update-task-status
-    [this task-id status status-message]
-    (let [task-statuses @granule-task-status-atom
-          index (first (keep-indexed #(when (= task-id (:task-id %2))
-                                         %1)
-                                     task-statuses))]
-      (swap! (:task-status-atom this) (fn [task-statuses]
-                                       (-> task-statuses
-                                           (assoc-in [index :status] status)
-                                           (assoc-in [index :status-message] status-message))))))
+   [this task-id status status-message]
+   (let [task-statuses @granule-task-status-atom
+         index (first (keep-indexed #(when (= task-id (:task-id %2))
+                                       %1)
+                                    task-statuses))]
+     (swap! (:granule-task-status-atom this) (fn [task-statuses]
+                                               (-> task-statuses
+                                                   (assoc-in [index :status] status)
+                                                   (assoc-in [index :status-message] status-message))))))
 
 
   (update-bulk-update-granule-status
-    [this task-id concept-id status status-message]
-    ;; @granule-status-atom is a lazy seq so force into []
-    (let [gran-statuses (into [] @granule-status-atom)
-          index (first (keep-indexed #(when (and (= concept-id (:concept-id %2))
-                                                 (= task-id (:task-id %2)))
-                                         %1)
-                                     gran-statuses))]
-      (swap! (:granule-status-atom this) (fn [gran-statuses]
-                                            (-> (into [] gran-statuses)
-                                                (assoc-in [index :status] status)
-                                                (assoc-in [index :status-message] status-message))))
-      (let [gran-statuses (into [] @granule-status-atom) ; Need to refresh after change
-            task-granules (filter #(= task-id (:task-id %)) gran-statuses)
-            pending-granules (filter #(= "PENDING" (:status %)) task-granules)
-            failed-granules (filter #(= "FAILED" (:status %)) task-granules)
-            skipped-granules (filter #(= "SKIPPED" (:status %)) task-granules)]
-        (when-not (seq pending-granules)
-          (let [task-statuses @granule-task-status-atom
-                index (first (keep-indexed #(when (= task-id (:task-id %2))
-                                               %1)
-                                           task-statuses))]
-            (swap! (:task-status-atom this) (fn [task-statuses]
-                                             (-> task-statuses
-                                                 (assoc-in [index :status] "COMPLETE")
-                                                 (assoc-in [index :status-message]
-                                                   (granule-data-bulk-update/generate-task-status-message
-                                                     (count failed-granules)
-                                                     (count skipped-granules)
-                                                     (count task-granules)))))))))))
+   [this task-id granule-ur status status-message]
+   ;; @granule-status-atom is a lazy seq so force into []
+   (let [gran-statuses (into [] @granule-status-atom)
+         index (first (keep-indexed #(when (and (= granule-ur (:granule-ur %2))
+                                                (= task-id (:task-id %2)))
+                                       %1)
+                                    gran-statuses))]
+     (swap! (:granule-status-atom this) (fn [gran-statuses]
+                                          (-> (into [] gran-statuses)
+                                              (assoc-in [index :status] status)
+                                              (assoc-in [index :status-message] status-message))))
+     (let [gran-statuses (into [] @granule-status-atom) ; Need to refresh after change
+           task-granules (filter #(= task-id (:task-id %)) gran-statuses)
+           pending-granules (filter #(= "PENDING" (:status %)) task-granules)
+           failed-granules (filter #(= "FAILED" (:status %)) task-granules)
+           skipped-granules (filter #(= "SKIPPED" (:status %)) task-granules)]
+       (when-not (seq pending-granules)
+         (let [task-statuses @granule-task-status-atom
+               index (first (keep-indexed #(when (= task-id (:task-id %2))
+                                             %1)
+                                          task-statuses))]
+           (swap! (:granule-task-status-atom this) (fn [task-statuses]
+                                                     (-> task-statuses
+                                                         (assoc-in [index :status] "COMPLETE")
+                                                         (assoc-in [index :status-message]
+                                                                   (granule-data-bulk-update/generate-task-status-message
+                                                                    (count failed-granules)
+                                                                    (count skipped-granules)
+                                                                    (count task-granules)))))))))))
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   (reset-bulk-update
-    [this]
-    (reset! task-status-atom [])
-    (reset! collection-status-atom [])
-    (reset! task-id-atom 0)
-    (reset! granule-task-status-atom [])
-    (reset! granule-status-atom [])
-    (reset! granule-task-id-atom 0))
+   [this]
+   (reset! task-status-atom [])
+   (reset! collection-status-atom [])
+   (reset! task-id-atom 0))
+
+  (reset-bulk-granule-update
+   [this]
+   (reset! granule-task-status-atom [])
+   (reset! granule-status-atom [])
+   (reset! granule-task-id-atom 0))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   lifecycle/Lifecycle
 
   (start
-    [this system]
-    this)
+   [this system]
+   this)
   (stop
-    [this system]
-    this))
+   [this system]
+   this))
 
 (defn create-db
   []

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -29,6 +29,15 @@
    (:bulk-update-params msg)
    (:user-id msg)))
 
+(defmethod handle-provider-event :granules-bulk
+  [context message]
+  (granule-bulk-update-service/handle-granules-bulk-event
+   context
+   (:provider-id message)
+   (:task-id message)
+   (:bulk-update-params message)
+   (:user-id message)))
+
 (defmethod handle-provider-event :granule-bulk-update
   [context message]
   (granule-bulk-update-service/handle-granule-bulk-update-event

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/echo10.clj
@@ -1,5 +1,5 @@
 (ns cmr.ingest.services.granule-bulk-update.echo10
-  "Contains functions to update ECHO10 granule xml for bulk update."
+  "Contains functions to update ECHO10 granule xml for OPeNDAP url bulk update."
   (:require
    [clojure.data.xml :as xml]
    [clojure.data.zip.xml :as zx]

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/echo10.clj
@@ -1,0 +1,129 @@
+(ns cmr.ingest.services.granule-bulk-update.echo10
+  "Contains functions to update ECHO10 granule xml for bulk update."
+  (:require
+   [clojure.zip :as zip]
+   [clojure.data.zip.xml :as zx]
+   [clojure.data.xml :as xml]
+   [cmr.common.xml :as cx]))
+
+(def OPENDAP_RESOURCE_TYPE
+  "OnlineResource Type of OPenDAP url in ECHO10 granule schema"
+  "GET DATA : OPENDAP DATA")
+
+(def tags-after
+  "Defines the element tags that come after OnlinResources in ECHO10 Granule xml schema"
+  #{:Orderable :DataFormat :Visible :CloudCover :MetadataStandardName :MetadataStandardVersion
+    :AssociatedBrowseImages :AssociatedBrowseImageUrls})
+
+(defn xml-elem->online-resource-url
+  [elem]
+  (let [url (cx/string-at-path elem [:URL])
+        description (cx/string-at-path elem [:Description])
+        resource-type (cx/string-at-path elem [:Type])
+        mime-type (cx/string-at-path elem [:MimeType])]
+    {:url url
+      :description description
+      :type resource-type
+      :mime-type mime-type}))
+
+(defn- xml-elem->online-resources
+  "Returns online-resource-urls elements from a parsed XML structure"
+  [xml-struct]
+  (let [urls (map xml-elem->online-resource-url
+                  (cx/elements-at-path
+                    xml-struct
+                    [:OnlineResources :OnlineResource]))]
+    (when (seq urls)
+      urls)))
+
+(defn- validate-online-resources
+  "Returns error if there are more than one online resources with type OPENDAP_RESOURCE_TYPE"
+  [resources]
+  (let [opendap-resources (filter #(= OPENDAP_RESOURCE_TYPE (:type %)) resources)
+        opendap-count (count opendap-resources)]
+    (when (> opendap-count 1)
+      {:errors [(format "There can be no more than one OPeNDAP resource URL in the metadata, but there are %d."
+                      opendap-count)]})))
+
+
+(defn- update-opendap-resource
+  "Returns the online resource with URL set to the given value if its type is OPENDAP_RESOURCE_TYPE"
+  [online-resource url]
+  (if (= OPENDAP_RESOURCE_TYPE (:type online-resource))
+    (assoc online-resource :url url)
+    online-resource))
+
+(defn- updated-online-resources
+  "Take the parsed online resources in the original metadata, update the existing opendap url
+   with the given value or add an opendap resource if there is none. "
+  [online-resources url]
+  (let [updated (map #(update-opendap-resource % url) online-resources)]
+    (if (some #(= OPENDAP_RESOURCE_TYPE (:type %)) updated)
+      updated
+      (conj updated {:url url :type OPENDAP_RESOURCE_TYPE}))))
+
+(defn- updated-zipper-resources
+  "Take the parsed online resources in the original metadata and the desired OPeNDAP url,
+   returns the updated online resources xml element that can be used by zipper to update the xml. "
+  [online-resources url]
+  (let [resources (updated-online-resources online-resources url)]
+    (xml/element
+     :OnlineResources {}
+     (for [r resources]
+       (let [{:keys [url description type mime-type]} r]
+         (xml/element :OnlineResource {}
+                    (xml/element :URL {} url)
+                    (when description (xml/element :Description {} description))
+                    (xml/element :Type {} type)
+                    (when mime-type (xml/element :MimeType {} mime-type))))))))
+
+(defn- url->online-resource-elem
+  "Returns the OnlineResource xml element for the given url"
+  [url]
+  (xml/element :OnlineResource {}
+              (xml/element :URL {} url)
+              (xml/element :Type {} OPENDAP_RESOURCE_TYPE)))
+
+(defn- add-online-resources
+  "Takes in a zipper location, call the given insert function and url value to add OnlineResources"
+  [loc insert-fn url]
+  (insert-fn loc
+             (xml/element :OnlineResources {} (url->online-resource-elem url))))
+
+(defn- add-opendap-url*
+  "Take a parsed granule xml, add an OnlineResources node with the given OPeNDAP url.
+   Returns the zipper representation of the updated xml."
+  [parsed online-resources url]
+  (let [zipper (zip/xml-zip parsed)
+        start-loc (-> zipper zip/down)]
+    (loop [loc start-loc done false]
+      (if done
+        (zip/root loc)
+        (let [right-loc (zip/right loc)]
+          (cond
+            ;; at the end of the file, add to the right
+            (nil? right-loc)
+            (recur (add-online-resources loc zip/insert-right url) true)
+
+            ;; at an OnlineResources element, replace the node with updated value
+            (= :OnlineResources (-> right-loc zip/node :tag))
+            (recur (zip/replace right-loc (updated-zipper-resources online-resources url)) true)
+
+            ;; at an element after OnlineResources, add to the left
+            (some tags-after [(-> right-loc zip/node :tag)])
+            (recur (add-online-resources right-loc zip/insert-left url) true)
+
+            ;; no action needs to be taken, move to the next node
+            :else
+            (recur right-loc false)))))))
+
+(defn add-opendap-url
+  "Takes the granule ECHO10 xml and an OPeNDAP url and returns the updated xml
+   with an OnlineResources element added for the OPeNDAP url.
+   Returns error in the format of {:error error-message} if there are any validation errors."
+  [gran-xml value]
+  (let [parsed (xml/parse-str gran-xml)
+        online-resources (xml-elem->online-resources parsed)]
+    (if-let [errors (validate-online-resources online-resources)]
+      errors
+      (xml/indent-str (add-opendap-url* parsed online-resources value)))))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -19,7 +19,7 @@
  (js/json-string->json-schema (slurp (io/resource "granule_bulk_update_schema.json"))))
 
 (defn- validate-granule-bulk-update
- [_ json]
+ [json]
  (js/validate-json! granule-bulk-update-schema json))
 
 (defn- update->instruction
@@ -42,7 +42,7 @@
   and granule statuses, and queue bulk granule update. Return task id, which comes
   from the db save."
   [context provider-id json-body user-id]
-  (validate-granule-bulk-update context json-body)
+  (validate-granule-bulk-update json-body)
   (let [instructions (-> json-body
                          (json/parse-string true)
                          request->instructions)

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -1,79 +1,159 @@
 (ns cmr.ingest.services.granule-bulk-update-service
   (:require
-   [camel-snake-kebab.core :as csk]
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [cmr.common-app.config :as common-config]
-   [cmr.common.concepts :as concepts]
+   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.validations.json-schema :as js]
    [cmr.ingest.data.granule-bulk-update :as data-granule-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
-   [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.ingest.services.bulk-update-service :as bulk-update-service]
+   [cmr.ingest.services.granule-bulk-update.echo10 :as echo10]
    [cmr.ingest.services.ingest-service :as ingest-service]
-   [cmr.transmit.metadata-db :as mdb]
-   [cmr.transmit.metadata-db2 :as mdb2]
-   [cmr.umm-spec.field-update :as field-update]))
+   [cmr.transmit.metadata-db :as mdb]))
 
-(def bulk-granule-update-schema
+(def granule-bulk-update-schema
  (js/json-string->json-schema (slurp (io/resource "granule_bulk_update_schema.json"))))
 
-(defmethod bulk-update-service/validate-bulk-update-post-params :granule
+(defn- validate-granule-bulk-update
  [_ json]
- (js/validate-json! bulk-granule-update-schema json))
+ (js/validate-json! granule-bulk-update-schema json))
 
-(defn handle-bulk-update-event
-  "For each granule-ur, queue bulk update messages"
-  [context provider-id task-id bulk-update-params]
-  (let [{:keys [updates operation update-field]} bulk-update-params]
-    (doseq [update updates]
-      (let [granule-ur (first update)
-            update-value (second update)
-            event-type (str operation ":" update-field)]
-       (ingest-events/publish-gran-bulk-update-event
-        context
-        (ingest-events/ingest-granule-bulk-update-event
-         provider-id
-         task-id
-         event-type
-         granule-ur
-         update-value))))))
+(defn- update->instruction
+  "Returns the granule bulk update instruction for a single update item"
+  [event-type item]
+  (let [[granule-ur url] item]
+    {:event-type event-type
+     :granule-ur granule-ur
+     :url url}))
+
+(defn- request->instructions
+  "Returns granule bulk update instructions for the given request"
+  [parsed-json]
+  (let [{:keys [operation update-field updates]} parsed-json
+        event-type (str operation ":" update-field)]
+    (map (partial update->instruction event-type) updates)))
 
 (defn validate-and-save-bulk-granule-update
- "Validate the bulk update POST parameters, save rows to the db for task
+ "Validate the granule bulk update request, save rows to the db for task
  and granule statuses, and queue bulk granule update. Return task id, which comes
  from the db save."
- [context provider-id json user-id]
- (bulk-update-service/validate-bulk-update-post-params :granule json)
- (let [bulk-update-params (json/parse-string json true)
-       task-id (try
-                 (data-granule-bulk-update/create-bulk-update-task
-                  context
-                  provider-id
-                  user-id
-                  json)
-                 (catch Exception e
-                   (let [message (.getMessage e)
-                         user-facing-message (if (string/includes? message "BULK_UPDATE_TASK_STATUS_UK")
-                                               "Bulk update task name needs to be unique within the provider."
-                                               message)]
-                     (errors/throw-service-errors
-                      :invalid-data
-                      [(str "error creating bulk update task: " user-facing-message)]))))]
-   ;; Queue the bulk update event
-   (handle-bulk-update-event context provider-id task-id bulk-update-params)
-   task-id))
+ [context provider-id json-body user-id]
+ (validate-granule-bulk-update context json-body)
+  (let [instructions (-> json-body
+                         (json/parse-string true)
+                         request->instructions)
+        task-id (try
+                  (data-granule-bulk-update/create-granule-bulk-update-task
+                   context
+                   provider-id
+                   user-id
+                   json-body
+                   instructions)
+                  (catch Exception e
+                    (let [message (.getMessage e)
+                          user-facing-message (if (string/includes? message "GBUT_PN_I")
+                                                "Granule bulk update task name needs to be unique within the provider."
+                                                message)]
+                      (errors/throw-service-errors
+                       :invalid-data
+                       [(str "error creating granule bulk update task: " user-facing-message)]))))]
+    ;; Queue the granules bulk update event
+    (ingest-events/publish-gran-bulk-update-event
+     context
+     (ingest-events/granules-bulk-event provider-id task-id user-id instructions))
+    task-id))
+
+(defn handle-granules-bulk-event
+  "For each granule-ur, queueu granule bulk update messages"
+  [context provider-id task-id bulk-update-params user-id]
+  (doseq [instruction bulk-update-params]
+    (ingest-events/publish-gran-bulk-update-event
+     context
+     (ingest-events/ingest-granule-bulk-update-event provider-id task-id user-id instruction))))
+
+(defmulti add-opendap-url
+  "Add OPeNDAP url to the given granule concept."
+  (fn [context concept url]
+    (mt/format-key (:format concept))))
+
+(defmethod add-opendap-url :echo10
+  [context concept url]
+  (echo10/add-opendap-url (:metadata concept) url))
+
+(defmethod add-opendap-url :default
+  [context concept url]
+  (errors/throw-service-errors
+   :invalid-data (format "Add OPeNDAP url is not supported for format [%s]" (:format concept))))
+
+(defmulti update-granule-concept
+  "Perform the update of the granule concept."
+  (fn [context concept bulk-update-params user-id]
+    (keyword (:event-type bulk-update-params))))
+
+(defmethod update-granule-concept :UPDATE_FIELD:OPeNDAPLink
+  [context concept bulk-update-params user-id]
+  (let [{:keys [format metadata]} concept
+        {:keys [granule-ur url]} bulk-update-params
+        updated-metadata (add-opendap-url context concept url)]
+    (if-let [err-messages (:errors updated-metadata)]
+      (errors/throw-service-errors :invalid-data err-messages)
+      (-> concept
+          (assoc :metadata updated-metadata)
+          (update :revision-id inc)
+          (assoc :revision-date (time-keeper/now))
+          (assoc :user-id user-id)))))
+
+(defmethod update-granule-concept :default
+[context concept bulk-update-params user-id]
+)
+
+(defn- update-granule-concept-and-status
+  "Perform update for the granule concept and granule bulk update status."
+  [context task-id concept granule-ur bulk-update-params user-id]
+  (if-let [updated-concept (update-granule-concept context concept bulk-update-params user-id)]
+    (do
+      (ingest-service/save-granule context updated-concept)
+      (data-granule-bulk-update/update-bulk-update-task-granule-status
+       context task-id granule-ur bulk-update-service/updated-status ""))
+    (data-granule-bulk-update/update-bulk-update-task-granule-status
+     context task-id granule-ur bulk-update-service/skipped-status
+     (format "Granule with granule-ur [%s] is not updated because the metadata format [%s] is not supported."
+             granule-ur (:format concept)))))
 
 (defn handle-granule-bulk-update-event
-  "Skeleton handler function"
   [context provider-id task-id bulk-update-params user-id]
   (let [{:keys [granule-ur]} bulk-update-params]
-    (data-granule-bulk-update/update-bulk-update-granule-status
-     context
-     task-id
-     granule-ur
-     bulk-update-service/failed-status
-     (format "Granule-ur [%s] is not associated with provider-id [%s]." granule-ur provider-id))))
+    (try
+      (if-let [concept (mdb/find-latest-concept
+                        context {:provider-id provider-id :granule-ur granule-ur} :granule)]
+        (if (:deleted concept)
+          (data-granule-bulk-update/update-bulk-update-task-granule-status
+           context task-id granule-ur bulk-update-service/failed-status
+           (format "Granule with granule-ur [%s] on provider [%s] is deleted. Can not be updated."
+                   granule-ur provider-id))
+          ;; granule found and not deleted, update the granule
+          (update-granule-concept-and-status
+           context task-id concept granule-ur bulk-update-params user-id))
+        ;; granule not found
+        (data-granule-bulk-update/update-bulk-update-task-granule-status
+         context task-id granule-ur bulk-update-service/failed-status
+         (format "Granule UR [%s] does not exist." granule-ur)))
+      (catch clojure.lang.ExceptionInfo ex-info
+        (error "handle-granule-bulk-update-event caught ExceptionInfo:" ex-info)
+        (if (= :conflict (:type (.getData ex-info)))
+          ;; Concurrent update - re-queue concept update
+          (ingest-events/publish-ingest-event
+           context
+           (ingest-events/ingest-granule-bulk-update-event
+            provider-id task-id user-id bulk-update-params))
+          (data-granule-bulk-update/update-bulk-update-task-granule-status
+           context task-id granule-ur bulk-update-service/failed-status (.getMessage ex-info))))
+      (catch Exception e
+        (error "handle-granule-bulk-update-event caught exception:" e)
+        (let [message (or (.getMessage e) bulk-update-service/default-exception-message)]
+          (data-granule-bulk-update/update-bulk-update-task-granule-status
+           context task-id granule-ur bulk-update-service/failed-status message))))))

--- a/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
@@ -8,6 +8,7 @@
    [cmr.common.util :as util :refer [defn-timed]]
    [cmr.ingest.config :as config]
    [cmr.ingest.data.bulk-update :as bulk-update]
+   [cmr.ingest.data.granule-bulk-update :as granule-bulk-update]
    [cmr.ingest.data.provider-acl-hash :as pah]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
    [cmr.oracle.connection :as conn]
@@ -32,6 +33,7 @@
   (let [queue-broker (get-in context [:system :queue-broker])]
     (queue-protocol/reset queue-broker))
   (bulk-update/reset-db context)
+  (granule-bulk-update/reset-db context)
   (cache/reset-caches context))
 
 (def health-check-fns

--- a/ingest-app/test/cmr/ingest/services/bulk_update_service_test.clj
+++ b/ingest-app/test/cmr/ingest/services/bulk_update_service_test.clj
@@ -9,7 +9,7 @@
 (def sample-message
   {:name "add opendap links"
    :operation :UPDATE_FIELD
-   :update-field "OPEnDAPLink"
+   :update-field "OPeNDAPLink"
    :updates [["SC:AE_5DSno.002:30500511" "url1234"]
              ["SC:AE_5DSno.002:30500512" "url3456"]
              ["SC:AE_5DSno.002:30500513" "url5678"]]})
@@ -23,7 +23,7 @@
                    clojure.lang.ExceptionInfo
                    #"required key"
                    (schema-validation/validate-json!
-                    granule-bulk-update/bulk-granule-update-schema
+                    granule-bulk-update/granule-bulk-update-schema
                     invalid-json))))
             "Missing :operation" :operation
             "Missing :update-field" :update-field

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/echo10_test.clj
@@ -1,0 +1,211 @@
+(ns cmr.ingest.services.granule-bulk-update.echo10-test
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.ingest.services.granule-bulk-update.echo10 :as echo10]))
+
+(def ^:private add-at-the-end-gran-xml
+  "ECHO10 granule for testing adding OPeNDAP url at the end of the xml."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+  </Granule>")
+
+(def ^:private add-at-the-end-gran-xml-result
+  "Result ECHO10 granule after adding OPeNDAP url at the end of the xml.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://example.com/foo</URL>
+         <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+   </OnlineResources>
+</Granule>\n")
+
+(def ^:private add-before-element-gran-xml
+  "ECHO10 granule for testing adding OPeNDAP url at before an element that comes after
+   the OnlineResources in the xml."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private add-before-element-gran-xml-result
+  "Result ECHO10 granule after adding OPeNDAP url before an element in the xml.
+  Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://example.com/foo</URL>
+         <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+   </OnlineResources>
+   <Orderable>false</Orderable>
+</Granule>\n")
+
+(def ^:private add-with-empty-gran-xml
+  "ECHO10 granule for testing adding OPeNDAP url with an empty OnlineResources element in the xml."
+  "<Granule>
+     <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+     <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+     <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+     <Collection>
+        <EntryId>AQUARIUS_L1A_SSS</EntryId>
+     </Collection>
+     <OnlineResources/>
+     <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private add-with-no-match-gran-xml
+  "ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <OnlineResources>
+       <OnlineResource>
+          <URL>http://example.com/doc</URL>
+          <Type>Documentation</Type>
+       </OnlineResource>
+       <OnlineResource>
+          <URL>http://example.com/Browse</URL>
+          <Type>Browse</Type>
+       </OnlineResource>
+    </OnlineResources>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private add-with-no-match-gran-xml-result
+  "ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://example.com/foo</URL>
+         <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/doc</URL>
+         <Type>Documentation</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/Browse</URL>
+         <Type>Browse</Type>
+      </OnlineResource>
+   </OnlineResources>
+   <Orderable>false</Orderable>
+</Granule>\n")
+
+(def ^:private update-opendap-url
+  "ECHO10 granule for testing updating OPeNDAP url at the first element of OnlineResources."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <OnlineResources>
+       <OnlineResource>
+          <URL>http://example.com/doc</URL>
+          <Type>Documentation</Type>
+       </OnlineResource>
+       <OnlineResource>
+          <URL>http://example.com/to_be_updated</URL>
+          <Type>GET DATA : OPENDAP DATA</Type>
+       </OnlineResource>
+       <OnlineResource>
+          <URL>http://example.com/Browse</URL>
+          <Type>Browse</Type>
+       </OnlineResource>
+    </OnlineResources>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private update-opendap-url-result
+  "ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://example.com/doc</URL>
+         <Type>Documentation</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/foo</URL>
+         <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/Browse</URL>
+         <Type>Browse</Type>
+      </OnlineResource>
+   </OnlineResources>
+   <Orderable>false</Orderable>
+</Granule>\n")
+
+(deftest add-opendap-url
+  (testing "add OnlineResources at various places in the xml"
+    (are3 [source result]
+      (is (= result
+             (echo10/add-opendap-url source "http://example.com/foo")))
+
+      "add OnlineResources at the end of the xml"
+      add-at-the-end-gran-xml
+      add-at-the-end-gran-xml-result
+
+      "add OnlineResources before an element in the xml"
+      add-before-element-gran-xml
+      add-before-element-gran-xml-result
+
+      "add OnlineResources to empty OnlineResources in the xml"
+      add-with-empty-gran-xml
+      add-before-element-gran-xml-result
+
+      "add OnlineResources to OnlineResources without OPeNDAP url in the xml"
+      add-with-no-match-gran-xml
+      add-with-no-match-gran-xml-result
+
+      "update OnlineResources when OPeNDAP url is present"
+      update-opendap-url
+      update-opendap-url-result)))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/echo10_test.clj
@@ -103,7 +103,7 @@
   </Granule>")
 
 (def ^:private add-with-no-match-gran-xml-result
-  "ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url.
+  "Result ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url.
    Do not format the following as whitespace matters in the string comparison in the test."
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <Granule>
@@ -131,7 +131,7 @@
 </Granule>\n")
 
 (def ^:private update-opendap-url
-  "ECHO10 granule for testing updating OPeNDAP url at the first element of OnlineResources."
+  "ECHO10 granule for testing updating OPeNDAP url existing in OnlineResources."
   "<Granule>
     <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
     <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
@@ -157,7 +157,7 @@
   </Granule>")
 
 (def ^:private update-opendap-url-result
-  "ECHO10 granule for testing adding OPeNDAP url to OnlineResources that has no OPeNDAP url.
+  "Result ECHO10 granule for testing updating OPeNDAP url existing in OnlineResources.
    Do not format the following as whitespace matters in the string comparison in the test."
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <Granule>
@@ -175,6 +175,61 @@
       <OnlineResource>
          <URL>http://example.com/foo</URL>
          <Type>GET DATA : OPENDAP DATA</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/Browse</URL>
+         <Type>Browse</Type>
+      </OnlineResource>
+   </OnlineResources>
+   <Orderable>false</Orderable>
+</Granule>\n")
+
+(def ^:private update-opendap-url-preserve-type
+  "ECHO10 granule for testing updating OPeNDAP url in OnlineResources, and it preserves the
+  existing resource type that is used."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <OnlineResources>
+       <OnlineResource>
+          <URL>http://example.com/doc</URL>
+          <Type>Documentation</Type>
+       </OnlineResource>
+       <OnlineResource>
+          <URL>http://example.com/to_be_updated</URL>
+          <Type>GET DATA : OPENDAP DATA (DODS)</Type>
+       </OnlineResource>
+       <OnlineResource>
+          <URL>http://example.com/Browse</URL>
+          <Type>Browse</Type>
+       </OnlineResource>
+    </OnlineResources>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private update-opendap-url-preserve-type-result
+  "Result ECHO10 granule for testing updating OPeNDAP url in OnlineResources and preserve the type.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineResources>
+      <OnlineResource>
+         <URL>http://example.com/doc</URL>
+         <Type>Documentation</Type>
+      </OnlineResource>
+      <OnlineResource>
+         <URL>http://example.com/foo</URL>
+         <Type>GET DATA : OPENDAP DATA (DODS)</Type>
       </OnlineResource>
       <OnlineResource>
          <URL>http://example.com/Browse</URL>
@@ -208,4 +263,8 @@
 
       "update OnlineResources when OPeNDAP url is present"
       update-opendap-url
-      update-opendap-url-result)))
+      update-opendap-url-result
+
+      "update OnlineResources when OPeNDAP url is present and preserves the existing type"
+      update-opendap-url-preserve-type
+      update-opendap-url-preserve-type-result)))

--- a/oracle-lib/src/cmr/oracle/sql_utils.clj
+++ b/oracle-lib/src/cmr/oracle/sql_utils.clj
@@ -49,6 +49,11 @@
   [stmt]
   (s/sql stmt))
 
+(defn run-sql
+  "Run the given sql statement in string. Only intended for internal use."
+  [db statement]
+  (j/db-do-prepared db statement []))
+
 (defn query
   "Execute a query and log how long it took."
   [db stmt-and-params]

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -1,6 +1,7 @@
 (ns cmr.system-int-test.ingest.granule-bulk-update.granule-bulk-update-test
   "CMR bulk update. Test the actual update "
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer :all]
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.data2.core :as data-core]
@@ -9,53 +10,98 @@
    [cmr.system-int-test.system :as system]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
    [cmr.system-int-test.utils.search-util :as search]))
 
-(use-fixtures :each (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"})
-                       (search/freeze-resume-time-fixture)]))
-
-(defn- grant-permissions-create-token
- "Test setup to create read/update ingest permissions for bulk update and
- return a token. Bulk update uses update permissions for the actual bulk update
- and read permissions for checking status."
- []
- (let [prov-admin-read-update-group-concept-id (echo-util/get-or-create-group (system/context) "prov-admin-read-update-group")]
-   (echo-util/grant-group-provider-admin (system/context) prov-admin-read-update-group-concept-id "PROV1" :read :update)
-   ;; Create and return token
-   (echo-util/login (system/context) "prov-admin-read-update" [prov-admin-read-update-group-concept-id])))
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
 (deftest bulk-granule-update-test
- (testing "valid request is accepted"
-   (let [token (grant-permissions-create-token)
-         coll1 (data-core/ingest-umm-spec-collection
-                "PROV1" (data-umm-c/collection {:EntryTitle "coll1"
-                                                :ShortName "short1"
-                                                :Version "V1"
-                                                :native-id "native1"}))
-         gran1 (ingest/ingest-concept
-                (data-core/item->concept
-                 (granule/granule-with-umm-spec-collection
-                  coll1
-                  (:concept-id coll1)
-                  {:native-id "gran-native1-1"
-                   :granule-ur "SC:AE_5DSno.002:30500512"})))
-         gran2 (ingest/ingest-concept
-                (data-core/item->concept
-                 (granule/granule-with-umm-spec-collection
-                  coll1
-                  (:concept-id coll1)
-                  {:native-id "gran-native1-1"
-                   :granule-ur "SC:AE_5DSno.002:30500511"})))
-         bulk-update {:name "add opendap links"
-                      :operation "UPDATE_FIELD"
-                      :update-field "OPEnDAPLink"
-                      :updates [["SC:AE_5DSno.002:30500511" "url1234"]
-                                ["SC:AE_5DSno.002:30500512" "url3456"]]}
-         response (ingest/bulk-update-granules "PROV1"
-                                               bulk-update
-                                               {:raw? true
-                                                :token token})]
-     (index/wait-until-indexed)
-     (is (= 200 (:status response)))
-     (is (not= nil? (:task-id response))))))
+  (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
+        coll1 (data-core/ingest-umm-spec-collection
+               "PROV1" (data-umm-c/collection {:EntryTitle "coll1"
+                                               :ShortName "short1"
+                                               :Version "V1"
+                                               :native-id "native1"}))
+        gran1 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-1"
+                  :granule-ur "SC:AE_5DSno.002:30500511"})))
+        gran2 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-2"
+                  :granule-ur "SC:AE_5DSno.002:30500512"})))
+        gran3 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-3"
+                  :granule-ur "SC:AE_5DSno.002:30500513"})
+                :umm-json))]
+    (testing "successful granule bulk update"
+      (let [bulk-update {:name "add opendap links"
+                         :operation "UPDATE_FIELD"
+                         :update-field "OPeNDAPLink"
+                         :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
+                                   ["SC:AE_5DSno.002:30500512" "https://url30500512"]]}
+            response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)]
+        (index/wait-until-indexed)
+        (is (= 200 (:status response)))
+        (is (not (nil? (:task-id response))))
+        ;; TODO: detailed status check will be added in CMR-7092
+        ))
+    (testing "partial successful granule bulk update"
+      (let [bulk-update {:name "add opendap links"
+                         :operation "UPDATE_FIELD"
+                         :update-field "OPeNDAPLink"
+                         :updates [["SC:AE_5DSno.002:30500513" "https://url30500513"]]}
+            response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)]
+        (index/wait-until-indexed)
+        (is (= 200 (:status response)))
+        (is (not (nil? (:task-id response))))
+        ;; TODO: detailed status check will be added in CMR-7092
+        ))
+    (testing "failed granule bulk update"
+      (let [bulk-update {:name "add opendap links"
+                         :operation "UPDATE_FIELD"
+                         :update-field "OPeNDAPLink"
+                         :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
+                                   ["SC:AE_5DSno.002:30500512" "https://url30500512"]
+                                   ["SC:AE_5DSno.002:30500513" "https://url30500513"]]}
+            response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)]
+        (index/wait-until-indexed)
+        (is (= 200 (:status response)))
+        (is (not (nil? (:task-id response))))
+        ;; TODO: detailed status check will be added in CMR-7092
+        ))))
+
+(deftest add-opendap-url
+  "test adding OPeNDAP url with real granule file that is already in CMR code base"
+  (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
+        coll (data-core/ingest-concept-with-metadata-file "CMR-4722/OMSO2.003-collection.xml"
+                                                          {:provider-id "PROV1"
+                                                           :concept-type :collection
+                                                           :native-id "OMSO2-collection"
+                                                           :format-key :dif10})
+        granule (data-core/ingest-concept-with-metadata-file "CMR-4722/OMSO2.003-granule.xml"
+                                                             {:provider-id "PROV1"
+                                                              :concept-type :granule
+                                                              :native-id "OMSO2-granule"
+                                                              :format-key :echo10})
+        {:keys [concept-id revision-id]} granule
+        target-metadata (-> "CMR-4722/OMSO2.003-granule-opendap-url.xml" io/resource slurp)
+        bulk-update {:operation "UPDATE_FIELD"
+                     :update-field "OPeNDAPLink"
+                     :updates [["OMSO2.003:OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5"
+                                "http://opendap-url.example.com"]]}
+        {:keys [status] :as response} (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)]
+    (index/wait-until-indexed)
+    (is (= 200 status))
+    (is (= target-metadata
+           (:metadata (mdb/get-concept concept-id (inc revision-id)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -10,8 +10,7 @@
    [cmr.system-int-test.system :as system]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
-   [cmr.system-int-test.utils.metadata-db-util :as mdb]
-   [cmr.system-int-test.utils.search-util :as search]))
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -169,32 +169,13 @@
 
 ;; Verify that the accept header works with returned errors
 (deftest subscription-ingest-with-errors-accept-header-test
-  (testing "json response, with no token"
-    (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
-                                     :metadata "")
-          response (ingest/ingest-concept
-                    concept-no-metadata
-                    {:accept-format :json
-                     :raw? true})
-          {:keys [errors]} (ingest/parse-ingest-body :json response)]
-      (is (re-find #"You do not have permission to perform that action." (first errors)))))
-  (testing "xml response, with no token"
-    (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
-                                     :metadata "")
-          response (ingest/ingest-concept
-                    concept-no-metadata
-                    {:accept-format :xml
-                     :raw? true})
-          {:keys [errors]} (ingest/parse-ingest-body :xml response)]
-      (is (re-find #"You do not have permission to perform that action." (first errors)))))
   (testing "json response"
     (let [concept-no-metadata (assoc (subscription-util/make-subscription-concept)
                                      :metadata "")
           response (ingest/ingest-concept
                     concept-no-metadata
                     {:accept-format :json
-                     :raw? true
-                     :token "mock-echo-system-token"})
+                     :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :json response)]
       (is (re-find #"required key \[Name\] not found" (first errors)))))
   (testing "xml response"
@@ -203,8 +184,7 @@
           response (ingest/ingest-concept
                     concept-no-metadata
                     {:accept-format :xml
-                     :raw? true
-                     :token "mock-echo-system-token"})
+                     :raw? true})
           {:keys [errors]} (ingest/parse-ingest-body :xml response)]
       (is (re-find #"required key \[Name\] not found" (first errors))))))
 


### PR DESCRIPTION
This PR integrated the existing granule bulk update API to queuing to actually process the ECHO10 granule metadata to add OPeNDAP url and update the granule bulk update status and overall task status. The integration tests does not have the verification of the granule bulk update status and overall task status part as that will be covered in ticket CMR-7092.

It also fixed the current broken master build that caused by a recent merge for subscription.