### PR TITLE
CMR-8064: Add support for bearer prefix in authorization header to mo…

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
@@ -34,12 +34,20 @@
     ;; Future enhancement: validate that min fields are provided
     (token-db/create context info)))
 
+(defn- strip-bearer-if-exists
+  "Remove 'Bearer' from the front of the token if it exists"
+  [token]
+  (if (= "Bearer" (subs token 0 6))
+    (subs token 7)
+    token))
+
 (defn- get-token-or-error
   "Helper for getting the token if it exists or thowing an error"
   [context token-id]
-  (if-let [token (token-db/fetch context token-id)]
-    token
-    (svc-errors/throw-service-error :unauthorized (str "Token [" token-id "] does not exist"))))
+  (let [token-id (strip-bearer-if-exists token-id)]
+    (if-let [token (token-db/fetch context token-id)]
+      token
+      (svc-errors/throw-service-error :unauthorized (str "Token [" token-id "] does not exist")))))
 
 (defn logout
   [context token-id]
@@ -90,29 +98,29 @@
 
 (defn build-routes [system]
   (routes
-    (context "/tokens" []
+   (context "/tokens" []
       ;; Login
-      (POST "/" {params :params context :request-context body :body}
-        (let [token (login context (slurp body))
-              url (str "http://localhost:3000/tokens/" (:id token))]
-          {:status 201
-           :content-type :json
-           :headers {"Location" url}
-           :body {:token token}}))
-      (POST "/get_token_info" {context :request-context headers :headers {token-id :id} :params}
-        (get-token-info context headers token-id))
-      (context "/:token-id" [token-id]
+     (POST "/" {params :params context :request-context body :body}
+       (let [token (login context (slurp body))
+             url (str "http://localhost:3000/tokens/" (:id token))]
+         {:status 201
+          :content-type :json
+          :headers {"Location" url}
+          :body {:token token}}))
+     (POST "/get_token_info" {context :request-context headers :headers {token-id :id} :params}
+       (get-token-info context headers token-id))
+     (context "/:token-id" [token-id]
         ;; Logout
-        (DELETE "/" {context :request-context}
-          (logout context token-id)
-          {:status 200})
-        (GET "/current_sids" {context :request-context}
+       (DELETE "/" {context :request-context}
+         (logout context token-id)
+         {:status 200})
+       (GET "/current_sids" {context :request-context}
           ;; Does not require sys admin token
-          (if (= "expired-token" token-id)
+         (if (= "expired-token" token-id)
             ;; echo-rest returns status code 400 for request with expired token
-            (ah/status-bad-request {:errors ["Token [expired-token] has expired."]})
-            (ah/status-ok (get-current-sids context token-id))))
-        (GET "/token_info" {context :request-context headers :headers}
-          (get-token-info context headers token-id))))
-    (GET "/availability" {context :request-context}
-      {:status 200})))
+           (ah/status-bad-request {:errors ["Token [expired-token] has expired."]})
+           (ah/status-ok (get-current-sids context token-id))))
+       (GET "/token_info" {context :request-context headers :headers}
+         (get-token-info context headers token-id))))
+   (GET "/availability" {context :request-context}
+     {:status 200})))

--- a/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
@@ -13,8 +13,7 @@
    [compojure.core :refer :all]))
 
 (def token-keys
-  #{
-    ;; Fields provided during login
+  #{;; Fields provided during login
     :username
     :client_id
     :password
@@ -35,15 +34,16 @@
     (token-db/create context info)))
 
 (defn- strip-bearer-if-exists
-  "Remove 'Bearer' from the front of the token if it exists"
+  "Remove 'Bearer ' from the front of the token if it exists"
   [token]
-  (if (= "Bearer" (subs token 0 6))
+  (if (and (>= (count token) 7) (= "Bearer " (subs token 0 7)))
     (subs token 7)
     token))
 
 (defn- get-token-or-error
   "Helper for getting the token if it exists or thowing an error"
   [context token-id]
+  (println token-id)
   (let [token-id (strip-bearer-if-exists token-id)]
     (if-let [token (token-db/fetch context token-id)]
       token

--- a/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
@@ -43,7 +43,6 @@
 (defn- get-token-or-error
   "Helper for getting the token if it exists or thowing an error"
   [context token-id]
-  (println token-id)
   (let [token-id (strip-bearer-if-exists token-id)]
     (if-let [token (token-db/fetch context token-id)]
       token


### PR DESCRIPTION
mock-echo-app does not support Authorization tokens that are prefixed with 'Bearer ' and will return a 'Token not found' error.  mock-echo-app will now check for the bearer prefix and remove it if it exists.

Generate a token:
```
curl -X POST http://localhost:3008/tokens -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"token": {"username":"admin", "password":"admin", "client_id":"dev test", "user_ip_address":"127.0.0.1","group_guids":[]}}'
```

Test token with Bearer prefix:
```
curl -X POST http://localhost:3003/collections.umm_json -H 'Authorization: Bearer ABC-1' -H1'Accept: application/vnd.nasa.cmr.u mm_results+json; version=1.16.4' -d 'concept_id=C1200000083-LARC'
```

Test token without Bearer prefix:
```
curl -X POST http://localhost:3003/collections.umm_json -H 'Authorization: ABC-1' -H1'Accept: application/vnd.nasa.cmr.u mm_results+json; version=1.16.4' -d 'concept_id=C1200000083-LARC'
```