### PR TITLE
CMR-7306

### DIFF
--- a/graph-db/serverless.yml
+++ b/graph-db/serverless.yml
@@ -12,6 +12,7 @@ provider:
     subnetIds: !Split [',', '${cf:${self:provider.stage}.subnetIds}']
   environment:
     CMR_ROOT: ${self:custom.variables.CMR_ROOT}
+    CMR_TOKEN_KEY: ${self:custom.variables.CMR_TOKEN_KEY}
     ENVIRONMENT: ${self:custom.variables.ENVIRONMENT}
     GREMLIN_URL: ${self:custom.variables.GREMLIN_URL}
     PAGE_SIZE: ${self:custom.variables.PAGE_SIZE}
@@ -80,6 +81,7 @@ custom:
   variables:
     # Default values for environment variables
     CMR_ROOT: ${env:CMR_ROOT, 'https://cmr.sit.earthdata.nasa.gov'}
+    CMR_TOKEN_KEY: ${env:CMR_TOKEN_KEY, 'SIT_TOKEN'}
     ENVIRONMENT: ${self:provider.stage}
     GREMLIN_URL: ${env:GREMLIN_URL, 'wss://${cf:neptune-${opt:stage}.DBClusterEndpoint}:8182/gremlin'}
     PAGE_SIZE: ${env:PAGE_SIZE, '1000'}

--- a/graph-db/serverless/src/utils/cmr/getEchoToken.js
+++ b/graph-db/serverless/src/utils/cmr/getEchoToken.js
@@ -16,7 +16,7 @@ export const getEchoToken = async () => {
 
   try {
     token = await getSecureParam(
-      `/${process.env.ENVIRONMENT}/graph-db/CMR_ECHO_SYSTEM_TOKEN`
+      `/${process.env.ENVIRONMENT}/graph-db/${process.env.CMR_TOKEN_KEY}`
     )
   } catch (error) {
     console.warn(`Could not get ECHO token: ${error}`)


### PR DESCRIPTION
Added CMR_TOKEN_KEY configuration to allow bootstrap UAT collections in SIT.

This PR addresses the issue where we couldn't retrieve the UAT CMR system token from UAT parameter store in the SIT environment and as a result, can't bootstrap UAT collections to SIT. 

We add the UAT CMR token in a new configuration parameter in graph-db secure parameter store which can be retrieved by the key that is set in `CMR_TOKEN_KEY`. We can then set the proper env variable in deployment to make sure we have the proper token to match the CMR_ROOT configuration.