### PR TITLE
CMR-7734: Update ACL ingest validation on group id to use new EDL groups

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_crud_test.clj
@@ -1567,3 +1567,18 @@
               {:user_id "user1"
                :system_object "DASHBOARD_ARC_CURATOR"}
               {:token token}))))))
+
+(deftest create-acl-with-edl-id
+  (testing "Can make an ACL with an EDL group ID (alphanumeric only)"
+    (let [acl (access-control/create-acl (test-util/conn-context)
+                                         {:group_permissions [{:group_id "EDLGroupName"
+                                                               :permissions ["create"]}]
+                                          :provider_identity {:provider_id "PROV2"
+                                                              :target "CATALOG_ITEM_ACL"}})
+          response (access-control/get-acl (test-util/conn-context)
+                                           (get acl :concept_id)
+                                           {:token "mock-echo-system-token" :raw? true
+                                            :include_full_acl true})]
+      (is (contains? acl :revision_id))
+      (is (contains? acl :concept_id))
+      (is (= "EDLGroupName" (:group_id (first (get-in response [:body :group_permissions]))))))))

--- a/access-control-app/src/cmr/access_control/services/acl_validation.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_validation.clj
@@ -96,7 +96,7 @@
 (defn- group-id-validation
   "Validates if group-ids are valid CMR concept-ids"
   [key-path group-id]
-  (let [regex #"AG\d+-\S+"]
+  (let [regex #"^AG\d+-\S+$|^[0-9a-zA-Z]+$"]
     (when-not (re-matches regex group-id)
       {key-path [(format "[%s] is not a valid group concept-id" group-id)]})))
 


### PR DESCRIPTION
Allows CRUD on ACLs with EDL Group names has group_id. According to URS docs, EDL Group names "must be comprised of letters and numbers with no spaces."

SID lookup based on EDL groups will be implemented in a future ticket. This ticket is merely a validation change. It is already possible to create/update an ACL with a bogus group_id (as long as it looks like the a group concept id) so allowing a new flavor of group_id (which will always be bogus, for now) follows the precedent.