### PR TITLE
CMR-7214: Add support for additional keyword searching

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -30,8 +30,8 @@
              (= \] last-char)))))
 
 (defn- prepare-keyword-field
-  [field-value]
   "Convert a string to lowercase then separate it into keywords"
+  [field-value]
   (when field-value
     (let [field-value (string/lower-case field-value)]
       (if (wrapped-keyword? field-value)

--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -20,8 +20,8 @@
   "Checks if the field-value about to be processed is a term surrounded by parens or brackets.
    If it is, we want to add the usual keywords, but also add the unwrapped field-value on its own."
   [field-value]
-  (let [first-char (first field-value)]
-       [last-char (last field-value)]
+  (let [first-char (first field-value)
+        last-char (last field-value)]
     (and (or (= \( first-char)
              (= \{ first-char)
              (= \[ first-char))

--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -16,12 +16,28 @@
   "Defines Regex to split strings with special characters into multiple words for keyword searches."
   #"[!@#$%^&()\-=_+{}\[\]|;'.,\\\"/:<>?`~* ]")
 
+(defn- wrapped-keyword?
+  "Checks if the field-value about to be processed is a term surrounded by parens or brackets.
+   If it is, we want to add the usual keywords, but also add the unwrapped field-value on its own."
+  [field-value]
+  (let [first-char (first field-value)]
+       [last-char (last field-value)]
+    (and (or (= \( first-char)
+             (= \{ first-char)
+             (= \[ first-char))
+         (or (= \) last-char)
+             (= \} last-char)
+             (= \] last-char)))))
+
 (defn- prepare-keyword-field
   [field-value]
   "Convert a string to lowercase then separate it into keywords"
   (when field-value
     (let [field-value (string/lower-case field-value)]
-      (into [field-value] (string/split field-value keywords-separator-regex)))))
+      (if (wrapped-keyword? field-value)
+        (as-> (subs field-value 1 (dec (.length field-value))) trimmed-value
+              (into [field-value trimmed-value] (string/split field-value keywords-separator-regex)))
+        (into [field-value] (string/split field-value keywords-separator-regex))))))
 
 (defn field-values->keyword-text
   "Returns the keyword text for the given list of field values."

--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -43,6 +43,7 @@
   "Returns the keyword text for the given list of field values."
   [field-values]
   (->> field-values
+       (mapcat #(string/split % #" "))
        (mapcat prepare-keyword-field)
        (keep not-empty)
        (apply sorted-set)

--- a/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
@@ -20,7 +20,7 @@
                            :Description "The map projection of the granule"
                            :Value "aa-value-1"
                            :DataType "STRING"}]
-   :AncillaryKeywords ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)"]
+   :AncillaryKeywords ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)" "(TMPA-RT-MULTI-TERM)"]
    :AssociatedDOIs [{:DOI "Associated-DOI-1"
                      :Title "Assoc Title 1"
                      :Authority "https://doi.org"}
@@ -289,7 +289,7 @@
 
     "AncillaryKeywords field"
     :AncillaryKeywords
-    ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)"]
+    ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)" "(TMPA-RT-MULTI-TERM)"]
 
     "CollectionCitations field"
     :CollectionCitations
@@ -415,15 +415,16 @@
                      :RelatedUrls
                      :ScienceKeywords
                      :DataCenters]]
-    (is (= ["(TMPA-RT)" "(USGS_EROS)" "001" "A test related url." "ATMOSPHERE" "ATMOSPHERIC WINDS" "AUTHOR" "Alice" "Bob"
-            "DATA ANALYSIS AND VISUALIZATION" "Data Center Contact" "DataCenterURL" "Doe"
-            "EARTH SCIENCE SERVICES" "EDG" "EOSDIS" "ESIP" "GENERAL DOCUMENTATION"
+    (is (= ["(TMPA-RT)" "(TMPA-RT-MULTI-TERM)" "(USGS_EROS)" "001" "A test related url." "ATMOSPHERE"
+            "ATMOSPHERIC WINDS" "AUTHOR" "Alice" "Bob" "DATA ANALYSIS AND VISUALIZATION" "Data Center Contact"
+            "DataCenterURL" "Doe" "EARTH SCIENCE SERVICES" "EDG" "EOSDIS" "ESIP" "GENERAL DOCUMENTATION"
             "GEOGRAPHIC INFORMATION SYSTEMS" "GET SERVICE" "HOME PAGE" "IRIS/PASSCAL" "John"
             "LP DAAC" "LPDAAC" "MICROWAVE" "MICROWAVE IMAGERY" "PublicationURL" "RADAR"
             "Related-url description." "SCIENCE CAT 3" "SCIENCE CONTACT" "SCIENCE TERM 3"
             "SCIENCE TOPIC 3" "SPECTRAL/ENGINEERING" "SURFACE WINDS" "Science Contact" "TEAM SPOCK"
             "Technical Contact" "Technical Contact" "USGS" "USGS/EROS" "VIIRS"
-            "Visible Infrared Imaging Radiometer suite." "White Marsh Institute of Health" "related-url-example-two.com" "related-url-example.com"]
+            "Visible Infrared Imaging Radiometer suite." "White Marsh Institute of Health"
+            "related-url-example-two.com" "related-url-example.com"]
            (sort
             (keyword-util/concept-keys->keywords
              sample-umm-collection-concept schema-keys))))))
@@ -453,19 +454,19 @@
                      :RelatedUrls
                      :ScienceKeywords
                      :DataCenters]]
-    (is (= (str "(tmpa-rt) (usgs_eros) 001 3 a a test related url. alice analysis and atmosphere "
-                "atmospheric atmospheric winds author bob cat center com contact daac data data "
-                "analysis and visualization data center contact datacenterurl description "
+    (is (= (str "(tmpa-rt) (tmpa-rt-multi-term) (usgs_eros) 001 3 a a test related url. alice analysis "
+                "and atmosphere atmospheric atmospheric winds author bob cat center com contact daac "
+                "data data analysis and visualization data center contact datacenterurl description "
                 "documentation doe earth earth science services edg engineering eosdis eros esip "
                 "example general general documentation geographic geographic information systems "
                 "get get service health home home page imagery imaging information infrared "
                 "institute iris iris/passcal john lp lp daac lpdaac marsh microwave microwave "
-                "imagery of page passcal publicationurl radar radiometer related related-url "
+                "imagery multi of page passcal publicationurl radar radiometer related related-url "
                 "description. related-url-example-two.com related-url-example.com rt science "
                 "science cat 3 science contact science term 3 science topic 3 service services "
                 "spectral spectral/engineering spock suite surface surface winds systems team team "
-                "spock technical technical contact term test tmpa tmpa-rt topic two url usgs "
-                "usgs/eros usgs_eros viirs visible visible infrared imaging radiometer suite. "
-                "visualization white white marsh institute of health winds")
+                "spock technical technical contact term test tmpa tmpa-rt tmpa-rt-multi-term topic "
+                "two url usgs usgs/eros usgs_eros viirs visible visible infrared imaging radiometer "
+                "suite. visualization white white marsh institute of health winds")
            (keyword-util/concept-keys->keyword-text
             sample-umm-collection-concept schema-keys)))))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
@@ -382,19 +382,14 @@
            sample-umm-collection-concept :ScienceKeywords)))))
 
 (deftest concept-key->keyword-text
-  (is (= (str "a a test related url. com datacenterurl description documentation edg example "
-              "general general documentation get get service home home page page publicationurl "
-              "related related-url description. related-url-example-two.com related-url-example.com "
-              "service test two url")
+  (is (= (str "a com datacenterurl description description. documentation edg example general get "
+              "home page publicationurl related related-url related-url-example-two.com "
+              "related-url-example.com service test two url url.")
         (keyword-util/concept-key->keyword-text
          sample-umm-collection-concept :RelatedUrls)))
-  (is (= (str "3 analysis and atmosphere atmospheric atmospheric winds cat "
-              "data data analysis and visualization earth earth science "
-              "services engineering geographic geographic information systems "
-              "imagery information microwave microwave imagery radar science "
-              "science cat 3 science term 3 science topic 3 services spectral "
-              "spectral/engineering surface surface winds systems term topic "
-              "visualization winds")
+  (is (= (str "3 analysis and atmosphere atmospheric cat data earth engineering geographic imagery "
+              "information microwave radar science services spectral spectral/engineering surface "
+              "systems term topic visualization winds")
         (keyword-util/concept-key->keyword-text
          sample-umm-collection-concept :ScienceKeywords))))
 

--- a/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
@@ -433,12 +433,12 @@
   (let [schema-keys [:LongName
                      :ShortName
                      :Version]]
-    (is (= "001 imaging infrared radiometer suite viirs visible visible infrared imaging radiometer suite."
+    (is (= "001 imaging infrared radiometer suite suite. viirs visible"
            (keyword-util/concept-keys->keyword-text
             sample-umm-collection-concept schema-keys))))
   (let [schema-keys [:ShortName
                      :ContactGroups]]
-    (is (= "contact science science contact spock team team spock viirs"
+    (is (= "contact science spock team viirs"
            (keyword-util/concept-keys->keyword-text
             sample-umm-collection-concept schema-keys))))
   (let [schema-keys [:ContactPersons]]
@@ -454,19 +454,14 @@
                      :RelatedUrls
                      :ScienceKeywords
                      :DataCenters]]
-    (is (= (str "(tmpa-rt) (tmpa-rt-multi-term) (usgs_eros) 001 3 a a test related url. alice analysis "
-                "and atmosphere atmospheric atmospheric winds author bob cat center com contact daac "
-                "data data analysis and visualization data center contact datacenterurl description "
-                "documentation doe earth earth science services edg engineering eosdis eros esip "
-                "example general general documentation geographic geographic information systems "
-                "get get service health home home page imagery imaging information infrared "
-                "institute iris iris/passcal john lp lp daac lpdaac marsh microwave microwave "
-                "imagery multi of page passcal publicationurl radar radiometer related related-url "
-                "description. related-url-example-two.com related-url-example.com rt science "
-                "science cat 3 science contact science term 3 science topic 3 service services "
-                "spectral spectral/engineering spock suite surface surface winds systems team team "
-                "spock technical technical contact term test tmpa tmpa-rt tmpa-rt-multi-term topic "
-                "two url usgs usgs/eros usgs_eros viirs visible visible infrared imaging radiometer "
-                "suite. visualization white white marsh institute of health winds")
+    (is (= (str "(tmpa-rt) (tmpa-rt-multi-term) (usgs_eros) 001 3 a alice analysis and atmosphere "
+                "atmospheric author bob cat center com contact daac data datacenterurl description "
+                "description. documentation doe earth edg engineering eosdis eros esip example "
+                "general geographic get health home imagery imaging information infrared institute "
+                "iris iris/passcal john lp lpdaac marsh microwave multi of page passcal publicationurl "
+                "radar radiometer related related-url related-url-example-two.com related-url-example.com "
+                "rt science service services spectral spectral/engineering spock suite suite. "
+                "surface systems team technical term test tmpa tmpa-rt tmpa-rt-multi-term topic two "
+                "url url. usgs usgs/eros usgs_eros viirs visible visualization white winds")
            (keyword-util/concept-keys->keyword-text
             sample-umm-collection-concept schema-keys)))))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/keyword_util.clj
@@ -20,7 +20,7 @@
                            :Description "The map projection of the granule"
                            :Value "aa-value-1"
                            :DataType "STRING"}]
-   :AncillaryKeywords ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC"]
+   :AncillaryKeywords ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)"]
    :AssociatedDOIs [{:DOI "Associated-DOI-1"
                      :Title "Assoc Title 1"
                      :Authority "https://doi.org"}
@@ -289,7 +289,7 @@
 
     "AncillaryKeywords field"
     :AncillaryKeywords
-    ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC"]
+    ["LP DAAC" "EOSDIS" "USGS/EROS" "ESIP" "USGS" "LPDAAC" "(TMPA-RT)" "(USGS_EROS)"]
 
     "CollectionCitations field"
     :CollectionCitations
@@ -415,7 +415,7 @@
                      :RelatedUrls
                      :ScienceKeywords
                      :DataCenters]]
-    (is (= ["001" "A test related url." "ATMOSPHERE" "ATMOSPHERIC WINDS" "AUTHOR" "Alice" "Bob"
+    (is (= ["(TMPA-RT)" "(USGS_EROS)" "001" "A test related url." "ATMOSPHERE" "ATMOSPHERIC WINDS" "AUTHOR" "Alice" "Bob"
             "DATA ANALYSIS AND VISUALIZATION" "Data Center Contact" "DataCenterURL" "Doe"
             "EARTH SCIENCE SERVICES" "EDG" "EOSDIS" "ESIP" "GENERAL DOCUMENTATION"
             "GEOGRAPHIC INFORMATION SYSTEMS" "GET SERVICE" "HOME PAGE" "IRIS/PASSCAL" "John"
@@ -453,18 +453,19 @@
                      :RelatedUrls
                      :ScienceKeywords
                      :DataCenters]]
-    (is (= (str "001 3 a a test related url. alice analysis and atmosphere atmospheric atmospheric "
-                "winds author bob cat center com contact daac data data analysis and visualization "
-                "data center contact datacenterurl description documentation doe earth earth science "
-                "services edg engineering eosdis eros esip example general general documentation "
-                "geographic geographic information systems get get service health home home page imagery "
-                "imaging information infrared institute iris iris/passcal john lp lp daac lpdaac marsh "
-                "microwave microwave imagery of page passcal publicationurl radar radiometer related "
-                "related-url description. related-url-example-two.com related-url-example.com science "
-                "science cat 3 science contact science term 3 science topic 3 service services spectral "
-                "spectral/engineering spock suite surface surface winds systems team team spock "
-                "technical technical contact term test topic two url usgs usgs/eros viirs visible "
-                "visible infrared imaging radiometer suite. visualization white white marsh institute "
-                "of health winds")
+    (is (= (str "(tmpa-rt) (usgs_eros) 001 3 a a test related url. alice analysis and atmosphere "
+                "atmospheric atmospheric winds author bob cat center com contact daac data data "
+                "analysis and visualization data center contact datacenterurl description "
+                "documentation doe earth earth science services edg engineering eosdis eros esip "
+                "example general general documentation geographic geographic information systems "
+                "get get service health home home page imagery imaging information infrared "
+                "institute iris iris/passcal john lp lp daac lpdaac marsh microwave microwave "
+                "imagery of page passcal publicationurl radar radiometer related related-url "
+                "description. related-url-example-two.com related-url-example.com rt science "
+                "science cat 3 science contact science term 3 science topic 3 service services "
+                "spectral spectral/engineering spock suite surface surface winds systems team team "
+                "spock technical technical contact term test tmpa tmpa-rt topic two url usgs "
+                "usgs/eros usgs_eros viirs visible visible infrared imaging radiometer suite. "
+                "visualization white white marsh institute of health winds")
            (keyword-util/concept-keys->keyword-text
             sample-umm-collection-concept schema-keys)))))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/service_keyword_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/service_keyword_util.clj
@@ -146,12 +146,12 @@
   (let [schema-keys [:LongName
                      :Name
                      :Version]]
-    (is (= "1 1.9 3 9 airs airx3std for level opendap opendap service for airs level-3 retrieval products products retrieval service"
+    (is (= "1 1.9 3 9 airs airx3std for level level-3 opendap products retrieval service"
            (service-keyword-util/concept-keys->keyword-text
             sample-umm-service-concept schema-keys))))
   (let [schema-keys [:Name
                      :ContactGroups]]
-    (is (= "airx3std contact science science contact spock team team spock"
+    (is (= "airx3std contact science spock team"
            (service-keyword-util/concept-keys->keyword-text
             sample-umm-service-concept schema-keys))))
   (let [schema-keys [:ContactPersons]]
@@ -159,7 +159,7 @@
            (service-keyword-util/concept-keys->keyword-text
             sample-umm-service-concept schema-keys))))
   (let [schema-keys [:ServiceOrganizations]]
-    (is (= "and customer earth eros geological landsat ldpaac observation provider resource science service service provider services survey us us geological survey earth resource observation and science (eros) landsat customer services usgs usgs/eros"
+    (is (= "(eros) and customer earth eros geological landsat ldpaac observation provider resource science service services survey us usgs usgs/eros"
            (service-keyword-util/concept-keys->keyword-text
             sample-umm-service-concept schema-keys))))
   (let [schema-keys [:LongName
@@ -171,6 +171,6 @@
                      :URL
                      :ServiceKeywords
                      :ServiceOrganizations]]
-    (is (= "006 1 1.9 3 9 acdisc airs airx3std alice analysis and applications aqua author bob contact customer data data analysis and visualization data discovery data visualization discovery earth eosdis eros for geological gesdisc gov https https://acdisc.gesdisc.eosdis.nasa.gov/opendap/aqua_airs_level3/airx3std.006/ image landsat ldpaac level level3 nasa observation opendap opendap service opendap service for airs level-3 retrieval products processing products provider resource retrieval science science contact service service provider services spock statistical statistical applications survey team team spock us us geological survey earth resource observation and science (eros) landsat customer services usgs usgs/eros visualization visualization/image processing"
+    (is (= "(eros) 006 1 1.9 3 9 acdisc airs airx3std alice analysis and applications aqua author bob contact customer data discovery earth eosdis eros for geological gesdisc gov https https://acdisc.gesdisc.eosdis.nasa.gov/opendap/aqua_airs_level3/airx3std.006/ image landsat ldpaac level level-3 level3 nasa observation opendap processing products provider resource retrieval science service services spock statistical survey team us usgs usgs/eros visualization visualization/image"
            (service-keyword-util/concept-keys->keyword-text
             sample-umm-service-concept schema-keys)))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
@@ -112,7 +112,8 @@
                                       :Description "Home page of National Snow and Ice Data Center"})
         coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "coll1" :ShortName "S1"
                                                                             :VersionDescription "VersionDescription"}))
-        coll2 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "coll2" :ShortName "ABC!XYZ" :Version "V001"}))
+        coll2 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "Mitch made a (merry-go-round)"
+                                                                            :ShortName "ABC!XYZ" :Version "V001"}))
         coll3 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "coll3" :ShortName "S3" :CollectionDataType "OTHER"}))
         coll4 (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "coll4" :ShortName "S4" :CollectionDataType "OTHER"}))
         coll5 (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "coll5" :ShortName "Space!Laser"}))
@@ -204,6 +205,12 @@
 
         ;; entry title
         "coll1" [coll1]
+        "Mitch made a (merry-go-round)" [coll2]
+        "(merry-go-round)" [coll2]
+        "merry-go-round" [coll2]
+        "merry" [coll2]
+        "merry go round" [coll2]
+        "merry-go" []
 
         ;; entry id
         "ABC!XYZ_V001" [coll2]


### PR DESCRIPTION
This solves an issue where keywords such as `(TMPA-RT)` were decomposed into `["(TMPA-RT)", "tmpa", "rt"]` which prevents keyword searching for `TMPA-RT` since elasticsearch doesn't return inexact matches. To solve this, we add all existing keywords like before, but also as the contents of parens or brackets as well, if applicable - for example, in the above case, the new set of keywords would be `["(TMPA-RT)", "tmpa-rt", "tmpa", "rt"]`.