### PR TITLE
CMR-7216: Implemented has_granules_as_opensearch as alias of has_granules_or_cwic

### DIFF
--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -6,7 +6,7 @@
 
 (defconfig cwic-tag
   "has-granules-or-cwic should also return any collection with configured cwic-tag"
-  {:default "org.ceos.wgiss.cwic.granules.prod"})
+  {:default "opensearch.granule.osdd"})
 
 (defconfig collection-umm-version
   "Defines the latest collection umm version accepted by ingest - it's the latest official version.

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -83,6 +83,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Author](#c-author)
     * [With/without granules](#c-has-granules)
     * [With/without granules Or Cwic](#c-has-granules-or-cwic)
+    * [With/without granules Or OpenSearch](#c-has-granules-or-opensearch)
     * [OPeNDAP service URL](#c-has-opendap-url)
   * [Sorting Collection Results](#sorting-collection-results)
   * [Retrieving all Revisions of a Collection](#retrieving-all-revisions-of-a-collection)
@@ -1861,9 +1862,17 @@ When `has_granules` is set to "true" or "false", results will be restricted to c
 
 #### <a name="c-has-granules-or-cwic"></a> Find collections with or without granules, or the collection is tagged with the configured CWIC tag.
 
-The `has_granules_or_cwic` parameter can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured CWIC tag.  When false, results will be restricted to collections without granules.
+The `has_granules_or_cwic` parameter can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured CWIC tag.  When false, will return any collections without granules.
 
     curl "%CMR-ENDPOINT%/collections?has_granules_or_cwic=true"
+
+**Note:** this parameter will soon be retired in favor of a replacement parameter found below, `have_granules_or_opensearch`.
+
+#### <a name="c-has-granules-or-opensearch"></a> Find collections with or without granules, or the collection is tagged with the configured OpenSearch tag.
+
+The `has_granules_or_opensearch` parameter can be set to "true" or "false". When true, the results will be restricted to collections with granules or with the configured OpenSearch tag.  When false, will return any collections without granules.
+
+    curl "%CMR-ENDPOINT%/collections?has_granules_or_opensearch=true"
 
 #### <a name="c-has-opendap-url"></a> Find collections with or without an OPeNDAP service RelatedURL.
 

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -43,6 +43,7 @@
    :horizontal-data-resolution-range :range-facet
    :has-granules :has-granules
    :has-granules-or-cwic :has-granules-or-cwic
+   :has-granules-or-opensearch :has-granules-or-cwic
    :has-granules-created-at :multi-date-range
    :has-granules-revised-at :multi-date-range
    :has-opendap-url :boolean

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -311,6 +311,7 @@
     :score
     :has-granules
     :has-granules-or-cwic
+    :has-granules-or-opensearch
     :usage-relevancy-score
     :ongoing})
 

--- a/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_counts_search_test.clj
@@ -488,7 +488,29 @@
                      (search/find-refs :collection
                                        {:has_granules_or_cwic false
                                         :page-size 20}
+                                       {:snake-kebab? false})))
+
+;as an alias, has-granules-or-opensearch should return the same results.
+    (testing "Search with has-granules-or-opensearch feature true"
+      (d/refs-match? [coll1 coll3 coll6 coll2
+                      coll7 coll8 coll9 coll10
+                      coll11 coll12 coll13 coll14
+                      coll15 coll16 coll17]
+                     (search/find-refs :collection
+                                       {:has_granules_or_opensearch true
+                                        :page-size 20}
+                                       {:snake-kebab? false})))
+
+    (testing "Search with has-granules-or-opensearch feature false"
+      (d/refs-match? [coll4 coll5 coll6
+                      coll7 coll8 coll9 coll10
+                      coll11 coll12 coll13 coll14
+                      coll15 coll16 coll17]
+                     (search/find-refs :collection
+                                       {:has_granules_or_opensearch false
+                                        :page-size 20}
                                        {:snake-kebab? false})))))
+
 
 (deftest search-collections-has-granules-or-cwic-sort-test
   (let [coll1 (make-coll 1 m/whole-world nil)


### PR DESCRIPTION
* Changed default configured tag for has_granules_or_cwic
* Also added has_granules_or_opensearch as aliased parameter
* Added new tests
* has_granules_or_cwic will be retired in the future