### PR TITLE
CMR-6932 - JWT and Heritage token support

### DIFF
--- a/collection-renderer-lib/README.md
+++ b/collection-renderer-lib/README.md
@@ -2,7 +2,12 @@
 
 A prototype renderer of collection metadata as HTML. This uses code from MMT that was copied into this repository.
 
+# Dependencies
+
+To run locally on the Mac shared-mime-info may need to be installed for mimemagic to run.
+
+* `brew install shared-mime-info`
+
 ## License
 
 Copyright © 2021 NASA
-

--- a/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
+++ b/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
@@ -5,7 +5,6 @@
    [clojure.data.codec.base64 :as base64]
    [clojure.string :as string]
    [cmr.common-app.config :as config]
-   [cmr.common.log :refer [debug info warn error]]
    [cmr.common.services.errors :as errors]
    [cmr.transmit.config :as transmit-config]))
 
@@ -28,7 +27,6 @@
    and it came from EarthDataLogin (EDL).
    Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
   [raw-token]
-  (warn "JWT token test:" (subs raw-token 0 (/ (count raw-token) 2)))
   (let [token (if (string/starts-with? raw-token "Bearer ")
                 (subs raw-token 7)
                 raw-token)]

--- a/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
+++ b/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
@@ -1,17 +1,66 @@
 (ns cmr.common-app.api.launchpad-token-validation
   "Validate Launchpad token."
   (:require
+   [cheshire.core :as json]
+   [clojure.data.codec.base64 :as base64]
+   [clojure.string :as string]
    [cmr.common-app.config :as config]
    [cmr.common.services.errors :as errors]
    [cmr.transmit.config :as transmit-config]))
 
+;; Note: Similar code exists at gov.nasa.echo.kernel.service.authentication
 (def URS_TOKEN_MAX_LENGTH 100)
+
+(defn is-heritage-token?
+  "Heritage token, meaning not the original style legacy token, but a modern
+   token made to be identifiable but also comply with the legacy standard. These
+   tokens are prefixed with 'EDL+'.
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
+  [token]
+  (string/starts-with? token "EDL+"))
+
+(defn is-legacy-token?
+  "A check of last resort, only used if all other checks have not passed.
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
+  [token]
+  (and (not (is-heritage-token? token))
+       (<= (count token) URS_TOKEN_MAX_LENGTH)))
+
+(defn is-jwt-token?
+  "Check if a token matches the JWT pattern (Base64.Base64.Base64) and if it
+   does, try to look inside the header section and verify that the token is JWT
+   and it came from EarthDataLogin (EDL).
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
+  [token]
+  (if (some? (re-find #"[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+" token))
+    (let [token-parts (string/split token #"\.")
+          token-header (first token-parts)
+          ;token-payload (second token-parts) ;;future work - look at experation date
+          ;token-signiture (last token-parts) ;;future work - verify signature
+          header-raw (String. (.decode (java.util.Base64/getDecoder) token-header))]
+      ;; don't parse the data unless it is really needed to prevent unnecessary
+      ;; processing. Check first to see if the data looks like JSON
+      (if (and (string/starts-with? header-raw "{")
+               (string/ends-with? header-raw "}"))
+        (try
+          (if-let [header-data (json/parse-string header-raw true)]
+            (and (= "JWT" (:typ header-data))
+                 (= "Earthdata Login" (:origin header-data)))
+            false)
+          (catch com.fasterxml.jackson.core.JsonParseException e false))
+        false))
+    false))
 
 (defn is-launchpad-token?
   "Returns true if the given token is a launchpad token.
-   Currently we only check the length of the token to decide."
+   If the token is not a Legacy (ECHO), Heritage (EDL+), or JWT (newest) token,
+   then it must be a Launchpad token.
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
   [token]
-  (> (count token) URS_TOKEN_MAX_LENGTH))
+  ;; note: ordered from least expensive to most
+  (not (or (is-heritage-token? token)
+           (is-legacy-token? token)
+           (is-jwt-token? token))))
 
 (defn validate-launchpad-token
   "Validate the token in request context is a Launchpad Token if launchpad token enforcement

--- a/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
+++ b/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
@@ -11,7 +11,7 @@
 ;; Note: Similar code exists at gov.nasa.echo.kernel.service.authentication
 (def URS_TOKEN_MAX_LENGTH 100)
 
-(defn remove-bearer
+(defn- remove-bearer
   "Remove the Bearer marker from the token"
   ([token] (remove-bearer token "Bearer "))
   ([token prefix]
@@ -19,7 +19,7 @@
      (subs token (count prefix))
      token)))
 
-(defn is-legacy-token?
+(defn- is-legacy-token?
   "There are two uses cases captured by this test, the Legacy token, the
    Heritage token (meaning a token made to behave like a legacy token but
    prefixed with EDL-).
@@ -28,7 +28,7 @@
   (or (string/starts-with? (remove-bearer token) "EDL-")
        (<= (count token) URS_TOKEN_MAX_LENGTH)))
 
-(defn is-jwt-token?
+(defn- is-jwt-token?
   "Check if a token matches the JWT pattern (Base64.Base64.Base64) and if it
    does, try to look inside the header section and verify that the token is JWT
    and it came from EarthDataLogin (EDL).

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -1,6 +1,7 @@
 (ns cmr.common-app.test.api.launchpad-token-validation-tests
   "Unit tests for health checks"
   (:require
+   [clojure.data.codec.base64 :as base64]
    [clojure.test :refer :all]
    [cmr.common-app.api.launchpad-token-validation :as token]))
 
@@ -15,11 +16,18 @@
   (doseq [[expected input message] (map list expected-list input-list message-list)]
     (is (= expected (tester input)) (str "Failed: " message " not " expected))))
 
+
+(defn random-base64
+  [len]
+  (let [junk (apply str (take len (repeatedly #(char (+ (rand 26) 65)))))]
+    (String. (base64/encode (.getBytes junk)) "UTF-8")))
+
 (deftest token-tests
   ;; Security Note, these are valid looking tokens but are not and never were
   ;; active tokens. Can be generated with something like SecureRandom.hex 32
   ;; under rails
-  (let [token-oauth "EDL-O84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+  (let [token-legacy "78221B66-EF2B-9283-19B5-295D446B065B"
+        token-oauth "EDL-O84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-user "EDL-U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-client "EDL-C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-ropc "EDL-R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
@@ -29,15 +37,14 @@
                        "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
                        "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
                        ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
-        token-jwt-bearer (str "Bearer " token-jwt)
-        token-legacy "78221B66-EF2B-9283-19B5-295D446B065B"
-        token-bearer (str "Bearer " token-legacy)
-        all-names ["OAuth" "User" "Client" "ROPC" "JWT" "JWT-Bearer" "Generated" "Legacy" "Bearer"]
-        all-tokens [token-oauth token-user token-client token-ropc token-jwt token-jwt-bearer token-legacy token-bearer]
+        ;token-jwt-client (str token-jwt ":abcd0123ABCD")
+        token-launchpad (random-base64 4096)
+        all-names ["Legacy" "OAuth" "User" "Client" "ROPC" "JWT" "LaunchPad"]
+        all-tokens [token-legacy token-oauth token-user token-client token-ropc token-jwt token-launchpad]
         test-group (partial test-matrix all-tokens all-names)]
     (testing "Is token a JWT token?"
-      (test-group [false false false false true true false false] #'token/is-jwt-token?))
+      (test-group [false false false false false true false] #'token/is-jwt-token?))
     (testing "Is token a legacy token?"
-      (test-group [true true true true false false true true] #'token/is-legacy-token?))
+      (test-group [true true true true true false false] #'token/is-legacy-token?))
     (testing "Is token a LaunchPad token?"
-      (test-group [false false false false false false false false] #'token/is-launchpad-token?))))
+      (test-group [false false false false false false true] #'token/is-launchpad-token?))))

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -31,20 +31,22 @@
         token-user "EDL-U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-client "EDL-C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-ropc "EDL-R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-jwt1 (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
+        token-bearer (str "Bearer " token-user)
+        token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
                        "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
                        "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
                        "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
                        "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
                        ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
-        token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiUmVmcmVzaCIsInVpZCI6ImNjdWFkcmFkbyIsImNsaWVudF9pZCI6Ikt4eDh5RGlRUEtjb2Mya3VKOGROOFEiLCJleHAiOjE2MTcxMjM0MDEsImlhdCI6MTYxNzExOTIwMSwiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0.GEMVsVK62JWYvxYCGP1TEbcRYHKvRyWaJFQTy58uHRY")
+        token-jwt-bearer (str "Bearer " token-jwt)
+        token-jwt2 (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiUmVmcmVzaCIsInVpZCI6ImNjdWFkcmFkbyIsImNsaWVudF9pZCI6Ikt4eDh5RGlRUEtjb2Mya3VKOGROOFEiLCJleHAiOjE2MTcxMjM0MDEsImlhdCI6MTYxNzExOTIwMSwiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0.GEMVsVK62JWYvxYCGP1TEbcRYHKvRyWaJFQTy58uHRY")
         token-launchpad (random-base64 4096)
         all-names ["Legacy" "OAuth" "User" "Client" "ROPC" "JWT" "LaunchPad"]
-        all-tokens [token-legacy token-oauth token-user token-client token-ropc token-jwt token-launchpad]
+        all-tokens [token-legacy token-oauth token-user token-client token-ropc token-bearer token-jwt token-jwt-bearer token-launchpad]
         test-group (partial test-matrix all-tokens all-names)]
     (testing "Is token a JWT token?"
-      (test-group [false false false false false true false] #'token/is-jwt-token?))
+      (test-group [false false false false false false true true false] #'token/is-jwt-token?))
     (testing "Is token a legacy token?"
-      (test-group [true true true true true false false] #'token/is-legacy-token?))
+      (test-group [true true true true true true false false false] #'token/is-legacy-token?))
     (testing "Is token a LaunchPad token?"
-      (test-group [false false false false false false true] #'token/is-launchpad-token?))))
+      (test-group [false false false false false false false false true] #'token/is-launchpad-token?))))

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -1,0 +1,47 @@
+(ns cmr.common-app.test.api.launchpad-token-validation-tests
+  "Unit tests for health checks"
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common-app.api.launchpad-token-validation :as token]))
+
+(defn- test-matrix
+  "The input-list, message-list, and expected-list are all seq of the same size.
+   Items match in each seq and corrispond to the same test. 'input' is passed
+   to 'tester' and then tested with '=' against 'expected'. If the test fails
+   then 'message' is sent back to the test API. Parameter order allows for the
+   use of partial to fix parameters expected to change the least from one test
+   to the next"
+  [input-list message-list expected-list tester]
+  (doseq [[expected input message] (map list expected-list input-list message-list)]
+    (is (= expected (tester input)) (str "Failed: " message " not " expected))))
+
+(deftest token-tests
+  ;; Security Note, these are valid looking tokens but are not and never were
+  ;; active tokens. Can be generated with something like SecureRandom.hex 32
+  ;; under rails
+  (let [token-oauth "EDL+O84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-user "EDL+U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-client "EDL+C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-ropc "EDL+R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-jwt (str "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0"
+                       "NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5M"
+                       "DIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+        token-jwt-actual (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
+                              "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
+                              "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
+                              "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
+                              "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
+                              ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
+        token-legacy "78221B66-EF2B-9283-19B5-295D446B065B"
+        tokenBearer "Bearer 78221B66-EF2B-9283-19B5-295D446B065B"
+        all-names ["OAuth", "User" "Client" "ROPC" "JWT" "Legacy", "Bearer"]
+        all-tokens [token-oauth token-user token-client token-ropc token-jwt-actual token-legacy]
+        test-group (partial test-matrix all-tokens all-names)]
+    (testing "Is token a JWT token?"
+      (test-group [false false false false true false false] #'token/is-jwt-token?))
+    (testing "Is token a heritage token?"
+      (test-group [true true true true false false false] #'token/is-heritage-token?))
+    (testing "Is token a legacy token?"
+      (test-group [false false false false false true true] #'token/is-legacy-token?))
+    (testing "Is token a LaunchPad token?"
+      (test-group [false false false false false false false] #'token/is-launchpad-token?))))

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -17,7 +17,8 @@
     (is (= expected (tester input)) (str "Failed: " message " not " expected))))
 
 
-(defn random-base64
+(defn- random-base64
+  "Create a random string of base64 chars suitable to mimic a token"
   [len]
   (let [junk (apply str (take len (repeatedly #(char (+ (rand 26) 65)))))]
     (String. (base64/encode (.getBytes junk)) "UTF-8")))

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -31,13 +31,13 @@
         token-user "EDL-U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-client "EDL-C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-ropc "EDL-R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
+        token-jwt1 (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
                        "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
                        "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
                        "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
                        "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
                        ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
-        ;token-jwt-client (str token-jwt ":abcd0123ABCD")
+        token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiUmVmcmVzaCIsInVpZCI6ImNjdWFkcmFkbyIsImNsaWVudF9pZCI6Ikt4eDh5RGlRUEtjb2Mya3VKOGROOFEiLCJleHAiOjE2MTcxMjM0MDEsImlhdCI6MTYxNzExOTIwMSwiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0.GEMVsVK62JWYvxYCGP1TEbcRYHKvRyWaJFQTy58uHRY")
         token-launchpad (random-base64 4096)
         all-names ["Legacy" "OAuth" "User" "Client" "ROPC" "JWT" "LaunchPad"]
         all-tokens [token-legacy token-oauth token-user token-client token-ropc token-jwt token-launchpad]

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -31,7 +31,10 @@
         token-user "EDL-U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-client "EDL-C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
         token-ropc "EDL-R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+
         token-bearer (str "Bearer " token-user)
+        token-client-id (str token-user ":" (random-base64 22))
+
         token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
                        "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
                        "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
@@ -39,14 +42,36 @@
                        "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
                        ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
         token-jwt-bearer (str "Bearer " token-jwt)
-        token-jwt2 (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiUmVmcmVzaCIsInVpZCI6ImNjdWFkcmFkbyIsImNsaWVudF9pZCI6Ikt4eDh5RGlRUEtjb2Mya3VKOGROOFEiLCJleHAiOjE2MTcxMjM0MDEsImlhdCI6MTYxNzExOTIwMSwiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0.GEMVsVK62JWYvxYCGP1TEbcRYHKvRyWaJFQTy58uHRY")
+        token-jwt-client-id (str token-jwt ":" (random-base64 22))
+
         token-launchpad (random-base64 4096)
-        all-names ["Legacy" "OAuth" "User" "Client" "ROPC" "JWT" "LaunchPad"]
-        all-tokens [token-legacy token-oauth token-user token-client token-ropc token-bearer token-jwt token-jwt-bearer token-launchpad]
+        ; all-names, all-tokens, and test-group are all spaced by groups
+        all-names ["Legacy"                             ; Legacy token
+                   "OAuth" "User" "Client" "ROPC"       ; EDL tokens
+                   "EDL Bearer" "EDL Client-Id"         ; Decorated EDL tokens
+                   "JWT" "JWT Bearer" "JWT Client-Id"   ; JWT tokens
+                   "LaunchPad"]                         ; Launchpad token
+        all-tokens [token-legacy
+                    token-oauth token-user token-client token-ropc
+                    token-bearer token-client-id
+                    token-jwt token-jwt-bearer token-jwt-client-id
+                    token-launchpad]
         test-group (partial test-matrix all-tokens all-names)]
     (testing "Is token a JWT token?"
-      (test-group [false false false false false false true true false] #'token/is-jwt-token?))
+      (test-group [false
+                   false false false false
+                   false false
+                   true true true
+                   false] #'token/is-jwt-token?))
     (testing "Is token a legacy token?"
-      (test-group [true true true true true true false false false] #'token/is-legacy-token?))
+      (test-group [true
+                   true true true true
+                   true true
+                   false false false
+                   false] #'token/is-legacy-token?))
     (testing "Is token a LaunchPad token?"
-      (test-group [false false false false false false false false true] #'token/is-launchpad-token?))))
+      (test-group [false
+                   false false false false
+                   false false
+                   false false false
+                   true] #'token/is-launchpad-token?))))

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -19,29 +19,25 @@
   ;; Security Note, these are valid looking tokens but are not and never were
   ;; active tokens. Can be generated with something like SecureRandom.hex 32
   ;; under rails
-  (let [token-oauth "EDL+O84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-user "EDL+U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-client "EDL+C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-ropc "EDL+R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
-        token-jwt (str "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0"
-                       "NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5M"
-                       "DIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
-        token-jwt-actual (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
-                              "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
-                              "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
-                              "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
-                              "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
-                              ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
+  (let [token-oauth "EDL-O84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-user "EDL-U84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-client "EDL-C84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-ropc "EDL-R84a9c44c0ad2c628300477aa2568ba39e2fa47190f5dc16f95fb24086f7"
+        token-jwt (str "eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9n"
+                       "aW4iLCJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiT0F1dGgiLCJ"
+                       "1aWQiOiJhZG1pbiIsImNsaWVudF9pZCI6Im9YQUhISmMyLTc"
+                       "wbndXb2w2T2VIUFEiLCJleHAiOjE2MTYwMTg5OTcsImlhdCI"
+                       "6MTYxNjAxNTM5NywiaXNzIjoiRWFydGhkYXRhIExvZ2luIn0"
+                       ".-e7GTS6PJYD1fAuCoseOj4PdV5iqd521dCM1Hc_XjqI")
+        token-jwt-bearer (str "Bearer " token-jwt)
         token-legacy "78221B66-EF2B-9283-19B5-295D446B065B"
-        tokenBearer "Bearer 78221B66-EF2B-9283-19B5-295D446B065B"
-        all-names ["OAuth", "User" "Client" "ROPC" "JWT" "Legacy", "Bearer"]
-        all-tokens [token-oauth token-user token-client token-ropc token-jwt-actual token-legacy]
+        token-bearer (str "Bearer " token-legacy)
+        all-names ["OAuth" "User" "Client" "ROPC" "JWT" "JWT-Bearer" "Generated" "Legacy" "Bearer"]
+        all-tokens [token-oauth token-user token-client token-ropc token-jwt token-jwt-bearer token-legacy token-bearer]
         test-group (partial test-matrix all-tokens all-names)]
     (testing "Is token a JWT token?"
-      (test-group [false false false false true false false] #'token/is-jwt-token?))
-    (testing "Is token a heritage token?"
-      (test-group [true true true true false false false] #'token/is-heritage-token?))
+      (test-group [false false false false true true false false] #'token/is-jwt-token?))
     (testing "Is token a legacy token?"
-      (test-group [false false false false false true true] #'token/is-legacy-token?))
+      (test-group [true true true true false false true true] #'token/is-legacy-token?))
     (testing "Is token a LaunchPad token?"
-      (test-group [false false false false false false false] #'token/is-launchpad-token?))))
+      (test-group [false false false false false false false false] #'token/is-launchpad-token?))))

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -105,6 +105,7 @@
          "acls"
          "group-ids-guids"
          "health"
+         "providers"
          "write-enabled"]
         (url/search-read-caches-url) [
          "acls"


### PR DESCRIPTION
Improved the Launchpad test by adding checks for several of the different types of ECHO and EDL tokens.

Legacy Tokens: Old style ECHO tokens
Heritage Tokens: New tokens made to function like legacy tokens, but are identifiable.
JWT Tokens: Long, parsable tokens