### PR TITLE
CMR-6931: Moved schema changes to v1.1 instead of altering 1.0 directly

### DIFF
--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -43,7 +43,7 @@
 (defconfig subscription-umm-version
   "Defines the latest subscription umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"
-  {:default "1.0"})
+  {:default "1.1"})
 
 (defn ingest-accept-umm-version
   "Returns the latest umm version accepted by ingest for the given concept-type."

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
@@ -26,20 +26,18 @@
       "description": "The collection concept id of the granules subscribed.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 255 
+      "maxLength": 255
     },
     "Query": {
       "description": "The search query for the granules that matches the subscription.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 40000 
+      "maxLength": 40000
     }
   },
   "required": [
     "Name",
-    "SubscriberId",
-    "EmailAddress",
     "CollectionConceptId",
-    "Query" 
+    "Query"
   ]
 }

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-search-results-json-schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-sub-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["subscription"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "type": "string",
+          "minLength": 4,
+          "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "user-id": {
+          "description": "The id of the user who created this item revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "deleted": {
+          "description": "Indicates if the item represents a tombstone",
+          "type": "boolean"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date"]
+    }
+  },
+  "title": "UMM Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/versioning.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/versioning.clj
@@ -15,7 +15,7 @@
    :variable ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6" "1.7"]
    :service ["1.0" "1.1" "1.2" "1.3" "1.3.1" "1.3.2" "1.3.3" "1.3.4"]
    :tool ["1.0"]
-   :subscription ["1.0"]})
+   :subscription ["1.0" "1.1"]})
 
 (def current-collection-version
   "The current version of the collection UMM schema."


### PR DESCRIPTION
* In my 6931 PR, the UMM-Sub v1.0 PR was edited directly. This was a mistake. Instead, should have created a v1.1 - this ticket does just that.