### PR TITLE
Cmr 7489 progressive collection update

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -329,7 +329,7 @@ curl -i -XPOST -H "Content-type: application/echo10+xml" \
 
 Collection metadata can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/collections/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id). The metadata that is uploaded is validated for XML well-formedness, XML schema validation, and against UMM validation rules. Keyword validation can be enabled with the [keyword validation header](#validate-keywords-header). If there is a need to retrieve the native-id of an already-ingested collection for updating, requesting the collection via the search API in UMM-JSON format will provide the native-id.
 
-Note: we now provide progressive collection update feature, which allows a collection to be updated with non-schema related validation errors that are existing validation errors for the previous collection revision. Only newly introduced validation errors will fail the update. Schema validation errors always fail the update.
+Note: we now provide progressive collection update feature through a new configuration parameter CMR_PROGRESSIVE_UPDATE_ENABLED, which is turned on by default. It allows a collection to be updated with non-schema related validation errors that are existing validation errors for the previous collection revision. Only newly introduced validation errors will fail the update. Schema validation errors always fail the update.
 
 ```
 curl -i -XPUT \

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -329,6 +329,8 @@ curl -i -XPOST -H "Content-type: application/echo10+xml" \
 
 Collection metadata can be created or updated by sending an HTTP PUT with the metadata to the URL `%CMR-ENDPOINT%/providers/<provider-id>/collections/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id). The metadata that is uploaded is validated for XML well-formedness, XML schema validation, and against UMM validation rules. Keyword validation can be enabled with the [keyword validation header](#validate-keywords-header). If there is a need to retrieve the native-id of an already-ingested collection for updating, requesting the collection via the search API in UMM-JSON format will provide the native-id.
 
+Note: we now provide progressive collection update feature, which allows a collection to be updated with non-schema related validation errors that are existing validation errors for the previous collection revision. Only newly introduced validation errors will fail the update. Schema validation errors always fail the update.
+
 ```
 curl -i -XPUT \
   -H "Content-type: application/echo10+xml" \

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -11,12 +11,14 @@
 
 (def VALIDATE_KEYWORDS_HEADER "cmr-validate-keywords")
 (def ENABLE_UMM_C_VALIDATION_HEADER "cmr-validate-umm-c")
+(def TESTING_EXISTING_ERRORS_HEADER "cmr-test-existing-errors")
 
 (defn get-validation-options
   "Returns a map of validation options with boolean values"
   [headers]
   {:validate-keywords? (= "true" (get headers VALIDATE_KEYWORDS_HEADER))
-   :validate-umm? (= "true" (get headers ENABLE_UMM_C_VALIDATION_HEADER))})
+   :validate-umm? (= "true" (get headers ENABLE_UMM_C_VALIDATION_HEADER))
+   :test-existing-errors? (= "true" (get headers TESTING_EXISTING_ERRORS_HEADER))})
 
 (defn validate-collection
   [provider-id native-id request]

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -7,6 +7,10 @@
    [cmr.oracle.config :as oracle-config]
    [cmr.oracle.connection :as conn]))
 
+(defconfig progressive-update-enabled
+  "Flag for whether or not collection progressive update is enabled."
+  {:default true :type Boolean})
+
 (defconfig bulk-update-cleanup-minimum-age
   "The minimum age(in days) of the rows in bulk-update-task-status table that can be cleaned up"
   {:default 90

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as string]
    [cmr.common.util :refer [defn-timed]]
+   [cmr.ingest.config :as config]
    [cmr.ingest.services.helper :as ingest-helper]
    [cmr.ingest.services.ingest-service.util :as util]
    [cmr.ingest.validation.validation :as v]
@@ -46,7 +47,7 @@
          ;;   Either throw newly introduced errors for validation on sanitized collection,
          ;;   or return existing errors as warnings(it could be nil)
          ;; else
-         ;;  throw errors for validation on sanitized collection
+         ;;  throw errors for validation on sanitized collection, if there are any.
          err-warnings (v/umm-spec-validate-collection
                        sanitized-collection sanitized-prev-collection validation-options context false)
          ;; Return warnings for schema validation errors going from xml -> UMM
@@ -61,6 +62,7 @@
          warnings (concat err-warnings warnings collection-warnings)]
      ;; The sanitized UMM Spec collection is returned so that ingest does not fail
      {:collection sanitized-collection
+      :prev-collection sanitized-prev-collection
       :warnings warnings})))
 
 (defn-timed validate-and-prepare-collection
@@ -71,17 +73,33 @@
         {:keys [provider-id native-id]} concept
         prev-concept (first (ingest-helper/find-visible-collections context {:provider-id provider-id
                                                                              :native-id native-id}))
-        {:keys [collection warnings]} (validate-and-parse-collection-concept context
-                                                                             concept
-                                                                             prev-concept
-                                                                             validation-options)
+        {:keys [collection prev-collection warnings]} (validate-and-parse-collection-concept
+                                                       context
+                                                       concept
+                                                       prev-concept
+                                                       validation-options)
         ;; Add extra fields for the collection
-        coll-concept (add-extra-fields-for-collection context concept collection)]
-    ;; Validate ingest business rules through umm-spec-lib
-    (v/validate-business-rules
-     context (assoc coll-concept :umm-concept collection) prev-concept)
+        coll-concept (assoc (add-extra-fields-for-collection context concept collection)
+                            :umm-concept collection)
+        prev-coll-concept (when prev-concept
+                            (add-extra-fields-for-collection context prev-concept prev-collection))
+        
+        ;; Validate ingest business rules through umm-spec-lib
+        ;; if progressive update is enabled, and it's collection update but not bulk update, 
+        ;;  Either throw newly introduced errors or return existing errors as warnings(it could be nil)
+        ;; else
+        ;;  throw errors if there are any.
+        progressive-coll-update? (and (config/progressive-update-enabled)
+                                      (not (:bulk-update? validation-options))
+                                      prev-collection)
+        err-warnings (v/validate-business-rules
+                      context
+                      coll-concept
+                      prev-concept
+                      prev-coll-concept
+                      progressive-coll-update?)]
     {:concept coll-concept
-     :warnings warnings}))
+     :warnings (concat warnings err-warnings)}))
 
 (defn-timed save-collection
   "Store a concept in mdb and indexer.

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as string]
    [cmr.common.util :refer [defn-timed]]
+   [cmr.ingest.services.helper :as ingest-helper]
    [cmr.ingest.services.ingest-service.util :as util]
    [cmr.ingest.validation.validation :as v]
    [cmr.transmit.metadata-db :as mdb]
@@ -26,42 +27,59 @@
 (defn validate-and-parse-collection-concept
   "Validates a collection concept and parses it. Returns the UMM record and any warnings from
   validation."
-  [context collection-concept validation-options]
-  (v/validate-concept-request collection-concept)
-  (when-not (:bulk-update? validation-options)
-    (v/validate-concept-metadata collection-concept))
-  (let [{:keys [format metadata]} collection-concept
-        collection (spec/parse-metadata context :collection format metadata {:sanitize? false})
-        sanitized-collection (spec/parse-metadata context :collection format metadata)
-        ;; Throw errors for validation on sanitized collection
-        _ (v/umm-spec-validate-collection sanitized-collection validation-options context false)
-        ;; Return warnings for schema validation errors going from xml -> UMM
-        warnings (v/validate-collection-umm-spec-schema collection validation-options)
-        ;; Return warnings for validation errors on collection without sanitization
-        collection-warnings (concat
-                             (v/umm-spec-validate-collection collection validation-options context true)
-                             (v/umm-spec-validate-collection-warnings
-                              collection validation-options context))
-        collection-warnings (map #(str (:path %) " " (string/join " " (:errors %)))
-                                 collection-warnings)
-        warnings (concat warnings collection-warnings)]
-    ;; The sanitized UMM Spec collection is returned so that ingest does not fail
-    {:collection sanitized-collection
-     :warnings warnings}))
+  ([context collection-concept validation-options]
+   (validate-and-parse-collection-concept context collection-concept nil validation-options))
+  ([context collection-concept prev-concept validation-options]
+   (v/validate-concept-request collection-concept)
+   (when-not (:bulk-update? validation-options)
+     (v/validate-concept-metadata collection-concept))
+   (let [{:keys [format metadata]} collection-concept
+         collection (spec/parse-metadata context :collection format metadata {:sanitize? false})
+         sanitized-collection (spec/parse-metadata context :collection format metadata)
+         sanitized-prev-collection (when prev-concept
+                                     (spec/parse-metadata
+                                      context
+                                      :collection
+                                      (:format prev-concept)
+                                      (:metadata prev-concept)))
+         ;; if progressive update is enabled, and it's not bulk update, and pre-concept exists
+         ;;   Either throw newly introduced errors for validation on sanitized collection,
+         ;;   or return existing errors as warnings(it could be nil)
+         ;; else
+         ;;  throw errors for validation on sanitized collection
+         err-warnings (v/umm-spec-validate-collection
+                       sanitized-collection sanitized-prev-collection validation-options context false)
+         ;; Return warnings for schema validation errors going from xml -> UMM
+         warnings (v/validate-collection-umm-spec-schema collection validation-options)
+         ;; Return warnings for validation errors on collection without sanitization
+         collection-warnings (concat
+                              (v/umm-spec-validate-collection collection validation-options context true)
+                              (v/umm-spec-validate-collection-warnings
+                               collection validation-options context))
+         collection-warnings (map #(str (:path %) " " (string/join " " (:errors %)))
+                                  collection-warnings)
+         warnings (concat err-warnings warnings collection-warnings)]
+     ;; The sanitized UMM Spec collection is returned so that ingest does not fail
+     {:collection sanitized-collection
+      :warnings warnings})))
 
 (defn-timed validate-and-prepare-collection
   "Validates the collection and adds extra fields needed for metadata db. Throws a service error
   if any validation issues are found and errors are enabled, otherwise returns errors as warnings."
   [context concept validation-options]
   (let [concept (update-in concept [:format] (partial util/fix-ingest-concept-format :collection))
+        {:keys [provider-id native-id]} concept
+        prev-concept (first (ingest-helper/find-visible-collections context {:provider-id provider-id
+                                                                             :native-id native-id}))
         {:keys [collection warnings]} (validate-and-parse-collection-concept context
                                                                              concept
+                                                                             prev-concept
                                                                              validation-options)
         ;; Add extra fields for the collection
         coll-concept (add-extra-fields-for-collection context concept collection)]
     ;; Validate ingest business rules through umm-spec-lib
     (v/validate-business-rules
-     context (assoc coll-concept :umm-concept collection))
+     context (assoc coll-concept :umm-concept collection) prev-concept)
     {:concept coll-concept
      :warnings warnings}))
 

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -97,7 +97,7 @@
                       coll-concept
                       prev-concept
                       prev-coll-concept
-                      progressive-coll-update?)]
+                      (assoc validation-options :progressive-coll-update progressive-coll-update?))]
     {:concept coll-concept
      :warnings (if (some #(:existing-errors %) warnings)
                  ;; combine the existing-errors in warnings and err-warnings.

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -99,7 +99,14 @@
                       prev-coll-concept
                       progressive-coll-update?)]
     {:concept coll-concept
-     :warnings (concat warnings err-warnings)}))
+     :warnings (if (some #(:existing-errors %) warnings)
+                 ;; combine the existing-errors in warnings and err-warnings.
+                 (map #(if (:existing-errors %)
+                         (assoc % :existing-errors (concat (:existing-errors %)
+                                                           (:existing-errors (first err-warnings))))
+                         %)
+                      warnings)
+                 (concat warnings err-warnings))}))
 
 (defn-timed save-collection
   "Store a concept in mdb and indexer.

--- a/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
@@ -42,7 +42,6 @@
     (when concept-id
       (let [mdb-concept-id (mdb/get-concept-id context concept-type provider-id native-id false)]
         (when (and mdb-concept-id (not= concept-id mdb-concept-id))
-          ;; progressive-coll-update doesn't apply to this case.
           [(format "Concept-id [%s] does not match the existing concept-id [%s] for native-id [%s]"
                    concept-id mdb-concept-id native-id)])))))
 
@@ -88,8 +87,6 @@
                                (map (partial has-granule-search-error context))
                                (remove nil?))]
         (when (seq search-errors)
-          ;; progressive-coll-update doesn't apply to this case - any collection update that breaks the
-          ;; collection-granule relationship rules introduces new error.
           search-errors)))))
 
 (def business-rule-validations

--- a/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
@@ -19,29 +19,35 @@
 
 (defn- version-is-not-nil-validation
   "Validates that the version is not nil"
-  [_ concept]
-  (when (nil? (get-in concept [:extra-fields :version-id]))
-    ["Version is required."]))
+  ([_ concept]
+   (version-is-not-nil-validation nil concept nil))
+  ([_ concept _]
+   (when (nil? (get-in concept [:extra-fields :version-id]))
+     ["Version is required."])))
 
 (defn delete-time-validation
   "Validates the concept delete-time.
   Returns error if the delete time exists and is before one minute from the current time."
-  [_ concept]
-  (let [delete-time (get-in concept [:extra-fields :delete-time])]
-    (when (some-> delete-time
-                  p/parse-datetime
-                  (t/before? (t/plus (tk/now) (t/minutes 1))))
-      [(format "DeleteTime %s is before the current time." delete-time)])))
+  ([_ concept]
+   (delete-time-validation nil concept nil))
+  ([_ concept _]
+   (let [delete-time (get-in concept [:extra-fields :delete-time])]
+     (when (some-> delete-time
+                   p/parse-datetime
+                   (t/before? (t/plus (tk/now) (t/minutes 1))))
+       [(format "DeleteTime %s is before the current time." delete-time)]))))
 
 (defn- concept-id-validation
   "Validates the concept-id if provided matches the metadata-db concept-id for the concept native-id"
-  [context concept]
-  (let [{:keys [concept-type provider-id native-id concept-id]} concept]
-    (when concept-id
-      (let [mdb-concept-id (mdb/get-concept-id context concept-type provider-id native-id false)]
-        (when (and mdb-concept-id (not= concept-id mdb-concept-id))
-          [(format "Concept-id [%s] does not match the existing concept-id [%s] for native-id [%s]"
-                   concept-id mdb-concept-id native-id)])))))
+  ([context concept]
+   (concept-id-validation context concept nil))
+  ([context concept _]
+   (let [{:keys [concept-type provider-id native-id concept-id]} concept]
+     (when concept-id
+       (let [mdb-concept-id (mdb/get-concept-id context concept-type provider-id native-id false)]
+         (when (and mdb-concept-id (not= concept-id mdb-concept-id))
+           [(format "Concept-id [%s] does not match the existing concept-id [%s] for native-id [%s]"
+                    concept-id mdb-concept-id native-id)]))))))
 
 (def collection-update-searches
   "Defines a list of functions that take the context, concept-id, updated UMM concept and the
@@ -73,21 +79,21 @@
 
 (defn- collection-update-validation
   "Validate collection update does not invalidate any existing granules."
-  [context concept]
-  (let [{:keys [provider-id extra-fields umm-concept native-id]} concept
-        {:keys [entry-title]} extra-fields
-        prev-concept (first (h/find-visible-collections context {:provider-id provider-id
-                                                                 :native-id native-id}))]
-    (when prev-concept
-      (let [prev-umm-concept (spec/parse-metadata context prev-concept)
-            has-granule-searches (mapcat
-                                  #(% context (:concept-id prev-concept) umm-concept prev-umm-concept)
-                                  collection-update-searches)
-            search-errors (->> has-granule-searches
-                               (map (partial has-granule-search-error context))
-                               (remove nil?))]
-        (when (seq search-errors)
-          search-errors)))))
+  ([context concept]
+   (collection-update-validation context concept nil))
+  ([context concept prev-concept]
+   (let [{:keys [extra-fields umm-concept]} concept
+         {:keys [entry-title]} extra-fields]
+     (when prev-concept
+       (let [prev-umm-concept (spec/parse-metadata context prev-concept)
+             has-granule-searches (mapcat
+                                   #(% context (:concept-id prev-concept) umm-concept prev-umm-concept)
+                                   collection-update-searches)
+             search-errors (->> has-granule-searches
+                                (map (partial has-granule-search-error context))
+                                (remove nil?))]
+         (when (seq search-errors)
+           search-errors))))))
 
 (def business-rule-validations
   "A map of concept-type to the list of the functions that validates concept ingest business rules."

--- a/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
@@ -21,7 +21,7 @@
   "Validates that the version is not nil"
   [_ concept _]
   (when (nil? (get-in concept [:extra-fields :version-id]))
-     ["Version is required."]))
+    ["Version is required."]))
 
 (defn delete-time-validation
   "Validates the concept delete-time.
@@ -43,8 +43,8 @@
       (let [mdb-concept-id (mdb/get-concept-id context concept-type provider-id native-id false)]
         (when (and mdb-concept-id (not= concept-id mdb-concept-id))
           ;; progressive-coll-update doesn't apply to this case.
-          {:errors [(format "Concept-id [%s] does not match the existing concept-id [%s] for native-id [%s]"
-                             concept-id mdb-concept-id native-id)]})))))
+          [(format "Concept-id [%s] does not match the existing concept-id [%s] for native-id [%s]"
+                   concept-id mdb-concept-id native-id)])))))
 
 (def collection-update-searches
   "Defines a list of functions that take the context, concept-id, updated UMM concept and the
@@ -90,7 +90,7 @@
         (when (seq search-errors)
           ;; progressive-coll-update doesn't apply to this case - any collection update that breaks the
           ;; collection-granule relationship rules introduces new error.
-          {:errors search-errors})))))
+          search-errors)))))
 
 (def business-rule-validations
   "A map of concept-type to the list of the functions that validates concept ingest business rules."

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -15,6 +15,7 @@
     [cmr.ingest.services.humanizer-alias-cache :as humanizer-alias-cache]
     [cmr.ingest.services.messages :as msg]
     [cmr.ingest.validation.business-rule-validation :as bv]
+    [cmr.transmit.config :as transmit-config]
     [cmr.transmit.search :as transmit-search]
     [cmr.umm-spec.json-schema :as json-schema]
     [cmr.umm-spec.umm-json :as umm-json]
@@ -200,6 +201,8 @@
                 (not (:bulk-update? validation-options)) 
                 prev-collection)
          (let [prev-err-messages (if (and (:test-existing-errors? validation-options)
+                                          ;; double check to make sure only the local and ci tests can use the header.
+                                          (transmit-config/echo-system-token? context)
                                           (= "mock-echo-system-token" (:token context)))
                                    ;; We can't really test the case when the errors are existing errors
                                    ;; because we can't ingest invalid collections into the system.

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -208,7 +208,7 @@
             (if new-err-messages
               (errors/throw-service-errors :invalid-data new-err-messages)
               ;; when there is no newly introduced errors, err-messages contains only existing errors.
-              [{:existing-errors err-messages}]))
+              [{:existing-errors (map #(str (:path %) " " (:errors %)) err-messages)}]))
          (errors/throw-service-errors :invalid-data err-messages))
        (do
          (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))

--- a/system-int-test/src/cmr/system_int_test/data2/core.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/core.clj
@@ -155,6 +155,7 @@
                                           :user-id
                                           :validate-keywords
                                           :validate-umm-c
+                                          :test-existing-errors
                                           :accept-format
                                           :warnings]))
          status (:status response)]

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -363,13 +363,14 @@
    (ingest-concept concept {}))
   ([concept options]
    (let [{:keys [metadata format concept-type concept-id revision-id provider-id native-id]} concept
-         {:keys [token client-id user-id validate-keywords validate-umm-c cmr-request-id x-request-id]} options
+         {:keys [token client-id user-id validate-keywords validate-umm-c cmr-request-id x-request-id test-existing-errors]} options
          accept-format (:accept-format options)
          method (get options :method :put)
          headers (util/remove-nil-keys {"Cmr-Concept-id" concept-id
                                         "Cmr-Revision-id" revision-id
                                         "Cmr-Validate-Keywords" validate-keywords
                                         "Cmr-Validate-Umm-C" validate-umm-c
+                                        "Cmr-Test-Existing-Errors" test-existing-errors
                                         "Echo-Token" token
                                         "User-Id" user-id
                                         "Client-Id" client-id

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
@@ -1,0 +1,89 @@
+(ns cmr.system-int-test.ingest.collection-progressive-update-test
+  "CMR Ingest collection progressive update integration tests"
+  (:require
+    [clj-time.core :as time-core]
+    [clojure.string :as string]
+    [clojure.test :refer :all]
+    [cmr.common.date-time-parser :as date-time-parser]
+    [cmr.common.util :as u :refer [are3]]
+    [cmr.system-int-test.data2.core :as data-core]
+    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
+    [cmr.system-int-test.utils.index-util :as index]
+    [cmr.system-int-test.utils.ingest-util :as ingest]
+    [cmr.umm-spec.models.umm-collection-models :as umm-c]
+    [cmr.umm-spec.models.umm-common-models :as umm-cmn]
+    [cmr.umm.umm-spatial :as umm-s]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}))
+
+(deftest collection-progressive-update-test 
+  (testing "Invalid additional attributes, temporal extents and data dates"
+    (let [coll (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                              {:EntryTitle "ERS-2_LEVEL0"
+                                                               :ShortName "ERS-2_L0"
+                                                               :Version "1"}))]
+      (index/wait-until-indexed)
+      (testing "Progressive update collection successful case - mimic existing errors"
+        (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
+              temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
+                                        :ending-date-time "2000-05-11T12:00:00Z"})]
+              data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2032) :Type "DELETE"})]
+              ;; when :test-existing-errors set to true, it's mimcing the case when the previous revision collection
+              ;; has the same validation errors as the current collection, which allows invalid collection to be ingested.
+              options {:test-existing-errors true}
+              response (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                                      {:EntryTitle "ERS-2_LEVEL0"
+                                                                       :ShortName "ERS-2_L0"
+                                                                       :Version "1"
+                                                                       :AdditionalAttributes additional-attributes
+                                                                       :TemporalExtents temporal-extents
+                                                                       :DataDates data-dates}
+                                                                      )
+                                                                      options)
+              expected-warnings "After translating item to UMM-C the metadata had the following issue: {:existing-errors (\"[:TemporalExtents 0 :RangeDateTimes 0] [\\\"BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]\\\"]\" \"[:AdditionalAttributes 0] [\\\"Parameter Range Begin is not allowed for type [STRING]\\\" \\\"Parameter Range End is not allowed for type [STRING]\\\"]\")}. [:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]. [:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING] Parameter Range End is not allowed for type [STRING]" 
+              {:keys [errors warnings concept-id revision-id]} response]
+          (is (= concept-id (:concept-id coll)))
+          (is (= revision-id (+ 1 (:revision-id coll))))
+          (is (= nil errors))
+          (is (= expected-warnings warnings))))
+
+        (testing "Progressive update collection successful case, real existing errors"
+        (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
+              temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
+                                        :ending-date-time "2000-05-11T12:00:00Z"})]
+              data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2032) :Type "DELETE"})]
+              ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors. 
+              response (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                                      {:EntryTitle "ERS-2_LEVEL0"
+                                                                       :ShortName "ERS-2_L0"
+                                                                       :Version "1"
+                                                                       :AdditionalAttributes additional-attributes
+                                                                       :TemporalExtents temporal-extents
+                                                                       :DataDates data-dates}
+                                                                      ))
+              expected-warnings "After translating item to UMM-C the metadata had the following issue: {:existing-errors (\"[:TemporalExtents 0 :RangeDateTimes 0] [\\\"BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]\\\"]\" \"[:AdditionalAttributes 0] [\\\"Parameter Range Begin is not allowed for type [STRING]\\\" \\\"Parameter Range End is not allowed for type [STRING]\\\"]\")}. [:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]. [:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING] Parameter Range End is not allowed for type [STRING]"
+              {:keys [errors warnings concept-id revision-id]} response]
+          (is (= concept-id (:concept-id coll)))
+          (is (= revision-id (+ 2 (:revision-id coll))))
+          (is (= nil errors))
+          (is (= expected-warnings warnings))))
+        
+        (testing "Progressive update collection failed case, introducing new data-dates errors"
+        (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
+              temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
+                                        :ending-date-time "2000-05-11T12:00:00Z"})]
+              data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2000) :Type "DELETE"})]
+              ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors.
+              response (try (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                                      {:EntryTitle "ERS-2_LEVEL0"
+                                                                       :ShortName "ERS-2_L0"
+                                                                       :Version "1"
+                                                                       :AdditionalAttributes additional-attributes
+                                                                       :TemporalExtents temporal-extents
+                                                                       :DataDates data-dates}
+                                                                      ))
+                         (catch Exception e
+                           (.toString e)))
+              exception "java.lang.Exception: Ingest failed when expected to succeed: {:errors (\"DeleteTime 2000-01-01T00:00:00.000Z is before the current time.\"), :status 422}"]
+              (is (= response exception)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
@@ -79,4 +79,4 @@
                            (catch Exception e
                              (.toString e)))
                 exception "java.lang.Exception: Ingest failed when expected to succeed: {:errors (\"DeleteTime 2000-01-01T00:00:00.000Z is before the current time.\"), :status 422}"]
-                (is (= response exception)))))))
+            (is (= response exception)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_progressive_update_test.clj
@@ -2,23 +2,19 @@
   "CMR Ingest collection progressive update integration tests"
   (:require
     [clj-time.core :as time-core]
-    [clojure.string :as string]
     [clojure.test :refer :all]
-    [cmr.common.date-time-parser :as date-time-parser]
-    [cmr.common.util :as u :refer [are3]]
     [cmr.system-int-test.data2.core :as data-core]
     [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
     [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
     [cmr.system-int-test.utils.index-util :as index]
     [cmr.system-int-test.utils.ingest-util :as ingest]
-    [cmr.umm-spec.models.umm-collection-models :as umm-c]
-    [cmr.umm-spec.models.umm-common-models :as umm-cmn]
-    [cmr.umm.umm-spatial :as umm-s]))
+    [cmr.umm-spec.models.umm-common-models :as umm-cmn]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}))
 
 (deftest collection-progressive-update-test 
   (testing "Invalid additional attributes, temporal extents and data dates"
+    ;; first ingest a valid collection.
     (let [coll (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
                                                               {:EntryTitle "ERS-2_LEVEL0"
                                                                :ShortName "ERS-2_L0"
@@ -27,19 +23,18 @@
       (testing "Progressive update collection successful case - mimic existing errors"
         (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
               temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
-                                        :ending-date-time "2000-05-11T12:00:00Z"})]
+                                                               :ending-date-time "2000-05-11T12:00:00Z"})]
               data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2032) :Type "DELETE"})]
-              ;; when :test-existing-errors set to true, it's mimcing the case when the previous revision collection
+              ;; when :test-existing-errors set to true and the token is mock-echo-system-token, it's mimcing the case when the previous revision collection
               ;; has the same validation errors as the current collection, which allows invalid collection to be ingested.
-              options {:test-existing-errors true}
+              options {:test-existing-errors true :token "mock-echo-system-token"}
               response (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
                                                                       {:EntryTitle "ERS-2_LEVEL0"
                                                                        :ShortName "ERS-2_L0"
                                                                        :Version "1"
                                                                        :AdditionalAttributes additional-attributes
                                                                        :TemporalExtents temporal-extents
-                                                                       :DataDates data-dates}
-                                                                      )
+                                                                       :DataDates data-dates})
                                                                       options)
               expected-warnings "After translating item to UMM-C the metadata had the following issue: {:existing-errors (\"[:TemporalExtents 0 :RangeDateTimes 0] [\\\"BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]\\\"]\" \"[:AdditionalAttributes 0] [\\\"Parameter Range Begin is not allowed for type [STRING]\\\" \\\"Parameter Range End is not allowed for type [STRING]\\\"]\")}. [:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]. [:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING] Parameter Range End is not allowed for type [STRING]" 
               {:keys [errors warnings concept-id revision-id]} response]
@@ -49,41 +44,39 @@
           (is (= expected-warnings warnings))))
 
         (testing "Progressive update collection successful case, real existing errors"
-        (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
-              temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
-                                        :ending-date-time "2000-05-11T12:00:00Z"})]
-              data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2032) :Type "DELETE"})]
-              ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors. 
-              response (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                                                      {:EntryTitle "ERS-2_LEVEL0"
-                                                                       :ShortName "ERS-2_L0"
-                                                                       :Version "1"
-                                                                       :AdditionalAttributes additional-attributes
-                                                                       :TemporalExtents temporal-extents
-                                                                       :DataDates data-dates}
-                                                                      ))
-              expected-warnings "After translating item to UMM-C the metadata had the following issue: {:existing-errors (\"[:TemporalExtents 0 :RangeDateTimes 0] [\\\"BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]\\\"]\" \"[:AdditionalAttributes 0] [\\\"Parameter Range Begin is not allowed for type [STRING]\\\" \\\"Parameter Range End is not allowed for type [STRING]\\\"]\")}. [:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]. [:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING] Parameter Range End is not allowed for type [STRING]"
-              {:keys [errors warnings concept-id revision-id]} response]
-          (is (= concept-id (:concept-id coll)))
-          (is (= revision-id (+ 2 (:revision-id coll))))
-          (is (= nil errors))
-          (is (= expected-warnings warnings))))
+          (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
+                temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
+                                                                 :ending-date-time "2000-05-11T12:00:00Z"})]
+                data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2032) :Type "DELETE"})]
+                ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors.
+                response (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                                        {:EntryTitle "ERS-2_LEVEL0"
+                                                                         :ShortName "ERS-2_L0"
+                                                                         :Version "1"
+                                                                         :AdditionalAttributes additional-attributes
+                                                                         :TemporalExtents temporal-extents
+                                                                         :DataDates data-dates}))
+                expected-warnings "After translating item to UMM-C the metadata had the following issue: {:existing-errors (\"[:TemporalExtents 0 :RangeDateTimes 0] [\\\"BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]\\\"]\" \"[:AdditionalAttributes 0] [\\\"Parameter Range Begin is not allowed for type [STRING]\\\" \\\"Parameter Range End is not allowed for type [STRING]\\\"]\")}. [:TemporalExtents 0 :RangeDateTimes 0] BeginningDateTime [2001-01-01T12:00:00.000Z] must be no later than EndingDateTime [2000-05-11T12:00:00.000Z]. [:AdditionalAttributes 0] Parameter Range Begin is not allowed for type [STRING] Parameter Range End is not allowed for type [STRING]"
+                {:keys [errors warnings concept-id revision-id]} response]
+            (is (= concept-id (:concept-id coll)))
+            (is (= revision-id (+ 2 (:revision-id coll))))
+            (is (= nil errors))
+            (is (= expected-warnings warnings))))
         
         (testing "Progressive update collection failed case, introducing new data-dates errors"
-        (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
-              temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
-                                        :ending-date-time "2000-05-11T12:00:00Z"})]
-              data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2000) :Type "DELETE"})]
-              ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors.
-              response (try (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                                                      {:EntryTitle "ERS-2_LEVEL0"
-                                                                       :ShortName "ERS-2_L0"
-                                                                       :Version "1"
-                                                                       :AdditionalAttributes additional-attributes
-                                                                       :TemporalExtents temporal-extents
-                                                                       :DataDates data-dates}
-                                                                      ))
-                         (catch Exception e
-                           (.toString e)))
-              exception "java.lang.Exception: Ingest failed when expected to succeed: {:errors (\"DeleteTime 2000-01-01T00:00:00.000Z is before the current time.\"), :status 422}"]
-              (is (= response exception)))))))
+          (let [additional-attributes [(data-umm-cmn/additional-attribute {:Name "int" :DataType "STRING" :ParameterRangeBegin 1 :ParameterRangeEnd 10})]
+                temporal-extents [(data-umm-cmn/temporal-extent {:beginning-date-time "2001-01-01T12:00:00Z"
+                                                                 :ending-date-time "2000-05-11T12:00:00Z"})]
+                data-dates [(umm-cmn/map->DateType {:Date (time-core/date-time 2000) :Type "DELETE"})]
+                ;; now that the previous concept containing validation errors, we don't need to pass options to mimic existing errors.
+                response (try (data-core/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
+                                                                             {:EntryTitle "ERS-2_LEVEL0"
+                                                                              :ShortName "ERS-2_L0"
+                                                                              :Version "1"
+                                                                              :AdditionalAttributes additional-attributes
+                                                                              :TemporalExtents temporal-extents
+                                                                              :DataDates data-dates}))
+                           (catch Exception e
+                             (.toString e)))
+                exception "java.lang.Exception: Ingest failed when expected to succeed: {:errors (\"DeleteTime 2000-01-01T00:00:00.000Z is before the current time.\"), :status 422}"]
+                (is (= response exception)))))))


### PR DESCRIPTION
Ingest validations include 3 parts: 1. Schema validation, 2. umm-spec collection validation 3. Business rule validation.  Out of these 3 validations, we now allow the users to update a collection with #2 and #3 validation errors, if these errors exist in the previous revision collection. If new validation errors are introduced, the update will fail. Updates with schema validation errors, existing or new, will always fail. 