### PR TITLE
CMR-7906

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1578,7 +1578,7 @@ Find collections that match all of the 'project' param values
 This supports `pattern`, `ignore_case` and option `and`.
 
 Find collections matching 'consortium' param value
-     
+
      curl "%CMR-ENDPOINT%/collections?consortium\[\]=CWIC"
 
 Find collections matching any of the 'consortium' param values
@@ -2732,7 +2732,7 @@ The response format is in JSON. Intervals are returned as tuples containing thre
 
 ### <a name="retrieve-provider-holdings"></a> Retrieve Provider Holdings
 
-Provider holdings can be retrieved as XML or JSON.
+Provider holdings can be retrieved as XML or JSON. It will show all CMR providers, collections and granule counts regardless of the user's ACL access.
 
 All provider holdings
 

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -334,7 +334,7 @@
                                    context query (qe/execute-query context query)))]
    {:results results :took execution-time :result-format mt/json}))
 
-(defn get-collections-by-providers
+(defn- get-collections-by-providers
   "Returns all collections limited optionally by the given provider ids"
   ([context skip-acls?]
    (get-collections-by-providers context nil skip-acls?))
@@ -375,7 +375,7 @@
                        provider-id
                        [provider-id])
         ;; get all collections limited by the list of providers in json format
-        collections (get-collections-by-providers context provider-ids false)
+        collections (get-collections-by-providers context provider-ids true)
         ;; get a mapping of collection to granule count
         collection-granule-count (idx/get-collection-granule-counts context provider-ids)
         ;; combine the granule count into collections to form provider holdings

--- a/system-int-test/test/cmr/system_int_test/search/provider_holdings_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/provider_holdings_test.clj
@@ -136,11 +136,11 @@
                (set (:results response))))))
 
     (testing "Retrieving provider holdings from the search application in various formats"
-       
+
       (testing "Retrieve all provider holdings in unsupported format opendata"
-        (try 
+        (try
           (search/provider-holdings-in-format :opendata {:token user-token})
-          (catch clojure.lang.ExceptionInfo e 
+          (catch clojure.lang.ExceptionInfo e
             (is (= {:status 400
                     :body "{\"errors\":[\"Unsupported format: opendata on the provider holdings endpoint.\"]}"}
                    (select-keys (ex-data e) [:status :body]))))))
@@ -174,10 +174,10 @@
               (is (= expected-all-holdings
                      (set (:results response))))))
           (testing "Retrieve provider holdings applies acls"
-            ;; Guests only have access to provider 1
+            ;; Guests have access to all providers regardless of the ACLs
             (let [response (search/provider-holdings-in-format format {:token guest-token})]
               (is (= 200 (:status response)))
-              (is (= (set (get all-holdings "PROV1"))
+              (is (= expected-all-holdings
                      (set (:results response))))))
           (testing "Retrieve provider holdings with echo-compatible true"
             (let [response (search/provider-holdings-in-format


### PR DESCRIPTION
Changed provider holdings endpoint to always show all provider holdings regardless of the user's ACL access.