### PR TITLE
Cmr 7221 tasks returned in desc order

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1492,6 +1492,7 @@ curl -i -XPOST \
 The task information of all granule bulk update tasks that has been applied on a provider can be retrieved by sending an HTTP GET request to `%CMR-ENDPOINT%/providers/<provider-id>/bulk-update/granules/status`
 
 This returns a list of: name, task id, created-at, status (IN_PROGRESS or COMPLETE), a status message, and the original request JSON body.
+The list is ordered by task id, in descending order so that the newest update will show up on the top.
 
 The supported response formats are application/xml and application/json. The default is application/xml.
 
@@ -1507,9 +1508,9 @@ curl -i \
 <result>
     <tasks>
         <task>
-            <created-at>2021-03-12T20:38:53.415Z</created-at>
-            <name>add opendap links: 1</name>
-            <task-id>1</task-id>
+            <created-at>2021-03-12T20:38:53.473Z</created-at>
+            <name>add opendap links: 3</name>
+            <task-id>3</task-id>
             <status>COMPLETE</status>
             <status-message>All granule updates completed successfully.</status-message>
             <request-json-body>{"name":"add opendap links","operation":"UPDATE_FIELD","update-field":"OPeNDAPLink","updates":[["SC:AE_5DSno.002:30500511","https://url30500511"],["SC:AE_5DSno.002:30500512","https://url30500512"]]}</request-json-body>
@@ -1523,9 +1524,9 @@ curl -i \
             <request-json-body>{"name":"add opendap links","operation":"UPDATE_FIELD","update-field":"OPeNDAPLink","updates":[["SC:AE_5DSno.002:30500518","https://url30500518"],["SC:coll2:30500519","https://url30500519"]]}</request-json-body>
         </task>
         <task>
-            <created-at>2021-03-12T20:38:53.473Z</created-at>
-            <name>3: 3</name>
-            <task-id>3</task-id>
+            <created-at>2021-03-12T20:38:53.415Z</created-at>
+            <name>add opendap links: 1</name>
+            <task-id>1</task-id>
             <status>COMPLETE</status>
             <status-message>Task completed with 1 FAILED and 1 UPDATED out of 2 total granule update(s).</status-message>
             <request-json-body>{"operation":"UPDATE_FIELD","update-field":"OPeNDAPLink","updates":[["SC:coll3:30500514","https://url30500514"],["SC:non-existent","https://url30500515"]]}</request-json-body>

--- a/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
@@ -92,7 +92,8 @@
                 (sql-utils/select
                  [:created-at :name :task-id :status :status-message :request-json-body]
                  (sql-utils/from "granule_bulk_update_tasks")
-                 (sql-utils/where `(= :provider-id ~provider-id))))
+                 (sql-utils/where `(= :provider-id ~provider-id))
+                 (sql-utils/order-by (sql-utils/desc `(+ :task-id 0)))))
           ;; Note: the column selected out of the database is created_at, instead of created-at.
           statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn))
                                (sql-utils/query conn stmt)))

--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_flow_test.clj
@@ -96,6 +96,71 @@
                                update2
                                (assoc bulk-update-options :accept-format :json :raw? true)))
             task2-id (str (:task-id update2-response))
+            ;; add a 9 more bulk update to test the sorting of the task-ids, in desc order, as numbers, not alphabetically.
+            update2-1-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-1-id (str (:task-id update2-1-response))
+            update2-2-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-2-id (str (:task-id update2-2-response))
+            update2-3-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-3-id (str (:task-id update2-3-response))
+            update2-4-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-4-id (str (:task-id update2-4-response))
+            update2-5-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-5-id (str (:task-id update2-5-response))
+            update2-6-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-6-id (str (:task-id update2-6-response))
+            update2-7-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-7-id (str (:task-id update2-7-response))
+            update2-8-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-8-id (str (:task-id update2-8-response))
+            update2-9-response (ingest/parse-bulk-update-body
+                                :json
+                                (ingest/bulk-update-granules
+                                 "PROV1"
+                                 update2
+                                 (assoc bulk-update-options :accept-format :json :raw? true)))
+            task2-9-id (str (:task-id update2-9-response))
+
             ;; run granule bulk update on PROV2 to verify get task status works for given provider
             update3 {:operation "UPDATE_FIELD"
                      :update-field "OPeNDAPLink"
@@ -113,6 +178,16 @@
         (is (= 200 (:status update3-response)))
 
         (ingest/update-granule-bulk-update-task-statuses)
+
+        (testing "Granule bulk update tasks response sorting on task-id in desc order as numbers"
+          (let [response (ingest/granule-bulk-update-tasks
+                          "PROV1"
+                          {:accept-format :json})
+                {:keys [status tasks]} response]
+            (is (= 200 status))
+            (is (= ["11" "10" "9" "8" "7" "6" "5" "4" "3" "2" "1"]
+                   (map :task-id tasks)))))
+
         (testing "Granule bulk update tasks response"
           ;; PROV1
           (are3 [accept-format]
@@ -128,6 +203,51 @@
                             :request-json-body update1-json}
                            {:task-id task2-id,
                             :name (str "add opendap links: " task2-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-1-id,
+                            :name (str "add opendap links: " task2-1-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-2-id,
+                            :name (str "add opendap links: " task2-2-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-3-id,
+                            :name (str "add opendap links: " task2-3-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-4-id,
+                            :name (str "add opendap links: " task2-4-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-5-id,
+                            :name (str "add opendap links: " task2-5-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-6-id,
+                            :name (str "add opendap links: " task2-6-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-7-id,
+                            :name (str "add opendap links: " task2-7-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-8-id,
+                            :name (str "add opendap links: " task2-8-id)
+                            :status-message "All granule updates completed successfully.",
+                            :status "COMPLETE",
+                            :request-json-body update2-json}
+                           {:task-id task2-9-id,
+                            :name (str "add opendap links: " task2-9-id)
                             :status-message "All granule updates completed successfully.",
                             :status "COMPLETE",
                             :request-json-body update2-json}])


### PR DESCRIPTION
task-id is a string that stores numbers.  We want the latest tasks to be returned on top, so we need add order by to the select statement to make sure it's in desc order, as a number.