### PR TITLE
CMR-7086: Remove the placeholder for not working stac links.

### DIFF
--- a/search-app/resources/templates/stac-search-docs.html
+++ b/search-app/resources/templates/stac-search-docs.html
@@ -3,12 +3,10 @@
 {% block main-content %}
 <h2>CMR STAC Links</h2>
 <p class="lead">
-   CMR STAC Links contain four parts:
+   CMR STAC Links contain two parts:
 </p>
 <ul>
   <li><a href="{{ stac-url }}">CMR STAC</a> - CMR STAC Catalog Endpoint</li>
   <li><a href="{{ cloudstac-url }}">CMR Cloud STAC</a> - CMR STAC Catalog Endpoint for Cloud-hosted Holdings Only</li>
-  <li><a href="{{ static-cloudstac-url }}">CMR Cloud STAC Static</a> - CMR STAC Static Catalog Endpoint for Cloud-hosted Holdings Only</li>
-  <li><a href="{{ stac-docs-url }}">CMR STAC Documentation</a> - CMR STAC Catalog Documentation</li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
Currently stac docs link and stac static catalog links are not decided yet. We want to remove them from CMR Search Landing Page before CMR-7086 goes to PROD. 