### PR TITLE
CMR-7318: Minor Jetty version bump

### DIFF
--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -37,10 +37,10 @@
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.clojure/tools.reader "1.3.2"]
                  ;;these dependencies should be updated in tandem with the ring dependiences below
-                 [org.eclipse.jetty/jetty-http "9.4.38.v20210224"]
-                 [org.eclipse.jetty/jetty-io "9.4.38.v20210224"]
-                 [org.eclipse.jetty/jetty-servlets "9.4.38.v20210224"]
-                 [org.eclipse.jetty/jetty-util "9.4.38.v20210224"]
+                 [org.eclipse.jetty/jetty-http "9.4.39.v20210325"]
+                 [org.eclipse.jetty/jetty-io "9.4.39.v20210325"]
+                 [org.eclipse.jetty/jetty-servlets "9.4.39.v20210325"]
+                 [org.eclipse.jetty/jetty-util "9.4.39.v20210325"]
                  ;; load jts core lib first to make sure it is available for shapefile integration,
                  ;; otherwise ES referenced 1.15.0 version will be mistakenly picked for shapefile
                  [org.locationtech.jts/jts-core "1.16.1"]


### PR DESCRIPTION
The last bump turned out to be insufficient; another minor version bump is needed.

Thankfully, this one does not require any matching Legacy Services changes - the builds are already green.