### PR TITLE
Cmr 7250 index wrong gcmd science keywords

### DIFF
--- a/common-lib/src/cmr/common/xml/simple_xpath.clj
+++ b/common-lib/src/cmr/common/xml/simple_xpath.clj
@@ -132,20 +132,20 @@
      :value value
      :sub-str? true}))
 
-(defn- create-elem-val-include-selector
+(defn- create-elem-val-substring-selector
   "Creates a selector that selects elements which have a child element with a
   value that includes a substring."
   [selector-str]
-  (let [[_ xpath value] (re-matches #"includes\((.+), *'(.+)'\)" selector-str)
+  (let [[_ xpath element-value] (re-matches #"contains\((.+), *'(.+)'\)" selector-str)
         parsed-xpath (parse-xpath xpath)]
     (when (not= (:source parsed-xpath) :from-context)
       (throw
         (Exception.
           (str "Nested XPath selectors can not be from the root. XPath: "
                xpath))))
-    {:type :element-value-include-selector
+    {:type :element-value-selector
      :selectors (:selectors parsed-xpath)
-     :element-value value
+     :element-value element-value
      :sub-str? true}))
 
 (defn- create-elem-val-equality-selector
@@ -239,11 +239,11 @@
     (re-matches #".+='.+'" selector-str)
     (create-elem-val-equality-selector selector-str)
 
-    (re-matches #".*contains\(.*" selector-str)
+    (re-matches #".*contains\(.*@.+" selector-str)
     (create-attrib-val-substring-selector selector-str)
 
-    (re-matches #".*includes\(.*" selector-str)
-    (create-elem-val-include-selector selector-str)
+    (re-matches #".*contains\(.+" selector-str)
+    (create-elem-val-substring-selector selector-str)
 
     :else
     (throw
@@ -385,24 +385,14 @@
                  (= selected-value value))))
            elements))
 
-(defmethod process-xml-selector :element-value-include-selector
-  [elements {:keys [selectors element-value sub-str?]}]
-  (filterv (fn [element]
-             (some (fn [selected-element]
-                     (if sub-str?
-                       (str/includes? (-> selected-element :content first) element-value)
-                       (= (-> selected-element :content first) element-value)))
-                   (process-selectors
-                     [element] selectors process-xml-selector)))
-           elements))
-
 (defmethod process-xml-selector :element-value-selector
-  [elements {:keys [selectors element-value not-equal?]}]
+  [elements {:keys [selectors element-value not-equal? sub-str?]}]
   (filterv (fn [element]
              (some (fn [selected-element]
-                     (if not-equal?
-                       (not= (-> selected-element :content first) element-value)
-                       (= (-> selected-element :content first) element-value)))
+                     (cond
+                       not-equal? (not= (-> selected-element :content first) element-value) 
+                       sub-str? (str/includes? (-> selected-element :content first) element-value)
+                       :else (= (-> selected-element :content first) element-value)))
                    (process-selectors
                      [element] selectors process-xml-selector)))
            elements))

--- a/common-lib/src/cmr/common/xml/simple_xpath.clj
+++ b/common-lib/src/cmr/common/xml/simple_xpath.clj
@@ -133,8 +133,8 @@
      :sub-str? true}))
 
 (defn- create-elem-val-include-selector
-  "Creates a selector that selects elements with an attribute with a given
-  value that matches by substring."
+  "Creates a selector that selects elements which have a child element with a
+  value that includes a substring."
   [selector-str]
   (let [[_ xpath value] (re-matches #"includes\((.+), *'(.+)'\)" selector-str)
         parsed-xpath (parse-xpath xpath)]

--- a/common-lib/test/cmr/common/test/xml/simple_xpath.clj
+++ b/common-lib/test/cmr/common/test/xml/simple_xpath.clj
@@ -218,7 +218,14 @@
                             "<author>Corets, Eva</author>"
                             "<author>Lucy, Steven</author>"
                             "<author>Corets, Eva</author>"
-                            "<author>Corets, Eva</author>"])))
+                            "<author>Corets, Eva</author>"])
+
+         "/catalog/book[contains(genre, 'anta')]/author"
+         (mapv x/parse-str ["<author>Ralls, Kim</author>"
+                            "<author>Corets, Eva</author>"
+                            "<author>Lucy, Steven</author>"
+                            "<author>Corets, Eva</author>"
+                            "<author>Corets, Eva</author>"]) ))
 
   (testing "xpaths within context"
     (let [xpath-context (sx/evaluate sample-xml (sx/parse-xpath "/catalog/book[1]"))]

--- a/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
+++ b/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
@@ -432,7 +432,7 @@
                         <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; SPECIES/POPULATION INTERACTIONS &gt; POPULATION DYNAMICS &gt; NONE &gt; NONE</gco:CharacterString>
                     </gmd:keyword>
                     <gmd:keyword>
-                        <gmx:Anchor>EARTH SCIENCE &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; ECOTOXICOLOGY &gt; TOXICITY LEVELS &gt; NONE &gt; NONE</gmx:Anchor>
+                        <gmx:Anchor>EARTH SCIENCE gmxAnchor &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; ECOTOXICOLOGY &gt; TOXICITY LEVELS &gt; NONE &gt; NONE</gmx:Anchor>
                     </gmd:keyword>
                     <gmd:type>
                         <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
@@ -477,7 +477,34 @@
             <gmd:descriptiveKeywords>
                 <gmd:MD_Keywords>
                     <gmd:keyword>
-                        <gco:CharacterString>wkm-oceanography</gco:CharacterString>
+                        <gmx:Anchor>skw-nottheme-oceanography</gmx:Anchor>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="nottheme">nottheme</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>Global Change Master Directory (GCMD) Science Keywords</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2012-09-15</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>wkw-oceanography</gco:CharacterString>
                     </gmd:keyword>
                     <gmd:type>
                         <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>

--- a/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
+++ b/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <gmi:MI_Metadata xmlns:eos="http://earthdata.nasa.gov/schema/eos" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://earthdata.nasa.gov/schema/eos https://cdn.earthdata.nasa.gov/iso/eos/1.0/eos.xsd http://www.isotc211.org/2005/gco https://cdn.earthdata.nasa.gov/iso/gco/1.0/gco.xsd http://www.isotc211.org/2005/gmd https://cdn.earthdata.nasa.gov/iso/gmd/1.0/gmd.xsd http://www.isotc211.org/2005/gmi https://cdn.earthdata.nasa.gov/iso/gmi/1.0/gmi.xsd http://www.opengis.net/gml/3.2 https://cdn.earthdata.nasa.gov/iso/gml/1.0/gml.xsd http://www.isotc211.org/2005/gmx https://cdn.earthdata.nasa.gov/iso/gmx/1.0/gmx.xsd http://www.isotc211.org/2005/gsr https://cdn.earthdata.nasa.gov/iso/gsr/1.0/gsr.xsd http://www.isotc211.org/2005/gss https://cdn.earthdata.nasa.gov/iso/gss/1.0/gss.xsd http://www.isotc211.org/2005/gts https://cdn.earthdata.nasa.gov/iso/gts/1.0/gts.xsd http://www.isotc211.org/2005/srv https://cdn.earthdata.nasa.gov/iso/srv/1.0/srv.xsd">
     <gmd:fileIdentifier>
         <gco:CharacterString>Investigation of Bird Mortality in the Playa Lakes of Southeastern New Mexico.</gco:CharacterString>
@@ -458,7 +459,7 @@
                     <gmd:thesaurusName>
                         <gmd:CI_Citation>
                             <gmd:title>
-                                <gco:CharacterString>Global Change Master Directory (GCMD) Science Keywords</gco:CharacterString>
+                                <gco:CharacterString>NASA / GCMD Science Keywords</gco:CharacterString>
                             </gmd:title>
                             <gmd:date>
                                 <gmd:CI_Date>

--- a/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
+++ b/umm-spec-lib/resources/example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml
@@ -1,0 +1,805 @@
+<gmi:MI_Metadata xmlns:eos="http://earthdata.nasa.gov/schema/eos" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://earthdata.nasa.gov/schema/eos https://cdn.earthdata.nasa.gov/iso/eos/1.0/eos.xsd http://www.isotc211.org/2005/gco https://cdn.earthdata.nasa.gov/iso/gco/1.0/gco.xsd http://www.isotc211.org/2005/gmd https://cdn.earthdata.nasa.gov/iso/gmd/1.0/gmd.xsd http://www.isotc211.org/2005/gmi https://cdn.earthdata.nasa.gov/iso/gmi/1.0/gmi.xsd http://www.opengis.net/gml/3.2 https://cdn.earthdata.nasa.gov/iso/gml/1.0/gml.xsd http://www.isotc211.org/2005/gmx https://cdn.earthdata.nasa.gov/iso/gmx/1.0/gmx.xsd http://www.isotc211.org/2005/gsr https://cdn.earthdata.nasa.gov/iso/gsr/1.0/gsr.xsd http://www.isotc211.org/2005/gss https://cdn.earthdata.nasa.gov/iso/gss/1.0/gss.xsd http://www.isotc211.org/2005/gts https://cdn.earthdata.nasa.gov/iso/gts/1.0/gts.xsd http://www.isotc211.org/2005/srv https://cdn.earthdata.nasa.gov/iso/srv/1.0/srv.xsd">
+    <gmd:fileIdentifier>
+        <gco:CharacterString>Investigation of Bird Mortality in the Playa Lakes of Southeastern New Mexico.</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+        <gco:CharacterString>eng</gco:CharacterString>
+    </gmd:language>
+    <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+    </gmd:characterSet>
+    <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="series">series</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:individualName>
+                <gco:CharacterString>TYLER B. STEVENS</gco:CharacterString>
+            </gmd:individualName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <gmd:CI_Telephone>
+                            <gmd:voice>
+                                <gco:CharacterString>(301) 614-6898</gco:CharacterString>
+                            </gmd:voice>
+                            <gmd:facsimile>
+                                <gco:CharacterString>301-614-5268</gco:CharacterString>
+                            </gmd:facsimile>
+                        </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <gmd:CI_Address>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>NASA Goddard Space Flight Center</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:deliveryPoint>
+                                <gco:CharacterString>Global Change Master Directory</gco:CharacterString>
+                            </gmd:deliveryPoint>
+                            <gmd:city>
+                                <gco:CharacterString>Greenbelt</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:administrativeArea>
+                                <gco:CharacterString>MD</gco:CharacterString>
+                            </gmd:administrativeArea>
+                            <gmd:postalCode>
+                                <gco:CharacterString>20771</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>USA</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>Tyler.B.Stevens@nasa.gov</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                    </gmd:address>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+                <gco:CharacterString>DOI/USGS/BRD/NWHC &amp;gt; National Wildlife Health Center, Biological Resources Division, USGS, U.S. Department of the Interior</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage>
+                                <gmd:URL>http://www.nwhc.usgs.gov/</gmd:URL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>http</gco:CharacterString>
+                            </gmd:protocol>
+                            <gmd:description gco:nilReason="missing"/>
+                            <gmd:function>
+                                <gmd:CI_OnLineFunctionCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
+                            </gmd:function>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onlineResource>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+        <gco:DateTime>2015-12-02T00:00:00.000Z</gco:DateTime>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName>
+        <gco:CharacterString>ISO 19115-2 Geographic Information - Metadata Part 2 Extensions for imagery and gridded data</gco:CharacterString>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+        <gco:CharacterString>ISO 19115-2:2009(E)</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+            <gmd:referenceSystemIdentifier>
+                <gmd:RS_Identifier>
+                    <gmd:code>
+                        <gco:CharacterString>CARTESIAN</gco:CharacterString>
+                    </gmd:code>
+                </gmd:RS_Identifier>
+            </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:metadataExtensionInfo>
+        <gmd:MD_MetadataExtensionInformation>
+            <gmd:extendedElementInformation>
+                <gmd:MD_ExtendedElementInformation>
+                    <gmd:name>
+                        <gco:CharacterString>Metadata Update Date</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:definition>
+                        <gco:CharacterString>Update Date</gco:CharacterString>
+                    </gmd:definition>
+                    <gmd:dataType>
+                        <gmd:MD_DatatypeCode codeList="" codeListValue="">Date</gmd:MD_DatatypeCode>
+                    </gmd:dataType>
+                    <gmd:domainValue>
+                        <gco:CharacterString>2015-12-02T00:00:00.000Z</gco:CharacterString>
+                    </gmd:domainValue>
+                    <gmd:parentEntity gco:nilReason="inapplicable"/>
+                    <gmd:rule gco:nilReason="inapplicable"/>
+                    <gmd:source gco:nilReason="inapplicable"/>
+                </gmd:MD_ExtendedElementInformation>
+            </gmd:extendedElementInformation>
+        </gmd:MD_MetadataExtensionInformation>
+    </gmd:metadataExtensionInfo>
+    <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gco:CharacterString>Investigation of Bird Mortality in the Playa Lakes of Southeastern New Mexico.</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:DateTime>1970-01-01T00:00:00</gco:DateTime>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                    <gmd:edition>
+                        <gco:CharacterString>Not provided</gco:CharacterString>
+                    </gmd:edition>
+                    <gmd:identifier>
+                        <gmd:MD_Identifier>
+                            <gmd:code>
+                                <gco:CharacterString>brdnwhc0001</gco:CharacterString>
+                            </gmd:code>
+                            <gmd:codeSpace>
+                                <gco:CharacterString>gov.nasa.esdis.umm.shortname</gco:CharacterString>
+                            </gmd:codeSpace>
+                            <gmd:description>
+                                <gco:CharacterString>Short Name</gco:CharacterString>
+                            </gmd:description>
+                        </gmd:MD_Identifier>
+                    </gmd:identifier>
+                    <gmd:identifier>
+                        <gmd:MD_Identifier>
+                            <gmd:code gco:nilReason="unknown"/>
+                            <gmd:codeSpace>
+                                <gco:CharacterString>gov.nasa.esdis.umm.doi</gco:CharacterString>
+                            </gmd:codeSpace>
+                            <gmd:description>
+                                <gco:CharacterString>Explanation: It is unknown if this record has a DOI.</gco:CharacterString>
+                            </gmd:description>
+                        </gmd:MD_Identifier>
+                    </gmd:identifier>
+                    <gmd:citedResponsibleParty>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:individualName>
+                                <gco:CharacterString>Joshua Dein, Laurie Baeten</gco:CharacterString>
+                            </gmd:individualName>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="author">author</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:citedResponsibleParty>
+                    <gmd:citedResponsibleParty>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:individualName>
+                                <gco:CharacterString>National Biological Service</gco:CharacterString>
+                            </gmd:individualName>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="publisher">publisher</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:citedResponsibleParty>
+                    <gmd:citedResponsibleParty>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:positionName>
+                                <gco:CharacterString>release place</gco:CharacterString>
+                            </gmd:positionName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:deliveryPoint>
+                                                <gco:CharacterString>Washington, D.C.</gco:CharacterString>
+                                            </gmd:deliveryPoint>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="publisher">publisher</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:citedResponsibleParty>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>Not provided Version Description: </gco:CharacterString>
+            </gmd:abstract>
+            <gmd:purpose gco:nilReason="missing">
+                <gco:CharacterString>1. Estimate weekly migratory waterfowl use and mean duration of stay on selected playa lakes in the Potash Area, 2. Estimate weekly migratory waterfowl mortality on the selected playas, 3. Determine the cause(s) of death of birds found on
+            and around the selected playas, 4. Determine if the ingestion of waters of selected playa lakes in southwestern New Mexico causes deleterious physiologic changes in mallards, with and without direct contact with the water. 5. Prepare an annotated
+            bibliography of the existing literature on the geology, hydrology, water quality, playa ecology, and historic and current land uses in the Secretary's Potash Region in relation to potential causes or contributing factors to migratory bird mortality
+            and the suitability of playas as wildlife habitat.Playa lakes are shallow basins that are scattered through 140,000square miles in Texas, New Mexico, Oklahoma, Kansas, and Colorado.They are characterized as water catchments that are most
+            oftenephemeral, drain internally, accumulate sediment, and serve asrecharge points to underground aquifers. An estimated 31% (2,460) ofthese playas occur in New Mexico. The playas are important winteringareas for many species of waterfowl in the
+            Central Flyway, and providerefuge for many birds along this migratory pathway (Playa Lakes JointVenture, 1994).In the early 1990's the deaths of hundreds of migratory birds weredocumented along the shorelines of several playas in southeastern
+            NewMexico in an area known as the Secretary's Potash Area. This area,including parts of Lea and Eddy Counties, has been the subject ofmining and mineral development for 60- 70 years. Potash extractionbegan in the early 1930's following the
+            development of oil and gasresources in the late 1920's, and continues today as a major industry.The playa basins in this area have served as convenient dischargesites for waters produced by these mining and refining operations.The frequency,
+            magnitude, and geographic extent of migratory birdmortality in this region has not been assessed since there have beenno extensive surveys of historical and current bird use or mortalityon these playas. Likewise, the cause of death of birds dying
+            duringthe early 1990's has not been adequately evaluated. Necropsy of asmall number of birds found dead during 1993 suggest that physical andphysiological effects of high salt concentrations in certain playascaused or contributed to their deaths.
+            Concern has been raised thatconstituents of discharge water from potash mining and/or oil and gasdevelopment into playas may also be involved in causing mortality.Water quality surveys performed on several of the playas experiencingmortality in 1992
+            showed that there were significant differences inmany chemical and biological properties between playas that havereceived discharges and those without a similar history (Davis andHopkins, 1993). Questions also have been raised concerning
+            thehydrologic and geologic relationships amongst the playas involved inavian mortality. Information may exist on many of these issues, butpertinent sources have yet to be collected and analyzed.In April 1994, the National Wildlife Health Center
+            (NWHC) and theSouthern Ecological Science Center (SESC) received directives toinitiate a collaborative study investigating bird mortality in theplaya lakes of southeastern New Mexico. The NWHC was assigned leadresponsibility for the project in
+            cooperation with the SESC and theNew Mexico Cooperative Fish and Wildlife Research Unit (NMCFWRU). Aliterature survey on topics related to historic and current land use,hydrology, geology, water quality, playa ecology, and bird use andmortality were
+            also to be included in the study.</gco:CharacterString>
+            </gmd:purpose>
+            <gmd:status>
+                <gmd:MD_ProgressCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed">completed</gmd:MD_ProgressCode>
+            </gmd:status>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>DOI/USGS/BRD/NWHC &amp;gt; National Wildlife Health Center, Biological Resources Division, USGS, U.S. Department of the Interior</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:onlineResource>
+                                <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                        <gmd:URL>http://www.nwhc.usgs.gov/</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:protocol>
+                                        <gco:CharacterString>http</gco:CharacterString>
+                                    </gmd:protocol>
+                                    <gmd:description gco:nilReason="missing"/>
+                                    <gmd:function>
+                                        <gmd:CI_OnLineFunctionCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
+                                    </gmd:function>
+                                </gmd:CI_OnlineResource>
+                            </gmd:onlineResource>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName>
+                        <gco:CharacterString>DOI/USGS/BRD/NWHC &amp;gt; National Wildlife Health Center, Biological Resources Division, USGS, U.S. Department of the Interior</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:onlineResource>
+                                <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                        <gmd:URL>http://www.nwhc.usgs.gov/</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:protocol>
+                                        <gco:CharacterString>http</gco:CharacterString>
+                                    </gmd:protocol>
+                                    <gmd:description gco:nilReason="missing"/>
+                                    <gmd:function>
+                                        <gmd:CI_OnLineFunctionCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information"/>
+                                    </gmd:function>
+                                </gmd:CI_OnlineResource>
+                            </gmd:onlineResource>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:individualName>
+                        <gco:CharacterString>JOSHUA  DEIN</gco:CharacterString>
+                    </gmd:individualName>
+                    <gmd:organisationName>
+                        <gco:CharacterString>DOI/USGS/BRD/NWHC &amp;gt; National Wildlife Health Center, Biological Resources Division, USGS, U.S. Department of the Interior</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>(608) 264-5411</gco:CharacterString>
+                                    </gmd:voice>
+                                    <gmd:facsimile>
+                                        <gco:CharacterString>(608) 271-4640</gco:CharacterString>
+                                    </gmd:facsimile>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>National Wildlife Health Center</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Biological Resources Division</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>6006 Shroeder Road</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>Madison</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>WI</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>53711</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>USA</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>joshua_dein@nbs.gov</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:individualName>
+                        <gco:CharacterString>JOSHUA  DEIN</gco:CharacterString>
+                    </gmd:individualName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>(608) 264-5411</gco:CharacterString>
+                                    </gmd:voice>
+                                    <gmd:facsimile>
+                                        <gco:CharacterString>(608) 271-4640</gco:CharacterString>
+                                    </gmd:facsimile>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>National Wildlife Health Center</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>Biological Resources Division</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>6006 Shroeder Road</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>Madison</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>WI</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>53711</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>USA</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>joshua_dein@nbs.gov</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOLOGICAL CLASSIFICATION &gt; ANIMALS/VERTEBRATES &gt; BIRDS &gt; NONE &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; AQUATIC ECOSYSTEMS &gt; LAKES &gt; NONE &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; AQUATIC ECOSYSTEMS &gt; LAKES &gt; SALINE LAKES &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; AQUATIC ECOSYSTEMS &gt; MARINE HABITAT &gt; NONE &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; SPECIES/POPULATION INTERACTIONS &gt; MIGRATORY RATES/ROUTES &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EARTH SCIENCE &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; SPECIES/POPULATION INTERACTIONS &gt; POPULATION DYNAMICS &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gmx:Anchor>EARTH SCIENCE &gt; BIOSPHERE &gt; ECOLOGICAL DYNAMICS &gt; ECOTOXICOLOGY &gt; TOXICITY LEVELS &gt; NONE &gt; NONE</gmx:Anchor>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>Global Change Master Directory (GCMD) Science Keywords</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date gco:nilReason="unknown"/>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gmx:Anchor>skw-oceanography</gmx:Anchor>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>Global Change Master Directory (GCMD) Science Keywords</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2012-09-15</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>wkm-oceanography</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName>
+                        <gmd:CI_Citation>
+                            <gmd:title>
+                                <gco:CharacterString>WMO_CategoryCode</gco:CharacterString>
+                            </gmd:title>
+                            <gmd:date>
+                                <gmd:CI_Date>
+                                    <gmd:date>
+                                        <gco:Date>2012-09-15</gco:Date>
+                                    </gmd:date>
+                                    <gmd:dateType>
+                                        <gmd:CI_DateTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                                    </gmd:dateType>
+                                </gmd:CI_Date>
+                            </gmd:date>
+                        </gmd:CI_Citation>
+                    </gmd:thesaurusName>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>CONTINENT &gt; NORTH AMERICA &gt; NONE &gt; NONE &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>CONTINENT &gt; NORTH AMERICA &gt; UNITED STATES OF AMERICA &gt; NEW MEXICO &gt; NONE &gt; NONE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName gco:nilReason="unknown"/>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>BIRD MORTALITY</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>BIRD USE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>BRD</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>CALCIUM</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>DEHYDRATION</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>EDDY COUNTY</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>INLAND SALINE WATERS</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>LAGUNA TOSTON</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>LEA COUNTY</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>MAGNESIUM</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>MALLARD</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>NATIONAL POTASH COMPANY</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>NEW MEXICO</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>NORTHERN SHOVELER</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>PLAYA LAKES</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>POTASH MANUFACTURING</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>POTASSIUM</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>SALT POISONING</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>SODIUM</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>SOUTHEASTERN NEW MEXICO</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>SULFATE</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>TOSTON COUNTY</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>USGS</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>USGWS</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>WATERFOWL</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:keyword>
+                        <gco:CharacterString>WILLIAMS SINK</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:thesaurusName gco:nilReason="unknown"/>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>Not provided</gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                    <gmd:thesaurusName gco:nilReason="unknown"/>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:resourceConstraints>
+                <gmd:MD_LegalConstraints>
+                    <gmd:useLimitation>
+                        <gco:CharacterString>
+        None
+    </gco:CharacterString>
+                    </gmd:useLimitation>
+                    <gmd:useLimitation>
+                        <gco:CharacterString>Restriction Comment: 
+        Individuals interested in obtaining the playa lakes data set should contact Dr. Joshua Dein of the National Wildlife Health Center at Biological Resources Division in Minneapolis, Minnesota.
+    </gco:CharacterString>
+                    </gmd:useLimitation>
+                </gmd:MD_LegalConstraints>
+            </gmd:resourceConstraints>
+            <gmd:aggregationInfo>
+                <gmd:MD_AggregateInformation>
+                    <gmd:aggregateDataSetName>
+                        <gmd:CI_Citation>
+                            <gmd:title gco:nilReason="missing"/>
+                            <gmd:date gco:nilReason="missing"/>
+                            <gmd:citedResponsibleParty>
+                                <gmd:CI_ResponsibleParty>
+                                    <gmd:contactInfo>
+                                        <gmd:CI_Contact>
+                                            <gmd:onlineResource>
+                                                <gmd:CI_OnlineResource>
+                                                    <gmd:linkage>
+                                                        <gmd:URL>http://mercury-ops2.ornl.gov/clearinghouse/send/xsltText2?fileURL=%2Fdata%2FMercury_instances%2Fusgs%2Fcsas%2Fharvested%2Fwww1.usgs.gov_metadata_mdata_USGS_NWHC_brdnwhc0001.xml&amp;full_datasource=Metadata+Clearinghouse+Principal+Node&amp;full_queryString=+Investigation+of+Bird+Mortality+in+the+Playa+Lakes+of+Southeastern+New+Mexico.&amp;ds_id=</gmd:URL>
+                                                    </gmd:linkage>
+                                                    <gmd:description>
+                                                        <gco:CharacterString>URLContentType: CollectionURL Type: EXTENDED METADATA</gco:CharacterString>
+                                                    </gmd:description>
+                                                </gmd:CI_OnlineResource>
+                                            </gmd:onlineResource>
+                                        </gmd:CI_Contact>
+                                    </gmd:contactInfo>
+                                    <gmd:role>
+                                        <gmd:CI_RoleCode codeList="" codeListValue=""/>
+                                    </gmd:role>
+                                </gmd:CI_ResponsibleParty>
+                            </gmd:citedResponsibleParty>
+                        </gmd:CI_Citation>
+                    </gmd:aggregateDataSetName>
+                    <gmd:associationType gco:nilReason="missing"/>
+                </gmd:MD_AggregateInformation>
+            </gmd:aggregationInfo>
+            <gmd:language>
+                <gco:CharacterString>eng</gco:CharacterString>
+            </gmd:language>
+            <gmd:topicCategory>
+                <gmd:MD_TopicCategoryCode>biota</gmd:MD_TopicCategoryCode>
+            </gmd:topicCategory>
+            <gmd:topicCategory>
+                <gmd:MD_TopicCategoryCode>inlandWaters</gmd:MD_TopicCategoryCode>
+            </gmd:topicCategory>
+            <gmd:topicCategory>
+                <gmd:MD_TopicCategoryCode>oceans</gmd:MD_TopicCategoryCode>
+            </gmd:topicCategory>
+            <gmd:extent>
+                <gmd:EX_Extent id="boundingExtent">
+                    <gmd:description>
+                        <gco:CharacterString>SpatialCoverageType=HORIZONTAL,SpatialGranuleSpatialRepresentation=NO_SPATIAL,CoordinateSystem=CARTESIAN</gco:CharacterString>
+                    </gmd:description>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox id="geo-6fd5151a-c8f6-4bed-adff-76ea4f1076ee">
+                            <gmd:extentTypeCode>
+                                <gco:Boolean>1</gco:Boolean>
+                            </gmd:extentTypeCode>
+                            <gmd:westBoundLongitude>
+                                <gco:Decimal>-105.0</gco:Decimal>
+                            </gmd:westBoundLongitude>
+                            <gmd:eastBoundLongitude>
+                                <gco:Decimal>-103.0</gco:Decimal>
+                            </gmd:eastBoundLongitude>
+                            <gmd:southBoundLatitude>
+                                <gco:Decimal>32.0</gco:Decimal>
+                            </gmd:southBoundLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>34.0</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:temporalElement>
+                        <gmd:EX_TemporalExtent>
+                            <gmd:extent>
+                                <gml:TimePeriod gml:id="df0eb5cde-4bd2-48a7-b2e9-3016796f6717">
+                                    <gml:beginPosition>1994-10-01T00:00:00.000Z</gml:beginPosition>
+                                    <gml:endPosition>1995-04-30T23:59:59.999Z</gml:endPosition>
+                                </gml:TimePeriod>
+                            </gmd:extent>
+                        </gmd:EX_TemporalExtent>
+                    </gmd:temporalElement>
+                </gmd:EX_Extent>
+            </gmd:extent>
+            <gmd:processingLevel>
+                <gmd:MD_Identifier>
+                    <gmd:code>
+                        <gco:CharacterString>Not provided</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:MD_Identifier>
+            </gmd:processingLevel>
+        </gmd:MD_DataIdentification>
+    </gmd:identificationInfo>
+    <gmd:contentInfo>
+        <gmd:MD_ImageDescription>
+            <gmd:attributeDescription/>
+            <gmd:contentType/>
+            <gmd:processingLevelCode>
+                <gmd:MD_Identifier>
+                    <gmd:code>
+                        <gco:CharacterString>Not provided</gco:CharacterString>
+                    </gmd:code>
+                    <gmd:codeSpace>
+                        <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+                    </gmd:codeSpace>
+                </gmd:MD_Identifier>
+            </gmd:processingLevelCode>
+        </gmd:MD_ImageDescription>
+    </gmd:contentInfo>
+    <gmd:dataQualityInfo>
+        <gmd:DQ_DataQuality>
+            <gmd:scope>
+                <gmd:DQ_Scope>
+                    <gmd:level>
+                        <gmd:MD_ScopeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="series">series</gmd:MD_ScopeCode>
+                    </gmd:level>
+                </gmd:DQ_Scope>
+            </gmd:scope>
+            <gmd:report>
+                <gmd:DQ_AccuracyOfATimeMeasurement>
+                    <gmd:measureIdentification>
+                        <gmd:MD_Identifier>
+                            <gmd:code>
+                                <gco:CharacterString>PrecisionOfSeconds</gco:CharacterString>
+                            </gmd:code>
+                        </gmd:MD_Identifier>
+                    </gmd:measureIdentification>
+                    <gmd:result>
+                        <gmd:DQ_QuantitativeResult>
+                            <gmd:valueUnit/>
+                            <gmd:value>
+                                <gco:Record xsi:type="gco:Real_PropertyType"/>
+                            </gmd:value>
+                        </gmd:DQ_QuantitativeResult>
+                    </gmd:result>
+                </gmd:DQ_AccuracyOfATimeMeasurement>
+            </gmd:report>
+            <gmd:report>
+                <gmd:DQ_QuantitativeAttributeAccuracy>
+                    <gmd:evaluationMethodDescription>
+                        <gco:CharacterString>
+        The data was screened statistically to identify possible outliers and influential measurements.
+    </gco:CharacterString>
+                    </gmd:evaluationMethodDescription>
+                    <gmd:result gco:nilReason="missing"/>
+                </gmd:DQ_QuantitativeAttributeAccuracy>
+            </gmd:report>
+            <gmd:lineage>
+                <gmd:LI_Lineage>
+                    <gmd:processStep>
+                        <gmi:LE_ProcessStep>
+                            <gmd:description gco:nilReason="unknown"/>
+                        </gmi:LE_ProcessStep>
+                    </gmd:processStep>
+                </gmd:LI_Lineage>
+            </gmd:lineage>
+        </gmd:DQ_DataQuality>
+    </gmd:dataQualityInfo>
+    <gmi:acquisitionInformation>
+        <gmi:MI_AcquisitionInformation>
+            <gmi:platform>
+                <eos:EOS_Platform id="d291eec2d-7dab-4d31-8405-21b4dc1456df">
+                    <gmi:identifier>
+                        <gmd:MD_Identifier>
+                            <gmd:code>
+                                <gco:CharacterString>Not provided</gco:CharacterString>
+                            </gmd:code>
+                            <gmd:codeSpace>
+                                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+                            </gmd:codeSpace>
+                        </gmd:MD_Identifier>
+                    </gmi:identifier>
+                    <gmi:description>
+                        <gco:CharacterString>Not provided</gco:CharacterString>
+                    </gmi:description>
+                    <gmi:instrument gco:nilReason="inapplicable"/>
+                </eos:EOS_Platform>
+            </gmi:platform>
+        </gmi:MI_AcquisitionInformation>
+    </gmi:acquisitionInformation>
+</gmi:MI_Metadata>

--- a/umm-spec-lib/src/cmr/umm_spec/iso_keywords.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/iso_keywords.clj
@@ -57,7 +57,7 @@
 
 (def science-keyword-title
   "String used to define the keyword title for science keywords."
-  "Global Change Master Directory (GCMD) Science Keywords")
+  "GCMD")
 
 (defn parse-keyword-str
   "Returns a seq of individual components of an ISO-19115-2 or SMAP keyword string."
@@ -122,20 +122,20 @@
                       keyword-type "']"))
 
         ;;for each descriptiveKeyword with the keyword-type, get /gmd:keyword/gco:CharacterString
-        ;;and /gmd:keyword/gmx:Anchor that satisfy the keyword-title condition.
+        ;;and /gmd:keyword/gmx:Anchor that includes the keyword-title.
         gco-values
          (for [desc-kw desc-kws-with-kw-type]
            (values-at desc-kw
                       (str "gmd:MD_Keywords"
-                           "[gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString='"
-                           keyword-title "']"
+                           "[includes(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
+                           keyword-title "')]"
                            "/gmd:keyword/gco:CharacterString")))
         gmx-values
          (for [desc-kw desc-kws-with-kw-type]
            (values-at desc-kw
                       (str "gmd:MD_Keywords"
-                           "[gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString='"
-                           keyword-title "']"
+                           "[includes(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
+                           keyword-title "')]"
                            "/gmd:keyword/gmx:Anchor")))
         keyword-values (concat gco-values gmx-values)]
     (flatten keyword-values)))

--- a/umm-spec-lib/src/cmr/umm_spec/iso_keywords.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/iso_keywords.clj
@@ -127,14 +127,14 @@
          (for [desc-kw desc-kws-with-kw-type]
            (values-at desc-kw
                       (str "gmd:MD_Keywords"
-                           "[includes(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
+                           "[contains(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
                            keyword-title "')]"
                            "/gmd:keyword/gco:CharacterString")))
         gmx-values
          (for [desc-kw desc-kws-with-kw-type]
            (values-at desc-kw
                       (str "gmd:MD_Keywords"
-                           "[includes(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
+                           "[contains(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString, '"
                            keyword-title "')]"
                            "/gmd:keyword/gmx:Anchor")))
         keyword-values (concat gco-values gmx-values)]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -119,6 +119,8 @@
   Category of each theme descriptive keyword to determine if it is a science keyword."
   [data-id-el sanitize?]
   (if-let [science-keywords (seq
+                              ;; kws/parse-science-keywords is shared by iso19115 and isosmap
+                              ;; "true" indicates it's isosmap case.
                               (->> (kws/parse-science-keywords data-id-el sanitize? true)
                                    (filter #(.contains kws/science-keyword-categories (:Category %)))))]
     science-keywords

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso_smap.clj
@@ -119,7 +119,7 @@
   Category of each theme descriptive keyword to determine if it is a science keyword."
   [data-id-el sanitize?]
   (if-let [science-keywords (seq
-                              (->> (kws/parse-science-keywords data-id-el sanitize?)
+                              (->> (kws/parse-science-keywords data-id-el sanitize? true)
                                    (filter #(.contains kws/science-keyword-categories (:Category %)))))]
     science-keywords
     (when sanitize?

--- a/umm-spec-lib/test/cmr/umm_spec/test/iso_keywords.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/iso_keywords.clj
@@ -26,13 +26,17 @@
           md-data-id-el (first (select cmr-7250-coll md-data-id-base-xpath))
           keyword-type iso-keywords/science-keyword-type
           keyword-title iso-keywords/science-keyword-title
+          ;; Verify skw-nottheme-oceanography not included(right title, wrong type.);
+          ;;        wkw-oceanography not included(right type, wrong title - WMO keyword);
+          ;;        EARTH SCIENCE gmxAnchor and skw-oceanography are included (gmx:Anchor cases)
+          ;;        Six other EARTH SCIENCE are included (gco:CharacterString cases).
           expected-skw ["EARTH SCIENCE > BIOLOGICAL CLASSIFICATION > ANIMALS/VERTEBRATES > BIRDS > NONE > NONE > NONE"
                         "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > LAKES > NONE > NONE > NONE"
                         "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > LAKES > SALINE LAKES > NONE > NONE"
                         "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > MARINE HABITAT > NONE > NONE > NONE"
                         "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > SPECIES/POPULATION INTERACTIONS > MIGRATORY RATES/ROUTES > NONE > NONE"
                         "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > SPECIES/POPULATION INTERACTIONS > POPULATION DYNAMICS > NONE > NONE"
-                        "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > ECOTOXICOLOGY > TOXICITY LEVELS > NONE > NONE"
+                        "EARTH SCIENCE gmxAnchor > BIOSPHERE > ECOLOGICAL DYNAMICS > ECOTOXICOLOGY > TOXICITY LEVELS > NONE > NONE"
                         "skw-oceanography"]]
       ;; descriptive-keywords-with-title function should return the right number of ScienceKeywords 
       (is (= expected-skw (iso-keywords/descriptive-keywords-with-title md-data-id-el keyword-type keyword-title))))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/iso_keywords.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/iso_keywords.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3]]
+   [cmr.common.xml.simple-xpath :refer [select]]
    [cmr.umm-spec.iso-keywords :as iso-keywords]))
 
 (deftest science-keyword-empty-value-test
@@ -14,3 +15,24 @@
       ;; Parse function should return nil - it is throwing a service error that
       ;; that we do not catch in this unit test
       (is (= nil (iso-keywords/parse-science-keywords cmr-6840-example-collection false))))))
+
+(deftest science-keyword-wmo-keyword-gco-gmx-mixed-test
+  (testing "WMO keyword is not translated to ScienceKeyword, both gco and gmx values are counted."
+    (let [cmr-7250-coll (-> "example-data/special-case-files/CMR-7250-Mix-WMO-And-ScienceKeywords.xml"
+                                          io/resource
+                                          io/file
+                                          slurp)
+          md-data-id-base-xpath "/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification"
+          md-data-id-el (first (select cmr-7250-coll md-data-id-base-xpath))
+          keyword-type iso-keywords/science-keyword-type
+          keyword-title iso-keywords/science-keyword-title
+          expected-skw ["EARTH SCIENCE > BIOLOGICAL CLASSIFICATION > ANIMALS/VERTEBRATES > BIRDS > NONE > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > LAKES > NONE > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > LAKES > SALINE LAKES > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > AQUATIC ECOSYSTEMS > MARINE HABITAT > NONE > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > SPECIES/POPULATION INTERACTIONS > MIGRATORY RATES/ROUTES > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > SPECIES/POPULATION INTERACTIONS > POPULATION DYNAMICS > NONE > NONE"
+                        "EARTH SCIENCE > BIOSPHERE > ECOLOGICAL DYNAMICS > ECOTOXICOLOGY > TOXICITY LEVELS > NONE > NONE"
+                        "skw-oceanography"]]
+      ;; descriptive-keywords-with-title function should return the right number of ScienceKeywords 
+      (is (= expected-skw (iso-keywords/descriptive-keywords-with-title md-data-id-el keyword-type keyword-title))))))


### PR DESCRIPTION
Clarification:
1. This change applies to iso19115 only. isosmap shouldn't be impacted.
2. ScienceKeywords for iso19115 should be the descriptiveKeywords with "theme" keyword type (current behavior)
 AND with gmd:thesaurusName's CharacterString value including "GCMD".  (new feature)  This is because NOAA uses the same type of theme for their Science keywords, as well as their WMO keywords.
3. We should get the values from both gco:CharacterString(current behavior) and gmx:Anchor (new feature)