### PR TITLE
CMR-7416 fixes single string multi bucket lists, adds tests

### DIFF
--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.edn :as edn]
    [clojure.set :as set]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [cmr.access-control.data.access-control-index :as index]
    [cmr.access-control.data.acl-json-results-handler :as result-handler]
    [cmr.access-control.data.acl-schema :as schema]
@@ -368,11 +368,11 @@
   "Check if string has embedded array, if not then return result conj'd with results,
    if so then convert it into an array of strings and concat that with results."
   [results result]
-  (let [result (str/trim result)]
-    (if (str/starts-with? result "[")
-      (as-> (str/replace result #"\[|\]|\\|\"" "") result
-            (str/split result #",")
-            (map str/trim result)
+  (let [result (string/trim result)]
+    (if (string/starts-with? result "[")
+      (as-> (string/replace result #"\[|\]|\\|\"" "") result
+            (string/split result #",")
+            (map string/trim result)
             (concat results result))
       (conj results result))))
 
@@ -408,9 +408,9 @@
          :items
          (map :s3-bucket-and-object-prefix-names)
          flatten
-         parse-single-string-multi-valued-bucket-lists
          distinct
-         (remove nil?))))
+         (remove nil?)
+         parse-single-string-multi-valued-bucket-lists)))
 
 (defn- get-and-cache-providers
   "Retrieves and caches the current providers in the database."

--- a/system-int-test/test/cmr/system_int_test/access_control/s3_bucket_route_test.clj
+++ b/system-int-test/test/cmr/system_int_test/access_control/s3_bucket_route_test.clj
@@ -54,6 +54,19 @@
                       :S3BucketAndObjectPrefixNames ["s3://aws.example-3.com" "s3"]
                       :S3CredentialsAPIEndpoint "http://api.example.com"
                       :S3CredentialsAPIDocumentationURL "http://docs.example.com"}}))
+
+        ;; CMR-7416
+        concept-4 (data-core/ingest-umm-spec-collection
+                   "PROV1"
+                   (data-umm-c/collection
+                    {:EntryTitle "s3-PROV1-2"
+                     :ShortName "s3 bucket test collection 2"
+                     :DirectDistributionInformation
+                     {:Region "us-east-1"
+                      :S3BucketAndObjectPrefixNames [" [\"test-daac/test-prefix1/\", \"test-daac/test-prefix2/\"]"]
+                      :S3CredentialsAPIEndpoint "http://api.example.com"
+                      :S3CredentialsAPIDocumentationURL "http://docs.example.com"}}))
+
         ;; create all access group
         all-prov-group-id (echo-util/get-or-create-group
                            (system/context)
@@ -112,12 +125,17 @@
        ["s3"
         "s3://aws.example-1.com"
         "s3://aws.example-2.com"
-        "s3://aws.example-3.com"]
+        "s3://aws.example-3.com"
+        "test-daac/test-prefix1/"
+        "test-daac/test-prefix2/"]
 
        "single provider filtering"
        {:user_id "user1"
         :provider ["PROV1"]}
-       ["s3" "s3://aws.example-1.com"]
+       ["s3"
+        "s3://aws.example-1.com"
+        "test-daac/test-prefix1/"
+        "test-daac/test-prefix2/"]
 
        "multiple provider filtering"
        {:user_id "user1"


### PR DESCRIPTION
This PR attempts address issue where bucket lists in metadata are ingested as a single json string array.  We want the buckets/prefixes to be returned in a consistent manner even when this is the case.  It might be better to add validation to prevent these type of values in the metadata, or ask data providers to refrain from ingesting values in this way.  This howerver fixes how the data, that currently exists, is returned.