### PR TITLE
CMR-7310

### DIFF
--- a/.github/workflows/graph-db.yml
+++ b/.github/workflows/graph-db.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.16.3]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     services:

--- a/graph-db/README.md
+++ b/graph-db/README.md
@@ -47,6 +47,14 @@ The Gremlin Console is a REPL environment that allows user to experiment with a 
 docker run -it -p 8182:8182 --network host tinkerpop/gremlin-console
 ```
 
+Then connect to the Gremlin Server and run Gremlin queries in the console, e.g.
+
+```
+:remote connect tinkerpop.server conf/remote.yaml
+:remote console
+g.V().count()
+```
+
 ### Graphexp
 Graphexp is a lightweight web interface to explore and display a graph stored in a Gremlin graph database, via the Gremlin server. This is an easy way to visualize nodes and edges in the graph database.
 Clone the graphexp repository at https://github.com/bricaud/graphexp


### PR DESCRIPTION
Limit the build Node.js version to 12.16.3 which is what is deployed to AWS.