### PR TITLE
CMR-7862 updates to handle other key types for cache info jobs

### DIFF
--- a/common-lib/src/cmr/common/cache/in_memory_cache.clj
+++ b/common-lib/src/cmr/common/cache/in_memory_cache.clj
@@ -51,7 +51,7 @@
 
 (defmethod size-in-bytes clojure.lang.IPersistentMap
   [m]
-  (+ (reduce + 0 (map (comp size-in-bytes name) (keys m)))
+  (+ (reduce + 0 (map size-in-bytes (keys m)))
      (reduce + 0 (map size-in-bytes (vals m)))))
 
 (defmethod size-in-bytes clojure.lang.IPersistentCollection

--- a/common-lib/test/cmr/common/test/cache/in_memory_cache.clj
+++ b/common-lib/test/cmr/common/test/cache/in_memory_cache.clj
@@ -128,4 +128,16 @@
 
       "compressed strings"
       (string->lz4-bytes umm-json)
-      836)))
+      836
+
+      "clojure.lang.PersistentArrayMap as key"
+      {(array-map [1 2] [3 4 5]) :array-map}
+      329
+
+      "map keyword->keyword"
+      {:a :b}
+      2
+
+      "map string->string"
+      {"c" "d"}
+      2)))

--- a/common-lib/test/cmr/common/test/cache/in_memory_cache.clj
+++ b/common-lib/test/cmr/common/test/cache/in_memory_cache.clj
@@ -140,4 +140,8 @@
 
       "map string->string"
       {"c" "d"}
-      2)))
+      2
+
+      "clojure.lang.PersistentVector as key"
+      {(vec [1]) :bar}
+      67)))


### PR DESCRIPTION
`clojure.lang.PesistentArrayVectors` and `clojure.lang.PersistentArrayMap` as cache keys were not being handled correctly in the job logging cache sizes. This PR corrects that problem.