### PR TITLE
CMR-6928 Subscription limit validation and tests

### DIFF
--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -91,7 +91,8 @@
         subscriber-id (:SubscriberId metadata)
         subscriptions (mdb/find-concepts
                        request-context
-                       {:subscriber-id (:SubscriberId metadata)}
+                       {:subscriber-id (:SubscriberId metadata)
+                        :latest true}
                        :subscription)
         active-subscriptions (remove :deleted subscriptions)]
      (when (>= (count active-subscriptions) (jobs/subscriptions-limit))

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -92,7 +92,7 @@
 
 (defn- check-subscription-limit
   "Given the  configuration for subscription limit, this valdiates that the
-  user has less than the limit before we allow more subscriptions to be
+  user has no more than the limit before we allow more subscriptions to be
   ingested by that user."
   [request-context subscription]
   (let [metadata (-> (:metadata subscription) (json/decode true))

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -129,9 +129,9 @@
                 (every? #(not= native-id (:native-id %)) active-duplicate-queries))
        (errors/throw-service-error
         :conflict
-        (format "The subscriber-id [%s] has already subscribed to the "
-                "collection with concept-id [%s] using the query [%s]. "
-                "Subscribers must use unique queries for each Collection."
+        (format "The subscriber-id [%s] has already subscribed to the 
+                collection with concept-id [%s] using the query [%s].
+                Subscribers must use unique queries for each Collection."
                 subscriber-id collection-id  normalized-query)))))
 
 (defn- get-subscriber-id

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -129,9 +129,9 @@
                 (every? #(not= native-id (:native-id %)) active-duplicate-queries))
        (errors/throw-service-error
         :conflict
-        (format "The subscriber-id [%s] has already subscribed to the 
-                collection with concept-id [%s] using the query [%s].
-                Subscribers must use unique queries for each Collection."
+        (format (str "The subscriber-id [%s] has already subscribed to the "
+                     "collection with concept-id [%s] using the query [%s]. "
+                     "Subscribers must use unique queries for each Collection.")
                 subscriber-id collection-id  normalized-query)))))
 
 (defn- get-subscriber-id

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -73,7 +73,7 @@
 (defn- validate-query
   "Performs a granule search using subscription query parameters for purposes of validation"
   [request-context subscription]
-  (let [metadata (-> (:metadata subscription) (json/decode true))
+  (let [metadata (json/decode (:metadata subscription) true)
         collection-id (:CollectionConceptId metadata)
         query-string (:Query metadata)
         query-params (jobs/create-query-params query-string)

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -95,7 +95,12 @@
                         :latest true}
                        :subscription)
         active-subscriptions (remove :deleted subscriptions)]
-     (when (>= (count active-subscriptions) (jobs/subscriptions-limit))
+     (def subscription-revision false)
+     (doseq [element active-subscriptions]
+      (if (and (= (:native-id element) (:native-id subscription))
+               (= (:provider-id element) (:provider-id subscription)))
+          (def subscription-revision true)))
+     (when (and (>= (count active-subscriptions) (jobs/subscriptions-limit)) (not subscription-revision))
        (errors/throw-service-error
         :conflict
         (format "The subscriber-id [%s] has already reached the subscription limit."

--- a/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
+++ b/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
@@ -59,6 +59,11 @@
   {:default 25
    :type Long})
 
+(defconfig subscriptions-limit
+  "The subscription limit for a single non-admin subscriber id."
+  {:default 100
+   :type Long})
+
 (defconfig mail-sender
   "The email sender's email address."
   {:default ""

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -65,32 +65,27 @@
                  :EntryTitle "entry-title-exceed-limit-3"})
                {:token "mock-echo-system-token"})]
      (testing "ingest on PROV1 with subscription request for subscriber-id below subscription limit"
-       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
-                                                                   :Name "Sub1"
+       (let [concept (subscription-util/make-subscription-concept {:Name "Sub1"
                                                                    :CollectionConceptId (:concept-id coll1)
-                                                                   :SubscriberId "user1"
-                                                                   :EmailAddress "foo@example.com"})
+                                                                   :SubscriberId "user1"})
+
              user1-token (echo-util/login (system/context) "user1")
              response (ingest/ingest-concept concept {:token user1-token})]
          (is (= 201 (:status response)))
          (is (mdb/concept-exists-in-mdb? (:concept-id response) (:revision-id response)))))
      (testing "ingest on PROV1 with subscription request for subscriber-id already at subscription limit"
-       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
-                                                                   :Name "Sub2"
+       (let [concept (subscription-util/make-subscription-concept {:Name "Sub2"
                                                                    :CollectionConceptId (:concept-id coll2)
-                                                                   :SubscriberId "user1"
-                                                                   :EmailAddress "foo@example.com"})
+                                                                   :SubscriberId "user1"})
              user1-token (echo-util/login (system/context) "user1")
              response (ingest/ingest-concept concept {:token user1-token})]
         (is (= 409 (:status response)))
         (is (= "The subscriber-id [user1] has already reached the subscription limit." (first (:errors response))))))
     (side/eval-form `(jobsub/set-subscriptions-limit! 100))
     (testing "ingest on PROV1 with subscription request for subscriber-id below updated subscription limit"
-      (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
-                                                                  :Name "Sub3"
+      (let [concept (subscription-util/make-subscription-concept {:Name "Sub3"
                                                                   :CollectionConceptId (:concept-id coll3)
-                                                                  :SubscriberId "user1"
-                                                                  :EmailAddress "foo@example.com"})
+                                                                  :SubscriberId "user1"})
             user1-token (echo-util/login (system/context) "user1")
             response (ingest/ingest-concept concept {:token user1-token})]
         (is (= 201 (:status response)))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer :all]
    [cmr.access-control.test.util :as ac-util]
    [cmr.common.util :refer [are3]]
+   [cmr.common-app.test.side-api :as side]
    [cmr.ingest.services.subscriptions-helper :as jobsub]
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.data2.core :as data-core]
@@ -42,6 +43,58 @@
                            (remove :deleted)
                            (map #(select-keys % [:concept-id :extra-fields :metadata])))]
     (#'jobsub/process-subscriptions (system/context) subscriptions)))
+
+(deftest subscription-count-exceeds-limit-test
+  (side/eval-form `(jobsub/set-subscriptions-limit! 1))
+  (let [coll1 (data-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll-exceed-limit-1"
+                 :EntryTitle "entry-title-exceed-limit-1"})
+               {:token "mock-echo-system-token"})
+        coll2 (data-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll-exceed-limit-2"
+                 :EntryTitle "entry-title-exceed-limit-2"})
+               {:token "mock-echo-system-token"})
+        coll3 (data-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll-exceed-limit-3"
+                 :EntryTitle "entry-title-exceed-limit-3"})
+               {:token "mock-echo-system-token"})]
+     (testing "ingest on PROV1 with subscription request for subscriber-id below subscription limit"
+       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
+                                                                   :Name "Sub1"
+                                                                   :CollectionConceptId (:concept-id coll1)
+                                                                   :SubscriberId "user1"
+                                                                   :EmailAddress "foo@example.com"})
+             user1-token (echo-util/login (system/context) "user1")
+             response (ingest/ingest-concept concept {:token user1-token})]
+         (is (= 201 (:status response)))
+         (is (mdb/concept-exists-in-mdb? (:concept-id response) (:revision-id response)))))
+     (testing "ingest on PROV1 with subscription request for subscriber-id already at subscription limit"
+       (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
+                                                                   :Name "Sub2"
+                                                                   :CollectionConceptId (:concept-id coll2)
+                                                                   :SubscriberId "user1"
+                                                                   :EmailAddress "foo@example.com"})
+             user1-token (echo-util/login (system/context) "user1")
+             response (ingest/ingest-concept concept {:token user1-token})]
+        (is (= 409 (:status response)))
+        (is (= "The subscriber-id [user1] has already reached the subscription limit." (first (:errors response))))))
+    (side/eval-form `(jobsub/set-subscriptions-limit! 100))
+    (testing "ingest on PROV1 with subscription request for subscriber-id below updated subscription limit"
+      (let [concept (subscription-util/make-subscription-concept {:provider-id "PROV1"
+                                                                  :Name "Sub3"
+                                                                  :CollectionConceptId (:concept-id coll3)
+                                                                  :SubscriberId "user1"
+                                                                  :EmailAddress "foo@example.com"})
+            user1-token (echo-util/login (system/context) "user1")
+            response (ingest/ingest-concept concept {:token user1-token})]
+        (is (= 201 (:status response)))
+        (is (mdb/concept-exists-in-mdb? (:concept-id response) (:revision-id response)))))))
 
 
 (deftest subscription-ingest-no-subscriber-id-test


### PR DESCRIPTION
This change limits the number subscriptions an individual user can create to 100 active subscriptions. If the user is already at the subscription limit, they will not be able to successfully create a new subscription. This will help prevent undue load or abuse. The tests validate a user can create subscriptions if they are below the limit and that they will be rejected if they are already at the limit.