### PR TITLE
CMR-7531

### DIFF
--- a/dev-system/src/cmr/dev_system/control.clj
+++ b/dev-system/src/cmr/dev_system/control.clj
@@ -95,6 +95,15 @@
            :headers {"Content-Type" "application/csv; charset=utf-8"}}
           (route/not-found "KMS resource not found\n"))))
 
+    ;; Retrieve smart handoff resources
+    (GET "/smart-handoff/:schema-filename" [schema-filename]
+      (let [resource (io/resource (str "smart-handoff/" schema-filename))]
+        (if resource
+          {:status 200
+           :body (slurp resource)
+           :headers {"Content-Type" "application/json; charset=utf-8"}}
+          (route/not-found "Smart handoff resource not found\n"))))
+
     ;; For debugging. Gets the state of the world in relations to ACLs and what's indexed
     (GET "/acl-state" []
       {:status 200

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3150,7 +3150,7 @@ __Example Response__
 
 ### <a name="retrieve-smart-handoff-schemas"></a> Retrieve Smart Handoff Schemas
 
-Smart handoff provides the ability for one application to automatically generate a link of the same data to another related application. It is achieved using [JSON-LD schema](https://en.wikipedia.org/wiki/JSON-LD) in [schema.org](https://schema.org/docs/schemas.html). The smart handoff endpoints are used to retrieve the JSON-LD schemas for smart handoff among clients: SOTO, Giovanni and EDSC.
+Smart handoffs provide the ability for one application (a) to automatically generate a link to another application (b). That link will preserve the 'context' of the search in application a and recreate it in application b. The context may include spatial, temporal, variable and free text filters. It is achieved using [JSON-LD schema](https://en.wikipedia.org/wiki/JSON-LD) in [schema.org](https://schema.org/docs/schemas.html). The smart handoff endpoints are used to retrieve the JSON-LD schemas for smart handoff among clients: SOTO, Giovanni and EDSC.
 
 To retrieve smart handoff schema for SOTO:
 ```

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3150,7 +3150,7 @@ __Example Response__
 
 ### <a name="retrieve-smart-handoff-schemas"></a> Retrieve Smart Handoff Schemas
 
-Smart handoff provides the ability for one application to automatically generate link of the same data to another related application. It is achieved using [JSON-LD schema](https://en.wikipedia.org/wiki/JSON-LD) in [schema.org](https://schema.org/docs/schemas.html). The smart handoff endpoints are used to retrieve the JSON-LD schemas for smart handoff among clients: SOTO, Giovanni and EDSC.
+Smart handoff provides the ability for one application to automatically generate a link of the same data to another related application. It is achieved using [JSON-LD schema](https://en.wikipedia.org/wiki/JSON-LD) in [schema.org](https://schema.org/docs/schemas.html). The smart handoff endpoints are used to retrieve the JSON-LD schemas for smart handoff among clients: SOTO, Giovanni and EDSC.
 
 To retrieve smart handoff schema for SOTO:
 ```

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -150,6 +150,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [Humanizers Report](#facets-humanizers-report)
   * [Search for Tiles](#search-for-tiles)
   * [Retrieve Controlled Keywords](#retrieve-controlled-keywords)
+  * [Retrieve Smart Handoff Schemas](#retrieve-smart-handoff-schemas)
   * [Find collections that have been deleted after a given date](#deleted-collections)
   * [Find granules that have been deleted after a given date](#deleted-granules)
   * [Tagging](#tagging)
@@ -3147,6 +3148,25 @@ __Example Response__
 }
 ```
 
+### <a name="retrieve-smart-handoff-schemas"></a> Retrieve Smart Handoff Schemas
+
+Smart handoff provides the ability for one application to automatically generate link of the same data to another related application. It is achieved using [JSON-LD schema](https://en.wikipedia.org/wiki/JSON-LD) in [schema.org](https://schema.org/docs/schemas.html). The smart handoff endpoints are used to retrieve the JSON-LD schemas for smart handoff among clients: SOTO, Giovanni and EDSC.
+
+To retrieve smart handoff schema for SOTO:
+```
+curl "%CMR-ENDPOINT%/smart-handoff/soto"
+```
+
+To retrieve smart handoff schema for Giovanni:
+```
+curl "%CMR-ENDPOINT%/smart-handoff/giovanni"
+```
+
+To retrieve smart handoff schema for EDSC:
+```
+curl "%CMR-ENDPOINT%/smart-handoff/edsc"
+```
+
 ### <a name="deleted-collections"></a> Find collections that have been deleted after a given date
 
 To support metadata harvesting, a harvesting client can search CMR for collections that are deleted after a given date. The only search parameter supported is `revision_date` and its format is slightly different from the `revision_date` parameter in regular collection search in that only one revision date can be provided and it can only be a starting date, not a date range. The only supported result format is xml references. The response is the references to the highest non-tombstone collection revisions of the collections that are deleted. e.g.
@@ -3613,7 +3633,7 @@ These parameters will match fields within a variable. They are case insensitive 
   * options: ignore_case, or
 measurement_identifiers parameter is a nested parameter with subfields: contextmedium, object and quantity. Multiple measurement_identifiers can be specified via different indexes to search variables. The following example searches for variables that have at least one measurement_identifier with contextmedium of Med1, object of Object1 and quantity of Q1, and another measurement_identifier with contextmedium of Med2 and object of Obj2.
 
-    
+
 ````
 curl -g "%CMR-ENDPOINT%/variables?measurement_identifiers\[0\]\[contextmedium\]=Med1&measurement_identifiers\[0\]\[object\]=Object1&measurement_identifiers\[0\]\[quantity\]=Q1&measurement_identifiers\[1\]\[contextmedium\]=med2&measurement_identifiers\[2\]\[object\]=Obj2"
 ````

--- a/search-app/resources/smart-handoff/edsc-schema.json
+++ b/search-app/resources/smart-handoff/edsc-schema.json
@@ -1,0 +1,42 @@
+{
+  "@context": "http://schema.org",
+  "@type": "ServiceChannel",
+  "url": "https://search.earthdata.nasa.gov",
+  "providesService": {
+    "@type": "Service",
+    "name": "Earthdata Search",
+    "url": "https://search.earthdata.nasa.gov",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://search.earthdata.nasa.gov/search?q={query}&qt={temporal}&sb={box}",
+      "query-input": [
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "temporal",
+          "defaultValue": {
+            "@id": "schema:datasetTimeInterval",
+            "@type": "Property"
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "box",
+          "defaultValue": {
+            "@type": "Place",
+            "geo": {
+              "@type": "GeoShape",
+              "box": "-90.0000 180.0000 90.0000 -180.0000"
+            }
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "query"
+        }
+      ]
+    }
+  }
+}

--- a/search-app/resources/smart-handoff/giovanni-schema.json
+++ b/search-app/resources/smart-handoff/giovanni-schema.json
@@ -1,0 +1,66 @@
+{
+  "@context": "http://schema.org",
+  "@type": "ServiceChannel",
+  "url": "https://giovanni.gsfc.nasa.gov/giovanni",
+  "providesService": {
+    "@type": "Service",
+    "name": "Giovanni",
+    "url": "https://giovanni.gsfc.nasa.gov/giovanni",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://giovanni.gsfc.nasa.gov/giovanni/#service=TmAvMp&starttime={start}&endtime={end}&bbox={box}&dataKeyword={collection}&data={variables}",
+      "query-input": [
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "start",
+          "defaultValue": {
+            "@id": "schema:startDate",
+            "@type": "Property"
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "end",
+          "defaultValue": {
+            "@id": "schema:endDate",
+            "@type": "Property"
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "box",
+          "defaultValue": {
+            "@type": "Place",
+            "geo": {
+              "@type": "GeoShape",
+              "box": "-90.0000 180.0000 90.0000 -180.0000"
+            }
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "collection",
+          "defaultValue": {
+            "@type": "DefinedTerm",
+            "@id": "https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-short-name",
+            "name": "CMR Shortname"
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "multipleValues": true,
+          "valueName": "variables",
+          "defaultValue": {
+            "@id": "schema:variableMeasured",
+            "@type": "Property"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/search-app/resources/smart-handoff/soto-schema.json
+++ b/search-app/resources/smart-handoff/soto-schema.json
@@ -1,0 +1,48 @@
+{
+  "@context": "http://schema.org",
+  "@type": "ServiceChannel",
+  "url": "https://podaac-tools.jpl.nasa.gov/soto",
+  "providesService": {
+    "@type": "Service",
+    "name": "State of the Ocean",
+    "url": "https://podaac-tools.jpl.nasa.gov/soto",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://podaac-tools.jpl.nasa.gov/soto/#b=BlueMarble_ShadedRelief_Bathymetry&l={layers}&ve={box}&d={start}",
+      "query-input": [
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "start",
+          "defaultValue": {
+            "@id": "schema:startDate",
+            "@type": "Property"
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "valueName": "box",
+          "defaultValue": {
+            "@type": "Place",
+            "geo": {
+              "@type": "GeoShape",
+              "box": "-90.0000 180.0000 90.0000 -180.0000"
+            }
+          }
+        },
+        {
+          "@type": "PropertyValueSpecification",
+          "valueRequired": false,
+          "multipleValues": true,
+          "valueName": "layers",
+          "defaultValue": {
+            "@type": "DefinedTerm",
+            "@id": "https://developer.earthdata.nasa.gov/gibs/gibs-api-for-developers#GIBSAPIforDevelopers-LayerConfigurationInformation",
+            "name": "PO.DAAC imagery layer. For example: GHRSST_L4_MUR_Sea_Surface_Temperature"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/search-app/src/cmr/search/api/routes.clj
+++ b/search-app/src/cmr/search/api/routes.clj
@@ -13,6 +13,7 @@
    [cmr.search.api.keyword :as keyword-api]
    [cmr.search.api.providers :as providers-api]
    [cmr.search.api.services :as services-api]
+   [cmr.search.api.smart-handoff :as smart-handoff-api]
    [cmr.search.api.tags :as tags-api]
    [cmr.search.api.tools :as tools-api]
    [cmr.search.data.metadata-retrieval.metadata-cache :as metadata-cache]
@@ -126,6 +127,9 @@
 
         ;; Add routes for searching tiles
         concepts-search-api/tiles-routes
+
+        ;; Add routes for smart handoff
+        smart-handoff-api/smart-handoff-routes
 
         ;; clear scroll routes
         concepts-search-api/clear-scroll-routes))))

--- a/search-app/src/cmr/search/api/smart_handoff.clj
+++ b/search-app/src/cmr/search/api/smart_handoff.clj
@@ -1,43 +1,11 @@
 (ns cmr.search.api.smart-handoff
   "Defines the API for retrieving smart handoff schemas defined in CMR."
   (:require
-   [clojure.java.io :as io]
-   [cmr.common-app.api.routes :as cr]
-   [cmr.common.mime-types :as mt]
+   [cmr.search.services.smart-handoff-service :as smart-handoff-service]
    [compojure.core :refer :all]
    [compojure.route :as route]))
 
-(def ^:private soto-schema
-  "relative path of SOTO schema in the resources directory"
-  "smart-handoff/soto-schema.json")
-
-(def ^:private giovanni-schema
-  "relative path of Giovanni schema in the resources directory"
-  "smart-handoff/giovanni-schema.json")
-
-(def ^:private edsc-schema
-  "relative path of EDSC schema in the resources directory"
-  "smart-handoff/edsc-schema.json")
-
-(def ^:private smart-handoff-headers
-  "smart handoff headers"
-  (assoc (:headers cr/options-response)
-         cr/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)))
-
 (def smart-handoff-routes
-  (context "/smart-handoff" []
-
-    (GET "/soto" request
-        {:status 200
-         :body (slurp (io/resource soto-schema))
-         :headers smart-handoff-headers})
-
-    (GET "/giovanni" request
-        {:status 200
-         :body (slurp (io/resource giovanni-schema))
-         :headers smart-handoff-headers})
-
-    (GET "/edsc" request
-        {:status 200
-         :body (slurp (io/resource edsc-schema))
-         :headers smart-handoff-headers})))
+  (context ["/smart-handoff/:client"] [client]
+    (GET "/" {:keys [request-context]}
+      (smart-handoff-service/retrieve-schema request-context client))))

--- a/search-app/src/cmr/search/api/smart_handoff.clj
+++ b/search-app/src/cmr/search/api/smart_handoff.clj
@@ -1,0 +1,43 @@
+(ns cmr.search.api.smart-handoff
+  "Defines the API for retrieving smart handoff schemas defined in CMR."
+  (:require
+   [clojure.java.io :as io]
+   [cmr.common-app.api.routes :as cr]
+   [cmr.common.mime-types :as mt]
+   [compojure.core :refer :all]
+   [compojure.route :as route]))
+
+(def ^:private soto-schema
+  "relative path of SOTO schema in the resources directory"
+  "smart-handoff/soto-schema.json")
+
+(def ^:private giovanni-schema
+  "relative path of Giovanni schema in the resources directory"
+  "smart-handoff/giovanni-schema.json")
+
+(def ^:private edsc-schema
+  "relative path of EDSC schema in the resources directory"
+  "smart-handoff/edsc-schema.json")
+
+(def ^:private smart-handoff-headers
+  "smart handoff headers"
+  (assoc (:headers cr/options-response)
+                  cr/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)))
+
+(def smart-handoff-routes
+  (context "/smart-handoff" []
+
+    (GET "/soto" request
+        {:status 200
+         :body (slurp (io/resource soto-schema))
+         :headers smart-handoff-headers})
+
+    (GET "/giovanni" request
+        {:status 200
+         :body (slurp (io/resource giovanni-schema))
+         :headers smart-handoff-headers})
+
+    (GET "/edsc" request
+        {:status 200
+         :body (slurp (io/resource edsc-schema))
+         :headers smart-handoff-headers})))

--- a/search-app/src/cmr/search/api/smart_handoff.clj
+++ b/search-app/src/cmr/search/api/smart_handoff.clj
@@ -22,7 +22,7 @@
 (def ^:private smart-handoff-headers
   "smart handoff headers"
   (assoc (:headers cr/options-response)
-                  cr/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)))
+         cr/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)))
 
 (def smart-handoff-routes
   (context "/smart-handoff" []

--- a/search-app/src/cmr/search/services/smart_handoff_service.clj
+++ b/search-app/src/cmr/search/services/smart_handoff_service.clj
@@ -1,0 +1,20 @@
+(ns cmr.search.services.smart-handoff-service
+  "Provides functions for smart handoff"
+  (:require
+    [cmr.common-app.api.routes :as cr]
+    [cmr.common.mime-types :as mt]
+    [cmr.transmit.smart-handoff :as smart-handoff]))
+
+(def ^:private smart-handoff-headers
+  "smart handoff headers"
+  (assoc (:headers cr/options-response)
+         cr/CONTENT_TYPE_HEADER (mt/with-utf-8 mt/json)))
+
+(defn retrieve-schema
+  "Retrieve the given smart handoff schema, returns the response."
+  [context client]
+  (let [schema-filename (str client "-schema.json")
+        {:keys [status body]} (smart-handoff/get-smart-handoff-schema context schema-filename)]
+    {:status status
+     :body body
+     :headers smart-handoff-headers}))

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -150,7 +150,7 @@
                           hrs/humanizer-report-generator-job])}]
     (transmit-config/system-with-connections
      sys
-     [:indexer :echo-rest :metadata-db :kms :access-control])))
+     [:indexer :echo-rest :metadata-db :kms :smart-handoff :access-control])))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -743,6 +743,18 @@
         :results (json/decode body)}
        response))))
 
+(defn get-smart-handoff-schema
+  "Calls the CMR search endpoint to retrieve the smart handoff schema for the given client."
+  [client]
+  (get-search-failure-data
+   (let [response (client/get (url/smart-handoff-url client)
+                              {:connection-manager (s/conn-mgr)})
+         {:keys [status body]} response]
+     (if (= 200 status)
+       {:status status
+        :body body}
+       response))))
+
 (defn get-humanizers-report-raw
   "Returns the humanizers report."
   ([]

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -388,6 +388,11 @@
   [keyword-scheme]
   (format "http://localhost:%s/keywords/%s" (transmit-config/search-port) (name keyword-scheme)))
 
+(defn smart-handoff-url
+  "Returns the URL for retrieving smart handoff schema for the given client."
+  [client]
+  (format "http://localhost:%s/smart-handoff/%s" (transmit-config/search-port) (name client)))
+
 (defn retrieve-concept-url
   ([type concept-id] (retrieve-concept-url type concept-id nil))
   ([type concept-id revision-id]

--- a/system-int-test/test/cmr/system_int_test/search/smart_handoff_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/smart_handoff_test.clj
@@ -6,7 +6,7 @@
    [cmr.system-int-test.utils.search-util :as search]))
 
 (deftest retrieve-smart-handoff-schemas
-  (testing "successful retrival of smart handoff schemas"
+  (testing "successful retrieval of smart handoff schemas"
     (are3
       [client]
       (let [expected-schema (->> client

--- a/system-int-test/test/cmr/system_int_test/search/smart_handoff_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/smart_handoff_test.clj
@@ -1,0 +1,32 @@
+(ns cmr.system-int-test.search.smart-handoff-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+(deftest retrieve-smart-handoff-schemas
+  (testing "successful retrival of smart handoff schemas"
+    (are3
+      [client]
+      (let [expected-schema (->> client
+                                 name
+                                 (format "smart-handoff/%s-schema.json")
+                                 io/resource
+                                 slurp)]
+        (is (= {:status 200
+                :body expected-schema}
+               (search/get-smart-handoff-schema client))))
+
+      "retrieve smart handoff schema for SOTO"
+      :soto
+
+      "retrieve smart handoff schema for Giovanni"
+      :giovanni
+
+      "retrieve smart handoff schema for EDSC"
+      :edsc))
+
+  (testing "retrieval of undefined schema returns 404 error"
+    (is (= 404
+           (:status (search/get-smart-handoff-schema :foo))))))

--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -86,6 +86,7 @@
 (def-app-conn-config indexer {:port 3004})
 (def-app-conn-config ingest {:port 3002})
 (def-app-conn-config kms {:port 2999, :relative-root-url "/kms"})
+(def-app-conn-config smart-handoff {:port 2999, :relative-root-url "/smart-handoff"})
 (def-app-conn-config metadata-db {:port 3001})
 ;; CMR open search is 3010
 (def-app-conn-config search {:port 3003})
@@ -220,7 +221,11 @@
    :urs {:protocol (urs-protocol)
          :host (urs-host)
          :port (urs-port)
-         :context (urs-relative-root-url)}})
+         :context (urs-relative-root-url)}
+   :smart-handoff {:protocol (smart-handoff-protocol)
+                   :host (smart-handoff-host)
+                   :port (smart-handoff-port)
+                   :context (smart-handoff-relative-root-url)}})
 
 (defn app-connection-system-key-name
   "The name of the app connection in the system"

--- a/transmit-lib/src/cmr/transmit/smart_handoff.clj
+++ b/transmit-lib/src/cmr/transmit/smart_handoff.clj
@@ -1,0 +1,23 @@
+(ns cmr.transmit.smart-handoff
+  "This namespace handles retrieval of smart handoff resources."
+  (:require
+    [clj-http.client :as client]
+    [cmr.common.log :as log :refer (debug info warn error)]
+    [cmr.transmit.config :as config]
+    [cmr.transmit.connection :as conn]))
+
+(defn get-smart-handoff-schema
+  "Returns the smart handoff schema with the given file name."
+  [context schema-filename]
+  (let [conn (config/context->app-connection context :smart-handoff)
+        url (format "%s/%s" (conn/root-url conn) schema-filename)
+        params (merge
+                (config/conn-params conn)
+                {:headers {:accept-charset "utf-8"}
+                 :throw-exceptions false})
+        start (System/currentTimeMillis)
+        response (client/get url params)]
+    (debug
+     (format
+      "Completed Get Smart Handoff Request to %s in [%d] ms" url (- (System/currentTimeMillis) start)))
+    response))


### PR DESCRIPTION
As a user I want to retrieve smart handoff schemas via a static API endpoint.

I made the change to pull the smart handoff schemas from a configurable online location and serve those schemas off the CMR smart handoff endpoint. We are going to push the smart handoff schemas into CMR code base and let github CMR repository be the source of truth. We will configure CMR to pull the schemas from github. The idea is that CMR will serve any new smart handoff schemas dynamically without any additional code change to CMR other than the updated schema.