### PR TITLE
CMR-8046 - a bug fix to isolate parse errors which can happen if CSV …

### DIFF
--- a/transmit-lib/src/cmr/transmit/kms.clj
+++ b/transmit-lib/src/cmr/transmit/kms.clj
@@ -168,15 +168,16 @@
 
 (defn- validate-subfield-names
   "Validates that the provided subfield names match the expected subfield names for the given
-  keyword scheme. Throws an exception if they do not match."
+  keyword scheme. Returns true if they match, false otherwise."
   [keyword-scheme subfield-names]
-  (let [expected-subfield-names (keyword-scheme keyword-scheme->expected-field-names)]
-    (when-not (= expected-subfield-names subfield-names)
-      (throw (Exception.
-               (format "Expected subfield names for %s to be %s, but were %s."
-                       (name keyword-scheme)
-                       (pr-str expected-subfield-names)
-                       (pr-str subfield-names)))))))
+  (let [expected-subfield-names (keyword-scheme keyword-scheme->expected-field-names)
+        names-match-result (= expected-subfield-names subfield-names)]
+    (when-not names-match-result
+      (error (format "Expected subfield names for %s to be %s, but were %s."
+                     (name keyword-scheme)
+                     (pr-str expected-subfield-names)
+                     (pr-str subfield-names))))
+    names-match-result))
 
 (defn- parse-entries-from-csv
   "Parses the CSV returned by the GCMD KMS. It is expected that the CSV will be returned in a
@@ -184,26 +185,28 @@
   a breakdown of the subfields for the keyword scheme, and from the third line on are the actual
   values.
 
-  Returns a sequence of full hierarchy maps."
+  keyword-schede shoud be something like :platforms
+  csv-content is the raw text of the CSV file to parse
+  Returns a sequence of full hierarchy maps or nil if subfield names do not match expected."
   [keyword-scheme csv-content]
   (let [all-lines (csv/read-csv csv-content)
         ;; Line 2 contains the subfield names
-        kms-subfield-names (map csk/->kebab-case-keyword (second all-lines))
-        _ (validate-subfield-names keyword-scheme kms-subfield-names)
-        keyword-entries (->> all-lines
-                             (drop NUM_HEADER_LINES)
-                             ;; Create a map for each row using the subfield-names as keys
-                             (map #(zipmap (keyword-scheme keyword-scheme->field-names) %))
-                             (map remove-blank-keys)
-                             ;; Only keep entries which map to full valid keywords
-                             (filter (keyword-scheme->required-field keyword-scheme)))
-        leaf-field-name (keyword-scheme keyword-scheme->leaf-field-name)
-        invalid-entries (find-invalid-entries keyword-entries leaf-field-name)]
-    ;; Print out warnings for any duplicate keywords so that we can create a Splunk alert.
-    (doseq [entry invalid-entries]
-      (warn (format "Found duplicate keywords for %s short-name [%s]: %s" (name keyword-scheme)
-                    (:short-name entry) entry)))
-    keyword-entries))
+        kms-subfield-names (map csk/->kebab-case-keyword (second all-lines))]
+    (when (validate-subfield-names keyword-scheme kms-subfield-names)
+      (let [keyword-entries (->> all-lines
+                                 (drop NUM_HEADER_LINES)
+                                 ;; Create a map for each row using the subfield-names as keys
+                                 (map #(zipmap (keyword-scheme keyword-scheme->field-names) %))
+                                 (map remove-blank-keys)
+                                 ;; Only keep entries which map to full valid keywords
+                                 (filter (keyword-scheme->required-field keyword-scheme)))
+            leaf-field-name (keyword-scheme keyword-scheme->leaf-field-name)
+            invalid-entries (find-invalid-entries keyword-entries leaf-field-name)]
+        ;; Print out warnings for any duplicate keywords so that we can create a Splunk alert.
+        (doseq [entry invalid-entries]
+          (warn (format "Found duplicate keywords for %s short-name [%s]: %s" (name keyword-scheme)
+                        (:short-name entry) entry)))
+        keyword-entries))))
 
 (defn- get-by-keyword-scheme
   "Makes a get request to the GCMD KMS. Returns the controlled vocabulary map for the given
@@ -220,7 +223,7 @@
   ;;     "{\"platforms\":\"static\"}"
   (let [gcmd-resource-name (keyword-scheme->kms-resource keyword-scheme)]
     (info (format "Loading KMS resource [%s] for [%s]..." gcmd-resource-name keyword-scheme))
-    (if (= "static" gcmd-resource-name)
+    (if (= "static" (str/lower-case gcmd-resource-name))
       ;; load the static file from the resource directory under indexer
       (let [gcmd-resource-path (str (format "static_kms_keywords/%s.csv" (name keyword-scheme)))
             data (slurp (jio/resource gcmd-resource-path))


### PR DESCRIPTION
Background: If KMS changes it's structure and CMR team does not get notified, CMR will fail to parse the new CSV file. When this happens, CMR use to throw an exception from inside a for loop where CMR integrates over schema names (platforms, instruments, science keywords) to download CSV files to process. When this happens nothing catches the exception and the for loop stops processing schemes meaning all schemes with valid data which happens latter in the loop do not get processed.

Fix: Don't throw exception. Instead, return true/false in a tester function and handle that state latter on. I also added some tests since we need to increase code coverage anyways.