### PR TITLE
CMR-7216: New has_granules_or_opensearch collection search parameter

### DIFF
--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -9,7 +9,7 @@
   {:default "org.ceos.wgiss.cwic.granules.prod"})
 
 (defconfig opensearch-tag
-  "has-granules-or-cwic should also return any collection with configured cwic-tag"
+  "has-granules-or-opensearch should also return any collection with configured opensearch-tag"
   {:default "opensearch.granule.osdd"})
 
 (defconfig collection-umm-version

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -8,6 +8,10 @@
   "has-granules-or-cwic should also return any collection with configured cwic-tag"
   {:default "org.ceos.wgiss.cwic.granules.prod"})
 
+(defconfig opensearch-tag
+  "has-granules-or-cwic should also return any collection with configured cwic-tag"
+  {:default "opensearch.granule.osdd"})
+
 (defconfig collection-umm-version
   "Defines the latest collection umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -314,6 +314,11 @@
                                    (some?
                                     (some #(= (common-config/cwic-tag) %)
                                           (map :tag-key-lowercase tags))))
+            :has-granules-or-opensearch (or
+                                         has-granules
+                                         (some?
+                                          (some #(= (common-config/opensearch-tag) %)
+                                                (map :tag-key-lowercase tags))))
             :granule-data-format granule-data-format
             :granule-data-format-lowercase (map str/lower-case granule-data-format)
             :entry-id entry-id

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -369,6 +369,7 @@
 
           :has-granules m/bool-field-mapping
           :has-granules-or-cwic m/bool-field-mapping
+          :has-granules-or-opensearch m/bool-field-mapping
           :has-variables m/bool-field-mapping
           :has-formats m/bool-field-mapping
           :has-transforms m/bool-field-mapping

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -82,7 +82,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Additional Attribute](#c-additional-attribute)
     * [Author](#c-author)
     * [With/without granules](#c-has-granules)
-    * [With/without granules Or Cwic](#c-has-granules-or-cwic)
+    * [With/without granules Or OpenSearch](#c-has-granules-or-opensearch)
     * [OPeNDAP service URL](#c-has-opendap-url)
   * [Sorting Collection Results](#sorting-collection-results)
   * [Retrieving all Revisions of a Collection](#retrieving-all-revisions-of-a-collection)
@@ -1859,11 +1859,11 @@ When `has_granules` is set to "true" or "false", results will be restricted to c
 
     curl "%CMR-ENDPOINT%/collections?has_granules=true"
 
-#### <a name="c-has-granules-or-cwic"></a> Find collections with or without granules, or the collection is tagged with the configured CWIC tag.
+#### <a name="c-has-granules-or-opensearch"></a> Find collections with or without granules, or the collection is tagged with the configured OpenSearch tag.
 
-The `has_granules_or_cwic` parameter can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured CWIC tag.  When false, results will be restricted to collections without granules.
+The `has_granules_or_opensearch` parameter can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured OpenSearch tag (opensearch.granules.osdd).  When false, results will be restricted to collections without granules.
 
-    curl "%CMR-ENDPOINT%/collections?has_granules_or_cwic=true"
+    curl "%CMR-ENDPOINT%/collections?has_granules_or_opensearch=true"
 
 #### <a name="c-has-opendap-url"></a> Find collections with or without an OPeNDAP service RelatedURL.
 

--- a/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_opensearch.clj
+++ b/search-app/src/cmr/search/data/complex_to_simple_converters/has_granules_or_opensearch.clj
@@ -1,0 +1,27 @@
+(ns cmr.search.data.complex-to-simple-converters.has-granules-or-opensearch
+  (:require
+   [cmr.common-app.services.search.complex-to-simple :as c2s]
+   [cmr.common-app.services.search.query-model :as cqm]
+   [cmr.search.models.query :as qm]
+   [cmr.search.services.query-execution.has-granules-or-opensearch-results-feature
+    :as has-granules-or-opensearch-base]
+   [cmr.search.services.query-execution.has-granules-results-feature :as has-granules-base]))
+
+;; The following protocol implementation ensures that a c.s.m.q.HasGranulesOrOpenSearchCondition record in our
+;; query model will be expanded into a form which can, in turn, be converted into another structure
+;; in our query model which can, once again, be converted into an Elasticsearch query.
+
+(extend-protocol c2s/ComplexQueryToSimple
+  cmr.search.models.query.HasGranulesOrOpenSearchCondition
+  (c2s/reduce-query-condition [this context]
+    ;; We need to limit the query to collections which have granules or to collections tagged OpenSearch,
+    ;; so we will use the has-granules-or-opensearch-map and get the keys (concept IDs) of entries with true values.
+    (let [has-granules-or-opensearch-map (has-granules-or-opensearch-base/get-has-granules-or-opensearch-map context)
+          has-granules-map (has-granules-base/get-has-granules-map context)
+          concept-ids (map key (filter val has-granules-map))
+          condition (cqm/string-conditions :concept-id concept-ids true)
+          or-opensearch-concept-ids (map key (filter val has-granules-or-opensearch-map))
+          or-opensearch-condition (cqm/string-conditions :concept-id or-opensearch-concept-ids true)]
+      (if (:has-granules-or-opensearch this)
+        or-opensearch-condition
+        (cqm/negated-condition condition)))))

--- a/search-app/src/cmr/search/models/query.clj
+++ b/search-app/src/cmr/search/models/query.clj
@@ -151,6 +151,7 @@
 ;; are known to have granules.
 (defrecord HasGranulesCondition [has-granules])
 (defrecord HasGranulesOrCwicCondition [has-granules-or-cwic])
+(defrecord HasGranulesOrOpenSearchCondition [has-granules-or-opensearch])
 
 (defmethod common-qm/default-sort-keys :granule
   [_]

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -311,6 +311,7 @@
     :score
     :has-granules
     :has-granules-or-cwic
+    :has-granules-or-opensearch
     :usage-relevancy-score
     :ongoing})
 

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_opensearch_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_opensearch_results_feature.clj
@@ -1,0 +1,79 @@
+(ns cmr.search.services.query-execution.has-granules-or-opensearch-results-feature
+  "This enables the :has-granules-or-opensearch feature for collection search results. When it is enabled
+  collection search results will include a boolean flag indicating whether the collection has
+  any granules at all as indicated by provider holdings."
+  (:require
+   [cmr.common-app.services.search.elastic-search-index :as common-esi]
+   [cmr.common-app.services.search.group-query-conditions :as gc]
+   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]
+   [cmr.common-app.services.search.query-execution :as query-execution]
+   [cmr.common-app.services.search.query-model :as qm]
+   [cmr.common.cache :as cache]
+   [cmr.common.cache.in-memory-cache :as mem-cache]
+   [cmr.common-app.config :as common-config]
+   [cmr.common.jobs :refer [defjob]]
+   [cmr.search.data.elastic-search-index :as idx]))
+
+(def REFRESH_HAS_GRANULES_OR_OPENSEARCH_MAP_JOB_INTERVAL
+  "The frequency in seconds of the refresh-has-granules-or-opensearch-map-job"
+  ;; default to 1 hour
+  3600)
+
+(def has-granules-or-opensearch-cache-key
+  :has-granules-or-opensearch-map)
+
+(defn create-has-granules-or-opensearch-map-cache
+  "Returns a 'cache' which will contain the cached has granules map."
+  []
+  (mem-cache/create-in-memory-cache))
+
+(defn get-opensearch-collections
+  "Returns the collection granule count by searching elasticsearch by aggregation"
+  [context provider-ids]
+  (let [condition (nf/parse-nested-condition :tags {:tag-key (common-config/opensearch-tag)} false false)
+        query (qm/query {:concept-type :collection
+                         :condition condition
+                         :page-size :unlimited})
+        results (common-esi/execute-query context query)]
+    (into {}
+          (for [coll-id (map :_id (get-in results [:hits :hits]))]
+            [coll-id 1]))))
+
+(defn- collection-granule-counts->has-granules-or-opensearch-map
+  "Converts a map of collection ids to granule counts to a map of collection ids to true or false
+  of whether the collection has any granules"
+  [coll-gran-counts]
+  (into {} (for [[coll-id num-granules] coll-gran-counts]
+             [coll-id (> num-granules 0)])))
+
+(defn refresh-has-granules-or-opensearch-map
+  "Gets the latest provider holdings and updates the has-granules-or-opensearch-map stored in the cache."
+  [context]
+  (let [has-granules-or-opensearch-map (collection-granule-counts->has-granules-or-opensearch-map
+                                        (merge
+                                         (idx/get-collection-granule-counts context nil)
+                                         (get-opensearch-collections context nil)))]
+    (cache/set-value (cache/context->cache context has-granules-or-opensearch-cache-key)
+                     :has-granules-or-opensearch has-granules-or-opensearch-map)))
+
+(defn get-has-granules-or-opensearch-map
+  "Gets the cached has granules map from the context which contains collection ids to true or false
+  of whether the collections have granules or not. If the has-granules-or-opensearch-map has not yet been cached
+  it will retrieve it and cache it."
+  [context]
+  (let [has-granules-or-opensearch-map-cache (cache/context->cache context has-granules-or-opensearch-cache-key)]
+    (cache/get-value has-granules-or-opensearch-map-cache
+                     :has-granules-or-opensearch
+                     (fn []
+                       (collection-granule-counts->has-granules-or-opensearch-map
+                        (merge
+                         (idx/get-collection-granule-counts context nil)
+                         (get-opensearch-collections context nil)))))))
+
+(defjob RefreshHasGranulesOrOpenSearchMapJob
+  [ctx system]
+  (refresh-has-granules-or-opensearch-map {:system system}))
+
+(def refresh-has-granules-or-opensearch-map-job
+  {:job-type RefreshHasGranulesOrOpenSearchMapJob
+   :interval REFRESH_HAS_GRANULES_OR_OPENSEARCH_MAP_JOB_INTERVAL})

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -49,6 +49,7 @@
     cmr.search.data.complex-to-simple-converters.attribute
     cmr.search.data.complex-to-simple-converters.has-granules
     cmr.search.data.complex-to-simple-converters.has-granules-or-cwic
+    cmr.search.data.complex-to-simple-converters.has-granules-or-opensearch
     cmr.search.data.complex-to-simple-converters.orbit
     cmr.search.data.complex-to-simple-converters.spatial
     cmr.search.data.complex-to-simple-converters.temporal
@@ -84,6 +85,7 @@
     cmr.search.services.query-execution.has-granules-created-at-feature
     cmr.search.services.query-execution.has-granules-results-feature
     cmr.search.services.query-execution.has-granules-or-cwic-results-feature
+    cmr.search.services.query-execution.has-granules-or-opensearch-results-feature
     cmr.search.services.query-execution.has-granules-revised-at-feature
     cmr.search.services.query-execution.highlight-results-feature
     cmr.search.services.query-execution.tags-results-feature

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -32,6 +32,7 @@
    [cmr.search.services.humanizers.humanizer-range-facet-service :as hrfs]
    [cmr.search.services.query-execution.has-granules-results-feature :as hgrf]
    [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as hgocrf]
+   [cmr.search.services.query-execution.has-granules-or-opensearch-results-feature :as hgoorf]
    [cmr.transmit.config :as transmit-config]))
 
 ;; Design based on http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts
@@ -119,6 +120,7 @@
                       context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)
                       :has-granules-map (hgrf/create-has-granules-map-cache)
                       :has-granules-or-cwic-map (hgocrf/create-has-granules-or-cwic-map-cache)
+                      :has-granules-or-opensearch-map (hgoorf/create-has-granules-or-opensearch-map-cache)
                       coll-cache/cache-key (coll-cache/create-cache)
                       metadata-transformer/xsl-transformer-cache-name (mem-cache/create-in-memory-cache)
                       acl/token-imp-cache-key (acl/create-token-imp-cache)
@@ -143,6 +145,7 @@
                           idx/refresh-index-names-cache-job
                           hgrf/refresh-has-granules-map-job
                           hgocrf/refresh-has-granules-or-cwic-map-job
+                          hgoorf/refresh-has-granules-or-opensearch-map-job
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           coll-cache/refresh-collections-cache-for-granule-acls-job
                           jvm-info/log-jvm-statistics-job

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -112,6 +112,7 @@
          "collections-for-gran-acls"
          "has-granules-map"
          "has-granules-or-cwic-map"
+         "has-granules-or-opensearch-map"
          "health"
          "humanizer-range-facet-cache"
          "humanizer-report-cache"

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -105,6 +105,7 @@
          "acls"
          "group-ids-guids"
          "health"
+         "providers"
          "write-enabled"]
         (url/search-read-caches-url) [
          "acls"


### PR DESCRIPTION
* This new parameter very heavily mirrors implementation for `has_granules_or_cwic`, as this parameter is meant to replace it. 