### PR TITLE
Cmr 6026 validate json at acl ingest

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
@@ -406,6 +406,22 @@
                                            "ECHO-Token" token}
                                  :throw-exceptions false})))))
 
+    (testing "Acceptance criteria: I receive an error if creating an ACL with JSON described in CMR-6026"
+      (is
+        (re-find #"Json parsing error:"
+                 (:body
+                   (client/post (access-control/acl-root-url
+                                 (transmit-config/context->app-connection
+                                  (test-util/conn-context)
+                                  :access-control))
+                                {:body "{\"group_permissions\": [ {\"user_type\": \"registered\",
+                                                                   \"permissions\": [\"read\"]}],
+                                         \"catalog_item_identity\": {\"name\": \"Example\",
+                                                                     \"provider_id\": \"prov-id\",}}"
+                                 :headers {"Content-Type" "application/json"
+                                           "ECHO-Token" token}
+                                 :throw-exceptions false})))))
+
     (testing "Acceptance criteria: I receive an error if creating an ACL with unsupported content type"
       (is
         (re-find #"The mime types specified in the content-type header \[application/xml\] are not supported."

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -119,12 +119,15 @@
   "Returns a Ring response with the result of trying to create the ACL with the given request body."
   [request-ctx headers body]
   (validate-content-type headers)
-  (acl-schema/validate-acl-json body)
-  (->> (json/parse-string body)
-       util/map-keys->kebab-case
-       (acl-service/create-acl request-ctx)
-       util/map-keys->snake_case
-       api-response))
+  (try
+    (acl-schema/validate-acl-json body)
+    (->> (json/parse-string body)
+         util/map-keys->kebab-case
+         (acl-service/create-acl request-ctx)
+         util/map-keys->snake_case
+         api-response)
+    (catch Exception e
+      (errors/throw-service-error :bad-request (str "Schema validation error: " (.getMessage e))))))
 
 (defn- update-acl
   "Returns a Ring response with the result of trying to update the ACL with the given concept id


### PR DESCRIPTION
Clarification: Access code does validate json at ingest. If the json body is malformed, you will get Invalid Json error, if it misses required fields, you will get Validation error. However, in this ticket, the extra "," is not considered to be  the cases above. It's throwing com.fasterxml.jackson.core.JsonParseException during the parsing of the json body.