### PR TITLE
CMR-7450: As a CMR Operator, I need the logs to emit enough identifying token information to help with troubleshooting

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -962,13 +962,17 @@
 
 (defn scrub-token
   "Scrub token:
-  1. When at least 15 chars long keep the first and the last 5 chars.
-  2. When at least 5 and no more than 14 chars long, remove last 5.
-  3. When less than 5 chars long, remove all chars.
-  4. Replace what's removed with XXX."
+  1. When at least 25 chars long keep the first 10 chars and the last 5 chars.
+  2. When at least 15 chars long keep the first and the last 5 chars.
+  3. When at least 5 and no more than 14 chars long, remove last 5.
+  4. When less than 5 chars long, remove all chars.
+  5. Replace what's removed with XXX."
   [token]
   (let [token-length (count token)]
     (cond
+      (>= token-length 25) (str (subs token 0 10)
+                                "XXX"
+                                (subs token (- token-length 5) token-length))
       (>= token-length 15) (str (subs token 0 5)
                                 "XXX"
                                 (subs token (- token-length 5) token-length))

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -5,6 +5,7 @@
    [clj-time.core :as t]
    [clojure.string :as s]
    [cmr.common.date-time-parser :as date-time-parser]
+   [cmr.common.log :refer [info]]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
@@ -50,6 +51,8 @@
                                             {:headers {"Accept" mt/json
                                                        "Echo-Token" (transmit-config/echo-system-token)}
                                              :form-params {:id token}})]
+
+      (info (format "get_token_info called with token [%s]" (common-util/scrub-token token)))
       (case (int status)
         200 (let [expires (some-> (get-in parsed [:token_info :expires])
                                   date-time-parser/parse-datetime)]

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -52,7 +52,7 @@
                                                        "Echo-Token" (transmit-config/echo-system-token)}
                                              :form-params {:id token}})]
 
-      (info (format "get_token_info call on token [%s] returned with status [%s]"
+      (info (format "get_token_info call on token [%s] (partially redacted) returned with status [%s]"
                     (common-util/scrub-token token) status))
       (case (int status)
         200 (let [expires (some-> (get-in parsed [:token_info :expires])
@@ -62,7 +62,7 @@
                 (get-in parsed [:token_info :user_name])
                 (errors/throw-service-error
                   :unauthorized
-                  (format "Token [%s] has expired. Note the token value has been partially redacted." 
+                  (format "Token [%s] has expired. Note the token value has been partially redacted."
                           (common-util/scrub-token token)))))
         401 (errors/throw-service-errors
               :unauthorized

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -52,7 +52,8 @@
                                                        "Echo-Token" (transmit-config/echo-system-token)}
                                              :form-params {:id token}})]
 
-      (info (format "get_token_info called with token [%s]" (common-util/scrub-token token)))
+      (info (format "get_token_info call on token [%s] returned with status [%s]"
+                    (common-util/scrub-token token) status))
       (case (int status)
         200 (let [expires (some-> (get-in parsed [:token_info :expires])
                                   date-time-parser/parse-datetime)]


### PR DESCRIPTION
For context - Legacy-Services used to emit the token into the logs outright, but those were redacted for security purposes. Due to the restrictive rails 3 build these were emitted under, a partially-redacted solution was unattainable. So, instead, we will log this info from the CMR side.