### PR TITLE
CMR-8021 Create an ingest test to be part of the system-validation-tests

### DIFF
--- a/system-validation-test/Gemfile.lock
+++ b/system-validation-test/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-21
 
 DEPENDENCIES
   cucumber (~> 7.0.0)

--- a/system-validation-test/README.md
+++ b/system-validation-test/README.md
@@ -22,7 +22,7 @@ And then execute:
 
 To run all tests invoke cucumber with the following
 
-    $ cucumber CMR_ROOT=https://cmr.my-instance.com CMR_TOKEN=$MY_CMR_EDL_TOKEN CMR_USER=$MY_EDL_USERNAME
+    $ cucumber CMR_ROOT=https://cmr.my-instance.com CMR_TOKEN=$MY_CMR_EDL_TOKEN CMR_USER=$MY_EDL_USERNAME CMR_TEST_PROV=$MY_CMR_TEST_PROV
 
 
 To perform a limited test use the `@quick` tag as shown below
@@ -31,6 +31,9 @@ To perform a limited test use the `@quick` tag as shown below
 
 
 When running the suite against a newly instantiated instance of CMR, use the `@quick` tag as other tests may make assumptions about data being present.
+
+When running @ingest tests, it's required to configure $MY_CMR_EDL_TOKEN in environment or cucumber profile to a
+provider that exists in the test environment.
 
 ### Tags
 

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -43,3 +43,11 @@ Feature: Basic Ingest API calls
     And I add extension "providers/PROV1/collections/TestColl1"
     When I submit a "DELETE" request
     Then the response status code is 200
+    And I wait "2.75" seconds for deletion to complete
+    Given I am searching for "collections"
+    And I clear the extension
+    And I want "json"
+    And I add a query param "short_name" of "TestColl1"
+    When I submit a "GET" request
+    Then the response status code is 200
+    And the response body is empty

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -3,36 +3,43 @@ Feature: Basic Ingest API calls
 
   Background:
     Given I use the authorization token from environment variable "CMR_TOKEN"
+    And the provider "PROV1" exists
+    And set body to the following XML "<Collection><ShortName>TestColl1</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
   @ingest
-  Scenario: Ingest of a Collection on PROV1
-    Given I am ingesting a "Collection" on "ingest"
-    And I add extension "providers/PROV1/collections/TestColl01"
+  Scenario: Ingest of a Collection
+    Given I am ingesting a "Collection"
+    And I add extension "providers/PROV1/collections/TestColl1"
     And I add header "Content-type=application/echo10+xml"
-    And I add body param "ShortName=TestColl01"
-    And I add body param "VersionId=Version01"
-    And I add body param "InsertTime=1999-12-31T19:00:00-05:00"
-    And I add body param "LastUpdate=1999-12-31T19:00:00-05:00"
-    And I add body param "LongName=TestCollection01"
-    And I add body param "DataSetId=LarcDatasetId"
-    And I add body param "Description=A minimal valid collection"
-    And I add body param "Orderable=true"
-    And I add body param "Visible=true"
     When I submit a "PUT" request
-    Then the response status code is 200
+    Then the response status code is in "200,201"
 
   @ingest
   Scenario: Searching for ingested Collection
+    Given I am ingesting a "Collection"
+    And I add extension "providers/PROV1/collections/TestColl1"
+    And I add header "Content-type=application/echo10+xml"
+    When I submit a "PUT" request
+    And I wait "1.75" seconds for ingest to complete
     Given I am searching for "collections"
+    And I clear the extension
+    And I clear headers
     And I want "json"
-    And I add a query param "short_name" of "TestColl01"
+    And I add a query param "short_name" of "TestColl1"
     When I submit a "GET" request
     Then the response status code is 200
     And the response body contains one of "data_center"
 
   @ingest
   Scenario: Deleting ingested Collection
+    Given I am ingesting a "Collection"
+    And I add extension "providers/PROV1/collections/TestColl1"
+    And I add header "Content-type=application/echo10+xml"
+    When I submit a "PUT" request
+    And I wait "1.75" seconds for ingest to complete
     Given I am deleting on "ingest"
-    And I add extension "providers/PROV1/collections/TestColl01"
+    And I clear the extension
+    And I clear headers
+    And I add extension "providers/PROV1/collections/TestColl1"
     When I submit a "DELETE" request
     Then the response status code is 200

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -1,0 +1,38 @@
+Feature: Basic Ingest API calls
+  Ingest collections for various formats
+
+  Background:
+    Given I use the authorization token from environment variable "CMR_TOKEN"
+
+  @ingest
+  Scenario: Ingest of a Collection on PROV1
+    Given I am ingesting a "Collection" on "ingest"
+    And I add extension "providers/PROV1/collections/TestColl01"
+    And I add header "Content-type=application/echo10+xml"
+    And I add body param "ShortName=TestColl01"
+    And I add body param "VersionId=Version01"
+    And I add body param "InsertTime=1999-12-31T19:00:00-05:00"
+    And I add body param "LastUpdate=1999-12-31T19:00:00-05:00"
+    And I add body param "LongName=TestCollection01"
+    And I add body param "DataSetId=LarcDatasetId"
+    And I add body param "Description=A minimal valid collection"
+    And I add body param "Orderable=true"
+    And I add body param "Visible=true"
+    When I submit a "PUT" request
+    Then the response status code is 200
+
+  @ingest
+  Scenario: Searching for ingested Collection
+    Given I am searching for "collections"
+    And I want "json"
+    And I add a query param "short_name" of "TestColl01"
+    When I submit a "GET" request
+    Then the response status code is 200
+    And the response body contains one of "data_center"
+
+  @ingest
+  Scenario: Deleting ingested Collection
+    Given I am deleting on "ingest"
+    And I add extension "providers/PROV1/collections/TestColl01"
+    When I submit a "DELETE" request
+    Then the response status code is 200

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -3,7 +3,7 @@ Feature: Basic Ingest API calls
 
   Background:
     Given I use the authorization token from environment variable "CMR_TOKEN"
-    And the provider "PROV1" exists
+    And the provider from environment variable "CMR_TEST_PROV" exists
     And set body to the following XML "<Collection><ShortName>TestColl1</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
   @ingest

--- a/system-validation-test/features/step_definitions/data_comparison_steps.rb
+++ b/system-validation-test/features/step_definitions/data_comparison_steps.rb
@@ -27,6 +27,12 @@ Then('the response body contains/includes {string}') do |body|
   expect(@response.body).to include(body)
 end
 
+Then('the response body is empty') do
+  pending('Need to set response type to json') unless @response_type == 'json'
+  json = JSON.parse(@response.body)
+  expect(json['feed']['entry'].length.zero?)
+end
+
 Then('saved value {string} is equal to saved value {string}') do |a, b|
   expect(@stashes[a]).to eq(@stashes[b])
 end
@@ -34,7 +40,6 @@ end
 Then('the response {string} count is at least {int}') do |json_key, length|
   path = JsonPath.new("$..#{json_key}")
   data = JSON.parse(@response.body)
-
   values = path.on(data)
   expect(values.length).to be >= length
 end

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -52,6 +52,30 @@ module CmrRestfulHelper
     response
   end
 end
+
+# Module to handle URLs for local and production environments
+# rubocop:disable Metrics/MethodLength
+module CmrUrlHelper
+  def get_url(concept_type, cmr_root)
+    case concept_type.downcase
+    when /^acls?$/
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3011/#{concept_type}" : "#{cmr_root}/access-control/acls"
+    when /^groups?$/
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3011/#{concept_type}" : "#{cmr_root}/access-control/groups"
+    when /^permissions?$/
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3011/#{concept_type}" : "#{cmr_root}/access-control/permissions"
+    when /^s3-buckets?$/
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3011/#{concept_type}" : "#{cmr_root}/access-control/s3-buckets"
+    when /^(concept|collection|granule|service|tool|variable)s?$/
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3003/#{concept_type}" : "#{cmr_root}/search/#{concept_type}"
+    else
+      raise "#{concept_type} searching is not available in CMR"
+    end
+  end
+end
+# rubocop:enable Metrics/MethodLength
+
+World CmrUrlHelper
 World CmrRestfulHelper
 
 Given('I use/set the authorization token from/with/using environment variable/value {string}') do |variable|
@@ -82,20 +106,7 @@ Given('I am not logged in') do
 end
 
 Given(/^I am (searching|querying|looking) for (an? )?"([\w\d\-_ ]+)"$/) do |_, _, concept_type|
-  @resource_url = case concept_type.downcase
-                  when /^acls?$/
-                    "#{cmr_root}/access-control/acls"
-                  when /^groups?$/
-                    "#{cmr_root}/access-control/groups"
-                  when /^permissions?$/
-                    "#{cmr_root}/access-control/permissions"
-                  when /^s3-buckets?$/
-                    "#{cmr_root}/access-control/s3-buckets"
-                  when /^(concept|collection|granule|service|tool|variable)s?$/
-                    "#{cmr_root}/search/#{concept_type}"
-                  else
-                    raise "#{concept_type} searching is not available in CMR"
-                  end
+  @resource_url = get_url(concept_type, cmr_root)
 end
 
 Given('I clear/reset/remove/delete the extension') do

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -78,7 +78,7 @@ module CmrUrlHelper
     when /^(concept|collection|granule|service|tool|variable)s?$/
       cmr_root == 'http://localhost' ? "#{cmr_root}:3003/#{concept_type}" : "#{cmr_root}/search/#{concept_type}"
     when /^(ingest)s?$/
-      cmr_root == 'http://localhost' ? "#{cmr_root}:3002/" : "#{cmr_root}/ingest/#{concept_type}"
+      cmr_root == 'http://localhost' ? "#{cmr_root}:3002/" : "#{cmr_root}/ingest/"
     else
       raise "#{concept_type} searching is not available in CMR"
     end

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -147,11 +147,14 @@ end
 Given(/^I (want|ask for|request) (an? )?"(\w+)"( (response|returned))?$/) do |_, _, format, _|
   @url_extension = case format.downcase
                    when 'json', 'xml', 'dif', 'dif10', 'echo10', 'atom', 'native', 'iso', 'iso19115'
+                     @response_type = format.downcase
                      ".#{format}"
                    when 'umm_json', 'umm'
+                     @response_type = format.downcase
                      # modern umm
                      '.umm_json'
                    when 'umm-json', 'legacy-umm-json', 'legacy-umm'
+                     @response_type = format.downcase
                      # legacy umm
                      '.umm-json'
                    else

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -124,8 +124,9 @@ Given(/^I am ingesting (a )?"([\w\d\-_ ]+)"$/) do |_, ingest_type|
   @ingest_type = ingest_type
 end
 
-Given(/^the provider "([\w\d\-_ ]+)" exists$/) do |provider_name|
-  pending("Need to create Provider #{provider_name}.") unless check_provider(provider_name, cmr_root)
+Given(/^the provider from environment variable "([\w\d\-_ ]+)" exists$/) do |provider_name|
+  pending("Need to set #{provider_name} in environment or cucumber profile") unless ENV[provider_name]
+  pending("Need to create Provider #{provider_name}.") unless check_provider(ENV[provider_name], cmr_root)
 end
 
 Given(/^I am deleting on "([\w\d\-_ ]+)"$/) do |concept_type|
@@ -250,7 +251,7 @@ Then(/^the response (status( code)?) is (\d+)$/) do |_, status_code|
 end
 
 Then(/^the response (status( code)?) is in "((\d+,?(\d+)?))+"$/) do |_, status_codes|
-  values = status_codes.split(",")
+  values = status_codes.split(',')
   expect((values.include? @response.code))
 end
 

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -55,8 +55,8 @@ module CmrRestfulHelper
     response
   end
 
-  def check_provider(provider_name)
-    url = 'http://localhost:3002/providers'
+  def check_provider(provider_name, cmr_root)
+    url = "#{get_url('ingest', cmr_root)}providers"
     response = HTTParty.get(url)
     response.body.include? provider_name
   end
@@ -125,7 +125,7 @@ Given(/^I am ingesting (a )?"([\w\d\-_ ]+)"$/) do |_, ingest_type|
 end
 
 Given(/^the provider "([\w\d\-_ ]+)" exists$/) do |provider_name|
-  pending("Need to create Provider #{provider_name}.") unless check_provider(provider_name)
+  pending("Need to create Provider #{provider_name}.") unless check_provider(provider_name, cmr_root)
 end
 
 Given(/^I am deleting on "([\w\d\-_ ]+)"$/) do |concept_type|


### PR DESCRIPTION
This change creates new tests in system-validation-tests to test the ingest of a collection, searching for the collection, and then deleting the collection to help verify data flow in CMR so new changes do not break CMR.