### PR TITLE
CMR-7792: Race condition fix

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_bulk_update/granule_bulk_update_test.clj
@@ -1672,8 +1672,8 @@
                            :updates ["granule_with_duplicate_opendap_types"]}
               {:keys [status task-id errors] :as response} (ingest/bulk-update-granules "PROV1" bulk-update bulk-update-options)]
 
-          (ingest/update-granule-bulk-update-task-statuses)
           (index/wait-until-indexed)
+          (ingest/update-granule-bulk-update-task-statuses)
 
           (is (= 200 status))
           (is (some? task-id))


### PR DESCRIPTION
Wait for granules to update and index before updating task statuses to avoid a race condition.