### PR TITLE
CMR-6975 Make the browse-scaler coverage report available to CI tools

### DIFF
--- a/browse-scaler/src/docker-compose.test.yml
+++ b/browse-scaler/src/docker-compose.test.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile.test
     volumes:
       - ./__test__:/app/artifacts
+      - ./coverage:/app/coverage
     command: npm run ci-test
     environment:
       - JEST_JUNIT_OUTPUT=./artifacts/junit.xml


### PR DESCRIPTION
The report was being generated but was not available outside the docker container. This publishes the coverage directory to the CI agent when tests are run.