### PR TITLE
CMR-7380: Exact same changes as in CMR-7380-keyword-search-on-phrase

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/query_to_elastic.clj
@@ -201,11 +201,20 @@
   cmr.common_app.services.search.query_model.TextCondition
   (condition->elastic
    [{:keys [field query-str]} concept-type]
-   (let [field (query-field->elastic-field field concept-type)]
-     {:query_string {:query (escape-query-string query-str)
-                     :analyzer :whitespace
-                     :default_field field
-                     :default_operator :and}}))
+   (let [elastic-field (query-field->elastic-field field concept-type)]
+     ;; For keyword phrase search with wildcard, we have to use span query.
+     (if (and (= :keyword-phrase field) (= :collection concept-type))
+       {:span_near
+         {:clauses [{:span_multi
+                      {:match
+                        {:wildcard
+                          {elastic-field (escape-query-string query-str)}}}}]
+          :slop 0
+          :in_order true}}
+       {:query_string {:query (escape-query-string query-str)
+                       :analyzer :whitespace
+                       :default_field elastic-field
+                       :default_operator :and}})))
 
   cmr.common_app.services.search.query_model.StringCondition
   (condition->elastic

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -40,6 +40,18 @@
    ; Don't bother storing term positions or term frequencies in this field
    :index_options "docs"})
 
+(def text-field-keyword-mapping
+  "Used for analyzed text fields"
+  {:type "text"
+   ; Norms are metrics about fields that elastic can use to weigh certian fields more than
+   ; others when computing a document relevance. A typical example is field length - short
+   ; fields are weighted more heavily than long feilds. We don't need them for scoring.
+   :norms false
+   ; Don't analyze the text, index it as is.
+   :analyzer "keyword"
+   ; Storing term positions in order to run span phrase query with wildcard in this field
+   :index_options "offsets"})
+
 (def binary-field-mapping
   {:type "binary"})
 

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -403,11 +403,11 @@
             :created-at created-at
             :coordinate-system coordinate-system
 
-            ;; fields added to support keyword searches
-            :keyword (k/create-keywords-field concept-id collection
-                                              {:platform-long-names platform-long-names
-                                               :instrument-long-names instrument-long-names
-                                               :entry-id entry-id})
+            ;; fields added to support keyword searches including the quoted string case.
+            :keyword2 (k/create-keywords-field concept-id collection
+                                               {:platform-long-names platform-long-names
+                                                :instrument-long-names instrument-long-names
+                                                :entry-id entry-id})
             :platform-ln-lowercase (map str/lower-case platform-long-names)
             :instrument-ln-lowercase (map str/lower-case instrument-long-names)
             :sensor-ln-lowercase (map str/lower-case sensor-long-names)

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/keyword.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/keyword.clj
@@ -1,14 +1,21 @@
 (ns cmr.indexer.data.concepts.collection.keyword
   "Contains functions to create keyword fields"
   (:require
-    [cmr.common.concepts :as concepts]
-    [cmr.common.util :as util]
-    [cmr.indexer.data.concepts.keyword-util :as keyword-util]))
+   [clojure.string :as str]
+   [cmr.common.concepts :as concepts]
+   [cmr.common.util :as util]
+   [cmr.indexer.data.concepts.keyword-util :as keyword-util]))
 
 (defn create-keywords-field
   [concept-id collection other-fields]
-  "Create a keyword field for keyword searches by concatenating several other fields
-  into a single string"
+  "Create a keyword field for keyword searches by concatenating 4 group of fields together:
+  1. All the keyword fields, unprocessed, for general keyword phrase search.
+  2. All the keyword fields, split on a set of special characters, for keyword phrase search when
+     the phrase exists in between special characters.
+  3. All the keyword fields, split on parens and brackets, for keyword phrase search when the phrase
+     exists in the parents or brackets, but contains some other special characters.
+  4. All the keyword fields, split into individual words, same as the original keyword search case.
+  The new way of indexing support both quoted and unquoted keyword searches."
   (let [{:keys [platform-long-names instrument-long-names entry-id]} other-fields
         provider-id (:provider-id (concepts/parse-concept-id concept-id))
         schema-keys [:Abstract
@@ -43,5 +50,24 @@
                   [concept-id]
                   [entry-id]
                   [provider-id]
-                  (keyword-util/concept-keys->keywords collection schema-keys))]
-    (keyword-util/field-values->keyword-text keywords)))
+                  (keyword-util/concept-keys->keywords collection schema-keys))
+        ;; split each keyword on special characters and extract out phrases surrounded by special characters.
+        sp-phrases (mapcat #(str/split % keyword-util/keyword-phrase-separator-regex) keywords)
+        ;; split each keyword on parens and brackets only and extract out the word/phrase inside that might contain
+        ;; other special characters like in "(merry-go-round)" where  "-" is considered special character.
+        paren-bracket-phrases (mapcat #(str/split % #"[(){}\[\]]") keywords)
+        ;; the index needed for the original unquoted keyword search.
+        keywords-in-words (keyword-util/field-values->individual-words keywords)]
+    ;; Lower-case the keywords and add a space at the beginning and the end of each field
+    ;; to help with partial keyword phrase matching: i.e. we don't need to distinguish if the match is at the beginning,
+    ;; or in the middle or at the end of the keyword field, we just need to match using general expression "* phrase *".
+    (->> keywords
+         ;; need to index additional keyword phrases that are surrounded by special characters because "* phrase *"
+         ;; won't find a match in keyword fields directly because of the extra space added to generalize the search.
+         (concat (keep not-empty sp-phrases))
+         (concat (keep not-empty paren-bracket-phrases))
+         (map #(str/lower-case %))
+         (map #(str " " % " "))
+         ;; The keyword-in-words here are used for unquoted keyword search. It's exactly the same as the existing
+         ;; keyword index fields, without the need to go through a whitespace analyzer.
+         (concat keywords-in-words))))

--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -16,6 +16,10 @@
   "Defines Regex to split strings with special characters into multiple words for keyword searches."
   #"[!@#$%^&()\-=_+{}\[\]|;'.,\\\"/:<>?`~* ]")
 
+(def keyword-phrase-separator-regex
+  "Defines Regex to split strings with special characters into multiple phrases for keyword phrase searches."
+  #"[!@#$%^&()\-=_+{}\[\]|;'.,\\\"/:<>?`~*]")
+
 (defn- wrapped-keyword?
   "Checks if the field-value about to be processed is a term surrounded by parens or brackets.
    If it is, we want to add the usual keywords, but also add the unwrapped field-value on its own."
@@ -48,6 +52,15 @@
        (keep not-empty)
        (apply sorted-set)
        (string/join \space)))
+
+(defn field-values->individual-words
+  "Return a list of individual keyword words for the given list of field values."
+  [field-values]
+  (->> field-values
+       (mapcat #(string/split % #" "))
+       (mapcat prepare-keyword-field)
+       (keep not-empty)
+       (apply sorted-set)))
 
 (defn contact-group->keywords
   "Converts a contact group into a vector of terms for keyword searches."

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -468,7 +468,7 @@
           :personnel m/string-field-mapping
 
           ;; analyzed field for keyword searches
-          :keyword m/text-field-mapping
+          :keyword2 m/text-field-keyword-mapping
           :long-name-lowercase m/string-field-mapping
           :project-ln-lowercase m/string-field-mapping
           :platform-ln-lowercase m/string-field-mapping

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1579,13 +1579,35 @@ Supports ignore_case and the following aliases for "NEAR\_REAL\_TIME": "near\_re
 
 #### <a name="c-keyword"></a> Find collections by keyword (free text) search
 
-Keyword searches are case insensitive and support wild cards ? and *.
-There is a limit of 30 wild cards allowed in keyword searches. Within 30 wild cards, there's also limit on the max keyword
+Keyword searches are case insensitive and support wild cards ? and *, in which '\*' matches zero or more characters and '?' matches any single character. There is a limit of 30 wild cards allowed in keyword searches. Within 30 wild cards, there's also limit on the max keyword
 string length. The longer the max keyword string length, the less number of keywords with wild cards allowed.
+
+The following searches on "alpha", "beta" and "g?mma" individually and returns the collections that contain all these individual words
+in the keyword fields that are indexed. Note: these words don't have to exist in the same keyword field, but they have to exsit as a
+space (or one of special character delimiter CMR uses) delimited word.
 
     curl "%CMR-ENDPOINT%/collections?keyword=alpha%20beta%20g?mma"
 
-The following fields are indexed for keyword search:
+We also support keyword phrase search. The following searches on "alpha beta g?mma" as a phrase and returns the collections with
+one or more indexed keyword field values that contain the phrase.
+
+    curl "%CMR-ENDPOINT%/collections?keyword=\"alpha%20beta%20g?mma\""
+
+Note: Currently we only support either keyword, or single keyword phrase search. We don't support mix of keyword and keyword phrase search and we don't support multiple keyword phrase search. These searches like the following will be rejected with error: <error>keyword phrase mixed with keyword, or another keyword-phrase are not supported. keyword phrase has to be enclosed by two escaped double quotes.</error>
+
+   curl "%CMR-ENDPOINT%/collections?keyword=\"phrase%20one\"%20\"phrase%20two\"" (multiple phrase case)
+   curl "%CMR-ENDPOINT%/collections?keyword=\"phrase%20one\"%20\word2" (mix of phrase and word case)
+   curl "%CMR-ENDPOINT%/collections?keyword=\"phrase%20one" (missing one \" case)
+
+Also \" is reserved for phrase boundary. For literal double quotes, use \\\". For example, to search for 'alpha "beta" g?mma' phrase, do the following:
+
+    curl "%CMR-ENDPOINT%/collections?keyword=\"alpha%20\\\"beta\\\"%20g?mma\""
+
+To search on 'alpha', '"beta"', 'g?mma' individually, do the following:
+
+    curl "%CMR-ENDPOINT%/collections?keyword=alpha%20\\\"beta\\\"%20g?mma"
+
+The following fields are indexed for keyword and keyword phrase search:
 
 * Concept ID
 * DOI value

--- a/search-app/src/cmr/search/services/query_walkers/keywords_extractor.clj
+++ b/search-app/src/cmr/search/services/query_walkers/keywords_extractor.clj
@@ -24,10 +24,10 @@
    The format is {:keywords [...] :field-keywords [...]}"
   [c]
   (let [keywords (extract-keywords-seq c)]
-   (when (or (seq (:keywords keywords)) (seq (:field-keywords keywords)))
-    (-> keywords
-        (update :keywords #(seq (distinct %)))
-        (update :field-keywords #(seq (distinct %)))))))
+    (when (or (seq (:keywords keywords)) (seq (:field-keywords keywords)))
+      (-> keywords
+          (update :keywords #(seq (distinct %)))
+          (update :field-keywords #(seq (distinct %)))))))
 
 (def ^:private keyword-string-fields
   "This defines the set of string condition fields that we will extract keyword terms from. Any condition
@@ -53,6 +53,15 @@
   "Converts value to lower case and splits on whitespace to create a list of keywords"
   [value]
   (-> value str/lower-case (str/split #"\s+")))
+
+(defn- extract-keywords-seq-from-keyword-value
+  "Converts keyword value to lower case and splits on whitespace to create a list of keywords.
+  Or if the value is a double quoted string, do not split on whitespace."
+  [value]
+  (let [t-value (str/trim value)]
+    (if (and (str/starts-with? t-value "\"") (str/ends-with? t-value "\""))
+      (-> t-value str/lower-case (str/replace #"^\"|\"$" "") vector)
+      (-> value str/lower-case (str/split #"\s+")))))
 
 (extend-protocol ExtractKeywords
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -91,7 +100,7 @@
   (extract-keywords-seq
    [{:keys [field query-str]}]
    (when (= field :keyword)
-     {:keywords (extract-keywords-seq-from-value query-str)}))
+     {:keywords (extract-keywords-seq-from-keyword-value query-str)}))
   (contains-keyword-condition?
    [{:keys [field]}]
    (= field :keyword))

--- a/system-int-test/test/cmr/system_int_test/search/collection_highlights_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_highlights_search_test.clj
@@ -228,6 +228,9 @@
 (deftest reserved-characters-test
   ;; This test documents the current elasticsearch highlighting behavior with respect to reserved
   ;; characters. The behavior is inconsistent for the : ? and * characters.
+  ;; Note: original reserved string "\"" is now used as keyword-phrase boundary, literal "\"" needs
+  ;; to be entered as "\\\"" to pass the keyword-phrase validation. It will be converted back to "\""
+  ;; afterwards.
   (let [reserved-strings #{"+" "-" "=" "&&" "||" ">" "<" "!" "(" ")" "{" "}" "[" "]" "^" "\"" "~" "*"
                            "?" ":" "\\" "/"}
         reserved-strings-with-different-behavior #{":" "?" "*"}]
@@ -244,8 +247,10 @@
                (get-search-results-summaries (search/find-concepts-in-json-with-json-query
                                               :collection
                                               {:include-highlights true}
-                                              {:keyword (format "MODIS%sTERRA"
-                                                                reserved-string)}))))))
+                                              {:keyword (if (= "\"" reserved-string)
+                                                          "MODIS\\\"TERRA"
+                                                          (format "MODIS%sTERRA"
+                                                                  reserved-string))}))))))
 
     (testing "Colons are highlighted along with the search string."
       (is (= #{["<em>MODIS:TERRA</em> dataset."]}

--- a/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_keyword_search_test.clj
@@ -161,10 +161,29 @@
 
         coll26 (d/ingest-umm-spec-collection "PROV4" (data-umm-c/collection {:EntryTitle "coll26" :ShortName "S26"
                                                                              :ContactPersons [personnel1]}) {:format :dif10})
+        coll26-1 (d/ingest-umm-spec-collection "PROV4" (data-umm-c/collection {:EntryTitle "coll26 one" :ShortName "S26 (sname one) \"sname one\""
+                                                                               :ContactPersons [personnel1]}) {:format :dif10})
         coll27 (d/ingest-umm-spec-collection "PROV5" (data-umm-c/collection {:EntryTitle "coll27" :ShortName "S27" :ContactPersons [personnel2]}) {:format :dif10})]
 
 
     (index/wait-until-indexed)
+
+    (testing "search by keyword-phrase unsupported cases."
+      (are3 [keyword-str]
+        (let [parameter-refs (search/find-refs :collection {:keyword keyword-str})
+              json-refs (search/find-refs-with-json-query :collection {} {:keyword keyword-str})]
+          (is (= {:errors [(str "keyword phrase mixed with keyword, or another keyword-phrase are not supported. "
+                                "keyword phrase has to be enclosed by two escaped double quotes.")]
+                  :status 400}
+                 parameter-refs
+                 json-refs)))
+
+        "mix of keyword and keyword phrase search: not supported yet."
+        "Mitch \"a (merry-go-round)\""
+        "multiple keyword phrase search: not supported yet."
+        "\"Mitch made\" \"a (merry-go-round)\""
+        "Missing one \" case"
+        "\"a (merry-go-round)"))
 
     (testing "search by keywords."
       (are [keyword-str items]
@@ -183,8 +202,10 @@
           (and parameter-matches? json-matches?))
 
         ;; search by contact persons
-        "Bob Hope" [coll26]
-        "bob.hope@nasa.gov" [coll26]
+        "Bob Hope" [coll26 coll26-1]
+        "\"Bob Hope\"" []
+        "bob.hope@nasa.gov" [coll26 coll26-1]
+        "\"bob.hope@nasa.gov\"" [coll26 coll26-1]
         "Victor" [coll27]
         "victor.fries@nsidc.gov" [coll27]
 
@@ -205,18 +226,38 @@
 
         ;; entry title
         "coll1" [coll1]
+        "\"coll1\"" [coll1]
+        "coll26" [coll26 coll26-1]
+         "\"coll26\"" [coll26 coll26-1]
         "Mitch made a (merry-go-round)" [coll2]
+        "\"Mitch made a (merry-go-round)\"" [coll2]
         "(merry-go-round)" [coll2]
+        "\"(merry-go-round)\"" [coll2]
         "merry-go-round" [coll2]
+        "\"merry-go-round\"" [coll2]
         "merry" [coll2]
+        "\"merry\"" [coll2]
         "merry go round" [coll2]
+        "\"merry go round\"" []
         "merry-go" []
+        "\"merry-go\"" []
+
+        ;; mix of keyword and keyword phrase search: not supported yet.
+        "Mitch \"a (merry-go-round)\"" []
+        ;; multiple keyword phrase search: not supported yet.
+        "\"Mitch made\" \"a (merry-go-round)\"" []
 
         ;; entry id
         "ABC!XYZ_V001" [coll2]
 
         ;; short name
         "XYZ" [coll2]
+        "\"XYZ\"" [coll2]
+        "sname one" [coll26-1]
+        "\"sname one\"" [coll26-1]
+        "(sname one)" [coll26-1]
+        "\"(sname one)\"" [coll26-1]
+        "\"(sname one) \\\"sname one\\\"\"" [coll26-1]
 
         ;; version id
         "V001" [coll2]
@@ -361,7 +402,7 @@
         "p*ce" [coll6]
         "NEA*REA*IME" [coll22]
         "nea*rea*ime" [coll22]
-        "\"Quoted*" [coll23]
+        "\\\"Quoted*" [coll23]
 
         ;; search by keywords using wildcard ?
         "XY?" [coll2]
@@ -913,17 +954,31 @@
              (println "Actual:" (map :name (:refs refs))))
            matches?)
          "begin!end" [1]
+         "\"begin!end\"" [1]
          "begin\\end" [19]
+         "\"begin\\end\"" [19]
+         "begin\\\"end" [26]
+         "\"begin\\\"end\"" [26]
          "begin<end" [27]
+         "\"begin<end\"" [27]
          "begin\\?end" [29]
+         "\"begin\\?end\"" [29]
          "begin~end" [31]
+         "\"begin~end\"" [31]
          "begin\\*end" [50]
+         "\"begin\\*end\"" [50]
          "begin" [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 47 50]
+         "\"begin\"" [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 47 50]
          "end" [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 47 50]
+         "\"end\"" [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 47 50]
          "&&" [0]
+         "\"&&\"" [0]
          "||" [0]
+         "\"||\"" [0]
          "48AND" [48]
-         "OR" [49])))
+         "\"48AND\"" [48]
+         "OR" [49]
+         "\"OR\"" [49])))
 
 ;; Test that the same collection short-name with different versions comes back
 ;; in descending order by version, even if the versions are in different formats


### PR DESCRIPTION
For some reason I merged my fix for CMR-7380 to nasa:CMR-7380-keyword-search-on-phrase, instead of nasa:master.  There are some changes to the files since I merged. To avoid conflict and possible errors. I think it's safer to create another branch and go through PR again to merge to master