### PR TITLE
CMR-7092, CMR-7210

### DIFF
--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -167,8 +167,8 @@
       (srvc-errors/throw-service-error
        :bad-request "Granule bulk update task status is only supported in JSON format."))))
 
-(defn get-provider-task-status
-  "Get the status for the given task for the provider including collection statuses"
+(defn get-collection-task-status
+  "Get the status for the given task including collection statuses"
   [provider-id task-id request]
   (let [{:keys [headers request-context]} request]
     (api-core/verify-provider-exists request-context provider-id)
@@ -189,7 +189,7 @@
         :collection-statuses collection-statuses}))))
 
 (defn get-granule-task-status
-  "Get the status for the given task for the provider including collection statuses"
+  "Get the status for the given task including granule statuses"
   [task-id request]
   (let [{:keys [headers request-context]} request
         _ (validate-granule-bulk-update-result-format headers)

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -192,7 +192,7 @@
            (bulk/get-provider-tasks :collection provider-id request))
          (GET "/status/:task-id"
            [task-id :as request]
-           (bulk/get-provider-task-status provider-id task-id request)))
+           (bulk/get-collection-task-status provider-id task-id request)))
        (context "/bulk-update/granules" []
          (POST "/"
            request

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -182,7 +182,7 @@
             provider-id request))
          (GET "/status" ; Gets all tasks for provider
            request
-           (bulk/get-provider-tasks provider-id request))
+           (bulk/get-provider-tasks :collection provider-id request))
          (GET "/status/:task-id"
            [task-id :as request]
            (bulk/get-provider-task-status provider-id task-id request)))
@@ -193,10 +193,7 @@
             provider-id request))
          (GET "/status" ; Gets all tasks for provider
            request
-           (bulk/get-provider-tasks provider-id request))
-         (GET "/status/:task-id"
-           [task-id :as request]
-           (bulk/get-provider-task-status provider-id task-id request)))))))
+           (bulk/get-provider-tasks :granule provider-id request)))))))
 
 (defn build-routes [system]
   (routes

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -93,6 +93,13 @@
            request
            (variables/ingest-variable
              nil native-id request coll-concept-id nil)))))
+    ;; granule bulk update status route
+    (api-core/set-default-error-format
+     :json
+     (context "/granule-bulk-update/status/:task-id" [task-id]
+       (GET "/"
+         request
+         (bulk/get-granule-task-status task-id request))))
     ;; Provider ingest routes
     (api-core/set-default-error-format
      :xml

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -186,7 +186,7 @@
   [context]
   (get-in context [:system :db]))
 
-(defn-timed get-bulk-update-statuses-for-provider
+(defn-timed get-collection-tasks
   "Returns bulk update statuses with task ids by provider"
   [context provider-id]
   (get-provider-bulk-update-status (context->db context) provider-id))

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -138,7 +138,8 @@
    [this provider-id]
    (some->> @granule-task-status-atom
             (filter #(= provider-id (:provider-id %)))
-            (map #(select-keys % [:created-at :name :task-id :status :status-message :instruction]))))
+            (map #(select-keys
+                   % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-bulk-granule-update-task-status
    [this task-id provider-id]

--- a/ingest-app/src/cmr/ingest/migrations/012_update_index_bulk_update_gran_status.clj
+++ b/ingest-app/src/cmr/ingest/migrations/012_update_index_bulk_update_gran_status.clj
@@ -1,0 +1,19 @@
+(ns cmr.ingest.migrations.012-update-index-bulk-update-gran-status
+  (:require
+   [config.ingest-migrate-helper :as h]))
+
+(defn up
+  "Migrates the database up to version 12."
+  []
+  (println "cmr.ingest.migrations.012-update-index-bulk-update-gran-status up...")
+  (h/sql "alter table CMR_INGEST.bulk_update_gran_status drop constraint bugs_pk drop index")
+  (h/sql "alter table CMR_INGEST.bulk_update_gran_status add constraint bugs_pk primary key (TASK_ID, GRANULE_UR)")
+  (h/sql "CREATE INDEX bugs_prov_i ON CMR_INGEST.bulk_update_gran_status(PROVIDER_ID)"))
+
+(defn down
+  "Migrates the database down from version 12."
+  []
+  (println "cmr.ingest.migrations.012-update-index-bulk-update-gran-status down...")
+  (h/sql "alter table CMR_INGEST.bulk_update_gran_status drop constraint bugs_pk drop index")
+  (h/sql "alter table CMR_INGEST.bulk_update_gran_status add constraint bugs_pk primary key (TASK_ID, PROVIDER_ID, GRANULE_UR)")
+  (h/sql "DROP INDEX bugs_prov_i"))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -88,7 +88,7 @@
 (defmethod add-opendap-url :default
   [context concept url]
   (errors/throw-service-errors
-   :invalid-data (format "Add OPeNDAP url is not supported for format [%s]" (:format concept))))
+   :invalid-data [(format "Add OPeNDAP url is not supported for format [%s]" (:format concept))]))
 
 (defmulti update-granule-concept
   "Perform the update of the granule concept."

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -276,6 +276,13 @@
           (transmit-config/ingest-port)
           provider-id))
 
+(defn ingest-granule-bulk-update-status-url
+  "Get the tasks and statuses for collection bulk update by provider"
+  [provider-id]
+  (format "http://localhost:%s/providers/%s/bulk-update/granules/status"
+          (transmit-config/ingest-port)
+          provider-id))
+
 (defn ingest-collection-bulk-update-task-status-url
   "Get the task and collection statuses by provider and task"
   [provider-id task-id]
@@ -284,12 +291,12 @@
           provider-id
           task-id))
 
-(defn ingest-collection-bulk-granule-update-url
-  "Bulk update collections"
-  [provider-id]
-  (format "http://localhost:%s/providers/%s/bulk-update/granules"
+(defn ingest-granule-bulk-update-task-status-url
+  "Get the task and collection statuses by provider and task"
+  [task-id]
+  (format "http://localhost:%s/granule-bulk-update/status/%s"
           (transmit-config/ingest-port)
-          provider-id))
+          task-id))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Search URLs

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
@@ -1,0 +1,149 @@
+(ns cmr.system-int-test.ingest.granule-bulk-update.granule-bulk-update-flow-test
+  "CMR granule bulk update work flow integration tests."
+  (:require
+    [cmr.system-int-test.data2.granule :as granule]
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
+                                           "provguid2" "PROV2"}))
+
+(deftest granule-bulk-update-workflow-test
+  (let [bulk-update-options {:token (e/login (s/context) "user1")}
+        ;; collection on PROV1
+        coll1 (data-core/ingest-umm-spec-collection
+               "PROV1" (data-umm-c/collection {:EntryTitle "coll1"
+                                               :ShortName "short1"
+                                               :Version "V1"
+                                               :native-id "native1"}))
+        coll2 (data-core/ingest-umm-spec-collection
+               "PROV1" (data-umm-c/collection {:EntryTitle "coll2"
+                                               :ShortName "short2"
+                                               :Version "V2"
+                                               :native-id "native2"}))
+        gran1 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-1"
+                  :granule-ur "SC:AE_5DSno.002:30500511"})))
+        gran2 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-2"
+                  :granule-ur "SC:AE_5DSno.002:30500512"})))
+        gran3 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll2
+                 (:concept-id coll2)
+                 {:native-id "gran-native2-3"
+                  :granule-ur "SC:coll2:30500513"})))
+        ;; collection on PROV2
+        coll3 (data-core/ingest-umm-spec-collection
+               "PROV2" (data-umm-c/collection {:EntryTitle "coll3"
+                                               :ShortName "short3"
+                                               :Version "V3"
+                                               :native-id "native3"}))
+        ;; granule on PROV2
+        gran4 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll3
+                 (:concept-id coll3)
+                 {:provider-id "PROV2"
+                  :native-id "gran-native3-4"
+                  :granule-ur "SC:coll3:30500514"})))]
+
+    (testing "Granule bulk update response in xml/json format"
+      (let [update1 {:name "add opendap links"
+                     :operation "UPDATE_FIELD"
+                     :update-field "OPeNDAPLink"
+                     :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
+                               ["SC:AE_5DSno.002:30500512" "https://url30500512"]]}
+            update1-json (json/generate-string update1)
+            ;; intentionally made the following call verbose to make sure we are parsing xml
+            update1-response (ingest/parse-bulk-update-body
+                              :xml
+                              (ingest/bulk-update-granules
+                               "PROV1"
+                               update1
+                               (assoc bulk-update-options :accept-format :xml :raw? true)))
+            task1-id (:task-id update1-response)
+            update2 {:name "add opendap links"
+                     :operation "UPDATE_FIELD"
+                     :update-field "OPeNDAPLink"
+                     :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
+                               ["SC:coll2:30500513" "https://url30500513"]]}
+            update2-json (json/generate-string update2)
+            ;; intentionally made the following call verbose to make sure we are parsing JSON
+            update2-response (ingest/parse-bulk-update-body
+                              :json
+                              (ingest/bulk-update-granules
+                               "PROV1"
+                               update2
+                               (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-id (str (:task-id update2-response))
+            ;; run granule bulk update on PROV2 to verify get task status works for given provider
+            update3 {:operation "UPDATE_FIELD"
+                     :update-field "OPeNDAPLink"
+                     :updates [["SC:coll3:30500514" "https://url30500514"]
+                               ["SC:non-existent" "https://url30500515"]]}
+            update3-json (json/generate-string update3)
+            update3-response (ingest/bulk-update-granules "PROV2" update3 bulk-update-options)
+            task3-id (str (:task-id update3-response))]
+        (qb-side-api/wait-for-terminal-states)
+        ;; verify granule bulk update status can be retrieved successfully
+        ;; which implies the responses are returned in the desired formats
+        (is (= 200 (:status update1-response)))
+        (is (= 200 (:status update2-response)))
+        (is (= 200 (:status update3-response)))
+
+        (testing "Granule bulk update tasks response"
+          ;; PROV1
+          (are3 [accept-format]
+            (let [response (ingest/granule-bulk-update-tasks
+                            "PROV1"
+                            {:accept-format accept-format})
+                  {:keys [status tasks]} response]
+              (is (= 200 status))
+              (is (= (set [{:task-id task1-id,
+                            :name (str "add opendap links: " task1-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update1-json}
+                           {:task-id task2-id,
+                            :name (str "add opendap links: " task2-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}])
+                     (set (map #(dissoc % :created-at) tasks)))))
+            "JSON" :json
+            "XML" :xml)
+
+          ;; PROV2, also with failing granule
+          (are3 [accept-format]
+            (let [response (ingest/granule-bulk-update-tasks
+                            "PROV2"
+                            {:accept-format accept-format})
+                  {:keys [status tasks]} response]
+              (is (= 200 status))
+              (is (= (set [{:task-id task3-id,
+                            :name (str task3-id ": " task3-id)
+                            :status-message "Task completed with 1 FAILED and 1 UPDATED out of 2 total granule update(s).",
+                            :status "COMPLETE",
+                            :request-json-body update3-json}])
+                     (set (map #(dissoc % :created-at) tasks)))))
+            "JSON" :json
+            "XML" :xml))))))


### PR DESCRIPTION
This PR adds support to retrieve granule bulk update task status and detailed task status for a given task. This also completes the granule bulk update integration tests with the full granule level verification and error handling.

See PR: https://github.com/nasa/Common-Metadata-Repository/pull/1196 for the API description, sample requests and responses.