### PR TITLE
CMR-7636: Fixed DataCenters translation from iso19115 to umm-json.

### DIFF
--- a/ingest-app/resources/CMR-7636/iso19115_test_data.xml
+++ b/ingest-app/resources/CMR-7636/iso19115_test_data.xml
@@ -1,0 +1,245 @@
+	<gmi:MI_Metadata xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmi="http://www.isotc211.org/2005/gmi"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gsr="http://www.isotc211.org/2005/gsr"
+                 xmlns:gss="http://www.isotc211.org/2005/gss"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:srv="http://www.isotc211.org/2005/srv"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://earthdata.nasa.gov/schema/eos https://cdn.earthdata.nasa.gov/iso/eos/1.0/eos.xsd http://www.isotc211.org/2005/gco https://cdn.earthdata.nasa.gov/iso/gco/1.0/gco.xsd http://www.isotc211.org/2005/gmd https://cdn.earthdata.nasa.gov/iso/gmd/1.0/gmd.xsd http://www.isotc211.org/2005/gmi https://cdn.earthdata.nasa.gov/iso/gmi/1.0/gmi.xsd http://www.opengis.net/gml/3.2 https://cdn.earthdata.nasa.gov/iso/gml/1.0/gml.xsd http://www.isotc211.org/2005/gmx https://cdn.earthdata.nasa.gov/iso/gmx/1.0/gmx.xsd http://www.isotc211.org/2005/gsr https://cdn.earthdata.nasa.gov/iso/gsr/1.0/gsr.xsd http://www.isotc211.org/2005/gss https://cdn.earthdata.nasa.gov/iso/gss/1.0/gss.xsd http://www.isotc211.org/2005/gts https://cdn.earthdata.nasa.gov/iso/gts/1.0/gts.xsd http://www.isotc211.org/2005/srv https://cdn.earthdata.nasa.gov/iso/srv/1.0/srv.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>NGA240</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gco:CharacterString>eng</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode
+        codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+
+  <gmd:contact>
+    <gmd:CI_ResponsibleParty>
+      <gmd:organisationName>
+        <gco:CharacterString>Next-Generation Ecosystem Experiments (NGEE) Arctic Project, Oak Ridge National Laboratory</gco:CharacterString>
+      </gmd:organisationName>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+
+  <gmd:dateStamp>
+    <gco:DateTime>2021-07-27T12:54:12.801286</gco:DateTime>
+  </gmd:dateStamp>
+
+  <!-- DOI -->
+  <gmd:dataSetURI>
+		<gco:CharacterString>https://doi.org/10.5440/1735941</gco:CharacterString>
+	</gmd:dataSetURI>
+
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+
+          <gmd:title>
+            <gco:CharacterString>NGEE Arctic Plant Traits: Fine Roots, Kougarok Road Mile Marker 64, Seward Peninsula, Alaska, 2016</gco:CharacterString>
+          </gmd:title>
+
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:DateTime>2021-07-27T12:54:12.801286</gco:DateTime>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode
+                    codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+
+          <gmd:edition>
+            <gco:CharacterString>1.0</gco:CharacterString>
+          </gmd:edition>
+
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>
+                  NGA240
+                </gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+
+          
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName>
+                <gco:CharacterString>Verity Salmon</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
+                                 codeListValue="originator">originator</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+          
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName>
+                <gco:CharacterString>Colleen Iversen</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
+                                 codeListValue="originator">originator</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+          
+          <gmd:citedResponsibleParty>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName>
+                <gco:CharacterString>Joanne Childs</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
+                                 codeListValue="originator">originator</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:citedResponsibleParty>
+          
+
+        </gmd:CI_Citation>
+      </gmd:citation>
+
+      <gmd:abstract>
+        <gco:CharacterString>Laboratory sample processing of these soils generated depth-specific data on soil properties as well as fine root biomass, length, %C, %N, delta13C, and delta15N. Only live fine roots were analyzed. Fine roots were not separated by species or plant functional type.Soil cores were collected from twelve vegetation biomass plots at the Kougarok hillslope in late July of 2016. The sampled plots were located across six ecotypes present at this site (n=2 replicates per ecotype). Soil cores were separated into depth intervals in the field and frozen for transport to Oak Ridge National Laboratory.The Next-Generation Ecosystem Experiments: Arctic (NGEE Arctic), was a 10-year research effort (2012-2022) to reduce uncertainty in Earth System Models by developing a predictive understanding of carbon-rich Arctic ecosystems and feedbacks to climate. NGEE Arctic was supported by the Department of Energy’s Office of Biological and Environmental Research.The NGEE Arctic project had two field research sites: 1) located within the Arctic polygonal tundra coastal region on the Barrow Environmental Observatory (BEO) and the North Slope near Utqiagvik (Barrow), Alaska and 2) multiple areas on the discontinuous permafrost region of the Seward Peninsula north of Nome, Alaska.Through observations, experiments, and synthesis with existing datasets, NGEE Arctic provided an enhanced knowledge base for multi-scale modeling and contributed to improved process representation at global pan-Arctic scales within the Department of Energy’s Earth system Model (the Energy Exascale Earth System Model, or E3SM), and specifically within the E3SM Land Model component (ELM).</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:purpose gco:nilReason="missing"/>
+      <gmd:status>
+        <gmd:MD_ProgressCode
+            codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ProgressCode"
+            codeListValue="complete">
+          complete
+        </gmd:MD_ProgressCode>
+      </gmd:status>
+
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE > BIOSPHERE > VEGETATION</gco:CharacterString>
+          </gmd:keyword>
+          
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE > LAND SURFACE > SOILS</gco:CharacterString>
+          </gmd:keyword>
+          
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+
+      <gmd:language>
+        <gco:CharacterString>eng</gco:CharacterString>
+      </gmd:language>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-164.837755</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-164.801947</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>65.153612</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>65.171006</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact gco:nilReason="missing"/>
+          <gmd:distributorFormat>
+            <gmd:MD_Format>
+              <gmd:name>
+              <gco:CharacterString>Format: Not provided MimeType: text/html</gco:CharacterString>
+              </gmd:name>
+              <gmd:version gco:nilReason="unknown"/>
+              <gmd:specification/>
+            </gmd:MD_Format>
+          </gmd:distributorFormat>
+          <gmd:distributorTransferOptions>
+            <gmd:MD_DigitalTransferOptions>
+
+              
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                  <gmd:URL>ftp://ngee.ornl.gov/data/outgoing/NGA240/documentation</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                  <gco:CharacterString>http</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                  <gco:CharacterString>DATA ACCESS</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:description>
+                  <gco:CharacterString></gco:CharacterString>
+                  </gmd:description>
+                  <gmd:function>
+                  <gmd:CI_OnLineFunctionCode
+                    codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                    codeListValue="download" />
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                  <gmd:URL>ftp://ngee.ornl.gov/data/outgoing/NGA240/data</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                  <gco:CharacterString>http</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                  <gco:CharacterString>DATA ACCESS</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:description>
+                  <gco:CharacterString></gco:CharacterString>
+                  </gmd:description>
+                  <gmd:function>
+                  <gmd:CI_OnLineFunctionCode
+                    codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                    codeListValue="download" />
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              
+
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:distributorTransferOptions>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+
+</gmi:MI_Metadata>

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_translation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_translation_test.clj
@@ -103,6 +103,20 @@
                (:UseConstraints parsed-umm-json)))
         (is (= 200 status))))
 
+    (testing (format "Translating iso19115 to umm-json produces the right DataCenters")
+      (let [input-format :iso19115
+            output-format :umm-json
+            options {:skip-sanitize-umm-c false}
+            input-xml (slurp (io/resource "CMR-7636/iso19115_test_data.xml"))
+            {:keys [status body]} (ingest/translate-metadata :collection input-format input-xml
+                                                                         output-format options)
+            parsed-umm-json (umm-spec/parse-metadata test-context :collection output-format body)]
+        (is (= [(umm-cmn/map->DataCenterType
+                 {:Roles ["ARCHIVER"] 
+                  :ShortName "Not provided"})]
+               (:DataCenters parsed-umm-json)))
+        (is (= 200 status))))
+
     (testing (format "Translating iso19115 to umm-json without skipping sanitizing makes use of default values")
       (let [input-format :iso19115
             output-format :umm-json

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2/data_contact.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2/data_contact.clj
@@ -252,7 +252,8 @@
                             (process-duplicate-data-centers data-centers (:data-centers-xml additional-contacts) sanitize?)
                             (process-duplicate-data-centers data-centers (:data-centers-xml distributors) sanitize?)
                             (process-duplicate-data-centers data-centers (:data-centers-xml processors) sanitize?)
-                            (process-duplicate-data-centers data-centers (:data-centers-xml cited-resp-party-contacts) sanitize?))]
+                            (process-duplicate-data-centers data-centers (:data-centers-xml cited-resp-party-contacts) sanitize?))
+       data-centers (remove nil? data-centers)]
   (merge
    {:DataCenters (if (seq data-centers)
                   data-centers


### PR DESCRIPTION
The original iso19115 collection ingests successfully even though it misses several required umm-json keys.

When translating from iso19115 to umm-json, all the missing required keys should be added because sanitize? is set to true. 

Testing showed all the missing required keys were added except for DataCenters. This is because there is a bug in the code when checking if DataCenters is missing from the original metadata. After the fix, DataCenters showed up and the resulted umm-json collection was ingested successfully.
