### PR TITLE
MMT-2813 - Changing TEA config gen. from API Gateway to Application Load Balancer

### DIFF
--- a/tea-config-generator/README.md
+++ b/tea-config-generator/README.md
@@ -43,11 +43,39 @@ use as a build and deployment environment when running under a CI/CD system.
 
 ## Deploying to AWS
 
+Several methods are provided to publish this application to specific CMR AWS
+environments. These processes can be reused for other similar environments based
+on need.
+
+### Deployment
+
 The [serverless.yml](serverless.yml) file will create an IAM role for the lambda
-functions. It will use the following Role name:
+functions and install them under an Application Load Balancer. The ARN is to be
+provided. The IAM role will use the following Role name:
 `tea-config-generator-role-${self:custom.env}-${self:provider.region}` and will
 use `arn:aws:iam::${aws:accountId}:policy/NGAPShRoleBoundary` for a Permissions
-Boundary.
+Boundary. This setup is suitable for situations where a public URL is applied at
+the Loadbalancer level. 
+
+* **NOTE**: This is the file used for deployment to SIT, UAT, and OPS
+
+
+### Sandbox
+The [serverless-sandbox.yml](serverless-sandbox.yml) file will also create an IAM
+role and be bound to the same Permissions Boundary, however it will use an API 
+Gateway to publish the lambda functions. The URL for the API Gateway can be used
+for internal testing or for use within an AWS account. 
+
+* **NOTE**: This is the file used for testing on AWS but not SIT, UAT, or OPS.
+
+
+### Local Use
+The [serverless-local.yml](serverless-local.yml) file is ment for use locally by
+developers of the application. It will locally publish an API Gateway and allow
+access to the lambda functions through that. It also includes an S3 bucket for
+displaying the HTML API documentation. 
+
+* **NOTE**: for localhost use only.
 
 ## Testing
 Read the details in the ./run.sh script. There are functions which have all the

--- a/tea-config-generator/README.md
+++ b/tea-config-generator/README.md
@@ -70,7 +70,7 @@ for internal testing or for use within an AWS account.
 
 
 ### Local Use
-The [serverless-local.yml](serverless-local.yml) file is ment for use locally by
+The [serverless-local.yml](serverless-local.yml) file is meant for use locally by
 developers of the application. It will locally publish an API Gateway and allow
 access to the lambda functions through that. It also includes an S3 bucket for
 displaying the HTML API documentation. 

--- a/tea-config-generator/handler.py
+++ b/tea-config-generator/handler.py
@@ -211,7 +211,7 @@ def generate_tea_config(event, context):
     result['headers'] = {'cmr-took': finish_timer(start),
         'content-type': 'text/yaml',
         'cmr-url': env['cmr-url'],
-        'cmr-auth': f'{token[0:12]}...',
+        'cmr-auth': f'{token[0:20]}...',
         'cmr-provider': provider}
 
     return result

--- a/tea-config-generator/handler.py
+++ b/tea-config-generator/handler.py
@@ -170,7 +170,16 @@ def generate_tea_config(event, context):
 
     start = datetime.datetime.now()
 
-    provider = event['pathParameters'].get('id')
+    provider = None
+    if 'pathParameters' in event:
+        provider = event['pathParameters'].get('id')
+    elif 'path' in event:
+        parts = event['path'].split('/', -1)
+        if 1<len(parts) and parts[-2] == 'provider':
+            provider = parts[-1]
+    if provider is None:
+        provider = event['queryStringParameters'].get('id')
+
     if provider is None or len(provider)<1:
         return aws_return_message(event,
             400,
@@ -202,6 +211,7 @@ def generate_tea_config(event, context):
     result['headers'] = {'cmr-took': finish_timer(start),
         'content-type': 'text/yaml',
         'cmr-url': env['cmr-url'],
-        'cmr-auth': token}
+        'cmr-auth': f'{token[0:12]}...',
+        'cmr-provider': provider}
 
     return result

--- a/tea-config-generator/run.sh
+++ b/tea-config-generator/run.sh
@@ -75,7 +75,7 @@ deploy()
       cp ./credentials ~/.aws/.
     fi
   fi
-  serverless deploy
+  serverless deploy --stage "${deploy_env}"
 }
 
 help_doc()
@@ -106,12 +106,13 @@ help_doc()
   printf "${format}" '-I' '' 'Install' 'Install dependent libraries'
 }
 
-while getopts 'hcCdDuUlLjt:orSeIx' opt; do
+while getopts 'hcCdDe:uUlLjt:orSeIx' opt; do
   case ${opt} in
     h) help_doc ;;
     c) color_mode='yes';;
     C) color_mode='no' ;;
     d) documentation ;;
+    e) deploy_env=${OPTARG} ;;
     D) deploy ; exit $? ;;
     u) python3 -m unittest discover -s ./ -p '*test.py' ;;
     U) python3 -m unittest discover -s ./ -p '*test.py' &> test.results.txt ;;

--- a/tea-config-generator/serverless-sandbox.yml
+++ b/tea-config-generator/serverless-sandbox.yml
@@ -24,29 +24,16 @@ functions:
   capabilities:
     handler: capabilities.capabilities
     events:
-      - alb:
-          listenerArn: ${self:custom.loadBalancer}
-          priority: 52
-          conditions:
-            path:
-              - ${self:custom.endPoint}/capabilities
-              - ${self:custom.endPoint}/
+      - http: GET ${self:custom.endPoint}/
+      - http: GET ${self:custom.endPoint}/capabilities
   status:
     handler: handler.health
     events:
-      - alb:
-          listenerArn: ${self:custom.loadBalancer}
-          priority: 51
-          conditions:
-            path: ${self:custom.endPoint}/status
+      - http: GET ${self:custom.endPoint}/status
   provider:
     handler: handler.generate_tea_config
     events:
-      - alb:
-          listenerArn: ${self:custom.loadBalancer}
-          priority: 50
-          conditions:
-            path: ${self:custom.endPoint}/provider*
+      - http: GET ${self:custom.endPoint}/provider/{id}
 
 resources:
   Resources:
@@ -74,7 +61,7 @@ plugins:
   - serverless-offline
   - serverless-s3-local
 custom:
-  loadBalancer: ${env:AWS_TEA_CONFIG_LOADBALANCER, 'arn:aws:elasticloadbalancing:us-east-1:832706493240:listener/app/cmr-services-sit/9bae549c0224bffd/e2610cc0267bd95e'}
+  loadBalancer: ${env:AWS_TEA_CONFIG_LOADBALANCER, ''}
   env: ${env:AWS_TEA_CONFIG_ENV, 'sit'}
   endPoint: /configuration/tea
   pythonRequirements:

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -11,6 +11,7 @@ provider:
   timeout: 15  # 7 seconds is the average run time currently
   region: us-east-1
   role: IamRoleTeaLambdaExecution
+  stage: ${opt:stage, self:provider.stage}
   environment:
     AWS_TEA_CONFIG_CMR: ${env:AWS_TEA_CONFIG_CMR, 'https://cmr.uat.earthdata.nasa.gov'}
     AWS_TEA_CONFIG_LOG_LEVEL: ${env:AWS_TEA_CONFIG_LOG, 'INFO'}
@@ -25,7 +26,7 @@ functions:
     handler: capabilities.capabilities
     events:
       - alb:
-          listenerArn: ${self:custom.loadBalancer}
+          listenerArn: ${cf:${opt:stage}.servicesLbListenerArn}
           priority: 52
           conditions:
             path:
@@ -74,7 +75,6 @@ plugins:
   - serverless-offline
   - serverless-s3-local
 custom:
-  loadBalancer: ${env:AWS_TEA_CONFIG_LOADBALANCER, 'arn:aws:elasticloadbalancing:us-east-1:832706493240:listener/app/cmr-services-sit/9bae549c0224bffd/e2610cc0267bd95e'}
   env: ${env:AWS_TEA_CONFIG_ENV, 'sit'}
   endPoint: /configuration/tea
   pythonRequirements:

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -11,7 +11,6 @@ provider:
   timeout: 15  # 7 seconds is the average run time currently
   region: us-east-1
   role: IamRoleTeaLambdaExecution
-  stage: ${opt:stage, self:provider.stage}
   environment:
     AWS_TEA_CONFIG_CMR: ${env:AWS_TEA_CONFIG_CMR, 'https://cmr.uat.earthdata.nasa.gov'}
     AWS_TEA_CONFIG_LOG_LEVEL: ${env:AWS_TEA_CONFIG_LOG, 'INFO'}

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -75,7 +75,6 @@ plugins:
   - serverless-offline
   - serverless-s3-local
 custom:
-  env: ${env:AWS_TEA_CONFIG_ENV, 'sit'}
   endPoint: /configuration/tea
   pythonRequirements:
     pythonBin: /usr/bin/python3

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -12,8 +12,9 @@ provider:
   region: us-east-1
   role: IamRoleTeaLambdaExecution
   environment:
-    AWS_TEA_CONFIG_CMR: ${env:AWS_TEA_CONFIG_CMR, 'https://cmr.uat.earthdata.nasa.gov'}
+    AWS_TEA_CONFIG_CMR: ${env:AWS_TEA_CONFIG_CMR, 'https://cmr.earthdata.nasa.gov'}
     AWS_TEA_CONFIG_LOG_LEVEL: ${env:AWS_TEA_CONFIG_LOG, 'INFO'}
+  stage: ${opt:stage, 'prod'}
 
 package:
 #  individually: true
@@ -25,7 +26,7 @@ functions:
     handler: capabilities.capabilities
     events:
       - alb:
-          listenerArn: ${cf:${opt:stage}.servicesLbListenerArn}
+          listenerArn: ${cf:${self:provider.stage}.servicesLbListenerArn}
           priority: 52
           conditions:
             path:
@@ -35,7 +36,7 @@ functions:
     handler: handler.health
     events:
       - alb:
-          listenerArn: ${self:custom.loadBalancer}
+          listenerArn: ${cf:${self:provider.stage}.servicesLbListenerArn}
           priority: 51
           conditions:
             path: ${self:custom.endPoint}/status
@@ -43,7 +44,7 @@ functions:
     handler: handler.generate_tea_config
     events:
       - alb:
-          listenerArn: ${self:custom.loadBalancer}
+          listenerArn: ${cf:${self:provider.stage}.servicesLbListenerArn}
           priority: 50
           conditions:
             path: ${self:custom.endPoint}/provider*
@@ -55,7 +56,7 @@ resources:
     IamRoleTeaLambdaExecution:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: tea-config-generator-role-${self:custom.env}-${self:provider.region}
+        RoleName: tea-config-generator-role-${self:provider.stage}-${self:provider.region}
         PermissionsBoundary: arn:aws:iam::${aws:accountId}:policy/NGAPShRoleBoundary
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -23,27 +23,32 @@ package:
 functions:
   capabilities:
     handler: capabilities.capabilities
+    events:
+      - http: GET ${self:custom.endPoint}/
+      - http: GET ${self:custom.endPoint}/capabilities
       - alb:
         listenerArn: ${self:custom.loadBalancer}
-        priority: 100
+        priority: 101
         conditions:
           path: ${self:custom.endPoint}/capabilities
-          path: ${self:custom.endPoint}/
-      #- http: GET ${self:custom.endPoint}/
-      #- http: GET ${self:custom.endPoint}/capabilities
   status:
     handler: handler.health
     events:
+      - http: GET ${self:custom.endPoint}/status
       - alb:
         listenerArn: ${self:custom.loadBalancer}
         priority: 100
         conditions:
           path: ${self:custom.endPoint}/status
-      # http: GET ${self:custom.endPoint}/status
   provider:
     handler: handler.generate_tea_config
     events:
       - http: GET ${self:custom.endPoint}/provider/{id}
+      - alb:
+        listenerArn: ${self:custom.loadBalancer}
+        priority: 100
+        conditions:
+          path: ${self:custom.endPoint}/provider/*
 
 resources:
   Resources:

--- a/tea-config-generator/serverless.yml
+++ b/tea-config-generator/serverless.yml
@@ -23,13 +23,23 @@ package:
 functions:
   capabilities:
     handler: capabilities.capabilities
-    events:
-      - http: GET ${self:custom.endPoint}/
-      - http: GET ${self:custom.endPoint}/capabilities
+      - alb:
+        listenerArn: ${self:custom.loadBalancer}
+        priority: 100
+        conditions:
+          path: ${self:custom.endPoint}/capabilities
+          path: ${self:custom.endPoint}/
+      #- http: GET ${self:custom.endPoint}/
+      #- http: GET ${self:custom.endPoint}/capabilities
   status:
     handler: handler.health
     events:
-      - http: GET ${self:custom.endPoint}/status
+      - alb:
+        listenerArn: ${self:custom.loadBalancer}
+        priority: 100
+        conditions:
+          path: ${self:custom.endPoint}/status
+      # http: GET ${self:custom.endPoint}/status
   provider:
     handler: handler.generate_tea_config
     events:
@@ -61,6 +71,7 @@ plugins:
   - serverless-offline
   - serverless-s3-local
 custom:
+  loadBalancer: arn:aws:elasticloadbalancing:us-east-1:832706493240:listener/app/cmr-services-sit/9bae549c0224bffd/e2610cc0267bd95e
   env: ${env:AWS_TEA_CONFIG_ENV, 'sit'}
   endPoint: /configuration/tea
   pythonRequirements:

--- a/tea-config-generator/tea/gen/get_acls.py
+++ b/tea-config-generator/tea/gen/get_acls.py
@@ -14,7 +14,8 @@ def get_acls(env,provider,token):
     headers = util.standard_headers({'Authorization': token, 'Content-Type': 'application/json'})
     url = (f'{cmr_url}/access-control/acls'
             f'?provider={provider}'
-            f'&identity_type=catalog_item')
+            '&identity_type=catalog_item'
+            '&page_size=2000')
     try:
         response = requests.get(url, headers=headers)
         json_data = response.json()


### PR DESCRIPTION
When trying to publish to sit, it was found that NGAP could not configure a path to point to an API Gatway application. serverless.yml was changed to instead publish to the CMR application load balancer. The path parameter code had to change as no way exists to setup a lambda path parameter in the load balancer.

To support sandbox which does not have a load balancer, a new configuration was created which should look like the old solution.