### PR TITLE
CMR-8143: Removed jackson-databind dependency from common libs.

### DIFF
--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[cheshire "5.10.0"]
                  [clj-time "0.15.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.13.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [compojure "1.6.1"]
                  [digest "1.4.8"]
                  [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -19,7 +19,8 @@
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.13.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [com.gfredericks/test.chuck "0.2.9"]
                  [com.taoensso/timbre "5.1.0"]
                  [commons-codec/commons-codec "1.11"]

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -15,7 +15,8 @@
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.6"]
                  [com.fasterxml.jackson.core/jackson-core "2.13.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [org.apache.logging.log4j/log4j-api "2.15.0"]
                  [org.clojure/clojure "1.10.0"]

--- a/schema-validation-lib/project.clj
+++ b/schema-validation-lib/project.clj
@@ -7,7 +7,8 @@
   :exclusions [[chesire]]
   :dependencies [[cheshire "5.10.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.13.2"]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [com.github.everit-org.json-schema/org.everit.json.schema "1.12.1"]
                  [org.clojure/clojure "1.10.0"]]
   :repositories [["jitpack.io" "https://jitpack.io"]]


### PR DESCRIPTION
This is to address the Snyk vulnerabilities reported at internal libraries.