### PR TITLE
CMR-7506: Bulk Granule Update for Checksum in ECHO10

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -21,7 +21,7 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
     * [PUT - Create or update a granule.](#create-update-granule)
     * [DELETE - Delete a granule.](#delete-granule)
   * /collections/\<collection-concept-id>/\<collection-revision-id>/variables/\<native-id>
-    * [PUT - Create or update a variable with assoication.](#create-update-variable)
+    * [PUT - Create or update a variable with association.](#create-update-variable)
   * /providers/\<provider-id>/variables/\<native-id>
     * [PUT - Update a variable.](#create-update-variable)
     * [DELETE - Delete a variable.](#delete-variable)
@@ -1158,7 +1158,7 @@ If the number of granules in need of update update exceeds 250,000, we ask that 
 Granule bulk update currently supports updating with the following operations, update fields and metadata formats:
 
 **operation: "UPDATE_FIELD", update-field: "OPeNDAPLink"**
-supported metadata formats:
+Supported metadata formats:
   - OPeNDAP url in OnlineResources for ECHO10 format
   - OPeNDAP url in RelatedUrls for UMM-G format
 
@@ -1166,7 +1166,7 @@ There can only be ONE on-prem and/or ONE Hyrax-in-the-cloud OPeNDAP url in the g
 The OPeNDAP url value provided in the granule bulk update request can be comma-separated urls, but it can have two at most: one is an on-prem url and the other is a Hyrax-in-the-cloud url. The exact url type is determined by matching the url against the same pattern above. During an update, the Hyrax-in-the-cloud url will overwrite any existing Hyrax-in-the-cloud OPeNDAP url in the granule metadata, and the on-prem url will overwrite any existing on-prem OPeNDAP url in the granule metadata.
 
 **operation: "UPDATE_FIELD", update-field: "S3Link"**
-supported metadata formats:
+Supported metadata formats:
   - S3 url in OnlineAccessURLs for ECHO10 format
   - S3 url in RelatedUrls for UMM-G format
 
@@ -1188,6 +1188,41 @@ curl -i -XPOST \
              ["granule_ur1", "https://via.placeholder.com/150"],
              ["granule_ur2", "https://via.placeholder.com/160"],
              ["granule_ur3", "https://via.placeholder.com/170,https://opendap.earthdata.nasa.gov/foo"]
+	]
+}'
+```
+
+Example granule bulk update response:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+    <status>200</status>
+    <task-id>5</task-id>
+</result>
+```
+
+**operation: "UPDATE_FIELD", update-field: "Checksum"**
+Supported metadata formats:
+  - Checksum in <DataGranule> element for ECHO10 format
+
+An `algorithm` can optionally be supplied with the new checksum `value` by specifying two values, comma-seperated (`value,algorithm`). If an update is requested for a granule with no existing `<Checksum>` element, then specifying an `algorithm` is required. Any values beyond the first two for a given granule are ignored.
+
+Example: Add/update checksum for 3 granules under PROV1. Granules 1 and 2 only receive checksum `value` updates, while granule 3 receives an update to checksum `value` *and* `algorithm`.
+
+```
+curl -i -XPOST \
+  -H "Cmr-Pretty:true" \
+  -H "Content-Type: application/json"
+  -H "Echo-Token: XXXX" \
+  %CMR-ENDPOINT%/providers/PROV1/bulk-update/granules \
+  -d
+'{ "name": "example of adding OPeNDAP link",
+	"operation": "UPDATE_FIELD",
+	"update-field":"Checksum",
+	"updates":[
+             ["granule_ur1", "92959a96fd69146c5fe7cbde6e5720f2"],
+             ["granule_ur2", "925a89b43f3caff507db0a86d20a2428007"],
+             ["granule_ur3", "a3dcb4d229de6fde0db5686dee47145d,SHA-256"]
 	]
 }'
 ```

--- a/ingest-app/resources/CMR-4722/OMSO2.003-granule-checksum.xml
+++ b/ingest-app/resources/CMR-4722/OMSO2.003-granule-checksum.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Granule>
+   <GranuleUR>OMSO2.003:OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</GranuleUR>
+   <InsertTime>2016-06-17T12:37:02Z</InsertTime>
+   <LastUpdate>2016-06-17T12:37:02Z</LastUpdate>
+   <Collection>
+      <ShortName>OMSO2</ShortName>
+      <VersionId>003</VersionId>
+   </Collection>
+   <DataGranule>
+      <DataGranuleSizeInBytes>39379225</DataGranuleSizeInBytes>
+      <SizeMBDataGranule>39.3792247772217</SizeMBDataGranule>
+      <Checksum>
+         <Value>0987654321</Value>
+         <Algorithm>MD5</Algorithm>
+      </Checksum>
+      <ProducerGranuleId>OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</ProducerGranuleId>
+      <DayNightFlag>DAY</DayNightFlag>
+      <ProductionDateTime>2016-06-15T19:15:23.000Z</ProductionDateTime>
+   </DataGranule>
+   <PGEVersionClass>
+      <PGEVersion>0.1.7</PGEVersion>
+   </PGEVersionClass>
+   <Temporal>
+      <RangeDateTime>
+         <BeginningDateTime>2004-10-01T23:07:20.000000Z</BeginningDateTime>
+         <EndingDateTime>2004-10-02T00:46:13.000000Z</EndingDateTime>
+      </RangeDateTime>
+   </Temporal>
+   <Spatial>
+      <HorizontalSpatialDomain>
+         <ZoneIdentifier>Text</ZoneIdentifier>
+         <Orbit>
+            <AscendingCrossing>-153.66</AscendingCrossing>
+            <StartLat>-77.975486</StartLat>
+            <StartDirection>D</StartDirection>
+            <EndLat>76.799534</EndLat>
+            <EndDirection>D</EndDirection>
+         </Orbit>
+      </HorizontalSpatialDomain>
+   </Spatial>
+   <OrbitCalculatedSpatialDomains>
+      <OrbitCalculatedSpatialDomain>
+         <OrbitNumber>1146</OrbitNumber>
+         <EquatorCrossingLongitude>-153.66</EquatorCrossingLongitude>
+         <EquatorCrossingDateTime>2004-10-01T23:56:44.000000Z</EquatorCrossingDateTime>
+      </OrbitCalculatedSpatialDomain>
+   </OrbitCalculatedSpatialDomains>
+   <MeasuredParameters>
+      <MeasuredParameter>
+         <ParameterName>Total Column Sulphur Dioxide</ParameterName>
+         <QAStats>
+            <QAPercentMissingData>-999</QAPercentMissingData>
+         </QAStats>
+         <QAFlags>
+            <AutomaticQualityFlag>Passed</AutomaticQualityFlag>
+            <AutomaticQualityFlagExplanation>Set to 'Failed' if processing error occurred,'Passed' otherwise</AutomaticQualityFlagExplanation>
+            <OperationalQualityFlag>Passed</OperationalQualityFlag>
+            <OperationalQualityFlagExplanation>This granule passed operational tests that were administered by the OMI SIPS.  QA metadata was extracted and the file was successfully read using standard HDF-EOS utilities.</OperationalQualityFlagExplanation>
+            <ScienceQualityFlag>Not Investigated</ScienceQualityFlag>
+            <ScienceQualityFlagExplanation>An updated science quality flag and explanation is put in the product .met file when a granule has been evaluated.  The flag value in this file, Not Investigated, is an automatic default that is put into every granule during production.</ScienceQualityFlagExplanation>
+         </QAFlags>
+      </MeasuredParameter>
+   </MeasuredParameters>
+   <OnlineAccessURLs>
+      <OnlineAccessURL>
+         <URL>http://aura.gesdisc.eosdis.nasa.gov/data//Aura_OMI_Level2/OMSO2.003/2004/275/OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</URL>
+      </OnlineAccessURL>
+   </OnlineAccessURLs>
+   <Orderable>false</Orderable>
+   <DataFormat>HDF-EOS5</DataFormat>
+</Granule>

--- a/ingest-app/resources/CMR-4722/OMSO2.003-granule-no-checksum.xml
+++ b/ingest-app/resources/CMR-4722/OMSO2.003-granule-no-checksum.xml
@@ -1,0 +1,67 @@
+<Granule>
+  <GranuleUR>OMSO2.003:no-checksum</GranuleUR>
+  <InsertTime>2016-06-17T12:37:02Z</InsertTime>
+  <LastUpdate>2016-06-17T12:37:02Z</LastUpdate>
+  <Collection>
+    <ShortName>OMSO2</ShortName>
+    <VersionId>003</VersionId>
+  </Collection>
+  <DataGranule>
+    <DataGranuleSizeInBytes>39379225</DataGranuleSizeInBytes>
+    <SizeMBDataGranule>39.3792247772217</SizeMBDataGranule>
+    <ProducerGranuleId>OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</ProducerGranuleId>
+    <DayNightFlag>DAY</DayNightFlag>
+    <ProductionDateTime>2016-06-15T19:15:23.000Z</ProductionDateTime>
+  </DataGranule>
+  <PGEVersionClass>
+    <PGEVersion>0.1.7</PGEVersion>
+  </PGEVersionClass>
+  <Temporal>
+    <RangeDateTime>
+      <BeginningDateTime>2004-10-01T23:07:20.000000Z</BeginningDateTime>
+      <EndingDateTime>2004-10-02T00:46:13.000000Z</EndingDateTime>
+    </RangeDateTime>
+  </Temporal>
+  <Spatial>
+    <HorizontalSpatialDomain>
+      <ZoneIdentifier>Text</ZoneIdentifier>
+      <Orbit>
+        <AscendingCrossing>-153.66</AscendingCrossing>
+        <StartLat>-77.975486</StartLat>
+        <StartDirection>D</StartDirection>
+        <EndLat>76.799534</EndLat>
+        <EndDirection>D</EndDirection>
+      </Orbit>
+    </HorizontalSpatialDomain>
+  </Spatial>
+  <OrbitCalculatedSpatialDomains>
+    <OrbitCalculatedSpatialDomain>
+      <OrbitNumber>1146</OrbitNumber>
+      <EquatorCrossingLongitude>-153.66</EquatorCrossingLongitude>
+      <EquatorCrossingDateTime>2004-10-01T23:56:44.000000Z</EquatorCrossingDateTime>
+    </OrbitCalculatedSpatialDomain>
+  </OrbitCalculatedSpatialDomains>
+  <MeasuredParameters>
+    <MeasuredParameter>
+      <ParameterName>Total Column Sulphur Dioxide</ParameterName>
+      <QAStats>
+        <QAPercentMissingData>-999</QAPercentMissingData>
+      </QAStats>
+      <QAFlags>
+        <AutomaticQualityFlag>Passed</AutomaticQualityFlag>
+        <AutomaticQualityFlagExplanation>Set to 'Failed' if processing error occurred,'Passed' otherwise</AutomaticQualityFlagExplanation>
+        <OperationalQualityFlag>Passed</OperationalQualityFlag>
+        <OperationalQualityFlagExplanation>This granule passed operational tests that were administered by the OMI SIPS.  QA metadata was extracted and the file was successfully read using standard HDF-EOS utilities.</OperationalQualityFlagExplanation>
+        <ScienceQualityFlag>Not Investigated</ScienceQualityFlag>
+        <ScienceQualityFlagExplanation>An updated science quality flag and explanation is put in the product .met file when a granule has been evaluated.  The flag value in this file, Not Investigated, is an automatic default that is put into every granule during production.</ScienceQualityFlagExplanation>
+      </QAFlags>
+    </MeasuredParameter>
+  </MeasuredParameters>
+  <OnlineAccessURLs>
+    <OnlineAccessURL>
+      <URL>http://aura.gesdisc.eosdis.nasa.gov/data//Aura_OMI_Level2/OMSO2.003/2004/275/OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</URL>
+    </OnlineAccessURL>
+  </OnlineAccessURLs>
+  <Orderable>false</Orderable>
+  <DataFormat>HDF-EOS5</DataFormat>
+</Granule>

--- a/ingest-app/resources/CMR-4722/OMSO2.003-granule-no-data-granule.xml
+++ b/ingest-app/resources/CMR-4722/OMSO2.003-granule-no-data-granule.xml
@@ -1,0 +1,60 @@
+<Granule>
+  <GranuleUR>OMSO2.003:no-data-granule</GranuleUR>
+  <InsertTime>2016-06-17T12:37:02Z</InsertTime>
+  <LastUpdate>2016-06-17T12:37:02Z</LastUpdate>
+  <Collection>
+    <ShortName>OMSO2</ShortName>
+    <VersionId>003</VersionId>
+  </Collection>
+  <PGEVersionClass>
+    <PGEVersion>0.1.7</PGEVersion>
+  </PGEVersionClass>
+  <Temporal>
+    <RangeDateTime>
+      <BeginningDateTime>2004-10-01T23:07:20.000000Z</BeginningDateTime>
+      <EndingDateTime>2004-10-02T00:46:13.000000Z</EndingDateTime>
+    </RangeDateTime>
+  </Temporal>
+  <Spatial>
+    <HorizontalSpatialDomain>
+      <ZoneIdentifier>Text</ZoneIdentifier>
+      <Orbit>
+        <AscendingCrossing>-153.66</AscendingCrossing>
+        <StartLat>-77.975486</StartLat>
+        <StartDirection>D</StartDirection>
+        <EndLat>76.799534</EndLat>
+        <EndDirection>D</EndDirection>
+      </Orbit>
+    </HorizontalSpatialDomain>
+  </Spatial>
+  <OrbitCalculatedSpatialDomains>
+    <OrbitCalculatedSpatialDomain>
+      <OrbitNumber>1146</OrbitNumber>
+      <EquatorCrossingLongitude>-153.66</EquatorCrossingLongitude>
+      <EquatorCrossingDateTime>2004-10-01T23:56:44.000000Z</EquatorCrossingDateTime>
+    </OrbitCalculatedSpatialDomain>
+  </OrbitCalculatedSpatialDomains>
+  <MeasuredParameters>
+    <MeasuredParameter>
+      <ParameterName>Total Column Sulphur Dioxide</ParameterName>
+      <QAStats>
+        <QAPercentMissingData>-999</QAPercentMissingData>
+      </QAStats>
+      <QAFlags>
+        <AutomaticQualityFlag>Passed</AutomaticQualityFlag>
+        <AutomaticQualityFlagExplanation>Set to 'Failed' if processing error occurred,'Passed' otherwise</AutomaticQualityFlagExplanation>
+        <OperationalQualityFlag>Passed</OperationalQualityFlag>
+        <OperationalQualityFlagExplanation>This granule passed operational tests that were administered by the OMI SIPS.  QA metadata was extracted and the file was successfully read using standard HDF-EOS utilities.</OperationalQualityFlagExplanation>
+        <ScienceQualityFlag>Not Investigated</ScienceQualityFlag>
+        <ScienceQualityFlagExplanation>An updated science quality flag and explanation is put in the product .met file when a granule has been evaluated.  The flag value in this file, Not Investigated, is an automatic default that is put into every granule during production.</ScienceQualityFlagExplanation>
+      </QAFlags>
+    </MeasuredParameter>
+  </MeasuredParameters>
+  <OnlineAccessURLs>
+    <OnlineAccessURL>
+      <URL>http://aura.gesdisc.eosdis.nasa.gov/data//Aura_OMI_Level2/OMSO2.003/2004/275/OMI-Aura_L2-OMSO2_2004m1001t2307-o01146_v003-2016m0615t191523.he5</URL>
+    </OnlineAccessURL>
+  </OnlineAccessURLs>
+  <Orderable>false</Orderable>
+  <DataFormat>HDF-EOS5</DataFormat>
+</Granule>

--- a/ingest-app/resources/granule_bulk_update_schema.json
+++ b/ingest-app/resources/granule_bulk_update_schema.json
@@ -11,7 +11,8 @@
       "type": "string",
       "enum": [
         "OPeNDAPLink",
-        "S3Link"
+        "S3Link",
+        "Checksum"
       ]
     },
     "UpdateTupleType": {

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/checksum/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/checksum/echo10.clj
@@ -1,0 +1,118 @@
+(ns cmr.ingest.services.granule-bulk-update.checksum.echo10
+  "Contains functions to update ECHO10 granule xml for S3 url bulk update."
+  (:require
+   [clojure.data.xml :as xml]
+   [clojure.string :as string]
+   [clojure.zip :as zip]
+   [cmr.common.xml :as cx]))
+
+(def ^:private tags-after-data-granule
+  "Defines the element tags that come after DataGranule in ECHO10 Granule xml schema"
+  #{:PGEVersionClass :Temporal :Spatial :OrbitCalculatedSpatialDomains :MeasuredParameters
+    :Platforms :Campaigns :AdditionalAttributes :InputGranules :TwoDCoordinateSystem :Price
+    :OnlineAccessURLs :OnlineResources :Orderable :DataFormat :Visible :CloudCover
+    :MetadataStandardName :MetadataStandardVersion :AssociatedBrowseImages :AssociatedBrowseImageUrls})
+
+(def ^:private tags-after-checksum
+  "Defines the element tags that come after Checksum in ECHO10 Granule xml schema"
+  #{:ReprocessingPlanned :ReprocessingActual :ProducerGranuleId :DayNightFlag :ProductionDateTime
+    :LocalVersionId :AdditionalFile})
+
+(defn- checksum-element
+  "Returns the OnlineAccessURL xml element for the given url"
+  [checksum]
+  (let [[value algorithm] checksum]
+    (xml/element :Checksum {}
+                 (xml/element :Value {} value)
+                 (xml/element :Algorithm {} algorithm))))
+
+(defn- updated-checksum-node
+  "Takes in a zipper location, call the given insert function and url values to add OnlineResources"
+  [checksum right-loc]
+  (println right-loc)
+  (checksum-element checksum))
+
+(defn- add-checksum
+  "Takes in a zipper location, call the given insert function and url values to add OnlineResources"
+  [loc insert-fn checksum]
+  (insert-fn loc (checksum-element checksum)))
+
+(defn- updated-data-granule-zipper-node
+  "Take a parsed granule xml, update the <Checksum> value and optionally the algorithm.
+  Returns the zipper representation of the updated xml."
+  [data-granule checksum]
+  (let [zipper (zip/xml-zip data-granule)
+        start-loc (-> zipper zip/down)]
+    (loop [loc start-loc done false]
+      (if done
+        (zip/root loc)
+        (let [right-loc (zip/right loc)]
+          (cond
+            ;; at the end of the file, add to the right
+            (nil? right-loc)
+            (recur (add-checksum loc zip/insert-right checksum) true)
+
+            ;; at a Checksum element, replace the node with updated value
+            (= :Checksum (-> right-loc zip/node :tag))
+            (recur (zip/replace right-loc (updated-checksum-node checksum right-loc))
+                   true)
+
+            ;; at an element after DataGranule, add to the left
+            (some tags-after-checksum [(-> right-loc zip/node :tag)])
+            (recur (add-checksum right-loc zip/insert-left checksum) true)
+
+            ;; no action needs to be taken, move to the next node
+            :else
+            (recur right-loc false)))))))
+
+(defn- add-data-granule-with-checksum
+  "Takes in a zipper location, call the given insert function and url values to add OnlineResources"
+  [loc insert-fn checksum]
+  (insert-fn loc
+             (xml/element :DataGranule {} (checksum-element checksum))))
+
+(defn- update-checksum
+  "Take a parsed granule xml, update the <Checksum> value and optionally the algorithm.
+  Returns the zipper representation of the updated xml."
+  [parsed checksum]
+  (println "test3")
+  (let [zipper (zip/xml-zip parsed)
+        start-loc (-> zipper zip/down)]
+    (loop [loc start-loc done false]
+      (if done
+        (zip/root loc)
+        (let [right-loc (zip/right loc)]
+          (cond
+            ;; at the end of the file, add to the right
+            (nil? right-loc)
+            (recur (add-data-granule-with-checksum loc zip/insert-right checksum) true)
+
+            ;; at a DataGranule element, replace the node with updated value
+            (= :DataGranule (-> right-loc zip/node :tag))
+            (recur (zip/replace right-loc (updated-data-granule-zipper-node checksum))
+                   true)
+
+            ;; at an element after DataGranule, add to the left
+            (some tags-after-data-granule [(-> right-loc zip/node :tag)])
+            (recur (add-data-granule-with-checksum right-loc zip/insert-left checksum) true)
+
+            ;; no action needs to be taken, move to the next node
+            :else
+            (recur right-loc false)))))))
+
+(defn- update-checksum-metadata
+  "Takes the granule ECHO10 xml and a checksum with optional algorithm.
+  Update the ECHO10 granule metadata with the checksum (and value, if supplied).
+  Returns the updated metadata."
+  [gran-xml checksum]
+  (let [parsed (xml/parse-str gran-xml)
+        result (update-checksum parsed checksum)]
+    (println "result: " result)
+    (xml/indent-str (update-checksum parsed checksum))))
+
+(defn update-checksum
+  "Update the ECHO10 granule metadata with checksum and optional algorithm.
+  Returns the granule concept with the updated metadata."
+  [concept checksum]
+  (let [updated-metadata (update-checksum-metadata (:metadata concept) checksum)]
+    (assoc concept :metadata updated-metadata)))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/checksum/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/checksum/echo10.clj
@@ -7,6 +7,13 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.xml :as cx]))
 
+(def ^:private tags-after-data-granule
+  "Defines the element tags that come after DataGranule in ECHO10 Granule xml schema"
+  #{:PGEVersionClass :Temporal :Spatial :OrbitCalculatedSpatialDomains :MeasuredParameters
+    :Platforms :Campaigns :AdditionalAttributes :InputGranules :TwoDCoordinateSystem :Price
+    :OnlineAccessURLs :OnlineResources :Orderable :DataFormat :Visible :CloudCover
+    :MetadataStandardName :MetadataStandardVersion :AssociatedBrowseImages :AssociatedBrowseImageUrls})
+
 (def ^:private tags-after-checksum
   "Defines the element tags that come after Checksum in a DataGranule element"
   #{:ReprocessingPlanned :ReprocessingActual :ProducerGranuleId :DayNightFlag :ProductionDateTime

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -254,21 +254,21 @@
    :invalid-data [(format "Appending s3 urls is not supported for format [%s]" (:format concept))]))
 
 (defmulti update-checksum
-  "Add s3 url to the given granule concept."
+  "Add checksum to the given granule concept."
   (fn [context concept urls]
     (mt/format-key (:format concept))))
 
 (defmethod update-checksum :echo10
-  [context concept new-value]
-  (checksum-echo10/update-checksum concept new-value))
+  [context concept checksum]
+  (checksum-echo10/update-checksum concept checksum))
 
 (defmethod update-checksum :umm-json
-  [context concept urls]
+  [context concept checksum]
   (errors/throw-service-errors
    :invalid-data ["Updating checksum for UMM_JSON is coming soon!"]))
 
 (defmethod update-checksum :default
-  [context concept urls]
+  [context concept checksum]
   (errors/throw-service-errors
    :invalid-data [(format "Updating checksum is not supported for format [%s]" (:format concept))]))
 

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -259,8 +259,8 @@
     (mt/format-key (:format concept))))
 
 (defmethod update-checksum :echo10
-  [context concept urls]
-  (checksum-echo10/update-checksum concept urls))
+  [context concept new-value]
+  (checksum-echo10/update-checksum concept new-value))
 
 (defmethod update-checksum :umm-json
   [context concept urls]

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -255,7 +255,7 @@
 
 (defmulti update-checksum
   "Add checksum to the given granule concept."
-  (fn [context concept urls]
+  (fn [context concept checksum]
     (mt/format-key (:format concept))))
 
 (defmethod update-checksum :echo10

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -339,10 +339,8 @@
    context concept bulk-update-params user-id append-s3-url))
 
 (defn- modify-checksum*
-  "Modify the S3Link data for the given concept with the provided URLs
-  using the provided transform function.
-  S3 links will be added to the existing concept. If a duplicate S3 link
-  is provided it will be ignored."
+  "Add or update the checksum value and algorithm for the given concept with the provided values
+  using the provided transform function."
   [context concept bulk-update-params user-id xf]
   (let [{:keys [format metadata]} concept
         {:keys [granule-ur new-value]} bulk-update-params

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -14,6 +14,7 @@
    [cmr.ingest.data.granule-bulk-update :as data-granule-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
    [cmr.ingest.services.bulk-update-service :as bulk-update-service]
+   [cmr.ingest.services.granule-bulk-update.checksum.echo10 :as checksum-echo10]
    [cmr.ingest.services.granule-bulk-update.opendap.echo10 :as opendap-echo10]
    [cmr.ingest.services.granule-bulk-update.opendap.opendap-util :as opendap-util]
    [cmr.ingest.services.granule-bulk-update.opendap.umm-g :as opendap-umm-g]
@@ -50,10 +51,10 @@
 (defn- update->instruction
   "Returns the granule bulk update instruction for a single update item"
   [event-type item]
-  (let [[granule-ur url] item]
+  (let [[granule-ur value] item]
     {:event-type event-type
      :granule-ur granule-ur
-     :url url}))
+     :new-value value}))
 
 (defn- request->instructions
   "Returns granule bulk update instructions for the given request"
@@ -252,6 +253,25 @@
   (errors/throw-service-errors
    :invalid-data [(format "Appending s3 urls is not supported for format [%s]" (:format concept))]))
 
+(defmulti update-checksum
+  "Add s3 url to the given granule concept."
+  (fn [context concept urls]
+    (mt/format-key (:format concept))))
+
+(defmethod update-checksum :echo10
+  [context concept urls]
+  (checksum-echo10/update-checksum concept urls))
+
+(defmethod update-checksum :umm-json
+  [context concept urls]
+  (errors/throw-service-errors
+   :invalid-data ["Updating checksum for UMM_JSON is coming soon!"]))
+
+(defmethod update-checksum :default
+  [context concept urls]
+  (errors/throw-service-errors
+   :invalid-data [(format "Updating checksum is not supported for format [%s]" (:format concept))]))
+
 (defmulti update-granule-concept
   "Perform the update of the granule concept."
   (fn [context concept bulk-update-params user-id]
@@ -264,8 +284,8 @@
   Successful updates will return the updated concept."
   [context concept bulk-update-params user-id xf]
   (let [{:keys [format metadata]} concept
-        {:keys [granule-ur url]} bulk-update-params
-        grouped-urls (opendap-util/validate-url url)
+        {:keys [granule-ur new-value]} bulk-update-params
+        grouped-urls (opendap-util/validate-url new-value)
         updated-concept (xf context concept grouped-urls)
         {updated-metadata :metadata updated-format :format} updated-concept]
     (if-let [err-messages (:errors updated-metadata)]
@@ -294,8 +314,8 @@
   is provided it will be ignored."
   [context concept bulk-update-params user-id xf]
   (let [{:keys [format metadata]} concept
-        {:keys [granule-ur url]} bulk-update-params
-        urls (s3-util/validate-url url)
+        {:keys [granule-ur new-value]} bulk-update-params
+        urls (s3-util/validate-url new-value)
         ;; invoke the appropriate transform
         updated-concept (xf context concept urls)
         {updated-metadata :metadata updated-format :format} updated-concept]
@@ -317,6 +337,31 @@
   [context concept bulk-update-params user-id]
   (modify-s3-link*
    context concept bulk-update-params user-id append-s3-url))
+
+(defn- modify-checksum*
+  "Modify the S3Link data for the given concept with the provided URLs
+  using the provided transform function.
+  S3 links will be added to the existing concept. If a duplicate S3 link
+  is provided it will be ignored."
+  [context concept bulk-update-params user-id xf]
+  (let [{:keys [format metadata]} concept
+        {:keys [granule-ur new-value]} bulk-update-params
+        ;; invoke the appropriate transform - for checksum, there is only one option (update)
+        updated-concept (xf context concept new-value)
+        {updated-metadata :metadata updated-format :format} updated-concept]
+    (if-let [err-messages (:errors updated-metadata)]
+      (errors/throw-service-errors :invalid-data err-messages)
+      (-> concept
+          (assoc :metadata updated-metadata)
+          (assoc :format updated-format)
+          (update :revision-id inc)
+          (assoc :revision-date (time-keeper/now))
+          (assoc :user-id user-id)))))
+
+(defmethod update-granule-concept :update_field:checksum
+  [context concept bulk-update-params user-id]
+  (modify-checksum*
+   context concept bulk-update-params user-id update-checksum))
 
 (defmethod update-granule-concept :default
   [context concept bulk-update-params user-id]

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/checksum/echo10_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/checksum/echo10_test.clj
@@ -1,0 +1,237 @@
+(ns cmr.ingest.services.granule-bulk-update.checksum.echo10-test
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util :refer [are3]]
+   [cmr.ingest.services.granule-bulk-update.checksum.echo10 :as echo10]))
+
+(def ^:private update-value-and-algorithm
+  "ECHO10 granule for testing updating granule checksum value and algorithm."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <DataGranule>
+      <Checksum>
+        <Value>1ff38cc592c4c5d0c8e3ca38be8f1eb1</Value>
+        <Algorithm>MD5</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+    </DataGranule>
+  </Granule>")
+
+(def ^:private update-value-and-algorithm-result
+  "Result ECHO10 granule after updating granule checksum value and algorithm.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <DataGranule>
+      <Checksum>
+         <Value>foo</Value>
+         <Algorithm>bar-32</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+   </DataGranule>
+</Granule>\n")
+
+(def ^:private update-value-only
+  "ECHO10 granule for testing updating granule checksum value only."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <DataGranule>
+      <Checksum>
+        <Value>1ff38cc592c4c5d0c8e3ca38be8f1eb1</Value>
+        <Algorithm>MD5</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+    </DataGranule>
+  </Granule>")
+
+(def ^:private update-value-only-result
+  "Result ECHO10 granule after updating granule checksum value only.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <DataGranule>
+      <Checksum>
+         <Value>foo</Value>
+         <Algorithm>MD5</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+   </DataGranule>
+</Granule>\n")
+
+(def ^:private add-checksum-element
+  "ECHO10 granule for testing adding a fresh checksum element to the DataGranule element."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <DataGranule>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+    </DataGranule>
+  </Granule>")
+
+(def ^:private add-checksum-element-result
+  "Result ECHO10 granule after adding a fresh checksum element to the DataGranule element.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <DataGranule>
+      <Checksum>
+         <Value>foo</Value>
+         <Algorithm>SHA-256</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+   </DataGranule>
+</Granule>\n")
+
+(def ^:private add-checksum-element-middle
+  "ECHO10 granule for testing adding a fresh checksum element to the DataGranule element
+   between two existing values, to make sure schema order for DataGranule children is respected."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <DataGranule>
+      <SizeMBDataGranule>24.7237091064453</SizeMBDataGranule>
+      <Checksum>
+         <Value>foo</Value>
+         <Algorithm>SHA-256</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+    </DataGranule>
+  </Granule>")
+
+(def ^:private add-checksum-element-middle-result
+  "Result ECHO10 granule after adding a fresh checksum element to the DataGranule element
+   between two existing values, to make sure schema order for DataGranule children is respected.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <DataGranule>
+      <SizeMBDataGranule>24.7237091064453</SizeMBDataGranule>
+      <Checksum>
+         <Value>fooValue</Value>
+         <Algorithm>SHA-256</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+   </DataGranule>
+</Granule>\n")
+
+(def ^:private update-checksum-element-middle
+  "ECHO10 granule for testing updating checksum, when it isn't the first element in the DataGranule."
+  "<Granule>
+    <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+    <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+    <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+    <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+    </Collection>
+    <DataGranule>
+      <SizeMBDataGranule>24.7237091064453</SizeMBDataGranule>
+      <Checksum>
+         <Value>old-foo</Value>
+         <Algorithm>SHA-256</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+    </DataGranule>
+  </Granule>")
+
+(def ^:private update-checksum-element-middle-result
+  "Result ECHO10 granule after updating checksum, when it isn't the first element in the DataGranule.
+   Do not format the following as whitespace matters in the string comparison in the test."
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Granule>
+   <GranuleUR>Q2011143115400.L1A_SCI</GranuleUR>
+   <InsertTime>2011-08-26T11:10:44.490Z</InsertTime>
+   <LastUpdate>2011-08-26T16:17:55.232Z</LastUpdate>
+   <Collection>
+      <EntryId>AQUARIUS_L1A_SSS</EntryId>
+   </Collection>
+   <DataGranule>
+      <SizeMBDataGranule>24.7237091064453</SizeMBDataGranule>
+      <Checksum>
+         <Value>new-foo</Value>
+         <Algorithm>Adler-32</Algorithm>
+      </Checksum>
+      <DayNightFlag>UNSPECIFIED</DayNightFlag>
+      <ProductionDateTime>2018-02-06T19:13:22Z</ProductionDateTime>
+   </DataGranule>
+</Granule>\n")
+
+(deftest update-checksum
+  (testing "various cases of updating checksum"
+    (are3 [checksum-value source result]
+      (is (= result (#'echo10/update-checksum-metadata source checksum-value)))
+
+      "Add both value and algorithm"
+      "foo,bar-32"
+      update-value-and-algorithm
+      update-value-and-algorithm-result
+
+      "Update value only, not algorithm"
+      "foo"
+      update-value-only
+      update-value-only-result
+
+      "Add values when there is no existing Checksum element, as new first data-granule element"
+      "foo,SHA-256"
+      add-checksum-element
+      add-checksum-element-result
+
+      "Add a checksum element between two existing data-granule elements"
+      "fooValue,SHA-256"
+      add-checksum-element-middle
+      add-checksum-element-middle-result
+
+      "Update a checksum element between two existing data-granule elements"
+      "new-foo,Adler-32"
+      update-checksum-element-middle
+      update-checksum-element-middle-result)))


### PR DESCRIPTION
* Targets XML element at `Granule/DataGranule/Checksum/<Value/Algorithm>
* If one value is supplied, only value is updated. If two values are supplied, they are assigned to value and algorithm respectively
* If the granule has no `<DataGranule>` element, then the update fails.