### PR TITLE
CMR-8119 Adds POST/parameter search for stac format

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -1201,7 +1201,7 @@ The STAC (SpatioTemporal Asset Catalog) result format is a specification for des
 
 CMR supports STAC result format for collection/granule retrieval and granule searches. Because STAC search is based on paging by page number, parameters `offset`, `scroll`, and `CMR-Scroll-Id` and `CMR-Search-After` headers are not supported with STAC format. The maximum number of results returned in STAC result format is 1 million.
 
-__Granule Retrieval in STAC Format Response Example__
+__Granule Retrieval in STAC Format Response Example via GET__
 
 ```json
 {
@@ -1295,6 +1295,96 @@ __Granule Retrieval in STAC Format Response Example__
     "limit": 1000000,
     "returned": 1,
     "matched": 3
+  }
+}
+```
+
+__Granule Retrieval in STAC Format Response Example via POST__
+
+```json
+{
+  "type" : "FeatureCollection",
+  "stac_version" : "1.0.0",
+  "numberMatched" : 3,
+  "numberReturned" : 1,
+  "features" : [ {
+    "properties" : {
+      "datetime" : "2011-02-01T12:00:00.000Z",
+      "start_datetime" : "2011-02-01T12:00:00.000Z",
+      "end_datetime" : "2011-02-11T12:00:00.000Z",
+      "eo:cloud_cover" : 20.0
+    },
+    "stac_extensions" : [ "https://stac-extensions.github.io/eo/v1.0.0/schema.json" ],
+    "collection" : "C1200000009-PROV1",
+    "id" : "G1200000011-PROV1",
+    "geometry" : {
+      "type" : "Polygon",
+      "coordinates" : [ [ [ 10.0, 0.0 ], [ 20.0, 0.0 ], [ 20.0, 30.0 ], [ 10.0, 30.0 ], [ 10.0, 0.0 ] ] ]
+    },
+    "bbox" : [ 10.0, 0.0, 20.0, 30.0 ],
+    "links" : [ {
+      "rel" : "self",
+      "href" : "http://localhost:3003/concepts/G1200000011-PROV1.stac"
+    }, {
+      "rel" : "parent",
+      "href" : "http://localhost:3003/concepts/C1200000009-PROV1.stac"
+    }, {
+      "rel" : "collection",
+      "href" : "http://localhost:3003/concepts/C1200000009-PROV1.stac"
+    }, {
+      "rel" : "root",
+      "href" : "http://localhost:3003/"
+    }, {
+      "rel" : "via",
+      "href" : "http://localhost:3003/concepts/G1200000011-PROV1.json"
+    }, {
+      "rel" : "via",
+      "href" : "http://localhost:3003/concepts/G1200000011-PROV1.umm_json"
+    } ],
+    "stac_version" : "1.0.0",
+    "type" : "Feature",
+    "assets" : {
+      "metadata" : {
+        "href" : "http://localhost:3003/concepts/G1200000011-PROV1.xml",
+        "type" : "application/xml"
+      }
+    }
+  } ],
+  "links" : [ {
+    "rel" : "self",
+    "href" : "http://localhost:3003/granules.stac?collection_concept_id=C1200000009-PROV1&pretty=true&page_num=2"
+  }, {
+    "rel" : "root",
+    "href" : "http://localhost:3003/"
+  }, {
+    "rel" : "prev",
+    "body" : {
+      "collection_concept_id" : "C1200000009-PROV1",
+      "page_num" : "1",
+      "page_size" : "1",
+      "pretty" : "true",
+      "provider" : "PROV1"
+    },
+    "method" : "POST",
+    "merge" : true,
+    "href" : "http://localhost:3003/granules.stac"
+  }, {
+    "rel" : "next",
+    "body" : {
+      "collection_concept_id" : "C1200000009-PROV1",
+      "page_num" : "3",
+      "page_size" : "1",
+      "pretty" : "true",
+      "provider" : "PROV1"
+    },
+    "method" : "POST",
+    "merge" : true,
+    "href" : "http://localhost:3003/granules.stac"
+  } ],
+  "context" : {
+    "returned" : 1,
+    "limit" : 1000000,
+    "matched" : 3
   }
 }
 ```

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -216,7 +216,7 @@
         scroll-id (:scroll-id scroll-id-and-search-params)
         cached-search-params (:search-params scroll-id-and-search-params)
         search-after (get headers (string/lower-case common-routes/SEARCH_AFTER_HEADER))
-        ctx (assoc ctx :query-string body :scroll-id scroll-id)
+        ctx (assoc ctx :query-string body :scroll-id scroll-id :query-params params)
         params (core-api/process-params concept-type params path-w-extension headers mt/xml)
         result-format (:result-format params)
         _ (block-excessive-queries ctx concept-type result-format params)
@@ -369,11 +369,11 @@
     (OPTIONS "/" req (common-routes/options-response))
     (GET "/"
       {params :params headers :headers ctx :request-context query-string :query-string}
-      (find-concepts (merge ctx {:method "GET"}) path-w-extension params headers query-string))
+      (find-concepts (merge ctx {:method :get}) path-w-extension params headers query-string))
     ;; Find concepts - form encoded or JSON
     (POST "/"
       {params :params headers :headers ctx :request-context body :body-copy}
-      (find-concepts (merge ctx {:method "POST"}) path-w-extension params headers body))))
+      (find-concepts (merge ctx {:method :post}) path-w-extension params headers body))))
 
 (def granule-timeline-routes
   "Routes for /search/granules/timeline."

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -77,25 +77,21 @@
     (let [content-type-header (get headers (string/lower-case common-routes/CONTENT_TYPE_HEADER))
           {:keys [scroll-id search-after query-string]} context
           {:keys [offset scroll]} params]
-      (if (and content-type-header query-string)
+      (when-not (:collection-concept-id (util/map-keys->kebab-case params))
         (svc-errors/throw-service-error
-         :bad-request "STAC result format is only supported for parameter searches")
-        (do
-          (when-not (:collection-concept-id (util/map-keys->kebab-case params))
-            (svc-errors/throw-service-error
-             :bad-request "collection_concept_id is required for searching in STAC result format"))
-          (when scroll
-            (svc-errors/throw-service-error
-             :bad-request "scroll is not allowed with STAC result format"))
-          (when offset
-            (svc-errors/throw-service-error
-             :bad-request "offset is not allowed with STAC result format"))
-          (when scroll-id
-            (svc-errors/throw-service-error
-             :bad-request "CMR-Scroll-Id header is not allowed with STAC result format"))
-          (when search-after
-            (svc-errors/throw-service-error
-             :bad-request "CMR-Search-After header is not allowed with STAC result format")))))))
+         :bad-request "collection_concept_id is required for searching in STAC result format"))
+      (when scroll
+        (svc-errors/throw-service-error
+         :bad-request "scroll is not allowed with STAC result format"))
+      (when offset
+        (svc-errors/throw-service-error
+         :bad-request "offset is not allowed with STAC result format"))
+      (when scroll-id
+        (svc-errors/throw-service-error
+         :bad-request "CMR-Scroll-Id header is not allowed with STAC result format"))
+      (when search-after
+        (svc-errors/throw-service-error
+         :bad-request "CMR-Search-After header is not allowed with STAC result format")))))
 
 (defn- find-concepts-by-json-query
   "Invokes query service to parse the JSON query, find results and return
@@ -373,11 +369,11 @@
     (OPTIONS "/" req (common-routes/options-response))
     (GET "/"
       {params :params headers :headers ctx :request-context query-string :query-string}
-      (find-concepts ctx path-w-extension params headers query-string))
+      (find-concepts (merge ctx {:method "GET"}) path-w-extension params headers query-string))
     ;; Find concepts - form encoded or JSON
     (POST "/"
       {params :params headers :headers ctx :request-context body :body-copy}
-      (find-concepts ctx path-w-extension params headers body))))
+      (find-concepts (merge ctx {:method "POST"}) path-w-extension params headers body))))
 
 (def granule-timeline-routes
   "Routes for /search/granules/timeline."

--- a/search-app/src/cmr/search/services/url_helper.clj
+++ b/search-app/src/cmr/search/services/url_helper.clj
@@ -52,10 +52,10 @@
   ([context]
    (format "%sgranules.stac"
            (tconfig/application-public-root-url context)))
-  ([context coll-concept-id]
-   (format "%sgranules.stac?collection_concept_id=%s"
+  ([context query-string]
+   (format "%sgranules.stac?%s"
            (tconfig/application-public-root-url context)
-           coll-concept-id))
+           query-string))
   ([context query-string page-num]
    (format "%sgranules.stac?%s&page_num=%s"
            (tconfig/application-public-root-url context)

--- a/search-app/src/cmr/search/services/url_helper.clj
+++ b/search-app/src/cmr/search/services/url_helper.clj
@@ -49,6 +49,9 @@
 
 (defn stac-request-url
   "Returns the request url for granule search in STAC format"
+  ([context]
+   (format "%sgranules.stac"
+           (tconfig/application-public-root-url context)))
   ([context coll-concept-id]
    (format "%sgranules.stac?collection_concept_id=%s"
            (tconfig/application-public-root-url context)

--- a/search-app/test/cmr/search/test/results_handlers/stac_results_handler.clj
+++ b/search-app/test/cmr/search/test/results_handlers/stac_results_handler.clj
@@ -155,7 +155,7 @@
   {:rel "root"
    :href "http://localhost:3003/"})
 
-(defn- prev-link
+(defn- prev-link-get
   "Returns the prev-link with the given page-num"
   [base-string page-num]
   (when page-num
@@ -163,20 +163,43 @@
      :method "GET"
      :href (href base-string page-num)}))
 
-(defn- next-link
+(defn- next-link-get
   "Returns the next-link with the given page-num"
   [base-string page-num]
  (when page-num
    {:rel "next"
-   :method "GET"
-   :href (href base-string page-num)}))
+    :method "GET"
+    :href (href base-string page-num)}))
+
+(defn- prev-link-post
+  "Returns the prev-link with the given page-num"
+  [query-string page-num]
+  (when page-num
+    (merge
+     (stac-results-handler/stac-post-body query-string)
+     {:rel "prev",
+      :method "POST",
+      :merge true,
+      :href "http://localhost:3003/granules.stac"})))
+
+(defn- next-link-post
+  "Returns the next-link with the given page-num"
+  [query-string page-num]
+  (when page-num
+    (merge
+     (stac-results-handler/stac-post-body query-string)
+     {:rel "next",
+      :method "POST",
+      :merge true,
+      :href "http://localhost:3003/granules.stac"})))
 
 (deftest get-fc-links
-  (testing "Get feature colection links"
+  (testing "GET feature colection links"
     (are3 [query-string page-size page-num base-string expected-nav]
       (let [context (merge {:system {:public-conf {:protocol "http"
                                                    :host "localhost"
-                                                   :port "3003"}}}
+                                                   :port "3003"}}
+                            :method "GET"}
                            {:query-string query-string})
              query {:page-size page-size
                     :offset (* (dec page-num) page-size)}
@@ -185,8 +208,90 @@
              expected-links (remove nil?
                                     [(self-link base-string self-num)
                                      root-link
-                                     (prev-link base-string prev-num)
-                                     (next-link base-string next-num)])]
+                                     (prev-link-get base-string prev-num)
+                                     (next-link-get base-string next-num)])]
+        (is (= expected-links
+               (#'stac-results-handler/get-fc-links context query hits))))
+
+      "default query string with no page-size or page-num"
+      "collection_concept_id=C111-PROV"
+      10
+      1
+      "collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query string with explicit page-num at the front of query string"
+      "page-num=1&collection_concept_id=C111-PROV"
+      10
+      1
+      "collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query string with explicit page_num at the front of query string"
+      "page_num=1&collection_concept_id=C111-PROV"
+      10
+      1
+      "collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query string with explicit page-num not at the front of query string"
+      "collection_concept_id=C111-PROV&page-num=1"
+      10
+      1
+      "collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query string with explicit page_num not at the front of query string"
+      "collection_concept_id=C111-PROV&page_num=1"
+      10
+      1
+      "collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query string with explicit page-size in query string"
+      "page_size=20&collection_concept_id=C111-PROV"
+      20
+      1
+      "page_size=20&collection_concept_id=C111-PROV"
+      [1 nil 2]
+
+      "query with both previous and next pages"
+      "page_size=2&page_num=5&collection_concept_id=C111-PROV"
+      2
+      5
+      "page_size=2&collection_concept_id=C111-PROV"
+      [5 4 6]
+
+      "query with no next page"
+      "page_size=10&page_num=3&collection_concept_id=C111-PROV"
+      10
+      3
+      "page_size=10&collection_concept_id=C111-PROV"
+      [3 2 nil]
+
+      "query with neither previous page nor next page"
+      "page_num=1&collection_concept_id=C111-PROV&page_size=30"
+      30
+      1
+      "collection_concept_id=C111-PROV&page_size=30"
+      [1 nil nil]))
+
+  (testing "POST feature colection links"
+    (are3 [query-string page-size page-num base-string expected-nav]
+      (let [context (merge {:system {:public-conf {:protocol "http"
+                                                   :host "localhost"
+                                                   :port "3003"}}
+                            :method "POST"}
+                           {:query-string query-string})
+             query {:page-size page-size
+                    :offset (* (dec page-num) page-size)}
+             hits 30
+             [self-num prev-num next-num] expected-nav
+             expected-links (remove nil?
+                                    [(self-link base-string self-num)
+                                     root-link
+                                     (prev-link-post base-string prev-num)
+                                     (next-link-post base-string next-num)])]
         (is (= expected-links
                (#'stac-results-handler/get-fc-links context query hits))))
 

--- a/system-int-test/src/cmr/system_int_test/data2/stac.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/stac.clj
@@ -2,12 +2,15 @@
   "Contains helper functions for converting granules into the expected map of parsed stac results."
   (:require
    [cmr.common.util :as util]
-   [cmr.system-int-test.utils.url-helper :as url]))
+   [cmr.system-int-test.utils.url-helper :as url]
+   [ring.util.codec :as codec]))
 
 (defn- href
   "Returns the link href"
   ([]
    (format "%sgranules.stac" (url/search-root)))
+  ([query-string]
+   (format "%sgranules.stac?%s" (url/search-root) query-string))
   ([query-string page-num]
    (format "%sgranules.stac?%s&page_num=%s" (url/search-root) query-string page-num)))
 
@@ -30,7 +33,7 @@
                 (when prev-num
                   {:rel "prev"
                    :method "POST"
-                   :body body
+                   :body (into (sorted-map) (assoc body :page_num (str prev-num)))
                    :merge true
                    :href (href)}))
               (if (= method "GET")
@@ -41,7 +44,7 @@
                 (when next-num
                   {:rel "next"
                    :method "POST"
-                   :body body
+                   :body (into (sorted-map) (assoc body :page_num (str next-num)))
                    :merge true
                    :href (href)}))]))))
 

--- a/system-int-test/src/cmr/system_int_test/data2/stac.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/stac.clj
@@ -6,26 +6,44 @@
 
 (defn- href
   "Returns the link href"
-  [query-string page-num]
-  (format "%sgranules.stac?%s&page_num=%s" (url/search-root) query-string page-num))
+  ([]
+   (format "%sgranules.stac" (url/search-root)))
+  ([query-string page-num]
+   (format "%sgranules.stac?%s&page_num=%s" (url/search-root) query-string page-num)))
 
 (defn- result-map->expected-links
   "Returns the stac links for the given result map"
-  [result-map]
-  (let [{:keys [query-string page-num prev-num next-num]} result-map]
-    (remove nil?
-            [{:rel "self"
-              :href (href query-string page-num)}
-             {:rel "root"
-              :href (url/search-root)}
-             (when prev-num
-               {:rel "prev"
-                :method "GET"
-                :href (href query-string prev-num)})
-             (when next-num
-               {:rel "next"
-                :method "GET"
-                :href (href query-string next-num)})])))
+  ([result-map]
+   (result-map->expected-links result-map "GET"))
+  ([result-map method]
+   (let [{:keys [query-string page-num prev-num next-num body]} result-map]
+     (remove nil?
+             [{:rel "self"
+               :href (href query-string page-num)}
+              {:rel "root"
+               :href (url/search-root)}
+              (if (= method "GET")
+                (when prev-num
+                  {:rel "prev"
+                   :method "GET"
+                   :href (href query-string prev-num)})
+                (when prev-num
+                  {:rel "prev"
+                   :method "POST"
+                   :body body
+                   :merge true
+                   :href (href)}))
+              (if (= method "GET")
+                (when next-num
+                  {:rel "next"
+                   :method "GET"
+                   :href (href query-string next-num)})
+                (when next-num
+                  {:rel "next"
+                   :method "POST"
+                   :body body
+                   :merge true
+                   :href (href)}))]))))
 
 (defn- granule->expected-stac
   "Returns the stac map of the granule.
@@ -77,15 +95,17 @@
   - geometry: stac geometry info. Since the different geometry test cases has been covered
               in unit tests. We use the same geometry for all granules in this test.
   - bbox: stac bbox info. Simplified similar to geometry."
-  [result-map]
-  (let [{:keys [matched granules]} result-map]
-    (util/remove-nil-keys
-     {:type "FeatureCollection"
-      :stac_version "1.0.0"
-      :numberMatched matched
-      :numberReturned (count granules)
-      :features (seq (map (partial granule->expected-stac result-map) granules))
-      :links (result-map->expected-links result-map)
-      :context {:returned (count granules)
-                :limit 1000000
-                :matched matched}})))
+  ([result-map]
+   (result-map->expected-stac result-map "GET"))
+  ([result-map method]
+   (let [{:keys [matched granules]} result-map]
+     (util/remove-nil-keys
+      {:type "FeatureCollection"
+       :stac_version "1.0.0"
+       :numberMatched matched
+       :numberReturned (count granules)
+       :features (seq (map (partial granule->expected-stac result-map) granules))
+       :links (result-map->expected-links result-map method)
+       :context {:returned (count granules)
+                 :limit 1000000
+                 :matched matched}}))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_format_test.clj
@@ -730,8 +730,24 @@
     (index/wait-until-indexed)
 
     (util/are3 [params result-map]
-      (let [response (search/find-concepts-stac :granule
-                                                (merge params {:collection-concept-id coll-concept-id}))
+      (let [response (search/find-concepts-stac
+                      :granule
+                      (merge params {:collection-concept-id coll-concept-id}))
+            post-response (client/post (url/search-url :granule)
+                                       {:accept "application/json; profile=stac-catalogue"
+                                        :content-type mt/form-url-encoded
+                                        :body (codec/form-encode (merge
+                                                                  params
+                                                                  {:collection-concept-id coll-concept-id}))
+                                        :throw-exceptions false
+                                        :connection-manager (s/conn-mgr)})
+            post-ext-response (client/post (format "%s.stac" (url/search-url :granule))
+                                           {:content-type mt/form-url-encoded
+                                            :body (codec/form-encode (merge
+                                                                      params
+                                                                      {:collection-concept-id coll-concept-id}))
+                                            :throw-exceptions false
+                                            :connection-manager (s/conn-mgr)})
             full-result-map (merge result-map
                                    {:coll-concept-id coll-concept-id
                                     :matched 3
@@ -743,10 +759,33 @@
                                                  [10.0 30.0]
                                                  [10.0 0.0]]]}
                                     :bbox [10.0 0.0 20.0 30.0]})]
+
         (is (search/mime-type-matches-response? response mt/stac))
         (is (= 200 (:status response)))
         (is (= (stac/result-map->expected-stac full-result-map)
-               (:results response))))
+               (:results response)))
+        (is (search/mime-type-matches-response? post-response mt/stac))
+        (is (= 200 (:status post-response)))
+        (is (= (stac/result-map->expected-stac (merge
+                                                full-result-map
+                                                {:body (merge {:collection_concept_id coll-concept-id}
+                                                              (-> params
+                                                                  util/map-keys->snake_case
+                                                                  (dissoc :page_num)
+                                                                  (update :page_size str)))})
+                                               "POST")
+               (json/decode (:body post-response) true)))
+        (is (search/mime-type-matches-response? post-ext-response mt/stac))
+        (is (= 200 (:status post-ext-response)))
+        (is (= (stac/result-map->expected-stac (merge
+                                                full-result-map
+                                                {:body (merge {:collection_concept_id coll-concept-id}
+                                                              (-> params
+                                                                  util/map-keys->snake_case
+                                                                  (dissoc :page_num)
+                                                                  (update :page_size str)))})
+                                               "POST")
+               (json/decode (:body post-ext-response) true))))
 
       "default page-size and page-num"
       nil
@@ -812,25 +851,6 @@
           (is (= ["STAC result format is only supported for granule searches"]
                  (:errors response)
                  (:errors ext-response)))))
-
-      (testing "stac search with POST"
-        (let [response (client/post (url/search-url :granule)
-                                    {:accept "application/json; profile=stac-catalogue"
-                                     :content-type mt/form-url-encoded
-                                     :body (codec/form-encode {:collection-concept-id coll-concept-id})
-                                     :throw-exceptions false
-                                     :connection-manager (s/conn-mgr)})
-              ext-response (client/post (format "%s.stac" (url/search-url :granule))
-                                        {:content-type mt/form-url-encoded
-                                         :body (codec/form-encode {:collection-concept-id coll-concept-id})
-                                         :throw-exceptions false
-                                         :connection-manager (s/conn-mgr)})]
-          (is (= 400
-                 (:status response)
-                 (:status ext-response)))
-          (is (= ["STAC result format is only supported for parameter searches"]
-                 (:errors (json/decode (:body response) true))
-                 (:errors (json/decode (:body ext-response) true))))))
 
       (testing "stac search with JSON query"
         (let [response (client/post


### PR DESCRIPTION
This PR allows for search-app concept search endpoint returning a stac format to use POST requests with parameters that are equivalent to GET requests with the same parameters.  This does not include JSON queries.