### PR TITLE
cmr-7220 follow up: changed tag, updated api doc

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/tag.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/tag.clj
@@ -30,10 +30,10 @@
 
 (def earthdata-cloud-s3-tag
   "The Earthdata cloud tag for s3 resources"
-  "gov.nasa.earthdata.cloud.s3")
+  "gov.nasa.earthdatacloud.s3")
 
 (defn has-cloud-s3-tag?
   "Looks through a list of tags and returns true if one of them is the
-  gov.nasa.earthdata.cloud.s3 tag"
+  earthdata-cloud-s3-tag"
   [tags]
   (some? (some #(= (:tag-key-lowercase %) earthdata-cloud-s3-tag) tags)))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/tag.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/tag.clj
@@ -16,7 +16,7 @@
 
 (deftest does-has-cloud-s3-tag-work
   "The function has-cloud-s3-tag should only return true if there is a
-   gov.nasa.earthdata.cloud.s3 tag in the list"
+   earthdata-cloud-s3-tag in the list"
   (let [bad1 (create-tag "This-Is-Not-The-Tag-Your-Looking-For" "My-Id" "Value")
         bad2 (create-tag "This-Is-Also-Not-The-Tag-Your-Looking-For" "My-Id" "Value")
         good (create-tag tag/earthdata-cloud-s3-tag "My-Id" "Value")

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1888,7 +1888,9 @@ The `has_granules_or_opensearch` parameter can be set to "true" or "false". When
 
     curl "%CMR-ENDPOINT%/collections?has_opendap_url=true"
 
-#### <a name="c-cloud-hosted"></a> Find collections that have a `DirectDistributionInformation` element or have been tagged with `gov.nasa.earthdata.cloud.s3`.
+#### <a name="c-cloud-hosted"></a> Find collections with data that is hosted in the cloud.
+
+The `cloud_hosted` parameter can be set to "true" or "false". When true, the results will be restricted to collections that have a `DirectDistributionInformation` element or have been tagged with `gov.nasa.earthdatacloud.s3`.
 
     curl "%CMR-ENDPOINT%/collections?cloud_hosted=true"
 


### PR DESCRIPTION
Production uses a different tag (dropping a period between data and cloud) then was used in development, so updating tag to match what production will be using. Also improving api documentation to match what similar parameters say.