### PR TITLE
Cmr 8073 - Changing the autocomplete and reindexing batch size to be operationally configurable 

### DIFF
--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -203,7 +203,7 @@
          flatten
          (remove anti-value-suggestion?))))
 
-(def REINDEX_BATCH_SIZE 10)
+(def REINDEX_BATCH_SIZE 1)
 
 (defn-timed reindex-autocomplete-suggestions-for-provider
   "Reindex autocomplete suggestion for a given provider"

--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -203,8 +203,6 @@
          flatten
          (remove anti-value-suggestion?))))
 
-(def REINDEX_BATCH_SIZE 1)
-
 (defn-timed reindex-autocomplete-suggestions-for-provider
   "Reindex autocomplete suggestion for a given provider"
   [context provider-id]
@@ -212,7 +210,7 @@
   (let [latest-collection-batches (meta-db/find-in-batches
                                    context
                                    :collection
-                                   REINDEX_BATCH_SIZE
+                                   (service/determine-reindex-batch-size provider-id)
                                    {:provider-id provider-id :latest true})]
     (reduce (fn [num-indexed coll-batch]
               (let [batch (collections->suggestion-docs context coll-batch provider-id)]

--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -203,7 +203,7 @@
          flatten
          (remove anti-value-suggestion?))))
 
-(def REINDEX_BATCH_SIZE 100)
+(def REINDEX_BATCH_SIZE 10)
 
 (defn-timed reindex-autocomplete-suggestions-for-provider
   "Reindex autocomplete suggestion for a given provider"

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -191,7 +191,7 @@
 (defconfig collection-large-file-providers-reindex-batch-size
   "Batch size used for re-indexing collections from providers that have large collections. These
   are usually ISO collections."
-  {:default 20
+  {:default 10
    :type Long})
 
 (defconfig collection-large-file-provider-list

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -191,7 +191,7 @@
 (defconfig collection-large-file-providers-reindex-batch-size
   "Batch size used for re-indexing collections from providers that have large collections. These
   are usually ISO collections."
-  {:default 5
+  {:default 10
    :type Long})
 
 (defconfig collection-large-file-provider-list

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -2,9 +2,9 @@
   "Provide functions to index concept"
   (:require
    [camel-snake-kebab.core :as camel-snake-kebab]
+   [cheshire.core :as json]
    [clj-time.core :as t]
    [clj-time.format :as f]
-   [clojure.string :as s]
    [cmr.acl.acl-fetcher :as acl-fetcher]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as cs]
@@ -183,7 +183,31 @@
                                    :subscription}
                                  concept-type))))
 
-(def REINDEX_BATCH_SIZE 2000)
+(defconfig collection-reindex-batch-size
+  "Batch size used for re-indexing collections."
+  {:default 2000
+   :type Long})
+
+(defconfig collection-large-file-providers-reindex-batch-size
+  "Batch size used for re-indexing collections from providers that have large collections. These
+  are usually ISO collections."
+  {:default 5
+   :type Long})
+
+(defconfig collection-large-file-provider-list
+  "Includes all the providers that have large collections."
+  {:default ["GHRSSTCWIC"]
+   :parser #(json/decode ^String %)})
+
+(defn determine-reindex-batch-size
+  "Few providers have really big collections and they force the metadata_db to run out of memory
+  when the batch sizes are reasonable for most other providers. This function will determine
+  the batch size to used based on providers to eliminate the out of memory exception. The values
+  used are defined in defconfigs above so that these values can be overriden in ops when necessary."
+  [provider]
+  (if (some #(= provider %) (collection-large-file-provider-list))
+    (collection-large-file-providers-reindex-batch-size)
+    (collection-reindex-batch-size)))
 
 (defn reindex-provider-collections
   "Reindexes all the collections in the providers given.
@@ -218,7 +242,7 @@
        (let [latest-collection-batches (meta-db/find-in-batches
                                         context
                                         :collection
-                                        REINDEX_BATCH_SIZE
+                                        (determine-reindex-batch-size provider-id)
                                         {:provider-id provider-id :latest true})]
          (bulk-index context latest-collection-batches {:all-revisions-index? false
                                                         :force-version? force-version?})))
@@ -230,10 +254,15 @@
        (let [all-revisions-batches (meta-db/find-in-batches
                                     context
                                     :collection
-                                    REINDEX_BATCH_SIZE
+                                    (determine-reindex-batch-size provider-id)
                                     {:provider-id provider-id})]
          (bulk-index context all-revisions-batches {:all-revisions-index? true
                                                     :force-version? force-version?}))))))
+
+(defconfig non-collection-reindex-batch-size
+  "Batch size used for re-indexing other things besides collections."
+  {:default 2000
+   :type Long})
 
 (defn reindex-tags
   "Reindexes all the tags. Only the latest revisions will be indexed"
@@ -242,7 +271,7 @@
   (let [latest-tag-batches (meta-db/find-in-batches
                             context
                             :tag
-                            REINDEX_BATCH_SIZE
+                            (non-collection-reindex-batch-size)
                             {:latest true})]
     (bulk-index context latest-tag-batches)))
 

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -191,12 +191,12 @@
 (defconfig collection-large-file-providers-reindex-batch-size
   "Batch size used for re-indexing collections from providers that have large collections. These
   are usually ISO collections."
-  {:default 10
+  {:default 20
    :type Long})
 
 (defconfig collection-large-file-provider-list
   "Includes all the providers that have large collections."
-  {:default ["GHRSSTCWIC"]
+  {:default ["GHRSSTCWIC" "NOAA_NCEI"]
    :parser #(json/decode ^String %)})
 
 (defn determine-reindex-batch-size

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -2,6 +2,7 @@
   "Tests for index service"
   (:require
    [clojure.test :refer :all]
+   [cmr.common.util :refer [are3]]
    [cmr.indexer.services.index-service :as index-svc]))
 
 (deftest index-concept-invalid-input-test
@@ -15,3 +16,14 @@
          "C123-PROV1" nil
          nil 1
          nil nil)))
+
+(deftest determine-reindex-batch-size-test
+  (testing "determining the reindexing batch size based on the given provider."
+    (are3 [expected-size provider]
+      (is (= expected-size (index-svc/determine-reindex-batch-size provider)))
+
+      "Testing a provider that has normal sized collections."
+      2000 "NSIDC"
+
+      "Testing a provider that has large sized collections."
+      10 "GHRSSTCWIC")))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -23,7 +23,7 @@
       (is (= expected-size (index-svc/determine-reindex-batch-size provider)))
 
       "Testing a provider that has normal sized collections."
-      2000 "NSIDC"
+      (index-svc/collection-reindex-batch-size) "NSIDC"
 
       "Testing a provider that has large sized collections."
-      10 "GHRSSTCWIC")))
+      (index-svc/collection-large-file-providers-reindex-batch-size) "GHRSSTCWIC")))


### PR DESCRIPTION
and can change for a list of providers that have large records. 