### PR TITLE
CMR-7448: Add token type to successful ingest logging

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
+++ b/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
@@ -60,6 +60,16 @@
   (not (or (is-legacy-token? token)
            (is-jwt-token? token))))
 
+(defn get-token-type
+  "Returns the type of a given token"
+  [token]
+  (cond
+    (= (transmit-config/echo-system-token) token) "System"
+    (re-seq #"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}" token) "Echo-Token"
+    (is-legacy-token? token) "Legacy-EDL"
+    (is-jwt-token? token) "JWT"
+    :else "Launchpad"))
+
 (defn validate-launchpad-token
   "Validate the token in request context is a Launchpad Token if launchpad token enforcement
    is turned on. This function should be called on routes that will ingest into CMR.

--- a/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
+++ b/common-app-lib/src/cmr/common_app/api/launchpad_token_validation.clj
@@ -63,12 +63,13 @@
 (defn get-token-type
   "Returns the type of a given token"
   [token]
-  (cond
-    (= (transmit-config/echo-system-token) token) "System"
-    (re-seq #"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}" token) "Echo-Token"
-    (is-legacy-token? token) "Legacy-EDL"
-    (is-jwt-token? token) "JWT"
-    :else "Launchpad"))
+  (when (string? token)
+    (cond
+      (= (transmit-config/echo-system-token) token) "System"
+      (re-seq #"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}" token) "Echo-Token"
+      (is-legacy-token? token) "Legacy-EDL"
+      (is-jwt-token? token) "JWT"
+      :else "Launchpad")))
 
 (defn validate-launchpad-token
   "Validate the token in request context is a Launchpad Token if launchpad token enforcement

--- a/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
+++ b/common-app-lib/test/cmr/common_app/test/api/launchpad_token_validation_tests.clj
@@ -75,4 +75,10 @@
                    false false false false
                    false false
                    false false false
-                   true] #'token/is-launchpad-token?))))
+                   true] #'token/is-launchpad-token?))
+    (testing "get-token-type"
+      (test-group ["Echo-Token"
+                   "Legacy-EDL" "Legacy-EDL" "Legacy-EDL" "Legacy-EDL"
+                   "Legacy-EDL" "Legacy-EDL"
+                   "JWT" "JWT" "JWT"
+                   "Launchpad"] token/get-token-type))))

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -252,7 +252,7 @@
   [concept request-context]
   (let [metadata-size-bytes (-> (:metadata concept) (.getBytes "UTF-8") alength)
         concept (assoc concept :metadata-size-bytes metadata-size-bytes)]
-    (info (format "Successfully ingested %s from client %s, toke_type %s"
+    (info (format "Successfully ingested %s from client %s, token_type %s"
                   (concept->loggable-string concept)
                   (:client-id request-context)
                   (lt-validation/get-token-type (:token request-context))))))

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -252,9 +252,14 @@
   [concept request-context]
   (let [metadata-size-bytes (-> (:metadata concept) (.getBytes "UTF-8") alength)
         concept (assoc concept :metadata-size-bytes metadata-size-bytes)]
-    (info (format "Successfully ingested %s from client %s"
+    (info (format "Successfully ingested %s from client %s using %s"
                   (concept->loggable-string concept)
-                  (:client-id request-context)))))
+                  (:client-id request-context)
+                  "a token type"))
+    (println (format "Successfully ingested %s from client %s, token_type %s"
+                  (concept->loggable-string concept)
+                  (:client-id request-context)
+                  (lt-validation/get-token-type (:token request-context))))))
 
 (defn set-default-error-format [default-response-format handler]
   "Ring middleware to add a default format to the exception-info created during exceptions. This

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -252,7 +252,7 @@
   [concept request-context]
   (let [metadata-size-bytes (-> (:metadata concept) (.getBytes "UTF-8") alength)
         concept (assoc concept :metadata-size-bytes metadata-size-bytes)]
-    (info (format "Successfully ingested %s from client %s using %s"
+    (info (format "Successfully ingested %s from client %s, toke_type %s"
                   (concept->loggable-string concept)
                   (:client-id request-context)
                   (lt-validation/get-token-type (:token request-context))))))

--- a/ingest-app/src/cmr/ingest/api/core.clj
+++ b/ingest-app/src/cmr/ingest/api/core.clj
@@ -255,10 +255,6 @@
     (info (format "Successfully ingested %s from client %s using %s"
                   (concept->loggable-string concept)
                   (:client-id request-context)
-                  "a token type"))
-    (println (format "Successfully ingested %s from client %s, token_type %s"
-                  (concept->loggable-string concept)
-                  (:client-id request-context)
                   (lt-validation/get-token-type (:token request-context))))))
 
 (defn set-default-error-format [default-response-format handler]


### PR DESCRIPTION
This captures granules, collections, and more.