### PR TITLE
CMR-7235 APPEND_TO_FIELD operator for bulk granule update

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1143,9 +1143,9 @@ supported metadata formats:
   - S3Link url in OnlineResources for ECHO10 format
   - S3Link url in RelatedUrls for UMM-G format
 
-The S3 url value provided in the granule bulk update request can be comma-separated urls. Each url must start with s3:// (case-sensitive). This lowercase s3:// naming convention is to make the s3 links compatible with AWS S3 API. During bulk update, the provided S3 urls in the request will be updated by appending the new S3 links. Existing S3 links will be preserved. 
+The S3 url value provided in the granule bulk update request can be comma-separated urls. Each url must start with s3:// (case-sensitive). This lowercase s3:// naming convention is to make the s3 links compatible with AWS S3 API. During bulk update, the provided S3 urls in the request will be updated by appending the new S3 links. Existing S3 links will be preserved.
 
-If the URL passed to the update is already associated with the granule, the URL will not be duplicated.
+If the URL passed to the update is already associated with the granule, the URL will not be duplicated or updated.
 
 ``` bash
 curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/granules -d

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1103,6 +1103,39 @@ Updated granules are validated using business rule validations.  Updates will no
 
 Granule bulk update currently supports updating with the following operations, update fields and metadata formats:
 
+**operation: "APPEND_TO_FIELD", update-field: "OPENDAPLink"**
+Operationally identical to UPDATE_FIELD for OPeNDAPLink, see below.
+
+**operation: "APPEND_TO_FIELD", update-field: "S3Link"**
+supported metadata formats:
+  - S3Link url in OnlineResources for ECHO10 format
+  - S3Link url in RelatedUrls for UMM-G format
+
+The S3 url value provided in the granule bulk update request can be comma-separated urls. Each url must start with s3:// (case-sensitive). This lowercase s3:// naming convention is to make the s3 links compatible with AWS S3 API. During bulk update, the provided S3 urls in the request will be updated by appending the new S3 links. Existing S3 links will be preserved. 
+
+If a URL is passed to the update is already associated with the granule, the URL will not be duplicated.
+
+``` bash
+curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/granules -d
+'{ "name": "example of appending S3 links",
+	"operation": "APPEND_TO_FIELD",
+	"update-field":"S3Link",
+	"updates":[
+             ["granule_ur1", "s3://example.com/bucket1"],
+             ["granule_ur2", "s3://example.com/bucket2"],
+             ["granule_ur3", "s3://example.com/bucket3-east,s3://example.com/bucket3-west"]
+	]
+}'
+```
+
+Example granule bulk update response:
+```
+{
+ "status" : 200,
+ "task-id": 4
+}
+```
+
 **operation: "UPDATE_FIELD", update-field: "OPeNDAPLink"**
 supported metadata formats:
   - OPeNDAP url in OnlineResources for ECHO10 format

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1103,8 +1103,16 @@ Updated granules are validated using business rule validations.  Updates will no
 
 Granule bulk update currently supports updating with the following operations, update fields and metadata formats:
 
-**operation: "APPEND_TO_FIELD", update-field: "OPENDAPLink"**
-Operationally identical to UPDATE_FIELD for OPeNDAPLink, see below.
+**operation: "APPEND_TO_FIELD", update-field: "OPeNDAPLink"**
+supported metadata formats:
+  - S3Link url in OnlineResources for ECHO10 format
+  - S3Link url in RelatedUrls for UMM-G format
+
+Append operations on OPeNDAPLink will behave as follows
+ - If the granule does not contain a conflicting URL for the type (on-prem or Hyrax-in-the-cloud), the new value will be added.
+ - If the granule already contains URLs for both on-prem and cloud, the granule update will fail.
+
+URLs matching the pattern: https://opendap.*.earthdata.nasa.gov/* will be determined to be Hyrax-in-the-cloud, otherwise it will be on-prem.
 
 **operation: "APPEND_TO_FIELD", update-field: "S3Link"**
 supported metadata formats:
@@ -1113,7 +1121,7 @@ supported metadata formats:
 
 The S3 url value provided in the granule bulk update request can be comma-separated urls. Each url must start with s3:// (case-sensitive). This lowercase s3:// naming convention is to make the s3 links compatible with AWS S3 API. During bulk update, the provided S3 urls in the request will be updated by appending the new S3 links. Existing S3 links will be preserved. 
 
-If a URL is passed to the update is already associated with the granule, the URL will not be duplicated.
+If the URL passed to the update is already associated with the granule, the URL will not be duplicated.
 
 ``` bash
 curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/granules -d

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1109,10 +1109,34 @@ supported metadata formats:
   - S3Link url in RelatedUrls for UMM-G format
 
 Append operations on OPeNDAPLink will behave as follows
+ - OPeNDAP updates may contain a maximum of two URLs, separated by comma
+   - At most, only one of each OPeNDAP URL type may be included (on-prem or Hyrax-in-the-cloud)
+ - If the granule contains no OPeNDAP urls the new URLs will be added
  - If the granule does not contain a conflicting URL for the type (on-prem or Hyrax-in-the-cloud), the new value will be added.
  - If the granule already contains URLs for both on-prem and cloud, the granule update will fail.
 
 URLs matching the pattern: https://opendap.*.earthdata.nasa.gov/* will be determined to be Hyrax-in-the-cloud, otherwise it will be on-prem.
+
+``` bash
+curl -i -XPOST -H "Cmr-Pretty:true" -H "Content-Type: application/json" -H "Echo-Token: XXXX" %CMR-ENDPOINT%/providers/PROV1/bulk-update/granules -d
+'{ "name": "example of appending OPeNDAP links",
+	"operation": "APPEND_TO_FIELD",
+	"update-field":"OPeNDAPLink",
+	"updates":[
+             ["granule_ur1", "https://opendap.earthdata.nasa.gov/example"],
+             ["granule_ur2", "https://on-prem.example.com"],
+             ["granule_ur3", "https://opendap.earthdata.nasa.gov/example-2,https://on-prem.example-2.com"]
+	]
+}'
+```
+
+Example granule bulk update response:
+```
+{
+ "status" : 200,
+ "task-id": 6
+}
+```
 
 **operation: "APPEND_TO_FIELD", update-field: "S3Link"**
 supported metadata formats:

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1105,8 +1105,8 @@ Granule bulk update currently supports updating with the following operations, u
 
 **operation: "APPEND_TO_FIELD", update-field: "OPeNDAPLink"**
 supported metadata formats:
-  - S3Link url in OnlineResources for ECHO10 format
-  - S3Link url in RelatedUrls for UMM-G format
+  - OPeNDAPLink url in OnlineResources for ECHO10 format
+  - OPeNDAPLink url in RelatedUrls for UMM-G format
 
 Append operations on OPeNDAPLink will behave as follows
  - OPeNDAP updates may contain a maximum of two URLs, separated by comma

--- a/ingest-app/resources/granule_bulk_update_schema.json
+++ b/ingest-app/resources/granule_bulk_update_schema.json
@@ -3,7 +3,8 @@
     "OperationEnum": {
       "type": "string",
       "enum": [
-        "UPDATE_FIELD"
+        "UPDATE_FIELD",
+        "APPEND_TO_FIELD"
       ]
     },
     "UpdateFieldEnum": {

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
@@ -80,17 +80,7 @@
         other-resources (remove #(is-opendap? (:type %)) online-resources)
         current-opendap-urls (map :url opendap-resources)
 
-        _ (when-let [cloud-url (first (filter opendap-util/cloud-url? current-opendap-urls))]
-            (when (get url-map :cloud)
-              (errors/throw-service-errors
-               :invalid-data
-               [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP urls when there is one already present: " cloud-url)])))
-
-        _ (when-let [on-prem-url (first (filter opendap-util/on-prem-url? current-opendap-urls))]
-            (when (get url-map :on-prem)
-              (errors/throw-service-errors
-               :invalid-data
-               [(str "Update contains conflict, cannot append on-prem OPeNDAP urls when there is one already present: " on-prem-url)])))
+        _ (opendap-util/validate-append-no-conflicts current-opendap-urls url-map)
 
         cloud-resource (resources->updated-resource :cloud opendap-resources url-map)
         on-prem-resource (resources->updated-resource :on-prem opendap-resources url-map)

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
@@ -91,9 +91,9 @@
   "Take the parsed online resources in the original metadata and the desired OPeNDAP urls,
    return the updated online resources xml element that can be used by zipper to update the xml."
   [online-resources url-map operation]
-  (let [resources (if (= :replace operation)
-                    (updated-online-resources online-resources url-map)
-                    (appended-online-resources online-resources url-map))]
+  (let [resources (case operation
+                    :replace (updated-online-resources online-resources url-map)
+                    :append (appended-online-resources online-resources url-map))]
     (xml/element
      :OnlineResources {}
      (for [r resources]

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
@@ -84,13 +84,13 @@
             (when (get url-map :cloud)
               (errors/throw-service-errors
                :invalid-data
-               [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP urls when there is one already present:" cloud-url)])))
+               [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP urls when there is one already present: " cloud-url)])))
 
         _ (when-let [on-prem-url (first (filter opendap-util/on-prem-url? current-opendap-urls))]
             (when (get url-map :on-prem)
               (errors/throw-service-errors
                :invalid-data
-               [(str "Update contains conflict, cannot append on-prem OPeNDAP urls when there is one already present:" on-prem-url)])))
+               [(str "Update contains conflict, cannot append on-prem OPeNDAP urls when there is one already present: " on-prem-url)])))
 
         cloud-resource (resources->updated-resource :cloud opendap-resources url-map)
         on-prem-resource (resources->updated-resource :on-prem opendap-resources url-map)

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/echo10.clj
@@ -78,16 +78,16 @@
   [online-resources url-map]
   (let [opendap-resources (filter #(is-opendap? (:type %)) online-resources)
         other-resources (remove #(is-opendap? (:type %)) online-resources)
-        current-urls (map :url opendap-resources)
+        current-opendap-urls (map :url opendap-resources)
 
-        _ (when-let [cloud-url (get url-map :cloud)]
-            (when (= cloud-url (first (filter opendap-util/cloud-url? current-urls)))
+        _ (when-let [cloud-url (first (filter opendap-util/cloud-url? current-opendap-urls))]
+            (when (get url-map :cloud)
               (errors/throw-service-errors
                :invalid-data
                [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP urls when there is one already present:" cloud-url)])))
 
-        _ (when-let [on-prem-url (get url-map :on-prem)]
-            (when (= on-prem-url (first (filter opendap-util/on-prem-url? current-urls)))
+        _ (when-let [on-prem-url (first (filter opendap-util/on-prem-url? current-opendap-urls))]
+            (when (get url-map :on-prem)
               (errors/throw-service-errors
                :invalid-data
                [(str "Update contains conflict, cannot append on-prem OPeNDAP urls when there is one already present:" on-prem-url)])))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
@@ -16,6 +16,15 @@
       :cloud
       :on-prem)))
 
+(defn cloud-url?
+  "Returns true if the URL given matches a Hyrax-in-the-cloud (:cloud) URL pattern "
+  [url]
+  (= :cloud (url->opendap-type url)))
+
+(def on-prem-url?
+  "Returns true if the URL given matches :on-prem URL patterns"
+  (complement cloud-url?))
+
 (defn validate-url
   "Validate the given OPeNDAP url for granule bulk update. It can be no more than two urls
   separated by comma, and no more than one url matches the pattern

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/opendap_util.clj
@@ -52,3 +52,33 @@
            [(str "Invalid URL value, no more than one on-prem OPeNDAP url can be provided: "
                  url)]))
         grouped-urls))))
+
+(defn- validate-append-no-conflicting-on-prem
+  "Validate there is no on-prem url already present when appending a new on-prem-url
+  See also [[validate-append-no-conflicting-cloud]]"
+  [current-urls url-map]
+  (when-let [on-prem-url (first (filter on-prem-url? current-urls))]
+    (when (get url-map :on-prem)
+      (errors/throw-service-errors
+       :invalid-data
+       [(str "Update contains conflict, cannot append on-prem OPeNDAP urls when there is one already present: " on-prem-url)]))))
+
+(defn- validate-append-no-conflicting-cloud
+  "Validate there is no cloud url already present when appending a new cloud-url
+  See also [[validate-append-no-conflicting-on-prem]]"
+  [current-urls url-map]
+  (when-let [cloud-url (first (filter cloud-url? current-urls))]
+    (when (get url-map :cloud)
+      (errors/throw-service-errors
+       :invalid-data
+       [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP urls when there is one already present: " cloud-url)]))))
+
+(defn validate-append-no-conflicts
+  "Takes the current OPeNDAP urls and the map produced by [[validate-url]]
+  and checks whether there are any conflicts when appending.
+
+  * current-urls is expected to be a collection
+  * urls-map is expected to be in the form of {:on-prem [<url>] :cloud [<url>]}"
+  [current-urls urls-map]
+  (validate-append-no-conflicting-on-prem current-urls urls-map)
+  (validate-append-no-conflicting-cloud current-urls urls-map))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
@@ -72,9 +72,9 @@
 
 (defn append-opendap-url
   "Takes UMM-G record and grouped OPeNDAP urls in the format of
-  {:cloud [<cloud_url>] :on-prem [<on_prem_url>]}.
-  The cloud url will overwrite any existing Hyrax-in-the-cloud OPeNDAP url in the UMM-G record;
-  the on-prem url will overwrite any existing on-prem OPeNDAP url in the UMM-G record.
-  Returns the updated UMM-G record."
+  {:cloud [<cloud_url>] :on-prem [<on_prem_url>]} and appends data.
+  If the UMM-G record already contains a url for a type specified in
+  the update, cloud or on-prem, the update will fail and an exception will be thrown.
+  Returns the updated UMM-G record on success."
   [umm-gran grouped-urls]
   (update umm-gran :RelatedUrls #(appended-related-urls % grouped-urls)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.services.granule-bulk-update.opendap.umm-g
   "Contains functions to update UMM-G granule metadata for OPeNDAP url bulk update."
   (:require
+   [cmr.common.services.errors :as errors]
    [cmr.ingest.services.granule-bulk-update.opendap.opendap-util :as opendap-util]))
 
 (def ^:private OPENDAP_RELATEDURL_TYPE
@@ -17,7 +18,7 @@
   [related-url]
   (= OPENDAP_RELATEDURL_SUBTYPE (:Subtype related-url)))
 
-(defn- update-opendap-url
+(defn- update-opendap-url*
   "Returns the related url with given OPeNDAP url merged into the related-url."
   [url related-url]
   (if url
@@ -33,7 +34,7 @@
   (->> opendap-urls
        (filter #(= opendap-type (opendap-util/url->opendap-type (:URL %))))
        first
-       (update-opendap-url (first (opendap-type url-map)))))
+       (update-opendap-url* (first (opendap-type url-map)))))
 
 (defn- updated-related-urls
   "Take the RelatedUrls, update any existing opendap url with the given url-map."
@@ -45,7 +46,34 @@
         updated-urls (conj other-urls cloud-url on-prem-url)]
     (remove nil? updated-urls)))
 
-(defn add-opendap-url
+(defn- appended-related-urls
+  "Take the RelatedUrls, append opendap urls with the given url-map. URLs
+  already present will be ignored."
+  [related-urls url-map]
+  (let [opendap-resources (filter is-opendap? related-urls)
+        opendap-urls (map :url opendap-resources)
+
+        _ (when-let [cloud-url (get url-map :cloud)]
+            (when (= cloud-url (first (filter opendap-util/cloud-url? opendap-urls)))
+              (errors/throw-service-errors
+               :invalid-data
+               [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP url when there is one already present: "
+                     cloud-url)])))
+
+        _ (when-let [on-prem-url (get url-map :on-prem)]
+            (when (= on-prem-url (first (filter opendap-util/on-prem-url? opendap-urls)))
+              (errors/throw-service-errors
+               :invalid-data
+               [(str "Update contains conflict, cannot append on-prem url when there is one already present: "
+                     on-prem-url)])))
+
+        other-urls (remove is-opendap? related-urls)
+        cloud-url (urls->updated-url :cloud opendap-urls url-map)
+        on-prem-url (urls->updated-url :on-prem opendap-urls url-map)
+        updated-urls (conj other-urls cloud-url on-prem-url)]
+    (remove nil? updated-urls)))
+
+(defn update-opendap-url
   "Takes UMM-G record and grouped OPeNDAP urls in the format of
   {:cloud [<cloud_url>] :on-prem [<on_prem_url>]}.
   The cloud url will overwrite any existing Hyrax-in-the-cloud OPeNDAP url in the UMM-G record;
@@ -53,3 +81,12 @@
   Returns the updated UMM-G record."
   [umm-gran grouped-urls]
   (update umm-gran :RelatedUrls #(updated-related-urls % grouped-urls)))
+
+(defn append-opendap-url
+  "Takes UMM-G record and grouped OPeNDAP urls in the format of
+  {:cloud [<cloud_url>] :on-prem [<on_prem_url>]}.
+  The cloud url will overwrite any existing Hyrax-in-the-cloud OPeNDAP url in the UMM-G record;
+  the on-prem url will overwrite any existing on-prem OPeNDAP url in the UMM-G record.
+  Returns the updated UMM-G record."
+  [umm-gran grouped-urls]
+  (update umm-gran :RelatedUrls #(appended-related-urls % grouped-urls)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
@@ -53,19 +53,7 @@
   (let [opendap-resources (filter is-opendap? related-urls)
         opendap-urls (map :URL opendap-resources)
 
-        _ (when-let [cloud-url (first (filter opendap-util/cloud-url? opendap-urls))]
-            (when (seq (get url-map :cloud))
-              (errors/throw-service-errors
-               :invalid-data
-               [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP url when there is one already present: "
-                     cloud-url)])))
-
-        _ (when-let [on-prem-url (first (filter opendap-util/on-prem-url? opendap-urls))]
-            (when (seq (get url-map :on-prem))
-              (errors/throw-service-errors
-               :invalid-data
-               [(str "Update contains conflict, cannot append on-prem url when there is one already present: "
-                     on-prem-url)])))
+        _ (opendap-util/validate-append-no-conflicts opendap-urls url-map)
 
         other-urls (remove is-opendap? related-urls)
         cloud-url (urls->updated-url :cloud opendap-urls url-map)

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/opendap/umm_g.clj
@@ -51,17 +51,17 @@
   already present will be ignored."
   [related-urls url-map]
   (let [opendap-resources (filter is-opendap? related-urls)
-        opendap-urls (map :url opendap-resources)
+        opendap-urls (map :URL opendap-resources)
 
-        _ (when-let [cloud-url (get url-map :cloud)]
-            (when (= cloud-url (first (filter opendap-util/cloud-url? opendap-urls)))
+        _ (when-let [cloud-url (first (filter opendap-util/cloud-url? opendap-urls))]
+            (when (seq (get url-map :cloud))
               (errors/throw-service-errors
                :invalid-data
                [(str "Update contains conflict, cannot append Hyrax-in-the-cloud OPeNDAP url when there is one already present: "
                      cloud-url)])))
 
-        _ (when-let [on-prem-url (get url-map :on-prem)]
-            (when (= on-prem-url (first (filter opendap-util/on-prem-url? opendap-urls)))
+        _ (when-let [on-prem-url (first (filter opendap-util/on-prem-url? opendap-urls))]
+            (when (seq (get url-map :on-prem))
               (errors/throw-service-errors
                :invalid-data
                [(str "Update contains conflict, cannot append on-prem url when there is one already present: "

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
@@ -144,8 +144,9 @@
     (assoc concept :metadata updated-metadata)))
 
 (defn append-s3-url
-  "Takes the ECHO10 granule concept and a list of S3 urls.
-  Update the ECHO10 granule metadata with the S3 urls.
+  "Append the ECHO10 granule metadata with the S3 urls.
+  Existing URLs will be preserved. If an existing URL is included in
+  the list of updates, it will be updated.
   Returns the granule concept with the updated metadata."
   [concept urls]
   (let [updated-metadata (add-s3-url-to-metadata (:metadata concept) urls :append)]

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
@@ -63,7 +63,7 @@
   "Take the parsed OnlineAccessURLs in the original metadata and the desired S3 url,
    return the updated OnlineAccessURLs xml element that can be used by zipper to update the xml."
   [online-accesses urls operation]
-  (let [accesses (if (= :update operation)
+  (let [accesses (if (= :replace operation)
                    (updated-online-accesses online-accesses urls)
                    (appended-online-accesses online-accesses urls))]
     (xml/element
@@ -122,25 +122,25 @@
             :else
             (recur right-loc false)))))))
 
-(defn- add-s3-url-to-metadata
+(defn- update-s3-url-metadata
   "Takes the granule ECHO10 xml and a list of S3 urls.
   Update the ECHO10 granule metadata with the S3 urls.
   Returns the updated metadata.
 
   Valid operators are
-  :update
+  :replace
   :append"
   [gran-xml urls operation]
   (let [parsed (xml/parse-str gran-xml)
         online-accesses (xml-elem->online-access-urls parsed)]
     (xml/indent-str (add-s3-url* parsed online-accesses urls operation))))
 
-(defn add-s3-url
+(defn update-s3-url
   "Takes the ECHO10 granule concept and a list of S3 urls.
   Update the ECHO10 granule metadata with the S3 urls.
   Returns the granule concept with the updated metadata."
   [concept urls]
-  (let [updated-metadata (add-s3-url-to-metadata (:metadata concept) urls :update)]
+  (let [updated-metadata (update-s3-url-metadata (:metadata concept) urls :replace)]
     (assoc concept :metadata updated-metadata)))
 
 (defn append-s3-url
@@ -149,5 +149,5 @@
   be ignored.
   Returns the granule concept with the updated metadata."
   [concept urls]
-  (let [updated-metadata (add-s3-url-to-metadata (:metadata concept) urls :append)]
+  (let [updated-metadata (update-s3-url-metadata (:metadata concept) urls :append)]
     (assoc concept :metadata updated-metadata)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
@@ -26,8 +26,20 @@
         s3-urls (urls->s3-urls urls)]
     (concat s3-urls other-urls)))
 
+(defn- appended-related-urls
+  "Take the RelatedUrls, add any unique s3 urls, updating already existing urls"
+  [related-urls urls]
+  (let [s3-urls (urls->s3-urls urls)]
+    (concat related-urls s3-urls)))
+
 (defn add-s3-url
   "Takes UMM-G record and a list of S3 urls to update.
   Returns the updated UMM-G record."
   [umm-gran urls]
   (update umm-gran :RelatedUrls #(updated-related-urls % urls)))
+
+(defn append-s3-url
+  "Takes UMM-G record and a list of S3 urls to update.
+  Returns the updated UMM-G record."
+  [umm-gran urls]
+  (update umm-gran :RelatedUrls #(appended-related-urls % urls)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
@@ -23,19 +23,19 @@
   "Take the RelatedUrls, replace any existing s3 urls with the given urls."
   [related-urls urls]
   (let [other-urls (remove is-s3? related-urls)
-        s3-urls (urls->s3-urls urls)]
+        s3-urls (urls->s3-urls (distinct urls))]
     (concat s3-urls other-urls)))
 
 (defn- appended-related-urls
   "Take the RelatedUrls, add any unique s3 urls, ignoring already present s3 urls
   returning a new list of related-urls."
   [related-urls urls]
-  (let [existing-s3-urls (map :url related-urls)
-        s3-urls (clojure.set/difference (set urls) (set existing-s3-urls))
-        s3-resources (urls->s3-urls urls)]
-    (concat related-urls s3-resources)))
+  (let [s3-resources (filter is-s3? related-urls)
+        new-s3-urls (clojure.set/difference (set urls) (map :URL s3-resources))
+        new-s3-resources (urls->s3-urls new-s3-urls)]
+    (concat related-urls new-s3-resources)))
 
-(defn add-s3-url
+(defn update-s3-url
   "Takes UMM-G record and a list of S3 urls to update.
   Returns the updated UMM-G record."
   [umm-gran urls]

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
@@ -31,7 +31,7 @@
   returning a new list of related-urls."
   [related-urls urls]
   (let [s3-resources (filter is-s3? related-urls)
-        new-s3-urls (clojure.set/difference (set urls) (map :URL s3-resources))
+        new-s3-urls (clojure.set/difference (set urls) (set (map :URL s3-resources)))
         new-s3-resources (urls->s3-urls new-s3-urls)]
     (concat related-urls new-s3-resources)))
 

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
@@ -27,10 +27,13 @@
     (concat s3-urls other-urls)))
 
 (defn- appended-related-urls
-  "Take the RelatedUrls, add any unique s3 urls, updating already existing urls"
+  "Take the RelatedUrls, add any unique s3 urls, ignoring already present s3 urls
+  returning a new list of related-urls."
   [related-urls urls]
-  (let [s3-urls (urls->s3-urls urls)]
-    (concat related-urls s3-urls)))
+  (let [existing-s3-urls (map :url related-urls)
+        s3-urls (clojure.set/difference (set urls) (set existing-s3-urls))
+        s3-resources (urls->s3-urls urls)]
+    (concat related-urls s3-resources)))
 
 (defn add-s3-url
   "Takes UMM-G record and a list of S3 urls to update.
@@ -39,7 +42,7 @@
   (update umm-gran :RelatedUrls #(updated-related-urls % urls)))
 
 (defn append-s3-url
-  "Takes UMM-G record and a list of S3 urls to update.
+  "Takes UMM-G record and a list of S3 urls to append.
   Returns the updated UMM-G record."
   [umm-gran urls]
   (update umm-gran :RelatedUrls #(appended-related-urls % urls)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -238,7 +238,7 @@
 
 (defn- update-granule-opendap-fields
   "For OPeNDAP links, there may be at most 2 urls, 1 cloud, 1 on-prem.
-  therefor update and append bulk granule operations are identical."
+  therefore update and append bulk granule operations are identical."
   [context concept bulk-update-params user-id]
   (let [{:keys [format metadata]} concept
         {:keys [granule-ur url]} bulk-update-params

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -256,7 +256,9 @@
 
 (defn- modify-opendap-link*
   "For OPeNDAP links, there may be at most 2 urls, 1 cloud, 1 on-prem.
-  therefore update and append bulk granule operations are identical."
+  Updates containing a url type that is already present on the concept
+  will fail with an exception.
+  Successful updates will return the updated concept."
   [context concept bulk-update-params user-id xf]
   (let [{:keys [format metadata]} concept
         {:keys [granule-ur url]} bulk-update-params
@@ -284,7 +286,9 @@
 
 (defn- modify-s3-link*
   "Modify the S3Link data for the given concept with the provided URLs
-  using the provided transform function."
+  using the provided transform function.
+  S3 links will be added to the existing concept. If a duplicate S3 link
+  is provided it will be ignored."
   [context concept bulk-update-params user-id xf]
   (let [{:keys [format metadata]} concept
         {:keys [granule-ur url]} bulk-update-params

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
@@ -424,7 +424,7 @@
     (are3 [url-value source result]
       (let [grouped-urls (opendap-util/validate-url url-value)]
         (is (= result
-               (#'echo10/add-opendap-url-to-metadata source grouped-urls :replace))))
+               (#'echo10/update-opendap-url-metadata source grouped-urls :replace))))
 
       "add OnlineResources at the end of the xml"
       "http://example.com/foo"
@@ -501,7 +501,7 @@
     (are3 [url-value source result]
           (let [grouped-urls (opendap-util/validate-url url-value)]
             (is (= result
-                   (#'echo10/add-opendap-url-to-metadata source grouped-urls :append))))
+                   (#'echo10/update-opendap-url-metadata source grouped-urls :append))))
 
           "add OnlineResources at the end of the xml"
           "http://example.com/foo"
@@ -539,7 +539,7 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Update contains conflict"
-             (#'echo10/add-opendap-url-to-metadata source grouped-urls :append))))
+             (#'echo10/update-opendap-url-metadata source grouped-urls :append))))
 
       "throws during append OnlineResources when OPeNDAP url is present"
       "http://example.com/foo"

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
@@ -499,39 +499,39 @@
 (deftest append-opendap-url
   (testing "append OnlineResources at various places in the xml"
     (are3 [url-value source result]
-          (let [grouped-urls (opendap-util/validate-url url-value)]
-            (is (= result
-                   (#'echo10/update-opendap-url-metadata source grouped-urls :append))))
+      (let [grouped-urls (opendap-util/validate-url url-value)]
+        (is (= result
+               (#'echo10/update-opendap-url-metadata source grouped-urls :append))))
 
-          "add OnlineResources at the end of the xml"
-          "http://example.com/foo"
-          add-at-the-end-gran-xml
-          add-at-the-end-gran-xml-result
+      "add OnlineResources at the end of the xml"
+      "http://example.com/foo"
+      add-at-the-end-gran-xml
+      add-at-the-end-gran-xml-result
 
-          "add OnlineResources before an element in the xml"
-          "http://example.com/foo"
-          add-before-element-gran-xml
-          add-before-element-gran-xml-result
+      "add OnlineResources before an element in the xml"
+      "http://example.com/foo"
+      add-before-element-gran-xml
+      add-before-element-gran-xml-result
 
-          "add OnlineResources to empty OnlineResources in the xml"
-          "http://example.com/foo"
-          add-with-empty-gran-xml
-          add-before-element-gran-xml-result
+      "add OnlineResources to empty OnlineResources in the xml"
+      "http://example.com/foo"
+      add-with-empty-gran-xml
+      add-before-element-gran-xml-result
 
-          "add OnlineResources to OnlineResources without OPeNDAP url in the xml"
-          "http://example.com/foo"
-          add-with-no-match-gran-xml
-          add-with-no-match-gran-xml-result
+      "add OnlineResources to OnlineResources without OPeNDAP url in the xml"
+      "http://example.com/foo"
+      add-with-no-match-gran-xml
+      add-with-no-match-gran-xml-result
 
-          "update with on-prem in metadata, Hyrax-in-the-cloud in update"
-          "https://opendap.earthdata.nasa.gov/foo"
-          update-opendap-url
-          update-opendap-with-cloud-url-result
+      "update with on-prem in metadata, Hyrax-in-the-cloud in update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      update-opendap-url
+      update-opendap-with-cloud-url-result
 
-          "update with Hyrax-in-the-cloud in metadata, on-prem in update"
-          "http://example.com/foo"
-          update-cloud-opendap-url
-          update-cloud-opendap-url-with-on-prem-result))
+      "update with Hyrax-in-the-cloud in metadata, on-prem in update"
+      "http://example.com/foo"
+      update-cloud-opendap-url
+      update-cloud-opendap-url-with-on-prem-result))
 
   (testing "throws appropriate error messages"
     (are3 [url-value source]

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/echo10_test.clj
@@ -424,7 +424,7 @@
     (are3 [url-value source result]
       (let [grouped-urls (opendap-util/validate-url url-value)]
         (is (= result
-               (#'echo10/add-opendap-url-to-metadata source grouped-urls))))
+               (#'echo10/add-opendap-url-to-metadata source grouped-urls :replace))))
 
       "add OnlineResources at the end of the xml"
       "http://example.com/foo"
@@ -495,3 +495,80 @@
       "https://opendap.earthdata.nasa.gov/foo, http://example.com/foo"
       update-both-opendap-url
       update-cloud-opendap-url-with-both-result)))
+
+(deftest append-opendap-url
+  (testing "append OnlineResources at various places in the xml"
+    (are3 [url-value source result]
+          (let [grouped-urls (opendap-util/validate-url url-value)]
+            (is (= result
+                   (#'echo10/add-opendap-url-to-metadata source grouped-urls :append))))
+
+          "add OnlineResources at the end of the xml"
+          "http://example.com/foo"
+          add-at-the-end-gran-xml
+          add-at-the-end-gran-xml-result
+
+          "add OnlineResources before an element in the xml"
+          "http://example.com/foo"
+          add-before-element-gran-xml
+          add-before-element-gran-xml-result
+
+          "add OnlineResources to empty OnlineResources in the xml"
+          "http://example.com/foo"
+          add-with-empty-gran-xml
+          add-before-element-gran-xml-result
+
+          "add OnlineResources to OnlineResources without OPeNDAP url in the xml"
+          "http://example.com/foo"
+          add-with-no-match-gran-xml
+          add-with-no-match-gran-xml-result
+
+          "update with on-prem in metadata, Hyrax-in-the-cloud in update"
+          "https://opendap.earthdata.nasa.gov/foo"
+          update-opendap-url
+          update-opendap-with-cloud-url-result
+
+          "update with Hyrax-in-the-cloud in metadata, on-prem in update"
+          "http://example.com/foo"
+          update-cloud-opendap-url
+          update-cloud-opendap-url-with-on-prem-result))
+
+  (testing "throws appropriate error messages"
+    (are3 [url-value source]
+      (let [grouped-urls (opendap-util/validate-url url-value)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Update contains conflict"
+             (#'echo10/add-opendap-url-to-metadata source grouped-urls :append))))
+
+      "throws during append OnlineResources when OPeNDAP url is present"
+      "http://example.com/foo"
+      update-opendap-url
+
+      "OnlineResources when OPeNDAP url is present"
+      "http://example.com/foo"
+      update-opendap-url-preserve-type
+
+      "update with Hyrax-in-the-cloud in metadata, Hyrax-in-the-cloud in update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      update-cloud-opendap-url
+
+      "update with both in metadata and on-prem in update"
+      "http://example.com/foo"
+      update-both-opendap-url
+
+      "update with both in metadata and Hyrax-in-the-cloud in update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      update-both-opendap-url
+
+      "update with multiple urls, Hyrax-in-the-cloud in metadata"
+      "https://opendap.earthdata.nasa.gov/foo, http://example.com/foo"
+      update-cloud-opendap-url
+
+      "update with multiple urls, on-prem in metadata"
+      "https://opendap.earthdata.nasa.gov/foo, http://example.com/foo"
+      update-opendap-url
+
+      "update with multiple urls, both Hyrax-in-the-cloud and on-prem in metadata"
+      "https://opendap.earthdata.nasa.gov/foo, http://example.com/foo"
+      update-both-opendap-url)))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/umm_g_test.clj
@@ -180,43 +180,23 @@
                      {:URL "https://opendap.earthdata.nasa.gov/foo"
                       :Type "USE SERVICE API"
                       :Subtype "OPENDAP DATA"}
-                     doc-related-url]}
+                     doc-related-url]}))
 
+  (testing "throws when appropriate"
+    (are3 [url-value source]
+      (let [grouped-urls (opendap-util/validate-url url-value)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Update contains conflict"
+             (umm-g/append-opendap-url source grouped-urls))))
       "matching RelatedUrls in metadata, on-prem url update"
       "http://example.com/foo"
       {:RelatedUrls sample-urls}
-      {:RelatedUrls [{:URL "http://example.com/foo"
-                      :Type "USE SERVICE API"
-                      :Subtype "OPENDAP DATA"
-                      :Description "on-prem OPeNDAP Documentation"}
-                     {:URL "https://opendap.uat.earthdata.nasa.gov/to_be_updated"
-                      :Type "GET DATA"
-                      :Subtype "OPENDAP DATA"
-                      :Description "cloud OPeNDAP Documentation"}
-                     doc-related-url]}
-
-      "matching RelatedUrls in metadata, cloud url update"
-      "https://opendap.earthdata.nasa.gov/foo"
-      {:RelatedUrls sample-urls}
-      {:RelatedUrls [{:URL "http://example.com/to_be_updated"
-                      :Type "GET DATA"
-                      :Subtype "OPENDAP DATA"
-                      :Description "on-prem OPeNDAP Documentation"}
-                     {:URL "https://opendap.earthdata.nasa.gov/foo"
-                      :Type "USE SERVICE API"
-                      :Subtype "OPENDAP DATA"
-                      :Description "cloud OPeNDAP Documentation"}
-                     doc-related-url]}
 
       "matching RelatedUrls in metadata, cloud url and on-prem url update"
       "http://example.com/foo, https://opendap.earthdata.nasa.gov/foo"
       {:RelatedUrls sample-urls}
-      {:RelatedUrls [{:URL "http://example.com/foo"
-                      :Type "USE SERVICE API"
-                      :Subtype "OPENDAP DATA"
-                      :Description "on-prem OPeNDAP Documentation"}
-                     {:URL "https://opendap.earthdata.nasa.gov/foo"
-                      :Type "USE SERVICE API"
-                      :Subtype "OPENDAP DATA"
-                      :Description "cloud OPeNDAP Documentation"}
-                     doc-related-url]})))
+
+      "matching RelatedUrls in metadata, cloud url update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      {:RelatedUrls sample-urls})))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/opendap/umm_g_test.clj
@@ -27,12 +27,109 @@
     :Subtype "OPENDAP DATA"
     :Description "cloud OPeNDAP Documentation"}])
 
-(deftest add-opendap-url
+(deftest update-opendap-url
   (testing "add or update OPeNDAP url to UMM-G"
     (are3 [url-value source result]
       (let [grouped-urls (opendap-util/validate-url url-value)]
         (is (= result
-               (umm-g/add-opendap-url source grouped-urls))))
+               (umm-g/update-opendap-url source grouped-urls))))
+
+      "no RelatedUrls in metadata, on-prem url update"
+      "http://example.com/foo"
+      {}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}]}
+
+      "no RelatedUrls in metadata, cloud url update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      {}
+      {:RelatedUrls [{:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}]}
+
+      "no RelatedUrls in metadata, cloud url and on-prem url update"
+      "http://example.com/foo, https://opendap.earthdata.nasa.gov/foo"
+      {}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}
+                     {:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}]}
+
+      "non-matching RelatedUrls in metadata, on-prem url update"
+      "http://example.com/foo"
+      {:RelatedUrls [doc-related-url]}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}
+                     doc-related-url]}
+
+      "non-matching RelatedUrls in metadata, cloud url update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      {:RelatedUrls [doc-related-url]}
+      {:RelatedUrls [{:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}
+                     doc-related-url]}
+
+      "non-matching RelatedUrls in metadata, cloud url and on-prem url update"
+      "http://example.com/foo, https://opendap.earthdata.nasa.gov/foo"
+      {:RelatedUrls [doc-related-url]}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}
+                     {:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"}
+                     doc-related-url]}
+
+      "matching RelatedUrls in metadata, on-prem url update"
+      "http://example.com/foo"
+      {:RelatedUrls sample-urls}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"
+                      :Description "on-prem OPeNDAP Documentation"}
+                     {:URL "https://opendap.uat.earthdata.nasa.gov/to_be_updated"
+                      :Type "GET DATA"
+                      :Subtype "OPENDAP DATA"
+                      :Description "cloud OPeNDAP Documentation"}
+                     doc-related-url]}
+
+      "matching RelatedUrls in metadata, cloud url update"
+      "https://opendap.earthdata.nasa.gov/foo"
+      {:RelatedUrls sample-urls}
+      {:RelatedUrls [{:URL "http://example.com/to_be_updated"
+                      :Type "GET DATA"
+                      :Subtype "OPENDAP DATA"
+                      :Description "on-prem OPeNDAP Documentation"}
+                     {:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"
+                      :Description "cloud OPeNDAP Documentation"}
+                     doc-related-url]}
+
+      "matching RelatedUrls in metadata, cloud url and on-prem url update"
+      "http://example.com/foo, https://opendap.earthdata.nasa.gov/foo"
+      {:RelatedUrls sample-urls}
+      {:RelatedUrls [{:URL "http://example.com/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"
+                      :Description "on-prem OPeNDAP Documentation"}
+                     {:URL "https://opendap.earthdata.nasa.gov/foo"
+                      :Type "USE SERVICE API"
+                      :Subtype "OPENDAP DATA"
+                      :Description "cloud OPeNDAP Documentation"}
+                     doc-related-url]})))
+
+(deftest append-opendap-url
+  (testing "append missing url or fail if existing when adding OPeNDAP url to UMM-G"
+    (are3 [url-value source result]
+      (let [grouped-urls (opendap-util/validate-url url-value)]
+        (is (= result
+               (umm-g/append-opendap-url source grouped-urls))))
 
       "no RelatedUrls in metadata, on-prem url update"
       "http://example.com/foo"

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -473,83 +473,83 @@
 (deftest add-s3-url
   (testing "add OnlineAccessURLs at various places in the xml"
     (are3 [url-value source result]
-          (let [urls (s3-util/validate-url url-value)]
-            (is (= result
-                   (#'echo10/update-s3-url-metadata source urls :replace))))
+      (let [urls (s3-util/validate-url url-value)]
+        (is (= result
+               (#'echo10/update-s3-url-metadata source urls :replace))))
 
-          "add OnlineAccessURLs at the end of the xml"
-          "s3://abcd/foo"
-          add-at-the-end-gran-xml
-          add-at-the-end-gran-xml-result
+      "add OnlineAccessURLs at the end of the xml"
+      "s3://abcd/foo"
+      add-at-the-end-gran-xml
+      add-at-the-end-gran-xml-result
 
-          "add OnlineAccessURLs before an element in the xml"
-          "s3://abcd/foo"
-          add-before-element-gran-xml
-          add-before-element-gran-xml-result
+      "add OnlineAccessURLs before an element in the xml"
+      "s3://abcd/foo"
+      add-before-element-gran-xml
+      add-before-element-gran-xml-result
 
-          "add OnlineAccessURLs to empty OnlineAccessURLs in the xml"
-          "s3://abcd/foo"
-          add-with-empty-gran-xml
-          add-with-empty-gran-xml-result
+      "add OnlineAccessURLs to empty OnlineAccessURLs in the xml"
+      "s3://abcd/foo"
+      add-with-empty-gran-xml
+      add-with-empty-gran-xml-result
 
-          "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
-          "s3://abcd/foo"
-          add-with-no-match-gran-xml
-          add-with-no-match-gran-xml-result
+      "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
+      "s3://abcd/foo"
+      add-with-no-match-gran-xml
+      add-with-no-match-gran-xml-result
 
-          "update OnlineAccessURLs when single S3 url is present in xml"
-          "s3://abcd/foo"
-          update-s3-url
-          update-s3-url-result
+      "update OnlineAccessURLs when single S3 url is present in xml"
+      "s3://abcd/foo"
+      update-s3-url
+      update-s3-url-result
 
-          "Update OnlineAccessURLs when multiple S3 urls are present in xml"
-          "s3://abcd/foo"
-          update-multiple-s3-url
-          update-s3-url-result
-          
-          "update OnlineAccessURLs with multiple S3 urls in input"
-          "s3://abcd/foo,s3://abcd/bar"
-          update-s3-url
-          update-with-multiple-s3-url-result)))
+      "Update OnlineAccessURLs when multiple S3 urls are present in xml"
+      "s3://abcd/foo"
+      update-multiple-s3-url
+      update-s3-url-result
+      
+      "update OnlineAccessURLs with multiple S3 urls in input"
+      "s3://abcd/foo,s3://abcd/bar"
+      update-s3-url
+      update-with-multiple-s3-url-result)))
 
 (deftest append-s3-url
   (testing "append OnlineAccessURLs at various places in the xml"
     (are3 [url-value source result]
-          (let [urls (s3-util/validate-url url-value)]
-            (is (= result
-                   (#'echo10/update-s3-url-metadata source urls :append))))
+      (let [urls (s3-util/validate-url url-value)]
+        (is (= result
+               (#'echo10/update-s3-url-metadata source urls :append))))
 
-          "append OnlineAccessURLs at the end of the xml"
-          "s3://abcd/foo"
-          add-at-the-end-gran-xml
-          add-at-the-end-gran-xml-result
+      "append OnlineAccessURLs at the end of the xml"
+      "s3://abcd/foo"
+      add-at-the-end-gran-xml
+      add-at-the-end-gran-xml-result
 
-          "prepend OnlineAccessURLs before an element in the xml"
-          "s3://abcd/foo"
-          add-before-element-gran-xml
-          add-before-element-gran-xml-result
+      "prepend OnlineAccessURLs before an element in the xml"
+      "s3://abcd/foo"
+      add-before-element-gran-xml
+      add-before-element-gran-xml-result
 
-          "append OnlineAccessURLs to empty OnlineAccessURLs in the xml"
-          "s3://abcd/foo"
-          add-with-empty-gran-xml
-          add-with-empty-gran-xml-result
+      "append OnlineAccessURLs to empty OnlineAccessURLs in the xml"
+      "s3://abcd/foo"
+      add-with-empty-gran-xml
+      add-with-empty-gran-xml-result
 
-          "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
-          "s3://abcd/foo"
-          add-with-no-match-gran-xml
-          add-with-no-match-gran-xml-result
+      "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
+      "s3://abcd/foo"
+      add-with-no-match-gran-xml
+      add-with-no-match-gran-xml-result
 
-          "append OnlineAccessURLs when single S3 url is present in xml"
-          "s3://abcd/foo"
-          appended-s3-url
-          appended-s3-url-result
+      "append OnlineAccessURLs when single S3 url is present in xml"
+      "s3://abcd/foo"
+      appended-s3-url
+      appended-s3-url-result
 
-          "update OnlineAccessURLs when multiple S3 urls are present in xml"
-          "s3://abcd/foo,s3://abcd/bar"
-          appended-multiple-s3-url 
-          appended-multiple-s3-url-result
-          
-          "update OnlineAccessURLs with multiple S3 urls in input"
-          "s3://abcd/to_remain,s3://abcd/bar"
-          appended-multiple-s3-url
-          appended-updated-multiple-s3-url-result)))
+      "update OnlineAccessURLs when multiple S3 urls are present in xml"
+      "s3://abcd/foo,s3://abcd/bar"
+      appended-multiple-s3-url 
+      appended-multiple-s3-url-result
+      
+      "update OnlineAccessURLs with multiple S3 urls in input"
+      "s3://abcd/to_remain,s3://abcd/bar"
+      appended-multiple-s3-url
+      appended-updated-multiple-s3-url-result)))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -448,10 +448,6 @@
          <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
       </OnlineAccessURL>
       <OnlineAccessURL>
-         <URL>s3://abcd/to_remain</URL>
-         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
-      </OnlineAccessURL>
-      <OnlineAccessURL>
          <URL>http://example.com/doc</URL>
          <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
          <MimeType>text/html</MimeType>
@@ -459,6 +455,11 @@
       <OnlineAccessURL>
          <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
          <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
          <MimeType>GET DATA</MimeType>
       </OnlineAccessURL>
       <OnlineAccessURL>

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -475,7 +475,7 @@
     (are3 [url-value source result]
           (let [urls (s3-util/validate-url url-value)]
             (is (= result
-                   (#'echo10/add-s3-url-to-metadata source urls :replace))))
+                   (#'echo10/update-s3-url-metadata source urls :replace))))
 
           "add OnlineAccessURLs at the end of the xml"
           "s3://abcd/foo"
@@ -502,7 +502,7 @@
           update-s3-url
           update-s3-url-result
 
-          "update OnlineAccessURLs when multiple S3 urls are present in xml"
+          "Update OnlineAccessURLs when multiple S3 urls are present in xml"
           "s3://abcd/foo"
           update-multiple-s3-url
           update-s3-url-result
@@ -517,7 +517,7 @@
     (are3 [url-value source result]
           (let [urls (s3-util/validate-url url-value)]
             (is (= result
-                   (#'echo10/add-s3-url-to-metadata source urls :append))))
+                   (#'echo10/update-s3-url-metadata source urls :append))))
 
           "append OnlineAccessURLs at the end of the xml"
           "s3://abcd/foo"

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -224,6 +224,70 @@
    <Orderable>false</Orderable>
 </Granule>\n")
 
+(def ^:private appended-s3-url
+  "ECHO10 granule for testing updating S3 url existing in OnlineAccessURLs."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <OnlineAccessURLs>
+       <OnlineAccessURL>
+          <URL>http://example.com/doc</URL>
+          <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+          <MimeType>text/html</MimeType>
+       </OnlineAccessURL>
+       <OnlineAccessURL>
+          <URL>s3://abcd/to_remain</URL>
+          <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+          <MimeType>GET DATA</MimeType>
+       </OnlineAccessURL>
+       <OnlineAccessURL>
+          <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
+          <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+          <MimeType>GET DATA</MimeType>
+       </OnlineAccessURL>
+    </OnlineAccessURLs>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private appended-s3-url-result
+  "Result ECHO10 granule for testing appending S3 url existing in OnlineAccessURLs.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineAccessURLs>
+      <OnlineAccessURL>
+         <URL>s3://abcd/foo</URL>
+         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>http://example.com/doc</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+         <MimeType>text/html</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
+         <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+   </OnlineAccessURLs>
+   <Orderable>false</Orderable>
+</Granule>\n")
+
 (def ^:private update-multiple-s3-url
   "ECHO10 granule for testing updating multiple S3 url existing in OnlineAccessURLs."
   "<Granule>
@@ -291,44 +355,201 @@
    <Orderable>false</Orderable>
 </Granule>\n")
 
+(def ^:private appended-multiple-s3-url
+  "ECHO10 granule for testing updating multiple S3 url existing in OnlineAccessURLs."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <OnlineAccessURLs>
+       <OnlineAccessURL>
+          <URL>http://example.com/doc</URL>
+          <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+          <MimeType>text/html</MimeType>
+       </OnlineAccessURL>
+       <OnlineAccessURL>
+          <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
+          <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+          <MimeType>GET DATA</MimeType>
+       </OnlineAccessURL>
+       <OnlineAccessURL>
+          <URL>s3://abcd/to_remain</URL>
+          <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+          <MimeType>GET DATA</MimeType>
+       </OnlineAccessURL>
+       <OnlineAccessURL>
+          <URL>s3://abcd/to_remain2</URL>
+          <MimeType>GET DATA</MimeType>
+       </OnlineAccessURL>
+    </OnlineAccessURLs>
+    <Orderable>false</Orderable>
+  </Granule>")
+
+(def ^:private appended-multiple-s3-url-result
+  "ECHO10 granule for testing updating multiple S3 url existing in OnlineAccessURLs."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineAccessURLs>
+      <OnlineAccessURL>
+         <URL>s3://abcd/foo</URL>
+         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/bar</URL>
+         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>http://example.com/doc</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+         <MimeType>text/html</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
+         <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain2</URL>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+   </OnlineAccessURLs>
+   <Orderable>false</Orderable>
+</Granule>
+")
+
+(def ^:private appended-updated-multiple-s3-url-result
+  "ECHO10 granule for testing updating append with existing S3 url existing in OnlineAccessURLs."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <OnlineAccessURLs>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain</URL>
+         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/bar</URL>
+         <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>http://example.com/doc</URL>
+         <URLDescription>Files may be downloaded directly to your workstation from this link</URLDescription>
+         <MimeType>text/html</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>https://oceandata.sci.gsfc.nasa.gov/MODIS-Terra/L3BIN/</URL>
+         <URLDescription>OB.DAAC Data Distribution Website for MODIS-Terra L3B Sea Surface Temperature (SST) Product</URLDescription>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+      <OnlineAccessURL>
+         <URL>s3://abcd/to_remain2</URL>
+         <MimeType>GET DATA</MimeType>
+      </OnlineAccessURL>
+   </OnlineAccessURLs>
+   <Orderable>false</Orderable>
+</Granule>
+")
+
 (deftest add-s3-url
   (testing "add OnlineAccessURLs at various places in the xml"
     (are3 [url-value source result]
-      (let [urls (s3-util/validate-url url-value)]
-        (is (= result
-               (#'echo10/add-s3-url-to-metadata source urls))))
+          (let [urls (s3-util/validate-url url-value)]
+            (is (= result
+                   (#'echo10/add-s3-url-to-metadata source urls :replace))))
 
-      "add OnlineAccessURLs at the end of the xml"
-      "s3://abcd/foo"
-      add-at-the-end-gran-xml
-      add-at-the-end-gran-xml-result
+          "add OnlineAccessURLs at the end of the xml"
+          "s3://abcd/foo"
+          add-at-the-end-gran-xml
+          add-at-the-end-gran-xml-result
 
-      "add OnlineAccessURLs before an element in the xml"
-      "s3://abcd/foo"
-      add-before-element-gran-xml
-      add-before-element-gran-xml-result
+          "add OnlineAccessURLs before an element in the xml"
+          "s3://abcd/foo"
+          add-before-element-gran-xml
+          add-before-element-gran-xml-result
 
-      "add OnlineAccessURLs to empty OnlineAccessURLs in the xml"
-      "s3://abcd/foo"
-      add-with-empty-gran-xml
-      add-with-empty-gran-xml-result
+          "add OnlineAccessURLs to empty OnlineAccessURLs in the xml"
+          "s3://abcd/foo"
+          add-with-empty-gran-xml
+          add-with-empty-gran-xml-result
 
-      "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
-      "s3://abcd/foo"
-      add-with-no-match-gran-xml
-      add-with-no-match-gran-xml-result
+          "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
+          "s3://abcd/foo"
+          add-with-no-match-gran-xml
+          add-with-no-match-gran-xml-result
 
-      "update OnlineAccessURLs when single S3 url is present in xml"
-      "s3://abcd/foo"
-      update-s3-url
-      update-s3-url-result
+          "update OnlineAccessURLs when single S3 url is present in xml"
+          "s3://abcd/foo"
+          update-s3-url
+          update-s3-url-result
 
-      "update OnlineAccessURLs when multiple S3 urls are present in xml"
-      "s3://abcd/foo"
-      update-multiple-s3-url
-      update-s3-url-result
-      
-      "update OnlineAccessURLs with multiple S3 urls in input"
-      "s3://abcd/foo,s3://abcd/bar"
-      update-s3-url
-      update-with-multiple-s3-url-result)))
+          "update OnlineAccessURLs when multiple S3 urls are present in xml"
+          "s3://abcd/foo"
+          update-multiple-s3-url
+          update-s3-url-result
+          
+          "update OnlineAccessURLs with multiple S3 urls in input"
+          "s3://abcd/foo,s3://abcd/bar"
+          update-s3-url
+          update-with-multiple-s3-url-result)))
+
+(deftest append-s3-url
+  (testing "append OnlineAccessURLs at various places in the xml"
+    (are3 [url-value source result]
+          (let [urls (s3-util/validate-url url-value)]
+            (is (= result
+                   (#'echo10/add-s3-url-to-metadata source urls :append))))
+
+          "append OnlineAccessURLs at the end of the xml"
+          "s3://abcd/foo"
+          add-at-the-end-gran-xml
+          add-at-the-end-gran-xml-result
+
+          "prepend OnlineAccessURLs before an element in the xml"
+          "s3://abcd/foo"
+          add-before-element-gran-xml
+          add-before-element-gran-xml-result
+
+          "append OnlineAccessURLs to empty OnlineAccessURLs in the xml"
+          "s3://abcd/foo"
+          add-with-empty-gran-xml
+          add-with-empty-gran-xml-result
+
+          "add OnlineAccessURLs to OnlineAccessURLs without S3 url in the xml"
+          "s3://abcd/foo"
+          add-with-no-match-gran-xml
+          add-with-no-match-gran-xml-result
+
+          "append OnlineAccessURLs when single S3 url is present in xml"
+          "s3://abcd/foo"
+          appended-s3-url
+          appended-s3-url-result
+
+          "update OnlineAccessURLs when multiple S3 urls are present in xml"
+          "s3://abcd/foo,s3://abcd/bar"
+          appended-multiple-s3-url 
+          appended-multiple-s3-url-result
+          
+          "update OnlineAccessURLs with multiple S3 urls in input"
+          "s3://abcd/to_remain,s3://abcd/bar"
+          appended-multiple-s3-url 
+          appended-updated-multiple-s3-url-result)))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -444,11 +444,11 @@
    </Collection>
    <OnlineAccessURLs>
       <OnlineAccessURL>
-         <URL>s3://abcd/to_remain</URL>
+         <URL>s3://abcd/bar</URL>
          <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
       </OnlineAccessURL>
       <OnlineAccessURL>
-         <URL>s3://abcd/bar</URL>
+         <URL>s3://abcd/to_remain</URL>
          <URLDescription>This link provides direct download access via S3 to the granule.</URLDescription>
       </OnlineAccessURL>
       <OnlineAccessURL>

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/echo10_test.clj
@@ -551,5 +551,5 @@
           
           "update OnlineAccessURLs with multiple S3 urls in input"
           "s3://abcd/to_remain,s3://abcd/bar"
-          appended-multiple-s3-url 
+          appended-multiple-s3-url
           appended-updated-multiple-s3-url-result)))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -77,3 +77,55 @@
                       :Type "GET DATA VIA DIRECT ACCESS"
                       :Description "This link provides direct download access via S3 to the granule."}
                      doc-related-url]})))
+
+(deftest append-s3-url
+  (testing "append s3 url to UMM-G"
+    (are3 [url-value source result]
+          (let [urls (s3-util/validate-url url-value)]
+            (is (= (set result)
+                   (set (:RelatedUrls (umm-g/append-s3-url source urls))))))
+
+          "no RelatedUrls in metadata"
+          "s3://abc/foo"
+          {}
+          [{:URL "s3://abc/foo"
+            :Type "GET DATA VIA DIRECT ACCESS"
+            :Description "This link provides direct download access via S3 to the granule."}]
+
+          "non-matching S3 RelatedUrls in metadata"
+          "s3://abc/foo"
+          {:RelatedUrls [doc-related-url]}
+          [{:URL "s3://abc/foo"
+            :Type "GET DATA VIA DIRECT ACCESS"
+            :Description "This link provides direct download access via S3 to the granule."}
+           doc-related-url]
+
+          "non-matching S3 RelatedUrls in metadata, multiple s3 urls update"
+          "s3://abc/foo, s3://abc/bar"
+          {:RelatedUrls [doc-related-url]}
+          [{:URL "s3://abc/foo"
+            :Type "GET DATA VIA DIRECT ACCESS"
+            :Description "This link provides direct download access via S3 to the granule."}
+           {:URL "s3://abc/bar"
+            :Type "GET DATA VIA DIRECT ACCESS"
+            :Description "This link provides direct download access via S3 to the granule."}
+           doc-related-url]
+
+          "existing S3 RelatedUrls in metadata remain with new appended"
+          "s3://abc/foo"
+          {:RelatedUrls sample-urls}
+          (conj sample-urls
+                {:URL "s3://abc/foo"
+                 :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."})
+
+          "existing S3 RelatedUrls in metadata, multiple S3 urls update"
+          "s3://abc/foo, s3://abc/bar"
+          {:RelatedUrls sample-urls}
+          (conj sample-urls
+                {:URL "s3://abc/foo"
+                 :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."}
+                {:URL "s3://abc/bar"
+                 :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."}))))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -92,8 +92,8 @@
   (testing "append s3 url to UMM-G"
     (are3 [url-value source result]
           (let [urls (s3-util/validate-url url-value)]
-            (is (= (set result)
-                   (set (:RelatedUrls (umm-g/append-s3-url source urls))))))
+            (is (= result
+                   (:RelatedUrls (umm-g/append-s3-url source urls)))))
 
           "no RelatedUrls in metadata"
           "s3://abc/foo"
@@ -105,21 +105,21 @@
           "non-matching S3 RelatedUrls in metadata"
           "s3://abc/foo"
           {:RelatedUrls [doc-related-url]}
-          [{:URL "s3://abc/foo"
+          [doc-related-url
+           {:URL "s3://abc/foo"
             :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}
-           doc-related-url]
+            :Description "This link provides direct download access via S3 to the granule."}]
 
           "non-matching S3 RelatedUrls in metadata, multiple s3 urls update"
           "s3://abc/foo, s3://abc/bar"
           {:RelatedUrls [doc-related-url]}
-          [{:URL "s3://abc/foo"
+          [doc-related-url
+           {:URL "s3://abc/foo"
             :Type "GET DATA VIA DIRECT ACCESS"
             :Description "This link provides direct download access via S3 to the granule."}
            {:URL "s3://abc/bar"
             :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}
-           doc-related-url]
+            :Description "This link provides direct download access via S3 to the granule."}]
 
           "existing S3 RelatedUrls in metadata remain with new appended"
           "s3://abc/foo"

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -128,4 +128,15 @@
                  :Description "This link provides direct download access via S3 to the granule."}
                 {:URL "s3://abc/bar"
                  :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."})
+
+          "duplicates are handled"
+          "s3://abc/foo, s3://abc/bar, s3://abc/bar, s3://abc/bar"
+          {:RelatedUrls sample-urls}
+          (conj sample-urls
+                {:URL "s3://abc/foo"
+                 :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."}
+                {:URL "s3://abc/bar"
+                 :Type "GET DATA VIA DIRECT ACCESS"
                  :Description "This link provides direct download access via S3 to the granule."}))))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -157,4 +157,5 @@
                  :Description "This link provides direct download access via S3 to the granule."}
                 {:URL "s3://abc/bar"
                  :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."}))))
+                 :Description "This link provides direct download access via S3 to the granule."})
+          )))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -91,71 +91,70 @@
 (deftest append-s3-url
   (testing "append s3 url to UMM-G"
     (are3 [url-value source result]
-          (let [urls (s3-util/validate-url url-value)]
-            (is (= result
-                   (:RelatedUrls (umm-g/append-s3-url source urls)))))
+      (let [urls (s3-util/validate-url url-value)]
+        (is (= result
+               (:RelatedUrls (umm-g/append-s3-url source urls)))))
 
-          "no RelatedUrls in metadata"
-          "s3://abc/foo"
-          {}
-          [{:URL "s3://abc/foo"
-            :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}]
+      "no RelatedUrls in metadata"
+      "s3://abc/foo"
+      {}
+      [{:URL "s3://abc/foo"
+        :Type "GET DATA VIA DIRECT ACCESS"
+        :Description "This link provides direct download access via S3 to the granule."}]
 
-          "non-matching S3 RelatedUrls in metadata"
-          "s3://abc/foo"
-          {:RelatedUrls [doc-related-url]}
-          [doc-related-url
-           {:URL "s3://abc/foo"
-            :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}]
+      "non-matching S3 RelatedUrls in metadata"
+      "s3://abc/foo"
+      {:RelatedUrls [doc-related-url]}
+      [doc-related-url
+       {:URL "s3://abc/foo"
+        :Type "GET DATA VIA DIRECT ACCESS"
+        :Description "This link provides direct download access via S3 to the granule."}]
 
-          "non-matching S3 RelatedUrls in metadata, multiple s3 urls update"
-          "s3://abc/foo, s3://abc/bar"
-          {:RelatedUrls [doc-related-url]}
-          [doc-related-url
-           {:URL "s3://abc/foo"
-            :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}
-           {:URL "s3://abc/bar"
-            :Type "GET DATA VIA DIRECT ACCESS"
-            :Description "This link provides direct download access via S3 to the granule."}]
+      "non-matching S3 RelatedUrls in metadata, multiple s3 urls update"
+      "s3://abc/foo, s3://abc/bar"
+      {:RelatedUrls [doc-related-url]}
+      [doc-related-url
+       {:URL "s3://abc/foo"
+        :Type "GET DATA VIA DIRECT ACCESS"
+        :Description "This link provides direct download access via S3 to the granule."}
+       {:URL "s3://abc/bar"
+        :Type "GET DATA VIA DIRECT ACCESS"
+        :Description "This link provides direct download access via S3 to the granule."}]
 
-          "existing S3 RelatedUrls in metadata remain with new appended"
-          "s3://abc/foo"
-          {:RelatedUrls sample-urls}
-          (conj sample-urls
-                {:URL "s3://abc/foo"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."})
+      "existing S3 RelatedUrls in metadata remain with new appended"
+      "s3://abc/foo"
+      {:RelatedUrls sample-urls}
+      (conj sample-urls
+            {:URL "s3://abc/foo"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."})
 
-          "existing S3 RelatedUrls in metadata remain with new appended and no duplicate"
-          "s3://abc/foo,s3://abc/to_be_updated"
-          {:RelatedUrls sample-urls}
-          (conj sample-urls
-                {:URL "s3://abc/foo"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."})
+      "existing S3 RelatedUrls in metadata remain with new appended and no duplicate"
+      "s3://abc/foo,s3://abc/to_be_updated"
+      {:RelatedUrls sample-urls}
+      (conj sample-urls
+            {:URL "s3://abc/foo"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."})
 
-          "existing S3 RelatedUrls in metadata, multiple S3 urls update"
-          "s3://abc/foo, s3://abc/bar"
-          {:RelatedUrls sample-urls}
-          (conj sample-urls
-                {:URL "s3://abc/foo"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."}
-                {:URL "s3://abc/bar"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."})
+      "existing S3 RelatedUrls in metadata, multiple S3 urls update"
+      "s3://abc/foo, s3://abc/bar"
+      {:RelatedUrls sample-urls}
+      (conj sample-urls
+            {:URL "s3://abc/foo"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."}
+            {:URL "s3://abc/bar"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."})
 
-          "duplicates are handled"
-          "s3://abc/foo, s3://abc/bar, s3://abc/bar, s3://abc/bar"
-          {:RelatedUrls sample-urls}
-          (conj sample-urls
-                {:URL "s3://abc/foo"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."}
-                {:URL "s3://abc/bar"
-                 :Type "GET DATA VIA DIRECT ACCESS"
-                 :Description "This link provides direct download access via S3 to the granule."})
-          )))
+      "duplicates are handled"
+      "s3://abc/foo, s3://abc/bar, s3://abc/bar, s3://abc/bar"
+      {:RelatedUrls sample-urls}
+      (conj sample-urls
+            {:URL "s3://abc/foo"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."}
+            {:URL "s3://abc/bar"
+             :Type "GET DATA VIA DIRECT ACCESS"
+             :Description "This link provides direct download access via S3 to the granule."}))))

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/s3/umm_g_test.clj
@@ -30,8 +30,7 @@
   (testing "add or update s3 url to UMM-G"
     (are3 [url-value source result]
       (let [urls (s3-util/validate-url url-value)]
-        (is (= result
-               (umm-g/add-s3-url source urls))))
+        (is (= result (umm-g/update-s3-url source urls))))
 
       "no RelatedUrls in metadata"
       "s3://abc/foo"
@@ -76,6 +75,17 @@
                      {:URL "s3://abc/bar"
                       :Type "GET DATA VIA DIRECT ACCESS"
                       :Description "This link provides direct download access via S3 to the granule."}
+                     doc-related-url]}
+
+      "duplicates in request"
+      "s3://abc/foo, s3://abc/bar, s3://abc/bar"
+      {:RelatedUrls sample-urls}
+      {:RelatedUrls [{:URL "s3://abc/foo"
+                      :Type "GET DATA VIA DIRECT ACCESS"
+                      :Description "This link provides direct download access via S3 to the granule."}
+                     {:URL "s3://abc/bar"
+                      :Type "GET DATA VIA DIRECT ACCESS"
+                      :Description "This link provides direct download access via S3 to the granule."}
                      doc-related-url]})))
 
 (deftest append-s3-url
@@ -113,6 +123,14 @@
 
           "existing S3 RelatedUrls in metadata remain with new appended"
           "s3://abc/foo"
+          {:RelatedUrls sample-urls}
+          (conj sample-urls
+                {:URL "s3://abc/foo"
+                 :Type "GET DATA VIA DIRECT ACCESS"
+                 :Description "This link provides direct download access via S3 to the granule."})
+
+          "existing S3 RelatedUrls in metadata remain with new appended and no duplicate"
+          "s3://abc/foo,s3://abc/to_be_updated"
           {:RelatedUrls sample-urls}
           (conj sample-urls
                 {:URL "s3://abc/foo"

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_schema_test.clj
@@ -73,33 +73,47 @@
 
 (deftest operation-validation-test
   (are3 [operation expected-status]
-        (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
-                                   :accept-format :json
-                                   :raw? true}
-              request (assoc base-request :operation operation)
-              {:keys [body status]} (ingest/bulk-update-granules "PROV1"
-                                                                 request
-                                                                 bulk-update-options)
-              response (json/parse-string body true)]
-          (is (= status expected-status))
-          (when-not (= 200 expected-status)
-            (is (= (format "#/operation: %s is not a valid enum value" operation)
-                   (first (:errors response))))))
-        "valid"
-        "UPDATE_FIELD" 200
+   (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
+                              :accept-format :json
+                              :raw? true}
+         request (assoc base-request :operation operation)
+         {:keys [body status]} (ingest/bulk-update-granules "PROV1"
+                                                            request
+                                                            bulk-update-options)
+         response (json/parse-string body true)]
+     (is (= status expected-status))
+     (when-not (= 200 expected-status)
+       (is (= (format "#/operation: %s is not a valid enum value" operation)
+              (first (:errors response))))))
+   "valid"
+   "UPDATE_FIELD" 200
 
-        "invalid"
-        "CROMULENT_OPERATION" 400))
+   "valid"
+   "APPEND_TO_FIELD" 200
+
+   "invalid"
+   "CROMULENT_OPERATION" 400))
 
 (deftest update-field-validation-test
-  (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
-                             :accept-format :json
-                             :raw? true}
-        request (assoc base-request :update-field "CROMULANT_FIELD")
-        {:keys [body status]} (ingest/bulk-update-granules "PROV1"
-                                                           request
-                                                           bulk-update-options)
-        response (json/parse-string body true)]
-    (is (= 400 status))
-    (is (= "#/update-field: CROMULANT_FIELD is not a valid enum value"
-           (first (:errors response))))))
+  (are3 [field expected-status]
+   (let [bulk-update-options {:token (echo-util/login (sys/context) "user1")
+                              :accept-format :json
+                              :raw? true}
+         request (assoc base-request :update-field field)
+         {:keys [body status]} (ingest/bulk-update-granules "PROV1"
+                                                            request
+                                                            bulk-update-options)
+         response (json/parse-string body true)]
+     (is (= status expected-status))
+     (when-not (= 200 expected-status)
+       (is (= (format "#/update-field: %s is not a valid enum value" field)
+              (first (:errors response))))))
+
+   "valid"
+   "OPeNDAPLink" 200
+
+   "valid"
+   "S3Link" 200
+
+   "invalid"
+   "CROMULENT_FIELD" 400))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -428,3 +428,95 @@
         (is (string/includes? updated-metadata "s3://abcdefg/test-gran1"))
         (is (string/includes? updated-metadata "GET DATA VIA DIRECT ACCESS"))
         (is (string/includes? updated-metadata "This link provides direct download access via S3 to the granule."))))))
+
+(deftest append-s3-url
+  "test appending S3 url with real granule file that is already in CMR code base"
+  (testing "ECHO10 granule"
+    (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
+          coll (data-core/ingest-concept-with-metadata-file "CMR-4722/OMSO2.003-collection.xml"
+                                                            {:provider-id "PROV1"
+                                                             :concept-type :collection
+                                                             :native-id "OMSO2-collection"
+                                                             :format-key :dif10})
+          granule (data-core/ingest-concept-with-metadata-file "CMR-4722/OMSO2.003-granule.xml"
+                                                               {:provider-id "PROV1"
+                                                                :concept-type :granule
+                                                                :native-id "OMSO2-granule"
+                                                                :format-key :echo10})
+          {:keys [concept-id revision-id]} granule
+          target-metadata (-> "CMR-4722/OMSO2.003-granule-s3-url.xml" io/resource slurp)
+          bulk-update {:operation "APPEND_TO_FIELD"
+                       :update-field "S3Link"
+                       :updates [["OMSO2.003:OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5"
+                                  "s3://abcdefg/2016m0615t191523"]]}
+          {:keys [status] :as response} (ingest/bulk-update-granules
+                                         "PROV1" bulk-update bulk-update-options)]
+      (index/wait-until-indexed)
+      (is (= 200 status))
+      (is (= target-metadata
+             (:metadata (mdb/get-concept concept-id (inc revision-id)))))))
+
+  (testing "UMM-G granule"
+    (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
+          coll (data-core/ingest-concept-with-metadata-file
+                "umm-g-samples/Collection.json"
+                {:provider-id "PROV1"
+                 :concept-type :collection
+                 :native-id "test-coll1"
+                 :format "application/vnd.nasa.cmr.umm+json;version=1.16"})
+          granule (data-core/ingest-concept-with-metadata-file
+                   "umm-g-samples/GranuleExample.json"
+                   {:provider-id "PROV1"
+                    :concept-type :granule
+                    :native-id "test-gran1"
+                    :format "application/vnd.nasa.cmr.umm+json;version=1.6"})
+          {:keys [concept-id revision-id]} granule
+          bulk-update {:operation "APPEND_TO_FIELD"
+                       :update-field "S3Link"
+                       :updates [["Unique_Granule_UR_v1.6"
+                                  "s3://abcdefg/test-gran1"]]}
+          {:keys [status task-id] :as response} (ingest/bulk-update-granules
+                                                 "PROV1" bulk-update bulk-update-options)]
+      (index/wait-until-indexed)
+      (ingest/update-granule-bulk-update-task-statuses)
+
+      ;; verify the granule status is UPDATED
+      (is (= 200 status))
+      (is (some? task-id))
+      (let [status-response (ingest/granule-bulk-update-task-status task-id)
+            {:keys [task-status status-message granule-statuses]} status-response]
+        (is (= "COMPLETE" task-status))
+        (is (= "All granule updates completed successfully." status-message))
+        (is (= [{:granule-ur "Unique_Granule_UR_v1.6"
+                 :status "UPDATED"}]
+               granule-statuses)))
+      ;; verify the granule metadata is updated as expected
+      (let [original-metadata (:metadata (mdb/get-concept concept-id revision-id))
+            updated-metadata (:metadata (mdb/get-concept concept-id (inc revision-id)))]
+        ;; since the metadata will be returned in the latest UMM-G format,
+        ;; we can't compare the whole metadata to an expected string.
+        ;; We just verify the updated S3 url, type and description exists in the metadata.
+        ;; The different scenarios of the RelatedUrls update are covered in unit tests.
+        (is (not (string/includes? original-metadata "s3://abcdefg/test-gran1")))
+        (is (not (string/includes? original-metadata "GET DATA VIA DIRECT ACCESS")))
+        (is (not (string/includes? original-metadata "This link provides direct download access via S3 to the granule.")))
+
+        (is (string/includes? updated-metadata "s3://abcdefg/test-gran1"))
+        (is (string/includes? updated-metadata "GET DATA VIA DIRECT ACCESS"))
+        (is (string/includes? updated-metadata "This link provides direct download access via S3 to the granule.")))
+
+      (testing "append preserves existing S3 urls"
+        (let [bulk-update {:operation "APPEND_TO_FIELD"
+                           :update-field "S3Link"
+                           :updates [["Unique_Granule_UR_v1.6"
+                                      "s3://zyxwvut/test-gran1"]]}
+              {:keys [status task-id] :as response} (ingest/bulk-update-granules
+                                                     "PROV1" bulk-update bulk-update-options)]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
+            (is (string/includes? latest-metadata "s3://abcdefg/test-gran1"))
+            (is (string/includes? latest-metadata "s3://zyxwvut/test-gran1"))
+            (is (string/includes? latest-metadata "GET DATA VIA DIRECT ACCESS"))
+            (is (string/includes? latest-metadata "This link provides direct download access via S3 to the granule."))))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -469,7 +469,20 @@
           (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
             (is (string/includes? latest-metadata "s3://abcdefg/2016m0615t191523"))
             (is (string/includes? latest-metadata "s3://zyxwvut/2016m0615t191523"))
-            (is (string/includes? latest-metadata "This link provides direct download access via S3 to the granule.")))))))
+            (is (string/includes? latest-metadata "This link provides direct download access via S3 to the granule.")))))
+
+      (testing "append will not duplicate S3 urls"
+        (let [bulk-update {:operation "APPEND_TO_FIELD"
+                           :update-field "S3Link"
+                           :updates [["OMSO2.003:OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5"
+                                      "s3://zyxwvut/2016m0615t191523"]]}
+              {:keys [status task-id] :as response} (ingest/bulk-update-granules
+                                                     "PROV1" bulk-update bulk-update-options)]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
+            (is (= 1 (count (re-find #"s3://zyxwvut/2016m0615t191523" latest-metadata)))))))))
 
   (testing "UMM-G granule"
     (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
@@ -534,4 +547,17 @@
             (is (string/includes? latest-metadata "s3://abcdefg/test-gran1"))
             (is (string/includes? latest-metadata "s3://zyxwvut/test-gran1"))
             (is (string/includes? latest-metadata "GET DATA VIA DIRECT ACCESS"))
-            (is (string/includes? latest-metadata "This link provides direct download access via S3 to the granule."))))))))
+            (is (string/includes? latest-metadata "This link provides direct download access via S3 to the granule.")))))
+
+      (testing "append will not duplicate S3 urls"
+        (let [bulk-update {:operation "APPEND_TO_FIELD"
+                           :update-field "S3Link"
+                           :updates [["Unique_Granule_UR_v1.6"
+                                      "s3://zyxwvut/test-gran1"]]}
+              {:keys [status task-id] :as response} (ingest/bulk-update-granules
+                                                     "PROV1" bulk-update bulk-update-options)]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
+            (is (= 1 (count (re-find #"s3://zyxwvut/test-gran1" latest-metadata))))))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -89,7 +89,7 @@
                      :status "UPDATED"}]
                    granule-statuses)))))
 
-      (testing "failed OPeNDAP url granule bulk update"
+      (testing "failed OPeNDAP url granule bulk update : UPDATE_FIELD"
         (let [bulk-update {:name "add opendap links 2"
                            :operation "UPDATE_FIELD"
                            :update-field "OPeNDAPLink"
@@ -107,7 +107,7 @@
             (is (= "Task completed with 1 FAILED out of 1 total granule update(s)." status-message))
             (is (= [{:granule-ur "SC:AE_5DSno.002:30500513"
                      :status "FAILED"
-                     :status-message "Add OPeNDAP url is not supported for format [application/iso:smap+xml]"}]
+                     :status-message "Adding OPeNDAP url is not supported for format [application/iso:smap+xml]"}]
                    granule-statuses)))))
 
       (testing "partial successful OPeNDAP url granule bulk update"
@@ -217,7 +217,7 @@
             (is (= "Task completed with 1 FAILED out of 1 total granule update(s)." status-message))
             (is (= [{:granule-ur "SC:AE_5DSno.002:30500513"
                      :status "FAILED"
-                     :status-message "Add s3 url is not supported for format [application/iso:smap+xml]"}]
+                     :status-message "Adding s3 urls is not supported for format [application/iso:smap+xml]"}]
                    granule-statuses)))))
 
       (testing "partial successful S3 link granule bulk update"
@@ -482,7 +482,7 @@
           (ingest/update-granule-bulk-update-task-statuses)
 
           (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
-            (is (= 1 (count (re-find #"s3://zyxwvut/2016m0615t191523" latest-metadata)))))))))
+            (is (= 1 (count (re-seq #"s3://zyxwvut/2016m0615t191523" latest-metadata)))))))))
 
   (testing "UMM-G granule"
     (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
@@ -560,4 +560,4 @@
           (ingest/update-granule-bulk-update-task-statuses)
 
           (let [latest-metadata (:metadata (mdb/get-concept concept-id))]
-            (is (= 1 (count (re-find #"s3://zyxwvut/test-gran1" latest-metadata))))))))))
+            (is (= 1 (count (re-seq #"s3://zyxwvut/test-gran1" latest-metadata))))))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -184,14 +184,14 @@
       (let [granule (data-core/item->concept (granule/granule-with-umm-spec-collection collection (:concept-id collection)))
             response (ingest/ingest-concept granule {:accept-format :json :raw? true})]
         (index/wait-until-indexed)
-        (is (= {:revision-id 1}
-               (select-keys (ingest/parse-ingest-body :json response) [:revision-id])))))
+        (is (= {:concept-id "G1200000006-PROV1" :revision-id 1}
+               (select-keys (ingest/parse-ingest-body :json response) [:concept-id :revision-id])))))
     (testing "xml response"
       (let [granule (data-core/item->concept (granule/granule-with-umm-spec-collection collection (:concept-id collection)))
             response (ingest/ingest-concept granule {:accept-format :xml :raw? true})]
         (index/wait-until-indexed)
-        (is (= {:revision-id 1}
-               (select-keys (ingest/parse-ingest-body :xml response) [:revision-id])))))))
+        (is (= {:concept-id "G1200000007-PROV1" :revision-id 1}
+               (select-keys (ingest/parse-ingest-body :xml response) [:concept-id :revision-id])))))))
 
 ;; Verify that the accept header works with returned errors
 (deftest granule-ingest-with-errors-accept-header-test

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -184,14 +184,14 @@
       (let [granule (data-core/item->concept (granule/granule-with-umm-spec-collection collection (:concept-id collection)))
             response (ingest/ingest-concept granule {:accept-format :json :raw? true})]
         (index/wait-until-indexed)
-        (is (= {:concept-id "G1200000006-PROV1" :revision-id 1}
-               (select-keys (ingest/parse-ingest-body :json response) [:concept-id :revision-id])))))
+        (is (= {:revision-id 1}
+               (select-keys (ingest/parse-ingest-body :json response) [:revision-id])))))
     (testing "xml response"
       (let [granule (data-core/item->concept (granule/granule-with-umm-spec-collection collection (:concept-id collection)))
             response (ingest/ingest-concept granule {:accept-format :xml :raw? true})]
         (index/wait-until-indexed)
-        (is (= {:concept-id "G1200000007-PROV1" :revision-id 1}
-               (select-keys (ingest/parse-ingest-body :xml response) [:concept-id :revision-id])))))))
+        (is (= {:revision-id 1}
+               (select-keys (ingest/parse-ingest-body :xml response) [:revision-id])))))))
 
 ;; Verify that the accept header works with returned errors
 (deftest granule-ingest-with-errors-accept-header-test


### PR DESCRIPTION
New APPEND_TO_FIELD operation

## S3Link
* if no S3 link data exists creates and adds, (identical to UPDATE_FIELD)
* if new urls are unique, will add new S3 links, preserving existing

### OPeNDAPLink
Because no more than 1 url of type cloud and 1 url of type on-prem may exist. behavior of APPEND_TO_FIELD is as follows
* if URL type is not present it will be added
* fails if existing type is present
