### PR TITLE
CMR-7191 update bulk granule update schema to have stricter rules

### DIFF
--- a/ingest-app/resources/granule_bulk_update_schema.json
+++ b/ingest-app/resources/granule_bulk_update_schema.json
@@ -6,18 +6,29 @@
         "UPDATE_FIELD"
       ]
     },
+    "UpdateFieldEnum": {
+      "type": "string",
+      "enum": [
+        "OPeNDAPLink",
+        "S3Link"
+      ]
+    },
+    "UpdateTupleType": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "string"
+      },
+      "examples": [
+        ["SL:AB_5DSno.008:30500511", "s3://aws.example.com"]
+      ]
+    },
     "UpdateArgumentsType": {
-      "title": "Items",
       "type": "array",
       "minItems": 1,
       "items": {
-        "title": "Arguments",
-        "type": "string",
-        "default": "",
-        "examples": [
-          "SL:AB_5DSno.008:30500511"
-        ],
-        "pattern": "^.*$"
+        "$ref": "#/definitions/UpdateTupleType"
       }
     }
   },
@@ -33,11 +44,9 @@
   "properties": {
     "name": {
       "$id": "#root/name",
-      "title": "Name",
       "type": "string",
-      "default": "",
       "examples": [
-        "Add opendap links"
+        "Add OPeNDAP links"
       ],
       "pattern": "^.*$"
     },
@@ -45,23 +54,10 @@
       "$ref": "#/definitions/OperationEnum"
     },
     "update-field": {
-      "$id": "#root/update-field",
-      "title": "Update-field",
-      "type": "string",
-      "default": "",
-      "examples": [
-        "OPeNDAPLink"
-      ],
-      "pattern": "^.*$"
+      "$ref": "#/definitions/UpdateFieldEnum"
     },
     "updates": {
-      "$id": "#root/updates",
-      "title": "Updates",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/UpdateArgumentsType"
-      }
+      "$ref": "#/definitions/UpdateArgumentsType"
     }
   }
 }

--- a/ingest-app/resources/granule_bulk_update_schema.json
+++ b/ingest-app/resources/granule_bulk_update_schema.json
@@ -21,7 +21,7 @@
         "type": "string"
       },
       "examples": [
-        ["SL:AB_5DSno.008:30500511", "s3://aws.example.com"]
+        ["SL:AB_5DSno.008:30500511", "https://example.com/opendap/30500511"]
       ]
     },
     "UpdateArgumentsType": {

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
@@ -23,6 +23,11 @@
   Returns the parsed urls in a map under keys :cloud and :on-prem with the corresponding urls."
   [url]
   (let [urls (map string/trim (string/split url #","))]
+    (doseq [url urls]
+      (when (string/starts-with? url "s3://")
+        (errors/throw-service-errors
+         :invalid-data
+         [(str "OPeNDAP URL value cannot start with s3://, but was " url)])))
     (if (> (count urls) 2)
       (errors/throw-service-errors
        :invalid-data [(str "Invalid URL value, no more than two urls can be provided: " url)])

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -28,9 +28,34 @@
 (def granule-bulk-update-schema
  (js/json-string->json-schema (slurp (io/resource "granule_bulk_update_schema.json"))))
 
-(defn- validate-granule-bulk-update
- [json]
- (js/validate-json! granule-bulk-update-schema json))
+(defn- validate-granule-bulk-update-json
+  "Validate the request against the schema and return the parsed request."
+  [json]
+  (js/validate-json! granule-bulk-update-schema json))
+
+(defn- validate-granule-bulk-update-job-name
+  "Validates that if a name is provided for a job, it is unique to the provider."
+  [context request provider-id]
+  (when-let [job-name (:name request)]
+    (let [tasks (seq (data-granule-bulk-update/get-granule-tasks-by-provider context provider-id))
+          task-names (->> tasks
+                          (map :name)
+                          (map #(string/split % #":"))
+                          first)]
+      (when (some? (some #{job-name} task-names))
+        (errors/throw-service-errors
+         :bad-request
+         [(format (str "Granule bulk update task name needs to be unique within the provider. "
+                       "A granule bulk update job with the name [%s] already exist for provider [%s].")
+                  job-name
+                  provider-id)])))))
+
+(defn- duplicates
+  "Return any non-unique entries in a collection or nil if none are found."
+  [coll]
+  (seq (for [[id freq] (frequencies coll)
+             :when (> freq 1)]
+         id)))
 
 (defn- update->instruction
   "Returns the granule bulk update instruction for a single update item"
@@ -47,22 +72,35 @@
         event-type (string/lower-case (str operation ":" update-field))]
     (map (partial update->instruction event-type) updates)))
 
-(defn- duplicates
-  "Return duplicates in a collection."
-  [coll]
-  (for [[id freq] (frequencies coll)
-        :when (> freq 1)]
-    id))
+(defn- validate-granule-bulk-update-no-duplicates
+  "Validate no duplicate URs exist within the list of instructions"
+  [request]
+  (when-let [duplicate-urs (->> request
+                                request->instructions
+                                (pmap :granule-ur)
+                                duplicates)]
+    (errors/throw-service-errors
+     :bad-request
+     [(format (str "Duplicate granule URs are not allowed in bulk update requests. "
+                   "Detected the following duplicates [%s]")
+              (string/join "," duplicate-urs))])))
+
+(defn- validate-and-parse-bulk-granule-update
+  "Perform validation operations on bulk granule update requests."
+  [context json-body provider-id]
+  (validate-granule-bulk-update-json json-body)
+  (let [request (json/parse-string json-body true)]
+    (validate-granule-bulk-update-no-duplicates request)
+    (validate-granule-bulk-update-job-name context request provider-id)
+    request))
 
 (defn validate-and-save-bulk-granule-update
   "Validate the granule bulk update request, save rows to the db for task
   and granule statuses, and queue bulk granule update. Return task id, which comes
   from the db save."
   [context provider-id json-body user-id]
-  (validate-granule-bulk-update json-body)
-  (let [instructions (-> json-body
-                         (json/parse-string true)
-                         request->instructions)
+  (let [request (validate-and-parse-bulk-granule-update context json-body provider-id)
+        instructions (request->instructions request)
         task-id (try
                   (data-granule-bulk-update/create-granule-bulk-update-task
                    context
@@ -71,25 +109,12 @@
                    json-body
                    instructions)
                   (catch Exception e
-                    (error "validate-and-save-bulk-granule-update caught exception:" e)
-                    (let [message (.getMessage e)
-                          user-facing-message
-                          (condp #(string/includes? %2 %1) message
-                            "GBUT_PN_I"
-                            "Granule bulk update task name needs to be unique within the provider."
-
-                            "ORA-00001: unique constraint (CMR_INGEST.BUGS_PK)"
-                            (format (str "Duplicate granule URs are not allowed in bulk update requests. "
-                                         "Detected the following duplicates [%s]")
-                                    (->> instructions
-                                         (pmap :granule-ur)
-                                         duplicates
-                                         (string/join ",")))
-                            ;; default
-                            message)]
+                    (error "An exception occurred saving a bulk granule update request:" e)
+                    (let [message (.getMessage e)]
                       (errors/throw-service-errors
-                       :bad-request
-                       [(str "error creating granule bulk update task: " user-facing-message)]))))]
+                       :internal-error
+                       [(str "There was a problem saving a bulk granule update request."
+                             "Please try again, if the problem persists please contact cmr@nasa.gov.")]))))]
     ;; Queue the granules bulk update event
     (ingest-events/publish-gran-bulk-update-event
      context

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -33,23 +33,6 @@
   [json]
   (js/validate-json! granule-bulk-update-schema json))
 
-(defn- validate-granule-bulk-update-job-name
-  "Validates that if a name is provided for a job, it is unique to the provider."
-  [context request provider-id]
-  (when-let [job-name (:name request)]
-    (let [tasks (seq (data-granule-bulk-update/get-granule-tasks-by-provider context provider-id))
-          task-names (->> tasks
-                          (map :name)
-                          (map #(string/split % #":"))
-                          first)]
-      (when (some? (some #{job-name} task-names))
-        (errors/throw-service-errors
-         :bad-request
-         [(format (str "Granule bulk update task name needs to be unique within the provider. "
-                       "A granule bulk update job with the name [%s] already exist for provider [%s].")
-                  job-name
-                  provider-id)])))))
-
 (defn- duplicates
   "Return any non-unique entries in a collection or nil if none are found."
   [coll]
@@ -91,7 +74,6 @@
   (validate-granule-bulk-update-json json-body)
   (let [request (json/parse-string json-body true)]
     (validate-granule-bulk-update-no-duplicates request)
-    (validate-granule-bulk-update-job-name context request provider-id)
     request))
 
 (defn validate-and-save-bulk-granule-update

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -77,7 +77,7 @@
   [request]
   (when-let [duplicate-urs (->> request
                                 request->instructions
-                                (pmap :granule-ur)
+                                (map :granule-ur)
                                 duplicates)]
     (errors/throw-service-errors
      :bad-request

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -88,7 +88,7 @@
                             ;; default
                             message)]
                       (errors/throw-service-errors
-                       :invalid-data
+                       :bad-request
                        [(str "error creating granule bulk update task: " user-facing-message)]))))]
     ;; Queue the granules bulk update event
     (ingest-events/publish-gran-bulk-update-event

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -96,7 +96,7 @@
                       (errors/throw-service-errors
                        :internal-error
                        [(str "There was a problem saving a bulk granule update request."
-                             "Please try again, if the problem persists please contact cmr@nasa.gov.")]))))]
+                             "Please try again, if the problem persists please contact cmr-support@earthdata.nasa.gov.")]))))]
     ;; Queue the granules bulk update event
     (ingest-events/publish-gran-bulk-update-event
      context

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
@@ -13,12 +13,11 @@
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
-(def base-request {:name "sample bulk update"
-                   :operation "UPDATE_FIELD"
+(def base-request {:operation "UPDATE_FIELD"
                    :update-field "OPeNDAPLink"
                    :updates
-                   [["ur_1" "s3://aws.foo.com"]
-                    ["ur_2" "s3://aws.bar.com"]]})
+                   [["ur_1" "https://aws.foo.com"]
+                    ["ur_2" "https://aws.bar.com"]]})
 
 (deftest bulk-granule-schema-validation-test
   (are3
@@ -45,7 +44,7 @@
    "#/updates: expected minimum item count: 1, found: 0"
 
    "update entries: more than 2"
-   (fn [req] (update req :updates conj ["ur_3" "s3://aws.example.fiz" "s3://aws.example.baz"]))
+   (fn [req] (update req :updates conj ["ur_3" "https://aws.example.fiz" "https://aws.example.baz"]))
    "#/updates/2: expected maximum item count: 2, found: 3"
 
    "update entries: fewer than 2 (1)"
@@ -58,14 +57,15 @@
 
    "duplicate granule_ur in request"
    (fn [req] (update req
-                  :updates
-                  conj
-                  ["ur_1" "s3://aws.buz.com"]
-                  ["ur_2" "s3://aws.fiz.com"]
-                  ["ur_3" "s3://aws.ban.com"]))
-   (str "error creating granule bulk update task: "
-        "Duplicate granule URs are not allowed in bulk update requests. "
-        "Detected the following duplicates [ur_1,ur_2]")
+                    :updates
+                    conj
+                    ["ur_4" "https://aws.fiz.com"]
+                    ["ur_4" "https://aws.ban.com"]
+                    ["ur_4" "https://aws.bat.com"]
+                    ["ur_5" "https://aws.buz.com"]
+                    ["ur_5" "https://aws.baz.com"]))
+   (str "Duplicate granule URs are not allowed in bulk update requests. "
+        "Detected the following duplicates [ur_4,ur_5]")
 
    "invalid operation"
    (fn [req] (assoc req :operation "CROMULANT_OPERATION"))
@@ -74,3 +74,27 @@
    "invalid update-field"
    (fn [req] (assoc req :update-field "CROMULANT_FIELD"))
    "#/update-field: CROMULANT_FIELD is not a valid enum value"))
+
+(deftest duplicate-job-name-per-provider-validation-test
+  (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
+                             :accept-format :json
+                             :raw? true}
+        original (ingest/bulk-update-granules "PROV1"
+                                              (assoc base-request :name "sample")
+                                              bulk-update-options)
+
+        duplicate (ingest/bulk-update-granules "PROV1"
+                                               (assoc base-request :name "sample")
+                                               bulk-update-options)
+        duplicate-msg (-> duplicate
+                          :body
+                          (json/parse-string true)
+                          :errors
+                          first)]
+
+    (is (= 200 (:status original)) (:body original))
+
+    (is (= 400 (:status duplicate)))
+    (is (= (str "Granule bulk update task name needs to be unique within the provider. "
+                "A granule bulk update job with the name [sample] already exist for provider [PROV1].")
+           duplicate-msg))))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
@@ -1,0 +1,74 @@
+(ns cmr.system-int-test.ingest.bulk-update.bulk-granule-update-schema-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as sys]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(def base-request {:name "sample bulk update"
+                   :operation "UPDATE_FIELD"
+                   :update-field "OPeNDAPLink"
+                   :updates
+                   [["ur_1" "s3://aws.foo.com"]
+                    ["ur_2" "s3://aws.bar.com"]]})
+
+(deftest bulk-granule-schema-validation-test
+  (are3
+   [update-fn err-msg]
+   (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
+                              :accept-format :json
+                              :raw? true}
+         request (update-fn base-request)
+         {:keys [body]} (ingest/bulk-update-granules "PROV1"
+                                                     request
+                                                     bulk-update-options)
+         response (json/parse-string body true)]
+
+     (is (seq (:errors response)))
+     (is (seq (filter #(= err-msg %) (:errors response)))
+         (format "Error message containing [\"%s\"] was not found in %s"
+                 err-msg
+                 (pr-str response))))
+
+   "insufficient bulk operation targets"
+   (fn [m] (assoc m :updates []))
+   "#/updates: expected minimum item count: 1, found: 0"
+
+   "update entries: more than 2"
+   (fn [m] (update m :updates conj ["ur_3" "s3://aws.example.fiz" "s3://aws.example.baz"]))
+   "#/updates/2: expected maximum item count: 2, found: 3"
+
+   "update entries: fewer than 2 (1)"
+   (fn [m] (update m :updates conj ["ur_3"]))
+   "#/updates/2: expected minimum item count: 2, found: 1"
+
+   "update entries: fewer than 2 (0)"
+   (fn [m] (update m :updates conj []))
+   "#/updates/2: expected minimum item count: 2, found: 0"
+
+   "duplicate granule_ur in request"
+   (fn [m] (update m
+                  :updates
+                  conj
+                  ["ur_1" "s3://aws.buz.com"]
+                  ["ur_2" "s3://aws.fiz.com"]
+                  ["ur_3" "s3://aws.ban.com"]))
+   (str "error creating granule bulk update task: "
+        "Duplicate granule URs are not allowed in bulk update requests. "
+        "Detected the following duplicates [ur_1,ur_2]")
+
+   "invalid operation"
+   (fn [m] (assoc m :operation "CROMULANT_OPERATION"))
+   "#/operation: CROMULANT_OPERATION is not a valid enum value"
+
+   "invalid update-field"
+   (fn [m] (assoc m :update-field "CROMULANT_FIELD"))
+   "#/update-field: CROMULANT_FIELD is not a valid enum value"))

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
@@ -27,11 +27,12 @@
                               :accept-format :json
                               :raw? true}
          request (update-fn base-request)
-         {:keys [body]} (ingest/bulk-update-granules "PROV1"
-                                                     request
-                                                     bulk-update-options)
+         {:keys [body status]} (ingest/bulk-update-granules "PROV1"
+                                                            request
+                                                            bulk-update-options)
          response (json/parse-string body true)]
 
+     (is (= 400 status))
      (is (seq (filter #(= err-msg %) (:errors response)))
          (format "Error message containing [%s] was not found in [%s]"
                  err-msg

--- a/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/bulk_update/bulk_granule_update_schema_test.clj
@@ -32,9 +32,8 @@
                                                      bulk-update-options)
          response (json/parse-string body true)]
 
-     (is (seq (:errors response)))
      (is (seq (filter #(= err-msg %) (:errors response)))
-         (format "Error message containing [\"%s\"] was not found in %s"
+         (format "Error message containing [%s] was not found in [%s]"
                  err-msg
                  (pr-str response))))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
@@ -1,4 +1,4 @@
-(ns cmr.system-int-test.ingest.bulk-update.bulk-granule-update-schema-test
+(ns cmr.system-int-test.ingest.granule-bulk-update.granule-bulk-update-schema-test
   (:require
    [cheshire.core :as json]
    [clojure.string :as string]
@@ -39,6 +39,7 @@
 
    ;; Pass a mutate function to modify the base-request for the input
 
+   ;; Schema validations
    "insufficient bulk operation targets"
    (fn [req] (assoc req :updates []))
    "#/updates: expected minimum item count: 1, found: 0"
@@ -55,6 +56,16 @@
    (fn [req] (update req :updates conj []))
    "#/updates/2: expected minimum item count: 2, found: 0"
 
+   "invalid operation"
+   (fn [req] (assoc req :operation "CROMULANT_OPERATION"))
+   "#/operation: CROMULANT_OPERATION is not a valid enum value"
+
+   "invalid update-field"
+   (fn [req] (assoc req :update-field "CROMULANT_FIELD"))
+   "#/update-field: CROMULANT_FIELD is not a valid enum value"
+
+   ;; Business rules validation
+
    "duplicate granule_ur in request"
    (fn [req] (update req
                     :updates
@@ -65,15 +76,7 @@
                     ["ur_5" "https://aws.buz.com"]
                     ["ur_5" "https://aws.baz.com"]))
    (str "Duplicate granule URs are not allowed in bulk update requests. "
-        "Detected the following duplicates [ur_4,ur_5]")
-
-   "invalid operation"
-   (fn [req] (assoc req :operation "CROMULANT_OPERATION"))
-   "#/operation: CROMULANT_OPERATION is not a valid enum value"
-
-   "invalid update-field"
-   (fn [req] (assoc req :update-field "CROMULANT_FIELD"))
-   "#/update-field: CROMULANT_FIELD is not a valid enum value"))
+        "Detected the following duplicates [ur_4,ur_5]")))
 
 (deftest duplicate-job-name-per-provider-validation-test
   (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
@@ -77,27 +77,3 @@
                     ["ur_5" "https://aws.baz.com"]))
    (str "Duplicate granule URs are not allowed in bulk update requests. "
         "Detected the following duplicates [ur_4,ur_5]")))
-
-(deftest duplicate-job-name-per-provider-validation-test
-  (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
-                             :accept-format :json
-                             :raw? true}
-        original (ingest/bulk-update-granules "PROV1"
-                                              (assoc base-request :name "sample")
-                                              bulk-update-options)
-
-        duplicate (ingest/bulk-update-granules "PROV1"
-                                               (assoc base-request :name "sample")
-                                               bulk-update-options)
-        duplicate-msg (-> duplicate
-                          :body
-                          (json/parse-string true)
-                          :errors
-                          first)]
-
-    (is (= 200 (:status original)) (:body original))
-
-    (is (= 400 (:status duplicate)))
-    (is (= (str "Granule bulk update task name needs to be unique within the provider. "
-                "A granule bulk update job with the name [sample] already exist for provider [PROV1].")
-           duplicate-msg))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
@@ -41,15 +41,15 @@
    "#/updates: expected minimum item count: 1, found: 0"
 
    "update entries: more than 2"
-   ["ur_1" "https://aws.example.fiz" "https://aws.example.baz"]
+   [["ur_1" "https://aws.example.fiz" "https://aws.example.baz"]]
    "#/updates/2: expected maximum item count: 2, found: 3"
 
    "update entries: fewer than 2 (1)"
-   ["ur_1"]
+   [["ur_1"]]
    "#/updates/2: expected minimum item count: 2, found: 1"
 
    "update entries: fewer than 2 (0)"
-   []
+   [[]]
    "#/updates/2: expected minimum item count: 2, found: 0"
 
    ;; Business rules validation
@@ -76,7 +76,7 @@
         response (json/parse-string body true)]
     (is (= 400 status))
     (is (= "#/operation: CROMULANT_OPERATION is not a valid enum value"
-           (first (:errors body))))))
+           (first (:errors response))))))
 
 (deftest update-field-validation-test
   (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
@@ -89,4 +89,4 @@
         response (json/parse-string body true)]
     (is (= 400 status))
     (is (= "#/update-field: CROMULANT_FIELD is not a valid enum value"
-           (first (:errors body))))))
+           (first (:errors response))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
@@ -42,15 +42,15 @@
 
    "update entries: more than 2"
    [["ur_1" "https://aws.example.fiz" "https://aws.example.baz"]]
-   "#/updates/2: expected maximum item count: 2, found: 3"
+   "#/updates/0: expected maximum item count: 2, found: 3"
 
    "update entries: fewer than 2 (1)"
    [["ur_1"]]
-   "#/updates/2: expected minimum item count: 2, found: 1"
+   "#/updates/0: expected minimum item count: 2, found: 1"
 
    "update entries: fewer than 2 (0)"
    [[]]
-   "#/updates/2: expected minimum item count: 2, found: 0"
+   "#/updates/0: expected minimum item count: 2, found: 0"
 
    ;; Business rules validation
 
@@ -75,7 +75,7 @@
                                                            bulk-update-options)
         response (json/parse-string body true)]
     (is (= 400 status))
-    (is (= "#/operation: CROMULANT_OPERATION is not a valid enum value"
+    (is (= "#/operation: CROMULENT_OPERATION is not a valid enum value"
            (first (:errors response))))))
 
 (deftest update-field-validation-test

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -53,11 +53,18 @@
                  (:concept-id coll1)
                  {:native-id "gran-native1-4"
                   :granule-ur "SC:AE_5DSno.002:30500514"})
-                :umm-json))]
+                :umm-json))
+        gran5 (ingest/ingest-concept
+               (data-core/item->concept
+                (granule/granule-with-umm-spec-collection
+                 coll1
+                 (:concept-id coll1)
+                 {:native-id "gran-native1-5"
+                  :granule-ur "SC:AE_5DSno.002:30500515"})))]
 
     (testing "OPeNDAP url granule bulk update"
       (testing "successful OPeNDAP url granule bulk update"
-        (let [bulk-update {:name "add opendap links"
+        (let [bulk-update {:name "add opendap links 1"
                            :operation "UPDATE_FIELD"
                            :update-field "OPeNDAPLink"
                            :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
@@ -82,7 +89,7 @@
                    granule-statuses)))))
 
       (testing "failed OPeNDAP url granule bulk update"
-        (let [bulk-update {:name "add opendap links"
+        (let [bulk-update {:name "add opendap links 2"
                            :operation "UPDATE_FIELD"
                            :update-field "OPeNDAPLink"
                            :updates [["SC:AE_5DSno.002:30500513" "https://url30500513"]]}
@@ -102,7 +109,7 @@
                    granule-statuses)))))
 
       (testing "partial successful OPeNDAP url granule bulk update"
-        (let [bulk-update {:name "add opendap links"
+        (let [bulk-update {:name "add opendap links 3"
                            :operation "UPDATE_FIELD"
                            :update-field "OPeNDAPLink"
                            :updates [["SC:AE_5DSno.002:30500511" "https://url30500511"]
@@ -129,12 +136,13 @@
                                              task-id)}]
                    granule-statuses)))))
       (testing "invalid OPeNDAP url value in instruction"
-        (let [bulk-update {:name "add opendap links"
+        (let [bulk-update {:name "add opendap links 4"
                            :operation "UPDATE_FIELD"
                            :update-field "OPeNDAPLink"
                            :updates [["SC:AE_5DSno.002:30500511" "https://foo,https://bar,https://baz"]
                                      ["SC:AE_5DSno.002:30500512" "https://foo, https://bar"]
-                                     ["SC:AE_5DSno.002:30500514" "https://opendap.sit.earthdata.nasa.gov/foo,https://opendap.earthdata.nasa.gov/bar"]]}
+                                     ["SC:AE_5DSno.002:30500514" "https://opendap.sit.earthdata.nasa.gov/foo,https://opendap.earthdata.nasa.gov/bar"]
+                                     ["SC:AE_5DSno.002:30500515" "s3://opendap.sit.earthdata.nasa.gov/foo"]]}
               response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)
               {:keys [status task-id]} response]
           (index/wait-until-indexed)
@@ -144,7 +152,7 @@
           (let [status-response (ingest/granule-bulk-update-task-status task-id)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
-            (is (= "Task completed with 3 FAILED out of 3 total granule update(s)."
+            (is (= "Task completed with 4 FAILED out of 4 total granule update(s)."
                    status-message))
             (is (= [{:granule-ur "SC:AE_5DSno.002:30500511"
                      :status "FAILED"
@@ -154,12 +162,15 @@
                      :status-message "Invalid URL value, no more than one on-prem OPeNDAP url can be provided: https://foo, https://bar"}
                     {:granule-ur "SC:AE_5DSno.002:30500514"
                      :status "FAILED"
-                     :status-message "Invalid URL value, no more than one Hyrax-in-the-cloud OPeNDAP url can be provided: https://opendap.sit.earthdata.nasa.gov/foo,https://opendap.earthdata.nasa.gov/bar"}]
+                     :status-message "Invalid URL value, no more than one Hyrax-in-the-cloud OPeNDAP url can be provided: https://opendap.sit.earthdata.nasa.gov/foo,https://opendap.earthdata.nasa.gov/bar"}
+                    {:granule-ur "SC:AE_5DSno.002:30500515"
+                     :status "FAILED"
+                     :status-message "OPeNDAP URL value cannot start with s3://, but was s3://opendap.sit.earthdata.nasa.gov/foo"}]
                    granule-statuses))))))
 
     (testing "S3 url granule bulk update"
       (testing "successful S3 url granule bulk update"
-        (let [bulk-update {:name "add S3 links"
+        (let [bulk-update {:name "add S3 links 1"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
@@ -184,7 +195,7 @@
                    granule-statuses)))))
 
       (testing "failed S3 link granule bulk update"
-        (let [bulk-update {:name "add s3 links"
+        (let [bulk-update {:name "add s3 links 2"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500513" "s3://url30500513"]]}
@@ -204,7 +215,7 @@
                    granule-statuses)))))
 
       (testing "partial successful S3 link granule bulk update"
-        (let [bulk-update {:name "add s3 links"
+        (let [bulk-update {:name "add s3 links 3"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
@@ -232,7 +243,7 @@
                    granule-statuses)))))
 
       (testing "invalid S3 url value in instruction"
-        (let [bulk-update {:name "add S3 links"
+        (let [bulk-update {:name "add S3 links 4"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500511" "https://foo"]


### PR DESCRIPTION
Would like some additional feedback about the format of the error messages returned by the JSON schema validation library. Specifically the "#/updates/2" referring to the instruction level schema. Should they be transformed into something more readable or fine as-is?