### PR TITLE
CMR-7354: Allow requester to specify verbosity of bulk granule update task status

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1309,7 +1309,16 @@ curl -i \
 
 To get a detailed task status for a given granule bulk update task, user can send an HTTP GET request to `%CMR-ENDPOINT%/granule-bulk-update/status/<task-id>`
 
-This returns the status of the bulk update task including the overall task status (IN_PROGRESS or COMPLETE), an overall task status message, the original request JSON body, and the status of each granule updated. The granule status includes the granule-ur, the granule update status (PENDING, UPDATED, SKIPPED, FAILED), and a status message. FAILED indicates an error occurred either updating the granule or during granule validation. SKIPPED indicates the update didn't happen because the update operation does not apply to the granule. The error will be reported in the granule status message.
+This returns the status of the bulk update task including the overall task status (IN_PROGRESS or COMPLETE), the name of the task, and the time the task began processing. Additionally, there are optional query parameters which will increase the verbosity of this response:
+
+`show_progress=true`
+When specified, this parameter will return a progress message indicating the number of granules which have been processed out of the total number of granules in the request.
+
+`show_granules=true`
+This parameter will return the individual granule status for all granules in the request, which includes the granule-ur and the granule update status (PENDING, UPDATED, SKIPPED, or FAILED). FAILED indicates an error occurred either updating the granule or during granule validation. SKIPPED indicates the update didn't happen because the update operation does not apply to the granule. The error will be reported in the granule status message. Note that this parameter can cause the response to become much larger, scaling with the size of the original bulk update request.
+
+`show_request=true`
+This parameter will return the original json body used to initiate the bulk update. Note that this parameter, like before, can cause the response to become much larger, scaling with the size of the original bulk update request.
 
 The only supported response format for granule bulk update task status is application/json.
 
@@ -1319,7 +1328,7 @@ Example of granule bulk update task status:
 curl -i \
   -H "Echo-Token: XXXX" \
   -H "Cmr-Pretty:true" \
-  %CMR-ENDPOINT%/granule-bulk-update/status/3
+  %CMR-ENDPOINT%/granule-bulk-update/status/3?show_granules=true&show_request=true
 
 {
   "status" : 200,
@@ -1347,4 +1356,3 @@ By default the bulk granule update jobs are checked for completion every 5 minut
 ```
 curl -XPOST -i -H "Echo-Token: XXXX" %CMR-ENDPOINT%/granule-bulk-update/status
 ```
-

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -90,11 +90,6 @@
      (for [k additional-keys]
       (xml/element k {} (get status k)))))))
 
-(defn- generate-progress-message
-  "Generate progress message for in in-progress bulk granule update"
-  [granule-statuses]
-  "status message in progress")
-
 (defmulti generate-provider-tasks-response
   "Convert a result to a proper response format"
   (fn [headers result]
@@ -193,39 +188,48 @@
         :request-json-body (:request-json-body task-status)
         :collection-statuses collection-statuses}))))
 
-(defn get-granule-task-status-terse
-  "Get the short and sweet status for the given task, which doesn't take require a full query of
-   granules in the task."
-  [task-id request show_request]
-  (let [{:keys [headers request-context]} request
-        _ (validate-granule-bulk-update-result-format headers)
-        gran-task (data-gran-bulk-update/get-granule-task-by-id request-context task-id)
-        provider-id (:provider-id gran-task)]
-    (when-not provider-id
-      (srvc-errors/throw-service-error
-       :not-found
-       (format "Granule bulk update task with task id [%s] could not be found." task-id)))
+(defn- generate-progress-message
+  "Generate progress message for an in-progress bulk granule update"
+  [granule-statuses]
+  (let [gran-count (count granule-statuses)
+        pending-count (count (filter #(= (:status %) "UPDATED") granule-statuses))]
 
-    (api-core/verify-provider-exists request-context provider-id)
-    (acl/verify-ingest-management-permission request-context :read :provider-object provider-id)
-
-    (let [{:keys [name created-at status status-message request-json-body]} gran-task
-          response-fields {:status 200
-                           :created-at created-at
-                           :name name
-                           :task-status status
-                           :status-message status-message}
-          response (if show_request
-                     (assoc response-fields :request-json-body request-json-body)
-                     response-fields)]
-      (api-core/generate-ingest-response (assoc headers "accept" mt/json) response))))
+    (if (= pending-count 0)
+     (format "All granules in this request have been processed.")
+     (format "Of %d total granules, %d granules have been processed and %d are still pending."
+            gran-count (- gran-count pending-count) pending-count))))
 
 
-
-(defn get-granule-task-status-verbose
+(defn- get-granule-task-status-response-generator
   "Get the verbose status for the given task including granule statuses. Since a detailed show_progress
    or show_granules has been requested, we must perform an expensive second query."
-  [task-id request show_progress show_granules show_request]
+  [request-context task-id gran-task params]
+  (let [{:keys [name created-at status status-message request-json-body]} gran-task
+        {:keys [show_request show_progress show_granules]} params
+        granule-statuses (when (or show_progress show_granules)
+                           (data-gran-bulk-update/get-bulk-update-granule-statuses-for-task
+                            request-context task-id))
+        response-fields {:status 200
+                         :created-at created-at
+                         :name name
+                         :task-status status
+                         :status-message status-message}
+        extra-fields (as-> {} intermediate
+                                (if show_progress
+                                  (assoc intermediate :progress (generate-progress-message granule-statuses))
+                                  intermediate)
+                                (if show_request
+                                  (assoc intermediate :request-json-body request-json-body)
+                                  intermediate)
+                                (if show_granules
+                                  (assoc intermediate :granule-statuses granule-statuses)
+                                  intermediate))]
+     (conj response-fields extra-fields)))
+
+(defn get-granule-task-status
+  "Get the short and sweet status for the given task, which doesn't take require a full query of
+   granules in the task."
+  [request task-id]
   (let [{:keys [headers request-context params]} request
         _ (validate-granule-bulk-update-result-format headers)
         gran-task (data-gran-bulk-update/get-granule-task-by-id request-context task-id)
@@ -238,41 +242,9 @@
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :read :provider-object provider-id)
 
-    (let [{:keys [name created-at status status-message request-json-body]} gran-task
-          granule-statuses (data-gran-bulk-update/get-bulk-update-granule-statuses-for-task
-                            request-context task-id)
-          response-fields {:status 200
-                           :created-at created-at
-                           :name name
-                           :task-status status
-                           :status-message status-message}
-          extra-fields (as-> {} intermediate
-                             (if show_progress
-                               (assoc intermediate :progress (generate-progress-message granule-statuses))
-                               intermediate)
-                             (if show_request
-                               (assoc intermediate :request-json-body request-json-body)
-                               intermediate)
-                             (if show_granules
-                               (assoc intermediate :granule-statuses granule-statuses)
-                               intermediate))
-
-          response (conj response-fields extra-fields)]
-      (api-core/generate-ingest-response (assoc headers "accept" mt/json) response))))
-
-
-(defn get-granule-task-status
-  "Verbosity decider"
-  [task-id request]
-  (let [{:keys [show_progress show_granules show_request]} (:params request)]
-    (println "show_progress: " show_progress)
-    (println "show_granules: " show_granules)
-    (println "show_request: " show_request)
-    (if (or (= show_progress "true")
-            (= show_granules "true"))
-      (get-granule-task-status-verbose task-id request show_progress show_granules show_request)
-      (get-granule-task-status-terse task-id request show_request))))
-
+    (api-core/generate-ingest-response
+     (assoc headers "accept" mt/json)
+     (get-granule-task-status-response-generator request-context task-id gran-task params))))
 
 (defn update-completed-granule-task-statuses
   "On demand capability to update granule task statuses. Marks bulk granule

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -201,8 +201,10 @@
 
 
 (defn- get-granule-task-status-response-generator
-  "Get the verbose status for the given task including granule statuses. Since a detailed show_progress
-   or show_granules has been requested, we must perform an expensive second query."
+  "Generates the response for a bulk granule update task status request. Depending on the parameters
+   show_request, show_progress, and show_granules, the response will be more or less verbose.
+   show_progress and show_granules require a full query of granules in the request, which can cause
+   this response generation to be much more expensive."
   [request-context task-id gran-task params]
   (let [{:keys [name created-at status status-message request-json-body]} gran-task
         {:keys [show_request show_progress show_granules]} params
@@ -229,8 +231,7 @@
      (conj response-fields extra-fields)))
 
 (defn get-granule-task-status
-  "Get the short and sweet status for the given task, which doesn't take require a full query of
-   granules in the task."
+  "Handles bulk granule update task status requests."
   [request task-id]
   (let [{:keys [headers request-context params]} request
         _ (validate-granule-bulk-update-result-format headers)

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -205,7 +205,8 @@
   [request-context task-id gran-task params]
   (let [{:keys [name created-at status status-message request-json-body]} gran-task
         {:keys [show_request show_progress show_granules]} params
-        granule-statuses (when (or show_progress show_granules)
+        ;this call makes the status response much more expensive to retrieve
+        granule-statuses (when (or (= "true" show_progress) (= "true" show_granules))
                            (data-gran-bulk-update/get-bulk-update-granule-statuses-for-task
                             request-context task-id))
         response-fields {:status 200
@@ -214,13 +215,13 @@
                          :task-status status
                          :status-message status-message}
         extra-fields (as-> {} intermediate
-                                (if show_progress
+                                (if (= "true" show_progress)
                                   (assoc intermediate :progress (generate-progress-message granule-statuses))
                                   intermediate)
-                                (if show_request
+                                (if (= "true" show_request)
                                   (assoc intermediate :request-json-body request-json-body)
                                   intermediate)
-                                (if show_granules
+                                (if (= "true" show_granules)
                                   (assoc intermediate :granule-statuses granule-statuses)
                                   intermediate))]
      (conj response-fields extra-fields)))

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -193,10 +193,10 @@
   [granule-statuses]
   (let [gran-count (count granule-statuses)
         pending-count (count (filter #(= (:status %) "PENDING") granule-statuses))]
-    (if (= pending-count 0)
+    (if (zero? pending-count)
      (format "Complete.")
      (format "Of %d total granules, %d granules have been processed and %d are still pending."
-            gran-count (- gran-count pending-count) pending-count))))
+      gran-count (- gran-count pending-count) pending-count))))
 
 
 (defn- get-granule-task-status-response-generator

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -191,7 +191,6 @@
 (defn- generate-status-progress-message
   "Generate progress message for an in-progress bulk granule update"
   [granule-statuses]
-  (println granule-statuses)
   (let [gran-count (count granule-statuses)
         pending-count (count (filter #(= (:status %) "PENDING") granule-statuses))]
     (if (= pending-count 0)
@@ -231,7 +230,7 @@
      (conj response-fields extra-fields)))
 
 (defn get-granule-task-status
-  "Handles bulk granule update task status requests."
+  "Get the status for the given bulk granule update task"
   [request task-id]
   (let [{:keys [headers request-context params]} request
         _ (validate-granule-bulk-update-result-format headers)

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -188,9 +188,10 @@
         :request-json-body (:request-json-body task-status)
         :collection-statuses collection-statuses}))))
 
-(defn- generate-progress-message
+(defn- generate-status-progress-message
   "Generate progress message for an in-progress bulk granule update"
   [granule-statuses]
+  (println granule-statuses)
   (let [gran-count (count granule-statuses)
         pending-count (count (filter #(= (:status %) "PENDING") granule-statuses))]
     (if (= pending-count 0)
@@ -216,7 +217,8 @@
                          :status-message status-message}
         extra-fields (as-> {} intermediate
                                 (if (= "true" show_progress)
-                                  (assoc intermediate :progress (generate-progress-message granule-statuses))
+                                  (assoc intermediate :progress (generate-status-progress-message
+                                                                 granule-statuses))
                                   intermediate)
                                 (if (= "true" show_request)
                                   (assoc intermediate :request-json-body request-json-body)

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -192,10 +192,9 @@
   "Generate progress message for an in-progress bulk granule update"
   [granule-statuses]
   (let [gran-count (count granule-statuses)
-        pending-count (count (filter #(= (:status %) "UPDATED") granule-statuses))]
-
+        pending-count (count (filter #(= (:status %) "PENDING") granule-statuses))]
     (if (= pending-count 0)
-     (format "All granules in this request have been processed.")
+     (format "Complete.")
      (format "Of %d total granules, %d granules have been processed and %d are still pending."
             gran-count (- gran-count pending-count) pending-count))))
 

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -108,7 +108,7 @@
        (context "/:task-id" [task-id]
          (GET "/"
            request
-           (bulk/get-granule-task-status task-id request)))))
+           (bulk/get-granule-task-status request task-id)))))
     ;; Provider ingest routes
     (api-core/set-default-error-format
      :xml

--- a/ingest-app/test/cmr/ingest/api/bulk.clj
+++ b/ingest-app/test/cmr/ingest/api/bulk.clj
@@ -1,0 +1,25 @@
+(ns cmr.ingest.api.subscriptions-test
+  "tests functions in bulk update api"
+  (:require
+    [clojure.test :refer :all]
+    [cmr.common.util :as u :refer [are3]]
+    [cmr.ingest.api.bulk :as bulk]))
+
+(deftest generate-status-progress-message
+  (are3 [granule-statuses message]
+    (is (= message (#'bulk/generate-status-progress-message granule-statuses)))
+
+    "All updates complete"
+    [{:granule-ur "GranUR1" :status "UPDATED"}
+     {:granule-ur "GranUR2" :status "UPDATED"}]
+    "Complete."
+
+    "Some updates complete"
+    [{:granule-ur "GranUR1" :status "PENDING"}
+     {:granule-ur "GranUR2" :status "FAILED"}
+     {:granule-ur "GranUR3" :status "UPDATED"}]
+    "Of 3 total granules, 2 granules have been processed and 1 are still pending."
+
+    "No updates complete"
+    [{:granule-ur "GranUR1" :status "PENDING"}]
+    "Of 1 total granules, 0 granules have been processed and 1 are still pending."))

--- a/ingest-app/test/cmr/ingest/api/bulk_test.clj
+++ b/ingest-app/test/cmr/ingest/api/bulk_test.clj
@@ -1,4 +1,4 @@
-(ns cmr.ingest.api.subscriptions-test
+(ns cmr.ingest.api.bulk-test
   "tests functions in bulk update api"
   (:require
     [clojure.test :refer :all]

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -697,7 +697,6 @@
   [concept-type provider-id task-id options]
   (let [accept-format (get options :accept-format)
         query-params (get options :query-params)
-        _ (println query-params)
         token (:token options)
         task-status-url (if (= :collection concept-type)
                           (url/ingest-collection-bulk-update-task-status-url provider-id task-id)

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -696,6 +696,8 @@
   "Implementation function to get the bulk update task status for the given task id"
   [concept-type provider-id task-id options]
   (let [accept-format (get options :accept-format)
+        query-params (get options :query-params)
+        _ (println query-params)
         token (:token options)
         task-status-url (if (= :collection concept-type)
                           (url/ingest-collection-bulk-update-task-status-url provider-id task-id)
@@ -704,6 +706,7 @@
                 :url task-status-url
                 :connection-manager (s/conn-mgr)
                 :throw-exceptions false}
+        params (merge params (when query-params {:query-params query-params}))
         params (merge params (when accept-format {:accept accept-format}))
         params (merge params (when token {:headers {transmit-config/token-header token}}))
         default-result-format (if (= :collection concept-type) :xml :json)

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
@@ -179,13 +179,15 @@
                                   :status-message (format "Granule UR [SC:non-existent] in task-id [%s] does not exist."
                                                           task3-id)}]}]
             (testing "default result format"
-              (let [response (ingest/granule-bulk-update-task-status task3-id)]
+              (let [status-req-options {:query-params {:show_granules "true" :show_request "true"}}
+                    response (ingest/granule-bulk-update-task-status task3-id status-req-options)]
                 (is (= task3-expected
                        (dissoc response :created-at)))))
 
             (testing "JSON result format"
-              (let [response (ingest/granule-bulk-update-task-status
-                              task3-id {:accept-format :json})]
+              (let [status-req-options {:query-params {:show_granules "true" :show_request "true"}
+                                        :accept-format :json}
+                    response (ingest/granule-bulk-update-task-status task3-id status-req-options)]
                 (is (= task3-expected
                        (dissoc response :created-at)))))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -733,13 +733,15 @@
          (is (= nil request-json-body))
          (is (= nil progress)))
       (testing "status with show_progress=true"
-        (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+        (let [status-req-options {:query-params {:show_progress "true"}}
+              status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
               {:keys [progress request-json-body granule-statuses]} status-response]
           (is (= nil granule-statuses))
           (is (= nil request-json-body))
           (is (= "Complete." progress))))
       (testing "status with show_granules=true, show_progress=false"
-        (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+        (let [status-req-options {:query-params {:show_granules "true" :show_progress "false"}}
+              status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
               {:keys [progress request-json-body granule-statuses]} status-response]
           (is (= [{:granule-ur "SC:AE_5DSno.002:30500511"
                    :status "UPDATED"}
@@ -751,13 +753,15 @@
           (is (= nil request-json-body))
           (is (= nil progress))))
       (testing "status with show_request=true"
-        (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+        (let [status-req-options {:query-params {:show_request "true"}}
+              status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
               {:keys [progress request-json-body granule-statuses]} status-response]
           (is (= nil granule-statuses))
           (is (string/includes? request-json-body "{\"name\":\"add S3 links 1\",\"operation\":\"UPDATE_FIELD\""))
           (is (= nil progress))))
       (testing "maximum verbosity, all parameters set to true"
-        (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+        (let [status-req-options {:query-params {:show_granules "true" :show_request "true" :show_progress "true"}}
+              status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
               {:keys [progress request-json-body granule-statuses]} status-response]
           (is (= [{:granule-ur "SC:AE_5DSno.002:30500511"
                    :status "UPDATED"}

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -78,7 +78,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "All granule updates completed successfully." status-message))
@@ -102,7 +103,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 1 FAILED out of 1 total granule update(s)." status-message))
@@ -125,7 +127,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 1 FAILED and 2 UPDATED out of 3 total granule update(s)."
@@ -154,7 +157,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 4 FAILED out of 4 total granule update(s)."
@@ -188,7 +192,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "All granule updates completed successfully." status-message))
@@ -212,7 +217,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 1 FAILED out of 1 total granule update(s)." status-message))
@@ -235,7 +241,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 1 FAILED and 2 UPDATED out of 3 total granule update(s)."
@@ -263,7 +270,8 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-req-options {:query-params {:show_granules "true"}}
+                status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [task-status status-message granule-statuses]} status-response]
             (is (= "COMPLETE" task-status))
             (is (= "Task completed with 2 FAILED out of 2 total granule update(s)."
@@ -330,7 +338,8 @@
       ;; verify the granule status is UPDATED
       (is (= 200 status))
       (is (some? task-id))
-      (let [status-response (ingest/granule-bulk-update-task-status task-id)
+      (let [status-req-options {:query-params {:show_granules "true"}}
+            status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
             {:keys [task-status status-message granule-statuses]} status-response]
         (is (= "COMPLETE" task-status))
         (is (= "All granule updates completed successfully." status-message))
@@ -408,7 +417,8 @@
       ;; verify the granule status is UPDATED
       (is (= 200 status))
       (is (some? task-id))
-      (let [status-response (ingest/granule-bulk-update-task-status task-id)
+      (let [status-req-options {:query-params {:show_granules "true"}}
+            status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
             {:keys [task-status status-message granule-statuses]} status-response]
         (is (= "COMPLETE" task-status))
         (is (= "All granule updates completed successfully." status-message))
@@ -512,7 +522,8 @@
       ;; verify the granule status is UPDATED
       (is (= 200 status))
       (is (some? task-id))
-      (let [status-response (ingest/granule-bulk-update-task-status task-id)
+      (let [status-req-options {:query-params {:show_granules "true"}}
+            status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
             {:keys [task-status status-message granule-statuses]} status-response]
         (is (= "COMPLETE" task-status))
         (is (= "All granule updates completed successfully." status-message))
@@ -636,7 +647,8 @@
       ;; verify the granule status is UPDATED
       (is (= 200 status))
       (is (some? task-id))
-      (let [status-response (ingest/granule-bulk-update-task-status task-id)
+      (let [status-req-options {:query-params {:show_granules "true"}}
+            status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
             {:keys [task-status status-message granule-statuses]} status-response]
         (is (= "COMPLETE" task-status))
         (is (= "All granule updates completed successfully." status-message))
@@ -669,7 +681,8 @@
                                     (:RelatedUrls (json/parse-string latest-metadata true))))))))))))
 
 (deftest status-verbosity-test
-  (let [coll1 (data-core/ingest-umm-spec-collection
+  (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
+        coll1 (data-core/ingest-umm-spec-collection
                "PROV1" (data-umm-c/collection {:EntryTitle "coll1"
                                                :ShortName "short1"
                                                :Version "V1"
@@ -715,8 +728,7 @@
                   :granule-ur "SC:AE_5DSno.002:30500515"})))]
     (testing "Specify bulk granule status verbosity"
       (testing "least verbose"
-        (let [bulk-update-options {:token (echo-util/login (system/context) "user1")}
-              bulk-update {:name "add S3 links 1"
+        (let [bulk-update {:name "add S3 links 1"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
@@ -736,14 +748,13 @@
             (is (= nil request-json-body))
             (is (= nil progress)))))
       (testing "show_progress=true"
-        (let [bulk-update-options {:token (echo-util/login (system/context) "user1")
-                                   :query-params {:show_progress "true"}}
-              bulk-update {:name "add S3 links 1"
+        (let [bulk-update {:name "add S3 links 1"
                            :operation "UPDATE_FIELD"
                            :update-field "S3Link"
                            :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
                                      ["SC:AE_5DSno.002:30500512" "s3://url1, s3://url2,s3://url3"]
                                      ["SC:AE_5DSno.002:30500514" "s3://url30500514"]]}
+              status-req-options {:query-params {:show_progress "true"}}
               response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)
               {:keys [status task-id]} response]
           (index/wait-until-indexed)
@@ -751,9 +762,82 @@
 
           (is (= 200 status))
           (is (some? task-id))
-          (let [status-response (ingest/granule-bulk-update-task-status task-id)
+          (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
                 {:keys [progress request-json-body granule-statuses]} status-response]
-            ;these three are all unincluded by default (least verbose)
             (is (= nil granule-statuses))
             (is (= nil request-json-body))
-            (is (= nil progress))))))))
+            (is (= "Complete." progress)))))
+      (testing "show_granules=true, show_progress=false"
+        (let [bulk-update {:name "add S3 links 1"
+                           :operation "UPDATE_FIELD"
+                           :update-field "S3Link"
+                           :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
+                                     ["SC:AE_5DSno.002:30500512" "s3://url1, s3://url2,s3://url3"]
+                                     ["SC:AE_5DSno.002:30500514" "s3://url30500514"]]}
+              status-req-options {:query-params {:show_progress "false" :show_granules "true"}}
+              response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)
+              {:keys [status task-id]} response]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (is (= 200 status))
+          (is (some? task-id))
+          (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+                {:keys [progress request-json-body granule-statuses]} status-response]
+            (is (= [{:granule-ur "SC:AE_5DSno.002:30500511"
+                     :status "UPDATED"}
+                    {:granule-ur "SC:AE_5DSno.002:30500512"
+                     :status "UPDATED"}
+                    {:granule-ur "SC:AE_5DSno.002:30500514"
+                     :status "UPDATED"}]
+                   granule-statuses))
+            (is (= nil request-json-body))
+            (is (= nil progress)))))
+      (testing "show_request=true"
+        (let [bulk-update {:name "add S3 links 1"
+                           :operation "UPDATE_FIELD"
+                           :update-field "S3Link"
+                           :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
+                                     ["SC:AE_5DSno.002:30500512" "s3://url1, s3://url2,s3://url3"]
+                                     ["SC:AE_5DSno.002:30500514" "s3://url30500514"]]}
+              status-req-options {:query-params {:show_request "true"}}
+              response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)
+              {:keys [status task-id]} response]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (is (= 200 status))
+          (is (some? task-id))
+          (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+                {:keys [progress request-json-body granule-statuses]} status-response]
+            (is (= nil granule-statuses))
+            (is (string/includes? request-json-body "{\"name\":\"add S3 links 1\",\"operation\":\"UPDATE_FIELD\""))
+            (is (= nil progress)))))
+      (testing "maximum verbosity"
+        (let [bulk-update {:name "add S3 links 1"
+                           :operation "UPDATE_FIELD"
+                           :update-field "S3Link"
+                           :updates [["SC:AE_5DSno.002:30500511" "s3://url30500511"]
+                                     ["SC:AE_5DSno.002:30500512" "s3://url1, s3://url2,s3://url3"]
+                                     ["SC:AE_5DSno.002:30500514" "s3://url30500514"]]}
+              status-req-options {:query-params {:show_request "true"
+                                                 :show_granules "true"
+                                                 :show_progress "true"}}
+              response (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)
+              {:keys [status task-id]} response]
+          (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
+
+          (is (= 200 status))
+          (is (some? task-id))
+          (let [status-response (ingest/granule-bulk-update-task-status task-id status-req-options)
+                {:keys [progress request-json-body granule-statuses]} status-response]
+            (is (= [{:granule-ur "SC:AE_5DSno.002:30500511"
+                     :status "UPDATED"}
+                    {:granule-ur "SC:AE_5DSno.002:30500512"
+                     :status "UPDATED"}
+                    {:granule-ur "SC:AE_5DSno.002:30500514"
+                     :status "UPDATED"}]
+                   granule-statuses))
+            (is (string/includes? request-json-body "{\"name\":\"add S3 links 1\",\"operation\":\"UPDATE_FIELD\""))
+            (is (= "Complete." progress))))))))


### PR DESCRIPTION
Recognize three new query parameters on the `ingest/granule-bulk-update/status/:task-id` endpoint: `show_progress`, `show_request`, and `show_granules`. Details on these parameters effect are found in the updated `api.md`