### PR TITLE
CMR-7080 default sorting keys

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/query_model.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_model.clj
@@ -278,6 +278,11 @@
   (fn [concept-type]
     concept-type))
 
+(defmethod default-sort-keys :default
+  [_]
+  ;; No sorting by default
+  [])
+
 (defmulti concept-type->default-query-attribs
   "Multimethod for returning the default query attributes for a given concept type."
   (fn [concept-type]


### PR DESCRIPTION
Resolves an issue in access-control where a multi-method has no definition for sorting collections. The definition for collections is defined in search-app, but access control does not have search as a dependency.