### PR TITLE
CMR-7215: Create UMM-Sub Schema v1.1, adding Type field

### DIFF
--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_subscription.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_subscription.clj
@@ -6,27 +6,39 @@
    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
    [cmr.umm-spec.models.umm-subscription-models :as umm-sub]
    [cmr.umm-spec.test.location-keywords-helper :as lkt]
-   [cmr.umm-spec.umm-spec-core :as umm-spec]))
+   [cmr.umm-spec.umm-spec-core :as umm-spec]
+   [cmr.umm-spec.versioning :as umm-versioning]))
 
 (def context (lkt/setup-context-for-test))
 
-(def ^:private sample-umm-subscription
-  {:Name "someSub"
-   :SubscriberId "someSubId"
-   :CollectionConceptId "C123-PROV1"
-   :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"})
+(def ^:private latest-umm-sub-verison umm-versioning/current-subscription-version)
+
+(defn- sample-umm-subscription
+  [version]
+  (get {"1.0" {:Name "someSub"
+               :SubscriberId "someSubId"
+               :CollectionConceptId "C123-PROV1"
+               :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"}
+        "1.1" {:Name "someSub"
+               :Type "granule"
+               :SubscriberId "someSubId"
+               :CollectionConceptId "C123-PROV1"
+               :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+               :MetadataSpecification
+               {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1"
+                :Name "UMM-Sub"
+                :Version "1.1"}}}
+       version))
+
 
 (defn- subscription
   "Returns a UMM-Sub record from the given attribute map."
   ([]
    (subscription {}))
   ([attribs]
-   (umm-sub/map->UMM-Sub (merge sample-umm-subscription attribs)))
-  ([index attribs]
-   (umm-sub/map->UMM-Sub
-    (merge sample-umm-subscription
-           {:Name (str "Name " index)}
-           attribs))))
+   (subscription attribs latest-umm-sub-verison))
+  ([attribs version]
+   (umm-sub/map->UMM-Sub (merge (sample-umm-subscription version) attribs))))
 
 (defn- umm-sub->concept
   "Returns a concept map from a UMM subscription item or tombstone."
@@ -50,13 +62,9 @@
 (defn subscription-concept
   "Returns the subscription for ingest with the given attributes"
   ([attribs]
+   (subscription-concept attribs latest-umm-sub-verison))
+  ([attribs umm-sub-version]
    (let [{:keys [provider-id native-id]} attribs]
-     (-> (subscription attribs)
-         (assoc :provider-id provider-id :native-id native-id)
-         umm-sub->concept)))
-  ([attribs index]
-   (let [{:keys [provider-id native-id]} attribs]
-     (-> index
-         (subscription attribs)
+     (-> (subscription attribs umm-sub-version)
          (assoc :provider-id provider-id :native-id native-id)
          umm-sub->concept))))

--- a/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
@@ -79,7 +79,7 @@
   ([metadata-attrs attrs]
    (make-subscription-concept metadata-attrs attrs 0))
   ([metadata-attrs attrs idx]
-   (make-subscription-concept metadata-attrs attrs 0 latest-umm-sub-verison))
+   (make-subscription-concept metadata-attrs attrs idx latest-umm-sub-verison))
   ([metadata-attrs attrs idx umm-sub-version]
    (-> (merge {:provider-id "PROV1" :Name (str "Name " idx)} metadata-attrs)
        (data-umm-sub/subscription-concept umm-sub-version)

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
@@ -156,7 +156,8 @@
        (testing "Subscription concepts are indexed."
          (let [{:keys [hits refs] :as response} (search/find-refs :subscription {})]
            (is (= 6 hits))
-           (is (= 6 (count refs)))))))))
+           (is (= 6 (count refs)))
+           ))))))
 
 (deftest ^:oracle bulk-index-all-subscriptions
   (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "UMM-Sub",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "Name": {
+      "description": "The name of a subscription.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "Type": {
+      "description": "The type of a subscription.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10,
+      "enum": [
+        "collection",
+        "granule"
+      ]
+    },
+    "SubscriberId": {
+      "description": "The userid of the subscriber.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 30
+    },
+    "EmailAddress": {
+      "description": "The email address of the subscriber.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "CollectionConceptId": {
+      "description": "The collection concept id of the granules subscribed.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "Query": {
+      "description": "The search query for the granules that matches the subscription.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40000
+    }
+  },
+  "required": [
+    "Name",
+    "Query",
+    "Type"
+  ]
+}

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
@@ -41,11 +41,51 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 40000
+    },
+    "MetadataSpecification": {
+      "description": "Requires the client, or user, to add in schema information into every variable record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
+      "$ref": "#/definitions/MetadataSpecificationType"
     }
   },
   "required": [
     "Name",
     "Query",
-    "Type"
-  ]
+    "Type",
+    "MetadataSpecification"
+  ],
+  "definitions": {
+    "MetadataSpecificationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object requires any metadata record that is validated by this schema to provide information about the schema.",
+      "properties": {
+        "URL": {
+          "description": "This element represents the URL where the schema lives. The schema can be downloaded.",
+          "type": "string",
+          "enum": [
+            "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1"
+          ]
+        },
+        "Name": {
+          "description": "This element represents the name of the schema.",
+          "type": "string",
+          "enum": [
+            "UMM-Sub"
+          ]
+        },
+        "Version": {
+          "description": "This element represents the version of the schema.",
+          "type": "string",
+          "enum": [
+            "1.1"
+          ]
+        }
+      },
+      "required": [
+        "URL",
+        "Name",
+        "Version"
+      ]
+    }
+  }
 }

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-json-schema.json
@@ -13,8 +13,6 @@
     "Type": {
       "description": "The type of a subscription.",
       "type": "string",
-      "minLength": 1,
-      "maxLength": 10,
       "enum": [
         "collection",
         "granule"

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1/umm-sub-search-results-json-schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-sub-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["subscription"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "type": "string",
+          "minLength": 4,
+          "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "user-id": {
+          "description": "The id of the user who created this item revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "deleted": {
+          "description": "Indicates if the item represents a tombstone",
+          "type": "boolean"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date"]
+    }
+  },
+  "title": "UMM Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/metadata_specification.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/metadata_specification.clj
@@ -12,6 +12,8 @@
    :service "UMM-S"
    :tool "UMM-T"
 
+   :subscription "UMM-Sub"
+
    ;; UMM-V can not be used due to visualizations. Concept IDs start with V.
    :variable "UMM-Var"
 

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
@@ -2,6 +2,7 @@
   "Contains functions for migrating between versions of the UMM subscription schema."
   (:require
    [clojure.string :as string]
+   [cmr.common.services.errors :as errors]
    [cmr.umm-spec.metadata-specification :as m-spec]
    [cmr.umm-spec.migration.version.interface :as interface]))
 
@@ -12,7 +13,13 @@
 (defmethod interface/migrate-umm-version [:subscription "1.0" "1.1"]
   [context subscription & _]
   (as-> subscription s
-      (if (> (count (:CollectionConceptId s)) 0)
-        (assoc s :Type "granule")
-        (assoc s :Type "collection"))
-      (m-spec/update-version s :subscription "1.1")))
+    (if (> (count (:CollectionConceptId s)) 0)
+      (assoc s :Type "granule")
+      (assoc s :Type "collection"))
+    (m-spec/update-version s :subscription "1.1")))
+
+(defmethod interface/migrate-umm-version [:subscription "1.1" "1.0"]
+  [context subscription & _]
+  (errors/throw-service-errors
+   :bad-request
+   [(str "Cannot migrate UMM-Sub v1.1 to v1.0.")]))

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
@@ -1,0 +1,18 @@
+(ns cmr.umm-spec.migration.version.subscription
+  "Contains functions for migrating between versions of the UMM subscription schema."
+  (:require
+   [clojure.string :as string]
+   [cmr.umm-spec.metadata-specification :as m-spec]
+   [cmr.umm-spec.migration.version.interface :as interface]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ;;; subscription Migration Implementations
+
+
+(defmethod interface/migrate-umm-version [:subscription "1.0" "1.1"]
+  [context subscription & _]
+  (as-> subscription s
+      (if (> (count (:CollectionConceptId s)) 0)
+        (assoc s :Type "granule")
+        (assoc s :Type "collection"))
+      (m-spec/update-version s :subscription "1.1")))

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_subscription_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_subscription_models.clj
@@ -8,6 +8,9 @@
    ;; The name of a subscription.
    Name
 
+  ;;  The type of a subscription.
+   Type
+
    ;; The userid of the subscriber.
    SubscriberId
 
@@ -19,5 +22,10 @@
 
    ;; The search query for the granules that matches the subscription.
    Query
+
+   ;; Requires the user to add in schema information into every service record. It includes the
+   ;; schema's name, version, and URL location. The information is controlled through enumerations
+   ;; at the end of this schema.
+   MetadataSpecification
   ])
 (record-pretty-printer/enable-record-pretty-printing UMM-Sub)

--- a/umm-spec-lib/src/cmr/umm_spec/models/umm_subscription_models.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/models/umm_subscription_models.clj
@@ -8,7 +8,7 @@
    ;; The name of a subscription.
    Name
 
-  ;;  The type of a subscription.
+   ;;  The type of a subscription.
    Type
 
    ;; The userid of the subscriber.
@@ -29,3 +29,18 @@
    MetadataSpecification
   ])
 (record-pretty-printer/enable-record-pretty-printing UMM-Sub)
+
+;; This object requires any metadata record that is validated by this schema to provide information
+;; about the schema.
+(defrecord MetadataSpecificationType
+  [
+   ;; This element represents the URL where the schema lives. The schema can be downloaded.
+   URL
+
+   ;; This element represents the name of the schema.
+   Name
+
+   ;; This element represents the version of the schema.
+   Version
+  ])
+(record-pretty-printer/enable-record-pretty-printing MetadataSpecificationType)

--- a/umm-spec-lib/src/cmr/umm_spec/versioning.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/versioning.clj
@@ -16,7 +16,7 @@
    :variable ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6" "1.7" "1.8" "1.8.1"]
    :service ["1.0" "1.1" "1.2" "1.3" "1.3.1" "1.3.2" "1.3.3" "1.3.4" "1.4" "1.4.1" "1.5.0"]
    :tool ["1.0" "1.1" "1.1.1" "1.2.0"]
-   :subscription ["1.0"]})
+   :subscription ["1.0" "1.1"]})
 
 (def current-collection-version
   "The current version of the collection UMM schema."

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
@@ -37,3 +37,6 @@
 (deftest migrate-1_0->1_1
   (is (= granule-subscription-concept-1_1
          (migrate-subscription "1.0" "1.1" granule-subscription-concept-1_0))))
+
+(deftest migrate-1_1->1_0
+  (is (thrown? clojure.lang.ExceptionInfo (migrate-subscription "1.1" "1.0" granule-subscription-concept-1_1))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
@@ -1,0 +1,39 @@
+(ns cmr.umm-spec.test.migration.version.subscription
+  (:require
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.test.test-check-ext :as ext :refer [defspec]]
+   [cmr.umm-spec.migration.version.core :as vm]
+   [cmr.umm-spec.test.location-keywords-helper :as lkt]
+   [cmr.umm-spec.test.umm-generators :as umm-gen]
+   [cmr.umm-spec.umm-spec-core :as core]
+   [cmr.umm-spec.util :as u]
+   [cmr.umm-spec.versioning :as v]
+   [com.gfredericks.test.chuck.clojure-test :refer [for-all]]))
+
+;; All migrations in this file will migrate variables in this way
+(def migrate-subscription (partial vm/migrate-umm {} :subscription))
+
+(def granule-subscription-concept-1_0
+  {:Name "subscription-1"
+   :SubscriberId "subscriber-id-1"
+   :EmailAddress "email-address@cmr.gov"
+   :CollectionConceptId "C1200000005-PROV1"
+   :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"})
+
+(def granule-subscription-concept-1_1
+  {:Name "subscription-1"
+   :Type "granule"
+   :SubscriberId "subscriber-id-1"
+   :EmailAddress "email-address@cmr.gov"
+   :CollectionConceptId "C1200000005-PROV1"
+   :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+   :MetadataSpecification
+   {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1"
+    :Name "UMM-Sub"
+    :Version "1.1"}})
+
+(deftest migrate-1_0->1_1
+  (is (= granule-subscription-concept-1_1
+         (migrate-subscription "1.0" "1.1" granule-subscription-concept-1_0))))


### PR DESCRIPTION
Update the UMM Subscription Schema in preparation for collection subscriptions.
1. Added the `Type` field.  Accepts values `granule` or `collection`
2. Removed the requirement for `CollectionConceptId` as it will be empty in `collection` subscriptions
3. Added `MetadataSpecification`