### PR TITLE
CMR-8021-2 Enhancement to 8021: Create an ingest test to be part of the system-validation-tests

### DIFF
--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -5,12 +5,12 @@ Feature: Basic Ingest API calls
     Given I use the authorization token from environment variable "CMR_TOKEN"
     And the provider from environment variable "CMR_TEST_PROV" exists
 
-    And set body to the following XML "<Collection><ShortName>TestCollection8021</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId01</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
+    And set body to the following XML "<Collection><ShortName>TestCollection001</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId0001</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
   @ingest
   Scenario: Ingest of a Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     Then the response status code is in "200,201"
@@ -18,7 +18,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Searching for ingested Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
@@ -29,7 +29,7 @@ Feature: Basic Ingest API calls
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
     And I want "json"
-    And I add a query param "short_name" of "TestCollection8021"
+    And I add a query param "short_name" of "TestCollection001"
     When I submit a "GET" request
     Then the response status code is 200
     And the response body contains one of "data_center"
@@ -37,7 +37,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Deleting ingested Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
@@ -47,7 +47,7 @@ Feature: Basic Ingest API calls
     And I clear headers
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
     When I submit a "DELETE" request
     Then the response status code is 200
     And I wait "2.25" seconds for deletion to complete
@@ -58,7 +58,7 @@ Feature: Basic Ingest API calls
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
     And I want "json"
-    And I add a query param "short_name" of "TestCollection8021"
+    And I add a query param "short_name" of "TestCollection001"
     When I submit a "GET" request
     Then the response status code is 200
     And the response body is empty

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -4,12 +4,13 @@ Feature: Basic Ingest API calls
   Background:
     Given I use the authorization token from environment variable "CMR_TOKEN"
     And the provider from environment variable "CMR_TEST_PROV" exists
-    And set body to the following XML "<Collection><ShortName>TestColl1</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
+
+    And set body to the following XML "<Collection><ShortName>TestCollection8021</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId01</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
   @ingest
   Scenario: Ingest of a Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/PROV1/collections/TestColl1"
+    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     Then the response status code is in "200,201"
@@ -17,15 +18,17 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Searching for ingested Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/PROV1/collections/TestColl1"
+    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
-    And I wait "1.75" seconds for ingest to complete
+    And I wait "2.25" seconds for ingest to complete
     Given I am searching for "collections"
     And I clear the extension
     And I clear headers
+    And I clear the body
+    And I use the authorization token from environment variable "CMR_TOKEN"
     And I want "json"
-    And I add a query param "short_name" of "TestColl1"
+    And I add a query param "short_name" of "TestCollection8021"
     When I submit a "GET" request
     Then the response status code is 200
     And the response body contains one of "data_center"
@@ -33,21 +36,26 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Deleting ingested Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/PROV1/collections/TestColl1"
+    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
-    And I wait "1.75" seconds for ingest to complete
+    And I wait "2.25" seconds for ingest to complete
     Given I am deleting on "ingest"
     And I clear the extension
     And I clear headers
-    And I add extension "providers/PROV1/collections/TestColl1"
+    And I clear the body
+    And I use the authorization token from environment variable "CMR_TOKEN"
+    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
     When I submit a "DELETE" request
     Then the response status code is 200
-    And I wait "2.75" seconds for deletion to complete
+    And I wait "2.25" seconds for deletion to complete
     Given I am searching for "collections"
     And I clear the extension
+    And I clear headers
+    And I clear the body
+    And I use the authorization token from environment variable "CMR_TOKEN"
     And I want "json"
-    And I add a query param "short_name" of "TestColl1"
+    And I add a query param "short_name" of "TestCollection8021"
     When I submit a "GET" request
     Then the response status code is 200
     And the response body is empty

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -10,7 +10,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Ingest of a Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     Then the response status code is in "200,201"
@@ -18,12 +18,13 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Searching for ingested Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
     Given I am searching for "collections"
     And I clear the extension
+    And I clear the url path
     And I clear headers
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
@@ -36,21 +37,23 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Deleting ingested Collection
     Given I am ingesting a "Collection"
-    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
     Given I am deleting on "ingest"
     And I clear the extension
+    And I clear the url path
     And I clear headers
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
-    And I add extension "providers/DEMO_PROV/collections/TestCollection8021"
+    And I add url path "providers/DEMO_PROV/collections/TestCollection8021"
     When I submit a "DELETE" request
     Then the response status code is 200
     And I wait "2.25" seconds for deletion to complete
     Given I am searching for "collections"
     And I clear the extension
+    And I clear the url path
     And I clear headers
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -120,7 +120,7 @@ Given(/^set body to the following XML "(.+)"$/) do |xml|
 end
 
 Given(/^I clear the body$/) do
-  @body = ''
+  @body = nil
 end
 
 Given(/^I am ingesting (a )?"([\w\d\-_ ]+)"$/) do |_, ingest_type|
@@ -145,8 +145,16 @@ Given('I clear/reset/remove/delete the extension') do
   @url_extension = nil
 end
 
+Given('I clear/reset/remove/delete the url path') do
+  @url_path = nil
+end
+
 Given('I use/add extension {string}') do |extension|
   @url_extension = extension
+end
+
+Given('I use/add url path {string}') do |path|
+  @url_path = path
 end
 
 Given(/^I (want|ask for|request) (an? )?"(\w+)"( (response|returned))?$/) do |_, _, format, _|
@@ -235,14 +243,15 @@ Given(/^I (set|add) (a )?(search|query) (param(eter)?|term) "([\w\d\-_+\[\]]+)" 
 end
 
 When(/^I (submit|send) (a|another) "(\w+)" request to "(.*)"$/) do |_, _, method, url|
-  url = "#{cmr_root}#{url}#{@url_extension}"
+  url = "#{cmr_root}#{url}#{@url_extension}#{@url_path}"
   options = { query: @query,
               headers: @headers }
   @response = submit_query(method, url, options)
 end
 
 When(/^I (submit|send) (a|another) "(\w+)" request$/) do |_, _, method|
-  url = "#{@resource_url}#{@url_extension}"
+  url = "#{@resource_url}#{@url_extension}#{@url_path}"
+  # puts url
   options = { query: @query,
               body: @body,
               headers: @headers }

--- a/system-validation-test/features/step_definitions/rest_steps.rb
+++ b/system-validation-test/features/step_definitions/rest_steps.rb
@@ -119,6 +119,10 @@ Given(/^set body to the following XML "(.+)"$/) do |xml|
   @body = xml
 end
 
+Given(/^I clear the body$/) do
+  @body = ''
+end
+
 Given(/^I am ingesting (a )?"([\w\d\-_ ]+)"$/) do |_, ingest_type|
   @resource_url = get_url('ingest', cmr_root)
   @ingest_type = ingest_type


### PR DESCRIPTION
This enhancement makes changes from CMR-8021 which fix the response requests to function properly both in SIT and local environments.

Parent:
[CMR-8021](https://github.com/nasa/Common-Metadata-Repository/pull/1487): [created new validation tests in system-validation-tests to perform an ingest operation to verify data-flow in CMR so new changes do not break CMR.](https://github.com/nasa/Common-Metadata-Repository/pull/1487)