### PR TITLE
adding a third level to the keyword output of related urls

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
@@ -42,7 +42,7 @@
    :measurement-name [:context-medium :object :quantity]
    :concepts [:short-name]
    :iso-topic-categories [:iso-topic-category]
-   :related-urls [:type :subtype]
+   :related-urls [:url-content-type :type :subtype]
    :granule-data-format [:short-name :uuid]})
 
 (def FIELD_NOT_PRESENT

--- a/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/keyword_endpoint_test.clj
@@ -316,6 +316,146 @@
                          "uuid" "027dee16-b361-481e-868d-add966eb5b71"}
                         {"value" "Daily Climatology",
                          "uuid" "f86e464a-cf9d-4e15-a39b-501855d1dc5a"}]}
+   :related-urls {"url_content_type"
+                [{"value" "VisualizationURL"
+                  "uuid" "87764ebf-992b-4ef7-b760-91d5e0ae9a37"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "GET RELATED VISUALIZATION"
+                    "uuid" "dd2adc64-c7bd-4dbf-976b-f0496966817c"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "WORLDVIEW" "uuid" "eeff646c-6faf-468e-a0ab-ff78fc6f86f9"}
+                     {"value" "MAP" "uuid" "e6f9524a-e4bc-460a-bdf3-a5e8f0e921a9"}
+                     {"value" "GIOVANNI" "uuid" "690210ef-4cf8-4645-b68d-921466bba6a2"}
+                     {"value" "SOTO" "uuid" "389ab1cf-fbf4-49ee-bf22-e40643fa00f6"}]}]}
+                 {"value" "DistributionURL"
+                  "uuid" "eb6586b7-2d3e-44e9-b8f6-e8b11549f4a1"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "GET CAPABILITIES"
+                    "uuid" "2892b502-2c66-42d5-af3d-bcddb57d9195"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "GIBS" "uuid" "ca5440d6-a9e4-416b-8e35-c4769f664b95"}
+                     {"value" "OpenSearch" "uuid" "09c6e3ea-f8e0-4052-8b41-c3b1269799ed"}]}
+                   {"value" "GET DATA VIA DIRECT ACCESS"
+                    "uuid" "172cd72d-30d3-4795-8660-dc38820faba0"}
+                   {"value" "USE SERVICE API"
+                    "uuid" "d117cf5c-8d23-4662-be62-7b883cecb219"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "OpenSearch" "uuid" "89b80cbd-027f-4eab-823f-ae00c268f5bf"}
+                     {"value" "WEB MAP TILE SERVICE (WMTS)" "uuid" "7aac9f91-20c4-4234-9153-e850c8ace8a9"}
+                     {"value" "SERVICE CHAINING" "uuid" "411d2781-822c-4c48-8d5b-4b51b100ce0a"}
+                     {"value" "WEB COVERAGE SERVICE (WCS)" "uuid" "029540bb-7f5c-44ba-8578-61e2f858be60"}
+                     {"value" "GRADS DATA SERVER (GDS)" "uuid" "5c0cd574-0255-4202-9b5b-3da8711b7ed7"}
+                     {"value" "MAP SERVICE" "uuid" "0c3aa5c6-f1f9-4c16-aa96-30672028d26c"}
+                     {"value" "OPENDAP DATA" "uuid" "eae7a041-b004-48df-8d4e-d758969e3185"}
+                     {"value" "WEB FEATURE SERVICE (WFS)" "uuid" "c4d406e6-7a34-42aa-bd79-f7f9265cc7bd"}
+                     {"value" "THREDDS DATA" "uuid" "77cae7cb-4676-4c69-a88b-d78971496f97"}
+                     {"value" "WEB MAP SERVICE (WMS)" "uuid" "b0e2089c-3c1d-4c12-b833-e07365a4038e"}
+                     {"value" "TABULAR DATA STREAM (TDS)" "uuid" "7b664934-70c4-4694-b8c1-416e7c91afb9"}]}
+                   {"value" "DOWNLOAD SOFTWARE"
+                    "uuid" "ca8b62c9-5f31-40bd-92a9-8d30081309e2"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "MOBILE APP" "uuid" "5fedeefd-2609-488c-a897-fe168cae34dd"}]}
+                   {"value" "GOTO WEB TOOL"
+                    "uuid" "ffccf1c0-f25d-4747-ac4a-f09444383031"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "LIVE ACCESS SERVER (LAS)" "uuid" "20ab6d52-f5a7-439c-a044-6ef2452a2838"}
+                     {"value" "SUBSETTER" "uuid" "bf37a20c-8e99-4187-b91b-3ea254f006f9"}
+                     {"value" "HITIDE" "uuid" "a7225578-b398-4222-a7a0-8f5175338ddf"}
+                     {"value" "MAP VIEWER" "uuid" "c1c61697-b4bd-467c-9db4-5bd0115545a3"}
+                     {"value" "SIMPLE SUBSET WIZARD (SSW)" "uuid" "6ffc54ea-001a-4c03-afff-5086b2da8f59"}]}
+                   {"value" "GET DATA" "uuid" "750f6c61-0f15-4185-94d8-c029dec04bc5"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "GIOVANNI" "uuid" "2e869d22-88fe-43dc-852d-9f50c911ad02"}
+                     {"value" "NOAA CLASS" "uuid" "a36f1716-a310-41f5-b4d8-6c6a5fc933d9"}
+                     {"value" "MIRADOR" "uuid" "9b05d2a3-9a5a-425c-b6ed-59e0e56814fa"}
+                     {"value" "USGS EARTH EXPLORER" "uuid" "4485a5b6-d84c-4c98-980e-164863ca518f"}
+                     {"value" "Subscribe" "uuid" "38219044-ad26-4a32-98c0-dca8ad3cd29a"}
+                     {"value" "CERES Ordering Tool" "uuid" "93bc7186-2634-49ae-a8da-312d893ef15e"}
+                     {"value" "Earthdata Search" "uuid" "5b8013bb-0b15-4811-8aa3-bfc108c3a041"}
+                     {"value" "Sub-Orbital Order Tool" "uuid" "459decfe-53ee-41ce-b608-d7578b04ef7b"}
+                     {"value" "DATA TREE" "uuid" "3c2a68a6-d8c2-4f14-8208-e57a4446ad71"}
+                     {"value" "Order" "uuid" "bd91340d-a8b3-4c01-b262-71e50fe69c83"}
+                     {"value" "LAADS" "uuid" "0b50c12d-a6ae-4d63-b42b-d99bf7aa2da0"}
+                     {"value" "DATACAST URL" "uuid" "2fc3797c-71b5-4d01-8ae1-d5634ec625ce"}
+                     {"value" "LANCE" "uuid" "aa11ac15-3042-4634-b47e-acc368f608bd"}
+                     {"value" "VIRTUAL COLLECTION" "uuid" "78d28911-a87c-40a0-ada2-c14f7cfb0834"}
+                     {"value" "MODAPS" "uuid" "26431afd-cb37-4772-9e97-3a36f6dff32d"}
+                     {"value" "PORTAL" "uuid" "49be0345-a6af-4608-98d8-9b2343e60077"}
+                     {"value" "IceBridge Portal" "uuid" "3c60609c-d48d-47c4-b069-43951fa0aea3"}
+                     {"value" "APPEEARS" "uuid" "6b8f0bfc-d9a4-4af1-9d94-6dcfade03bda"}
+                     {"value" "DATA COLLECTION BUNDLE" "uuid" "444f03b4-e588-42da-aee6-73028f3c45be"}
+                     {"value" "NOMADS" "uuid" "b434314f-949f-4c26-be57-2ea4c7f03643"}
+                     {"value" "VERTEX" "uuid" "5520d1de-f7f5-4798-9ebc-698885805489"}
+                     {"value" "DIRECT DOWNLOAD" "uuid" "8e33a2dd-df13-4079-8636-391abb5344c6"}
+                     {"value" "GoLIVE Portal" "uuid" "9bfb0f20-189e-411b-a678-768bf3fa256e"}
+                     {"value" "EOSDIS DATA POOL" "uuid" "3779ec72-c1e0-4a0f-aff8-8e2a2a7af486"}]}]}
+                 {"value" "PublicationURL"
+                  "uuid" "d75c66ca-d76c-4574-95fe-22505d6d00eb"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "VIEW RELATED INFORMATION"
+                    "uuid" "5ec1bb9d-0efc-4099-9b31-ec791bbd8145"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "PI DOCUMENTATION" "uuid" "367f8b8a-e57e-4c49-b971-0b5c6a484186"}
+                     {"value" "USER'S GUIDE" "uuid" "d1996d91-e824-4b24-b94e-3aae4543b63b"}
+                     {"value" "PRODUCTION HISTORY" "uuid" "0b597285-eaac-4cbd-94cc-d87ae8046681"}
+                     {"value" "PRODUCT USAGE" "uuid" "1132a0fc-888b-4332-ad0a-dc5c6e615afa"}
+                     {"value" "DELIVERABLES CHECKLIST" "uuid" "be0460d8-ca8e-45c8-b637-8fb4ce5a5e97"}
+                     {"value" "ANOMALIES" "uuid" "914cbb7e-5b20-4bcd-86e3-ffcfa26f0a73"}
+                     {"value" "MICRO ARTICLE" "uuid" "4f3c0b04-1fe6-4e11-994a-9cc4afd09ce0"}
+                     {"value" "DATA QUALITY" "uuid" "0eba3253-8eb7-4e43-9627-9cff48775e27"}
+                     {"value" "SCIENCE DATA PRODUCT VALIDATION" "uuid" "15b0a4c4-b39d-48f5-92d2-905e45e6dc6a"}
+                     {"value" "ALGORITHM THEORETICAL BASIS DOCUMENT (ATBD)" "uuid" "fd01f7ec-fdf6-4440-b974-75f12fb4ec5f"}
+                     {"value" "DATA RECIPE" "uuid" "547600e9-b60a-44eb-b14b-5c6e1f2c094e"}
+                     {"value" "CASE STUDY" "uuid" "3112d474-b44f-4af1-8266-c3dd6d28220f"}
+                     {"value" "READ-ME" "uuid" "aa3cea98-b20a-4de8-8f22-7a8b30784625"}
+                     {"value" "HOW-TO" "uuid" "7ebd73e5-b0aa-4cf2-ace5-1d3890c2c3ce"}
+                     {"value" "PRODUCT QUALITY ASSESSMENT" "uuid" "b7ed88ce-3f04-40ea-863e-ac58bd048ff3"}
+                     {"value" "INSTRUMENT/SENSOR CALIBRATION DOCUMENTATION" "uuid" "fc3c1abb-92c1-49c2-90d4-161c70cff44a"}
+                     {"value" "SCIENCE DATA PRODUCT SOFTWARE DOCUMENTATION" "uuid" "e8e6e972-832f-4501-a721-4108f33332d6"}
+                     {"value" "REQUIREMENTS AND DESIGN" "uuid" "86b8b121-d710-4c5b-84b0-7b40717f6c76"}
+                     {"value" "USER FEEDBACK PAGE" "uuid" "ab2fce71-e5f9-4ba6-bfb1-bc428a8b7dd8"}
+                     {"value" "IMPORTANT NOTICE" "uuid" "2af2cfc4-9390-43da-8fa8-1f272e8ee0b0"}
+                     {"value" "PUBLICATIONS" "uuid" "13a4deec-bd22-4864-9804-77fac181f484"}
+                     {"value" "GENERAL DOCUMENTATION" "uuid" "aebf20eb-39c7-4f4f-aecf-a628f703867b"}
+                     {"value" "PRODUCT HISTORY" "uuid" "b292f51f-d2b4-4e65-84a9-e50306238989"}
+                     {"value" "DATA PRODUCT SPECIFICATION" "uuid" "415cfe86-4d71-4100-8f35-6404caec1c91"}
+                     {"value" "PROJECT HOME PAGE" "uuid" "6e72d128-7d28-4bd0-bac0-8c5ffd8b31f1"}
+                     {"value" "PROCESSING HISTORY" "uuid" "7cfa5214-7f69-4355-b259-286be88f25d1"}
+                     {"value" "ALGORITHM DOCUMENTATION" "uuid" "fcc9411c-a1c9-415d-a16c-75c42f2cec45"}
+                     {"value" "DATA CITATION POLICY" "uuid" "40cf5001-15ec-4d9a-913c-bb323f2974fc"}]}]}
+                 {"value" "DataCenterURL"
+                  "uuid" "0809874c-debe-4e3c-beaf-ffb729817c41"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "HOME PAGE" "uuid" "5aa570e1-7387-4c18-80bd-61226b6e4f7e"}]}
+                 {"value" "CollectionURL"
+                  "uuid" "3d44d982-3083-4735-bd9e-250b8e565c0e"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "EXTENDED METADATA"
+                    "uuid" "3c9d4493-22fd-48a8-9af5-bf0d16b7ede5"
+                    "subfields" ["subtype"]
+                    "subtype"
+                    [{"value" "DMR++ MISSING DATA" "uuid" "4cc17021-b9cc-4b3f-a4f1-f05f7c1aeb2d"}
+                     {"value" "DMR++" "uuid" "f02b0c6a-7fd9-473d-a1cb-a6482e8daa61"}]}
+                   {"value" "PROJECT HOME PAGE" "uuid" "195302b8-b9c4-43f2-bf21-f59fe5329b2d"}
+                   {"value" "DATA SET LANDING PAGE" "uuid" "8826912b-c89e-4810-b446-39b98b5d937c"}
+                   {"value" "PROFESSIONAL HOME PAGE" "uuid" "f00cf885-8fc5-42ca-a70e-1689530f00cf"}]}
+                 {"value" "DataContactURL"
+                  "uuid" "a288a235-7857-4f36-81ae-56777eff3e79"
+                  "subfields" ["type"]
+                  "type"
+                  [{"value" "HOME PAGE" "uuid" "aa361eda-1e73-4e75-b172-210436029a01"}]}]}
    :spatial-keywords {"category"
                       [{"value" "GEOGRAPHIC REGION",
                         "uuid" "204270d9-8039-4768-851e-63635af5fb65",
@@ -434,10 +574,10 @@
 
 
 (deftest get-keywords-test
-  (util/are2
+  (util/are3
     [keyword-scheme expected-keywords]
-    (= {:status 200 :results expected-keywords}
-       (search/get-keywords-by-keyword-scheme keyword-scheme))
+    (is (= {:status 200 :results expected-keywords}
+           (search/get-keywords-by-keyword-scheme keyword-scheme)))
 
     "Testing correct keyword hierarchy returned for science keywords."
     :science_keywords (:science-keywords expected-hierarchy)
@@ -457,6 +597,9 @@
     "Testing correct keyword hierarchy returned for projects."
     :projects (:projects expected-hierarchy)
 
+    "Testing correct keyword hierarchy of 3 levels is returned for related URLs."
+    :related-urls (:related-urls expected-hierarchy)
+
     "Testing correct keyword hierarchy returned for temporal keywords."
     :temporal-keywords (:temporal-keywords expected-hierarchy)
 
@@ -471,7 +614,7 @@
     (is (= {:status 400
             :errors [ "Search parameter filters are not supported: [{:platform \"TRIMM\"}]" ]}
            (search/get-keywords-by-keyword-scheme :instruments "?platform=TRIMM&pretty=true")))))
-       
+
 (deftest invalid-keywords-test
   (testing "Invalid keyword scheme returns 400 error"
     (is (= {:status 400


### PR DESCRIPTION
The interface `http://localhost:3003/keywords/related_urls?pretty=true` now displays a three level keyword: `url_content_type->type->subtype`. url_content_type was added. A test was added as well to confirm this.