### PR TITLE
CMR-7248 Not halting system when scheduler cannot start

### DIFF
--- a/access-control-app/Dockerfile
+++ b/access-control-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-access-control-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3011

--- a/access-control-app/src/cmr/access_control/test/bootstrap.clj
+++ b/access-control-app/src/cmr/access_control/test/bootstrap.clj
@@ -25,15 +25,12 @@
   (info "Bootstrapping development data in access control")
   (let [context {:system system :token (transmit-config/echo-system-token)}
         ;; Find or create the administrators group.
-        {:keys [concept-id]} (or (try
-                                   (mdb-legacy/find-latest-concept
-                                    context
-                                    {:native-id (str/lower-case (transmit-config/administrators-group-name))
-                                     :provider-id "CMR"
-                                     :exclude-metadata true}
-                                    :access-group)
-                                   (catch Exception e
-                                     (error e)))
+        {:keys [concept-id]} (or (mdb-legacy/find-latest-concept
+                                  context
+                                  {:native-id (str/lower-case (transmit-config/administrators-group-name))
+                                   :provider-id "CMR"
+                                   :exclude-metadata true}
+                                  :access-group)
                                  (group-service/create-group context (administrators-group) {:skip-acls? true}))]
     ;; Add the echo system user to the group. Add members properly handles adding duplicate members
     ;; so there shouldn't be a problem.

--- a/access-control-app/src/cmr/access_control/test/bootstrap.clj
+++ b/access-control-app/src/cmr/access_control/test/bootstrap.clj
@@ -25,12 +25,15 @@
   (info "Bootstrapping development data in access control")
   (let [context {:system system :token (transmit-config/echo-system-token)}
         ;; Find or create the administrators group.
-        {:keys [concept-id]} (or (mdb-legacy/find-latest-concept
-                                  context
-                                  {:native-id (str/lower-case (transmit-config/administrators-group-name))
-                                   :provider-id "CMR"
-                                   :exclude-metadata true}
-                                  :access-group)
+        {:keys [concept-id]} (or (try
+                                   (mdb-legacy/find-latest-concept
+                                    context
+                                    {:native-id (str/lower-case (transmit-config/administrators-group-name))
+                                     :provider-id "CMR"
+                                     :exclude-metadata true}
+                                    :access-group)
+                                   (catch Exception e
+                                     (error e)))
                                  (group-service/create-group context (administrators-group) {:skip-acls? true}))]
     ;; Add the echo system user to the group. Add members properly handles adding duplicate members
     ;; so there shouldn't be a problem.

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -77,15 +77,12 @@
   "Calls acl search endpoint using object-identity-types. Pages through results as needed."
   [context object-identity-types]
   (let [page-size 2000
-        response (try
-                   (access-control/search-for-acls
-                    (assoc context :token (config/echo-system-token))
-                    {:identity-type (object-identity-types->identity-strings
-                                     object-identity-types)
-                     :include-full-acl true
-                     :page-size page-size})
-                   (catch java.lang.Exception e
-                     (warn "Failed to retrieve ACLs" e)))
+        response (access-control/search-for-acls
+                  (assoc context :token (config/echo-system-token))
+                  {:identity-type (object-identity-types->identity-strings
+                                   object-identity-types)
+                   :include-full-acl true
+                   :page-size page-size})
         total-pages (int (Math/ceil (/ (get response :hits 0) page-size)))]
     (if (> total-pages 1)
       ;; Take the items from first page of the response from above,

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -77,25 +77,32 @@
   "Calls acl search endpoint using object-identity-types. Pages through results as needed."
   [context object-identity-types]
   (let [page-size 2000
-        response (access-control/search-for-acls (assoc context :token (config/echo-system-token))
-                                                 {:identity-type (object-identity-types->identity-strings
-                                                                  object-identity-types)
-                                                  :include-full-acl true
-                                                  :page-size page-size})
-        total-pages (int (Math/ceil (/ (:hits response) page-size)))]
+        response (try
+                   (access-control/search-for-acls
+                    (assoc context :token (config/echo-system-token))
+                    {:identity-type (object-identity-types->identity-strings
+                                     object-identity-types)
+                     :include-full-acl true
+                     :page-size page-size})
+                   (catch java.lang.Exception e
+                     (warn "Failed to retrieve ACLs" e)))
+        total-pages (int (Math/ceil (/ (get response :hits 0) page-size)))]
     (if (> total-pages 1)
       ;; Take the items from first page of the response from above,
       ;; and concat each page after that in sequence.
-      (reduce (fn [all-items new-items]
-                (conj all-items new-items))
+      (reduce conj
               [response]
-              (for [page-num (range 2 (+ 1 total-pages))
-                    :let [response (access-control/search-for-acls (assoc context :token (config/echo-system-token))
-                                                                   {:identity-type (object-identity-types->identity-strings
-                                                                                    object-identity-types)
-                                                                    :include-full-acl true
-                                                                    :page-size page-size
-                                                                    :page-num page-num})]]
+              (for [page-num (range 2 (inc total-pages))
+                    :let [response (try
+                                     (access-control/search-for-acls
+                                      (assoc context :token (config/echo-system-token))
+                                      {:identity-type (object-identity-types->identity-strings
+                                                       object-identity-types)
+                                       :include-full-acl true
+                                       :page-size page-size
+                                       :page-num page-num})
+                                     (catch java.lang.Exception e
+                                       (warn "Failed to retrieve ACLs")))]]
                 response))
       [response])))
 

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -77,12 +77,11 @@
   "Calls acl search endpoint using object-identity-types. Pages through results as needed."
   [context object-identity-types]
   (let [page-size 2000
-        response (access-control/search-for-acls
-                  (assoc context :token (config/echo-system-token))
-                  {:identity-type (object-identity-types->identity-strings
-                                   object-identity-types)
-                   :include-full-acl true
-                   :page-size page-size})
+        response (access-control/search-for-acls (assoc context :token (config/echo-system-token))
+                                                 {:identity-type (object-identity-types->identity-strings
+                                                                  object-identity-types)
+                                                  :include-full-acl true
+                                                  :page-size page-size})
         total-pages (int (Math/ceil (/ (get response :hits 0) page-size)))]
     (if (> total-pages 1)
       ;; Take the items from first page of the response from above,
@@ -90,13 +89,12 @@
       (reduce conj
               [response]
               (for [page-num (range 2 (inc total-pages))
-                    :let [response (access-control/search-for-acls
-                                    (assoc context :token (config/echo-system-token))
-                                    {:identity-type (object-identity-types->identity-strings
-                                                     object-identity-types)
-                                     :include-full-acl true
-                                     :page-size page-size
-                                     :page-num page-num})]]
+                    :let [response (access-control/search-for-acls (assoc context :token (config/echo-system-token))
+                                                                   {:identity-type (object-identity-types->identity-strings
+                                                                                    object-identity-types)
+                                                                    :include-full-acl true
+                                                                    :page-size page-size
+                                                                    :page-num page-num})]]
                 response))
       [response])))
 

--- a/acl-lib/src/cmr/acl/acl_fetcher.clj
+++ b/acl-lib/src/cmr/acl/acl_fetcher.clj
@@ -90,16 +90,13 @@
       (reduce conj
               [response]
               (for [page-num (range 2 (inc total-pages))
-                    :let [response (try
-                                     (access-control/search-for-acls
-                                      (assoc context :token (config/echo-system-token))
-                                      {:identity-type (object-identity-types->identity-strings
-                                                       object-identity-types)
-                                       :include-full-acl true
-                                       :page-size page-size
-                                       :page-num page-num})
-                                     (catch java.lang.Exception e
-                                       (warn "Failed to retrieve ACLs")))]]
+                    :let [response (access-control/search-for-acls
+                                    (assoc context :token (config/echo-system-token))
+                                    {:identity-type (object-identity-types->identity-strings
+                                                     object-identity-types)
+                                     :include-full-acl true
+                                     :page-size page-size
+                                     :page-num page-num})]]
                 response))
       [response])))
 

--- a/bootstrap-app/Dockerfile
+++ b/bootstrap-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-bootstrap-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3006

--- a/bootstrap-app/src/cmr/db.clj
+++ b/bootstrap-app/src/cmr/db.clj
@@ -38,10 +38,10 @@
 
         (= "migrate" op)
         (drift/run
-         (conj
-          args
-          "-c" 
-          "config.bootstrap-migrate-config/app-migrate-config"))
+          (conj
+           (vec args)
+           "-c"
+           "config.bootstrap_migrate_config/app-migrate-config"))
 
         :else
         (info "Unsupported operation: " op))

--- a/common-lib/src/cmr/common/jobs.clj
+++ b/common-lib/src/cmr/common/jobs.clj
@@ -246,18 +246,22 @@
            (get system db-system-key)))
 
         ;; Start quartz
-        (let [scheduler (qs/start (qs/initialize))]
+        (try
+          (let [scheduler (qs/start (qs/initialize))]
 
-          ;; schedule all the jobs
-          (doseq [job jobs]
-            (schedule-job scheduler system-holder-var-name job))
+            ;; schedule all the jobs
+            (doseq [job jobs]
+              (schedule-job scheduler system-holder-var-name job))
 
-          (when (paused? (assoc this :qz-scheduler scheduler))
-            (warn "All jobs are currently paused"))
+            (when (paused? (assoc this :qz-scheduler scheduler))
+              (warn "All jobs are currently paused"))
 
-          (assoc this
-                 :running? true
-                 :qz-scheduler scheduler)))
+            (assoc this
+                   :running? true
+                   :qz-scheduler scheduler))
+          (catch Exception e
+            (error "Could not start scheduler" e)
+            (assoc this :running? false))))
       (errors/internal-error! "No jobs to schedule.")))
 
   (stop

--- a/common-lib/src/cmr/common/jobs.clj
+++ b/common-lib/src/cmr/common/jobs.clj
@@ -247,35 +247,25 @@
            (get system db-system-key)))
 
         ;; Start quartz
-        (try
-          (let [scheduler (qs/start (qs/initialize))]
+        (let [scheduler (qs/start (qs/initialize))]
 
-            ;; schedule all the jobs
-            (doseq [job jobs]
-              (schedule-job scheduler system-holder-var-name job))
+          ;; schedule all the jobs
+          (doseq [job jobs]
+            (schedule-job scheduler system-holder-var-name job))
 
-            (when (paused? (assoc this :qz-scheduler scheduler))
-              (warn "All jobs are currently paused"))
+          (when (paused? (assoc this :qz-scheduler scheduler))
+            (warn "All jobs are currently paused"))
 
-            (assoc this
-                   :running? true
-                   :qz-scheduler scheduler))
-          (catch org.quartz.JobPersistenceException e
-            (warn "Quartz Scheduler failed to start" e)
-            (assoc this :running? false))
-          (catch java.sql.SQLException e
-            (warn "Scheduler failed to start" e)
-            (assoc this :running? false))))
+          (assoc this
+                 :running? true
+                 :qz-scheduler scheduler)))
       (errors/internal-error! "No jobs to schedule.")))
 
   (stop
     [this system]
     (when (:running? this)
       ;; Shutdown and wait for jobs to complete
-      (try
-        (qs/shutdown qz-scheduler true)
-        (catch Exception e
-          (error "An exception occurred while stopping the JobScheduler" e)))
+      (qs/shutdown qz-scheduler true)
       (assoc this :running? false :qz-scheduler nil)))
 
   JobRunner

--- a/common-lib/src/cmr/common/system.clj
+++ b/common-lib/src/cmr/common/system.clj
@@ -25,15 +25,10 @@
                    #(when % (lifecycle/start % (:system system-tracker))))
         (update :started-components conj component-name))
     (catch Exception e
-      (case (type e)
-        java.sql.SQLException (warn "Failed to establish DB connection, continuing with degraded service and will retry.")
-        org.quartz.JobPersistenceException (warn "Failed to establish quartz connection, continuing with degraded service.")
-        ;; default
-        (do
-          (error (str "Exception occurred during startup. Shutting down started "
-                      "components"))
-          (stop (:system system-tracker) (:started-components system-tracker))
-          (throw e))))))
+      (error (str "Exception occurred during startup. Shutting down started "
+                  "components"))
+      (stop (:system system-tracker) (:started-components system-tracker))
+      (throw e))))
 
 (defn start
   "Starts the system using the given component order."
@@ -41,7 +36,7 @@
   (try
     (->> component-order
          (reduce start-component {:system s :started-components []})
-        :system)
+         :system)
     (catch Exception e
       (.printStackTrace e)
       (throw e))))

--- a/dev-system/Dockerfile
+++ b/dev-system/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-dev-system-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 2999

--- a/dev-system/README.md
+++ b/dev-system/README.md
@@ -79,8 +79,16 @@ $ docker build . -f Dockerfile.ecs
 ```
 
 To launch a microservice
-```
-$ docker run -e "CMR_URS_PASSWORD=<PASSWORD>" -p <SERVICE_PORT>:<SERVICE_PORT> -e "CMR_SYS_DBA_PASSWORD=<PASSWORD>" -e "CMR_ORACLE_JAR_REPO=<URL_FOR_MAVEN_REPO>" -e "CMR_INGEST_PASSWORD=<PASSWORD>" -e "CMR_BOOTSTRAP_PASSWORD=<PASSWORD>" -e "CMR_METADATA_DB_PASSWORD=<PASSWORD> <IMAGE_ID> java -cp cmr-standalone.jar clojure.main -m cmr.<SERVICE_NAME>.runner
+```sh
+docker run \
+-p <SERVICE_PORT>:<SERVICE_PORT> \
+-e "CMR_URS_PASSWORD=<PASSWORD>" \
+-e "CMR_SYS_DBA_PASSWORD=<PASSWORD>" \
+-e "CMR_ORACLE_JAR_REPO=<URL_FOR_MAVEN_REPO>" \
+-e "CMR_INGEST_PASSWORD=<PASSWORD>" \
+-e "CMR_BOOTSTRAP_PASSWORD=<PASSWORD>" \
+-e "CMR_METADATA_DB_PASSWORD=<PASSWORD> \
+<IMAGE_ID> java -cp cmr-standalone.jar clojure.main -m cmr.<SERVICE_NAME>.runner
 ```
 
 Where `<IMAGE_ID>` is the ID returned from the `docker build` command.

--- a/indexer-app/Dockerfile
+++ b/indexer-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-indexer-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3004

--- a/ingest-app/Dockerfile
+++ b/ingest-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-ingest-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3002

--- a/ingest-app/src/cmr/db.clj
+++ b/ingest-app/src/cmr/db.clj
@@ -36,10 +36,10 @@
 
         (= "migrate" op)
         (drift/run
-         (conj
-          args
-          "-c"
-          "config.ingest-migrate-config/app-migrate-config"))
+          (conj
+           (vec args)
+           "-c"
+           "config.ingest_migrate_config/app-migrate-config"))
 
         :else
         (info "Unsupported operation: " op))

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -104,7 +104,8 @@
      (context "/granule-bulk-update/status" []
        (POST "/"
          request
-         (bulk/update-completed-granule-task-statuses request))
+         (bulk/update-completed-granule-task-statuses request)
+         {:status 200})
        (context "/:task-id" [task-id]
          (GET "/"
            request

--- a/metadata-db-app/Dockerfile
+++ b/metadata-db-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-metadata-db-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3001

--- a/metadata-db-app/src/cmr/db.clj
+++ b/metadata-db-app/src/cmr/db.clj
@@ -92,10 +92,10 @@
 
         (= "migrate" op)
         (drift/run
-         (conj
-          args
-          "-c"
-          "config.mdb-migrate-config/app-migrate-config"))
+          (conj
+           (vec args)
+           "-c"
+           "config.mdb_migrate_config/app-migrate-config"))
 
         :else
         (info "Unsupported operation: " op))

--- a/mock-echo-app/Dockerfile
+++ b/mock-echo-app/Dockerfile
@@ -1,0 +1,8 @@
+FROM clojure:openjdk-8-lein
+
+COPY target/cmr-mock-echo-app-0.1.0-SNAPSHOT-standalone.jar /app/
+EXPOSE 3008
+
+WORKDIR /app
+
+CMD "java" "-classpath" "/app/cmr-mock-echo-app-0.1.0-SNAPSHOT-standalone.jar" "clojure.main" "-m" "cmr.mock-echo.runner"

--- a/search-app/Dockerfile
+++ b/search-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-search-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3003

--- a/virtual-product-app/Dockerfile
+++ b/virtual-product-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-8-lein
 
 COPY target/cmr-virtual-product-app-0.1.0-SNAPSHOT-standalone.jar /app/
 EXPOSE 3009


### PR DESCRIPTION
Adding better error handling to initializing a clean system bootstrapping by catching certain errors that occur when first running a system. This allows systems to come up when the database has not been initialized yet.