### PR TITLE
CMR-8138-1: Update references to Version column to ProductVersion

### DIFF
--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -85,7 +85,7 @@
       (do
         (warn (format (str "While constructing community metrics humanizer, "
                            "could not find corresponding collection when searching for the term %s. "
-                           "Csv line entry: %s")
+                           "CSV line entry: %s")
                       product
                       csv-line))
         product))))
@@ -102,21 +102,20 @@
           (errors/throw-service-error :invalid-data
                                       (format (str "Error parsing 'Hosts' CSV Data. "
                                                    "Hosts must be an integer. "
-                                                   "Csv line entry: %s")
+                                                   "CSV line entry: %s")
                                               csv-line))))
       (errors/throw-service-error :invalid-data
                                   (format (str "Error parsing 'Hosts' CSV Data. "
                                                "Hosts may not be empty. "
-                                               "Csv line entry: %s")
+                                               "CSV line entry: %s")
                                           csv-line)))))
 
 (defn- get-version
   "Version must be 20 characters or less."
   [csv-line version-col]
   (let [reported-version (read-csv-column csv-line version-col)]
-    (if (<= (count reported-version) 20)
-      reported-version
-      nil)))
+    (when (<= (count reported-version) 20)
+      reported-version)))
 
 (defn- csv-entry->community-usage-metric
   "Convert a line in the csv file to a community usage metric. Only storing short-name (product)
@@ -160,7 +159,9 @@
   [context]
   (try
     (get-community-usage-metrics context)
-    (catch Exception e [])))
+    (catch Exception e 
+      (warn e)
+      [])))
 
 (defn- community-usage-metrics-list->set
   "Convert list of {:short-name :access-count} maps into a set of short-names."

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -25,7 +25,7 @@
   [csv-header]
   (let [csv-header (mapv str/trim csv-header)]
     {:product-col (.indexOf csv-header "Product")
-     :version-col (.indexOf csv-header "Version")
+     :version-col (.indexOf csv-header "ProductVersion")
      :hosts-col (.indexOf csv-header "Hosts")}))
 
 (defn- read-csv-column
@@ -110,12 +110,21 @@
                                                "Csv line entry: %s")
                                           csv-line)))))
 
+(defn- get-version
+  "Version must be 20 characters or less."
+  [csv-line version-col]
+  (let [reported-version (read-csv-column csv-line version-col)]
+    (if (<= (count reported-version) 20)
+      reported-version
+      nil)))
+
 (defn- csv-entry->community-usage-metric
   "Convert a line in the csv file to a community usage metric. Only storing short-name (product)
    and access-count (hosts)."
-  [context csv-line product-col hosts-col current-metrics cache]
+  [context csv-line product-col hosts-col version-col current-metrics cache]
   (when (seq (remove empty? csv-line)) ; Don't process empty lines
     {:short-name (get-short-name context cache csv-line product-col current-metrics)
+     :version (get-version csv-line version-col)
      :access-count (get-access-count csv-line hosts-col)}))
 
 (defn- validate-and-read-csv
@@ -135,6 +144,8 @@
           (errors/throw-service-error :invalid-data "A 'Product' column is required in community usage CSV data"))
         (when (< (:hosts-col csv-columns) 0)
           (errors/throw-service-error :invalid-data "A 'Hosts' column is required in community usage CSV data"))
+        (when (< (:version-col csv-columns) 0)
+          (errors/throw-service-error :invalid-data "A 'ProductVersion' column is required in community usage CSV data"))
         (merge {:csv-lines (rest csv-lines)} csv-columns))
       (errors/throw-service-error :invalid-data "You posted empty content"))
     (errors/throw-service-error :invalid-data "You posted empty content")))
@@ -143,9 +154,13 @@
   "Retrieves the current community usage metrics from metadata-db.
    Returns an empty set if unable to retrieve metrics."
   [context]
+  (:community-usage-metrics (json/decode (:metadata (humanizer-service/fetch-humanizer-concept context)) true)))
+
+(defn- get-community-usage-metrics-or-empty-list
+  [context]
   (try
-    (:community-usage-metrics (json/decode (:metadata (humanizer-service/fetch-humanizer-concept context)) true))
-    (catch Exception e #{})))
+    (get-community-usage-metrics context)
+    (catch Exception e [])))
 
 (defn- community-usage-metrics-list->set
   "Convert list of {:short-name :access-count} maps into a set of short-names."
@@ -155,20 +170,21 @@
 (defn- community-usage-csv->community-usage-metrics
   "Validate the community usage csv and convert to a list of community usage metrics."
   [context community-usage-csv current-metrics]
-  (let [{:keys [csv-lines product-col hosts-col]} (validate-and-read-csv community-usage-csv)
+  (let [{:keys [csv-lines product-col hosts-col version-col]} (validate-and-read-csv community-usage-csv)
         short-name-cache (new java.util.HashMap)]
     (remove nil?
-            (map #(csv-entry->community-usage-metric context % product-col hosts-col current-metrics short-name-cache)
+            (map #(csv-entry->community-usage-metric context % product-col hosts-col version-col current-metrics short-name-cache)
                  csv-lines))))
 
 (defn- aggregate-usage-metrics
   "Combine access-counts for entries with the same short-name."
   [metrics]
-  (let [count-map (reduce (fn [m {:keys [short-name access-count]}]
-                            (update m short-name (fnil + 0) access-count))
-                          {}
-                          metrics)]
-    (map (fn [[k v]] {:short-name k :access-count v}) count-map)))
+  ;; name-version-groups is map of [short-name, version] [entries that match short-name/version]
+  (let [name-version-groups (group-by (juxt :short-name :version) metrics)] ; Group by short-name and version
+    ;; The first entry in each list has the short-name and version we want so just add up the access-counts
+    ;; in the rest and add that to the first entry to make the access-counts right
+    (map #(util/remove-nil-keys (assoc (first %) :access-count (reduce + (map :access-count %))))
+         (vals name-version-groups))))
 
 (defn- validate-metrics
   "Validate metrics against the JSON schema validation"
@@ -194,7 +210,7 @@
   (let [comprehensive (or (:comprehensive params) "false") ;; set default
         current-metrics (if (= "false" comprehensive)
                           (-> context
-                              (get-community-usage-metrics)
+                              (get-community-usage-metrics-or-empty-list)
                               (community-usage-metrics-list->set))
                           #{})
         metrics (community-usage-csv->community-usage-metrics context community-usage-csv current-metrics)

--- a/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_relevancy_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_relevancy_test.clj
@@ -25,7 +25,7 @@
                        hu/save-sample-humanizers-fixture]))
 
 (def sample-usage-csv
-  (str "Product,Version,Hosts\n"
+  (str "Product,ProductVersion,Hosts\n"
        "Usage-10,3,10\n"
        "Usage-100,1,100\n"
        "Usage-30,2,30\n"

--- a/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_usage_relevancy_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_relevancy/collection_usage_relevancy_test.clj
@@ -22,7 +22,7 @@
    [cmr.system-int-test.utils.search-util :as search]))
 
 (def sample-usage-csv
-  (str "Product,Version,Hosts\n"
+  (str "Product,ProductVersion,Hosts\n"
        "AMSR-L1A,3,10\n"
        "AG_VIRTUAL,1,100\n"
        "AG_MAPSS,2,30\n"
@@ -142,7 +142,7 @@
   (index/wait-until-indexed)
 
   ;; Ingest new community usage metrics and check that results change
-  (hu/ingest-community-usage-metrics (str "Product,Version,Hosts\n"
+  (hu/ingest-community-usage-metrics (str "Product,ProductVersion,Hosts\n"
                                           "AMSR-L1A,3,40\n"
                                           "AG_VIRTUAL,1,12\n"
                                           "AG_MAPSS,2,58\n"))
@@ -179,7 +179,7 @@
 ;; More complicated example/test with entries with version N/A - N/A version entries are
 ;; applied to all collections that match the short name
 (def sample-csv-not-provided-versions
-  (str "Product,Version,Hosts\n"
+  (str "Product,ProductVersion,Hosts\n"
        "AMSR-L1A,3,10\n"
        "AMSR-L1A,N/A,50\n"
        "AG_VIRTUAL,1,100\n"
@@ -214,7 +214,7 @@
            (map :name results)))))
 
 (deftest community-usage-version-formatting
-  (hu/ingest-community-usage-metrics (str "Product,Version,Hosts\n"
+  (hu/ingest-community-usage-metrics (str "Product,ProductVersion,Hosts\n"
                                           "AMSR-L1A,1,10\n"
                                           "AMSR-L1A,3,100\n"
                                           "AMSR-L1A,002,50\n"))

--- a/system-int-test/test/cmr/system_int_test/search/collection_sorting_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_sorting_search_test.clj
@@ -20,7 +20,7 @@
    [cmr.umm.collection.entry-id :as eid]))
 
 (def usage-csv
-  (str "Product,Version,Hosts\n"
+  (str "Product,ProductVersion,Hosts\n"
        "alpha,1,10\n"
        "alpha,2,10\n"
        "alpha,3,30\n"

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -254,13 +254,14 @@
                 admin-update-token
                 (format "Product,ProductVersion,Hosts\n%s,3,4" long-value))))))
 
-    ;; (testing "Maximum version length validations"
-    ;;   (let [long-value (apply str (repeat 21 "x"))]
-    ;;     (is (= {:status 400
-    ;;             :errors ["#/0/version: expected maxLength: 20, actual: 21"]}
-    ;;            (humanizer-util/update-community-usage-metrics
-    ;;             admin-update-token
-    ;;             (format "Product,Version,Hosts\nAST_09XT,%s,4" long-value))))))
+    (testing "Version is removed if length exceeds 20 characters"
+      (let [long-value (apply str (repeat 21 "x"))
+            {:keys [status concept-id revision-id]} (humanizer-util/update-community-usage-metrics
+                                                     admin-update-token
+                                                     (format "Product,ProductVersion,Hosts\nAST_09XT,%s,4" long-value))
+            {:keys [status body]} (humanizer-util/get-community-usage-metrics)]
+        (is (= status 200))
+        (is (= body [{:short-name "AST_09XT" :access-count 4}]))))
 
     (testing "Non-integer value for hosts (access-count)"
       (is (= {:status 422

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -16,14 +16,17 @@
 
 ;; Intentional space before version and empty CSV line for testing
 (def sample-usage-csv
-  "Product, Version,Hosts\r\nAMSR-L1A,3,4\nAG_VIRTUAL,3.2,6\nMAPSS_MOD04_L2,N/A,87\n")
+  "Product, ProductVersion,Hosts\r\nAMSR-L1A,3,4\nAG_VIRTUAL,3.2,6\nMAPSS_MOD04_L2,N/A,87\n")
 
 (def sample-usage-data
   [{:short-name "AMSR-L1A"
+    :version "3"
     :access-count 4}
    {:short-name "AG_VIRTUAL"
+    :version "3.2"
     :access-count 6}
    {:short-name "MAPSS_MOD04_L2"
+    :version "N/A"
     :access-count 87}])
 
 (deftest update-community-metrics-test
@@ -59,12 +62,12 @@
             {:keys [status concept-id revision-id]}
             (humanizer-util/update-community-usage-metrics
              admin-update-token
-             "Product,Version,Hosts\nAST_09XT,3,156")]
+             "Product,ProductVersion,Hosts\nAST_09XT,3,156")]
         (is (= 200 status))
         (is (= existing-concept-id concept-id))
         (is (= 2 revision-id))
         (humanizer-util/assert-humanizers-saved
-         {:community-usage-metrics [{:short-name "AST_09XT" :access-count 156}]}
+         {:community-usage-metrics [{:short-name "AST_09XT" :version "3" :access-count 156}]}
          "admin"
          concept-id
          revision-id)))))
@@ -87,7 +90,7 @@
              (humanizer-util/update-community-usage-metrics token sample-usage-csv))))))
 
 (def comprehensive-usage-test-csv
- "Provider,Product,ProductVersion,Hosts
+  "Provider,Product,ProductVersion,Hosts
   PROV1,SHORTNAME1,N/A,100
   PROV1,ENTRYTITLE2,N/A,100
   PROV1,ENTRYTITLE2:1,N/A,100
@@ -104,56 +107,56 @@
   PROV2,NONEXISTENTCOL2:1,N/A,1")
 
 (def comprehensive-usage-test-result
- [{:short-name "SHORTNAME1" :access-count 800}
-  {:short-name "SHORTNAME2" :access-count 20}
-  {:short-name "NONEXISTENTCOL1" :access-count 1}
-  {:short-name "NONEXISTENTCOL1:1" :access-count 1}
-  {:short-name "NONEXISTENTCOL2" :access-count 1}
-  {:short-name "NONEXISTENTCOL2:1" :access-count 1}])
+  [{:short-name "SHORTNAME1" :version "N/A" :access-count 800}
+   {:short-name "SHORTNAME2" :version "N/A" :access-count 20}
+   {:short-name "NONEXISTENTCOL1" :version "N/A" :access-count 1}
+   {:short-name "NONEXISTENTCOL1:1" :version "N/A" :access-count 1}
+   {:short-name "NONEXISTENTCOL2" :version "N/A" :access-count 1}
+   {:short-name "NONEXISTENTCOL2:1" :version "N/A" :access-count 1}])
 
 (deftest update-community-metrics-test-with-comprehensive
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE1"})
-                                 {:token "mock-echo-system-token"})
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRYTITLE1"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                          2
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE2"})
-                                 {:token "mock-echo-system-token"})
+                                         2
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRYTITLE2"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                          3
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRY:TITLE3"})
-                                 {:token "mock-echo-system-token"})
+                                         3
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRY:TITLE3"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection
-                                          {:ShortName "SHORTNAME2"
-                                           :EntryTitle "ENTRYTITLE4"})
-                                 {:token "mock-echo-system-token"})
+                                         {:ShortName "SHORTNAME2"
+                                          :EntryTitle "ENTRYTITLE4"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE1"})
-                                 {:token "mock-echo-system-token"})
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRYTITLE1"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
-                                          4
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRYTITLE2"})
-                                 {:token "mock-echo-system-token"})
+                                         4
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRYTITLE2"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
-                                          5
-                                          {:ShortName "SHORTNAME1"
-                                           :EntryTitle "ENTRY:TITLE3"})
-                                 {:token "mock-echo-system-token"})
+                                         5
+                                         {:ShortName "SHORTNAME1"
+                                          :EntryTitle "ENTRY:TITLE3"})
+                                {:token "mock-echo-system-token"})
   (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection
-                                          {:ShortName "SHORTNAME2"
-                                           :EntryTitle "ENTRYTITLE5"})
-                                 {:token "mock-echo-system-token"})
+                                         {:ShortName "SHORTNAME2"
+                                          :EntryTitle "ENTRYTITLE5"})
+                                {:token "mock-echo-system-token"})
   (index/wait-until-indexed)
   (testing "Create community usage with invalid comprehensive param"
     (let [response (humanizer-util/update-community-usage-metrics
-                     "mock-echo-system-token"
-                     comprehensive-usage-test-csv
-                     {:http-options {:query-params {:comprehensive "wrong"}}})]
+                    "mock-echo-system-token"
+                    comprehensive-usage-test-csv
+                    {:http-options {:query-params {:comprehensive "wrong"}}})]
       (is (= {:status 400
               :errors
               ["Parameter comprehensive must take value of true or false but was [wrong]"]}
@@ -161,9 +164,9 @@
 
   (testing "Create community usage with comprehensive is true"
     (let [response (humanizer-util/update-community-usage-metrics
-                     "mock-echo-system-token"
-                     comprehensive-usage-test-csv
-                     {:http-options {:query-params {:comprehensive "true"}}})]
+                    "mock-echo-system-token"
+                    comprehensive-usage-test-csv
+                    {:http-options {:query-params {:comprehensive "true"}}})]
       (humanizer-util/assert-humanizers-saved
        {:community-usage-metrics comprehensive-usage-test-result}
        "ECHO_SYS"
@@ -172,9 +175,9 @@
 
   (testing "Create community usage with comprehensive is false"
     (let [response (humanizer-util/update-community-usage-metrics
-                     "mock-echo-system-token"
-                     comprehensive-usage-test-csv
-                     {:http-options {:query-params {:comprehensive "false"}}})]
+                    "mock-echo-system-token"
+                    comprehensive-usage-test-csv
+                    {:http-options {:query-params {:comprehensive "false"}}})]
       (humanizer-util/assert-humanizers-saved
        {:community-usage-metrics comprehensive-usage-test-result}
        "ECHO_SYS"
@@ -183,8 +186,8 @@
 
   (testing "Create community usage with comprehensive is not included"
     (let [response (humanizer-util/update-community-usage-metrics
-                     "mock-echo-system-token"
-                     comprehensive-usage-test-csv)]
+                    "mock-echo-system-token"
+                    comprehensive-usage-test-csv)]
       (humanizer-util/assert-humanizers-saved
        {:community-usage-metrics comprehensive-usage-test-result}
        "ECHO_SYS"
@@ -218,16 +221,16 @@
 
     (testing "Missing CSV Column"
       (are3 [column-name csv]
-            (is (= {:status 422
-                    :errors [(format "A '%s' column is required in community usage CSV data"
-                                     column-name)]}
-                   (humanizer-util/update-community-usage-metrics admin-update-token csv)))
+        (is (= {:status 422
+                :errors [(format "A '%s' column is required in community usage CSV data"
+                                 column-name)]}
+               (humanizer-util/update-community-usage-metrics admin-update-token csv)))
 
-            "Missing product (short-name)"
-            "Product" "Version,Hosts\n3,4"
+        "Missing product (short-name)"
+        "Product" "ProductVersion,Hosts\n3,4"
 
-            "Missing hosts (access-count)"
-            "Hosts" "Product,Version\nAMSR-L1A,4"))
+        "Missing hosts (access-count)"
+        "Hosts" "Product,ProductVersion\nAMSR-L1A,4"))
 
     (testing "Empty Required CSV Column"
       (testing "Empty Product"
@@ -235,13 +238,13 @@
                 :errors ["Error parsing 'Product' CSV Data. Product may not be empty."]}
                (humanizer-util/update-community-usage-metrics
                 admin-update-token
-                "Product,Version,Hosts\n,4,64"))))
+                "Product,ProductVersion,Hosts\n,4,64"))))
       (testing "Empty Hosts"
         (is (= {:status 422
                 :errors ["Error parsing 'Hosts' CSV Data. Hosts may not be empty. Csv line entry: [\"AMSR-L1A\" \"4\" \"\"]"]}
                (humanizer-util/update-community-usage-metrics
                 admin-update-token
-                "Product,Version,Hosts\nAMSR-L1A,4,")))))
+                "Product,ProductVersion,Hosts\nAMSR-L1A,4,")))))
 
     (testing "Maximum product length validations"
       (let [long-value (apply str (repeat 86 "x"))]
@@ -249,7 +252,7 @@
                 :errors ["#/0/short-name: expected maxLength: 85, actual: 86"]}
                (humanizer-util/update-community-usage-metrics
                 admin-update-token
-                (format "Product,Version,Hosts\n%s,3,4" long-value))))))
+                (format "Product,ProductVersion,Hosts\n%s,3,4" long-value))))))
 
     ;; (testing "Maximum version length validations"
     ;;   (let [long-value (apply str (repeat 21 "x"))]
@@ -264,56 +267,56 @@
               :errors ["Error parsing 'Hosts' CSV Data. Hosts must be an integer. Csv line entry: [\"AMSR-L1A\" \"3\" \"x\"]"]}
              (humanizer-util/update-community-usage-metrics
               admin-update-token
-              "Product,Version,Hosts\nAMSR-L1A,3,x"))))))
+              "Product,ProductVersion,Hosts\nAMSR-L1A,3,x"))))))
 
 (def sample-aggregation-csv
   "Sample CSV to test aggregation of access counts in different CSV entries with the same short-name
    and version"
-  "Product,Version,Hosts\nAMSR-L1A,3,4\nAMSR-L1A,3,6\nAMSR-L1A,N/A,87\nAMSR-L1A,N/A,10\nMAPSS_MOD04_L2,4,12")
+  "Product,ProductVersion,Hosts\nAMSR-L1A,3,4\nAMSR-L1A,3,6\nAMSR-L1A,N/A,87\nAMSR-L1A,N/A,10\nMAPSS_MOD04_L2,4,12")
 
-;; (def sample-aggregation-data
-;;  "Expected sample aggregated data from sample-aggregation-csv"
-;;  [{:short-name "AMSR-L1A"
-;;    :version "3"
-;;    :access-count 10}
-;;   {:short-name "AMSR-L1A"
-;;    :version "N/A"
-;;    :access-count 97}
-;;   {:short-name "MAPSS_MOD04_L2"
-;;    :version "4"
-;;    :access-count 12}])
+(def sample-aggregation-data
+  "Expected sample aggregated data from sample-aggregation-csv"
+  [{:short-name "AMSR-L1A"
+    :version "3"
+    :access-count 10}
+   {:short-name "AMSR-L1A"
+    :version "N/A"
+    :access-count 97}
+   {:short-name "MAPSS_MOD04_L2"
+    :version "4"
+    :access-count 12}])
 
-;; ;; Test that metrics are combined appropriately when short-name and version match for different
-;; ;; CSV entries.
-;; (deftest aggregate-community-metrics-test
-;;   (testing "Successful community usage aggregation")
-;;   (let [admin-update-group-concept-id (echo-util/get-or-create-group (system/context) "admin-update-group")
-;;         _  (echo-util/grant-group-admin (system/context) admin-update-group-concept-id :update)
-;;         admin-update-token (echo-util/login (system/context) "admin" [admin-update-group-concept-id])
-;;         {:keys [status concept-id revision-id]} (humanizer-util/update-community-usage-metrics
-;;                                                  admin-update-token
-;;                                                  sample-aggregation-csv)]
-;;     (is (= 201 status))
-;;     (is concept-id)
-;;     (is (= 1 revision-id))
-;;     (humanizer-util/assert-humanizers-saved
-;;      {:community-usage-metrics sample-aggregation-data}
-;;      "admin"
-;;      concept-id
-;;      revision-id)))
+;; Test that metrics are combined appropriately when short-name and version match for different
+;; CSV entries.
+(deftest aggregate-community-metrics-test
+  (testing "Successful community usage aggregation"
+    (let [admin-update-group-concept-id (echo-util/get-or-create-group (system/context) "admin-update-group")
+          _  (echo-util/grant-group-admin (system/context) admin-update-group-concept-id :update)
+          admin-update-token (echo-util/login (system/context) "admin" [admin-update-group-concept-id])
+          {:keys [status concept-id revision-id]} (humanizer-util/update-community-usage-metrics
+                                                   admin-update-token
+                                                   sample-aggregation-csv)]
+      (is (= 201 status))
+      (is concept-id)
+      (is (= 1 revision-id))
+      (humanizer-util/assert-humanizers-saved
+       {:community-usage-metrics sample-aggregation-data}
+       "admin"
+       concept-id
+       revision-id))))
 
 (deftest commas-in-access-count-test
-  (testing "Successful community usage aggregation")
-  (let [admin-update-group-concept-id (echo-util/get-or-create-group (system/context) "admin-update-group")
-        _  (echo-util/grant-group-admin (system/context) admin-update-group-concept-id :update)
-        admin-update-token (echo-util/login (system/context) "admin" [admin-update-group-concept-id])
-        {:keys [status concept-id revision-id]}
-        (humanizer-util/update-community-usage-metrics
-         admin-update-token
-         "\"Product\",\"Version\",\"Hosts\"\n\"AMSR-L1A\",\"3\",\"4,186\"")]
-    (is (= 201 status))
-    (humanizer-util/assert-humanizers-saved
-     {:community-usage-metrics[{:short-name "AMSR-L1A"
-                                :version "3"
-                                :access-count 4186}]}
-     "admin" concept-id revision-id)))
+  (testing "Successful community usage aggregation"
+    (let [admin-update-group-concept-id (echo-util/get-or-create-group (system/context) "admin-update-group")
+          _  (echo-util/grant-group-admin (system/context) admin-update-group-concept-id :update)
+          admin-update-token (echo-util/login (system/context) "admin" [admin-update-group-concept-id])
+          {:keys [status concept-id revision-id]}
+          (humanizer-util/update-community-usage-metrics
+           admin-update-token
+           "\"Product\",\"ProductVersion\",\"Hosts\"\n\"AMSR-L1A\",\"3\",\"4,186\"")]
+      (is (= 201 status))
+      (humanizer-util/assert-humanizers-saved
+       {:community-usage-metrics [{:short-name "AMSR-L1A"
+                                   :version "3"
+                                   :access-count 4186}]}
+       "admin" concept-id revision-id))))

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -241,7 +241,7 @@
                 "Product,ProductVersion,Hosts\n,4,64"))))
       (testing "Empty Hosts"
         (is (= {:status 422
-                :errors ["Error parsing 'Hosts' CSV Data. Hosts may not be empty. Csv line entry: [\"AMSR-L1A\" \"4\" \"\"]"]}
+                :errors ["Error parsing 'Hosts' CSV Data. Hosts may not be empty. CSV line entry: [\"AMSR-L1A\" \"4\" \"\"]"]}
                (humanizer-util/update-community-usage-metrics
                 admin-update-token
                 "Product,ProductVersion,Hosts\nAMSR-L1A,4,")))))
@@ -265,7 +265,7 @@
 
     (testing "Non-integer value for hosts (access-count)"
       (is (= {:status 422
-              :errors ["Error parsing 'Hosts' CSV Data. Hosts must be an integer. Csv line entry: [\"AMSR-L1A\" \"3\" \"x\"]"]}
+              :errors ["Error parsing 'Hosts' CSV Data. Hosts must be an integer. CSV line entry: [\"AMSR-L1A\" \"3\" \"x\"]"]}
              (humanizer-util/update-community-usage-metrics
               admin-update-token
               "Product,ProductVersion,Hosts\nAMSR-L1A,3,x"))))))

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_community_usage_int_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_community_usage_int_test.clj
@@ -15,7 +15,7 @@
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
 (def sample-usage-csv
-  "Product,Version,Hosts\nAMSR-L1A,3,4\nAG_VIRTUAL,3.2,6\nMAPSS_MOD04_L2,N/A,87")
+  "Product,ProductVersion,Hosts\nAMSR-L1A,3,4\nAG_VIRTUAL,3.2,6\nMAPSS_MOD04_L2,N/A,87")
 
 (def sample-usage-data
   [{:short-name "AMSR-L1A"

--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -93,6 +93,7 @@
         ;; Validate that a connection manager is always present. This can cause poor performance if not.
         _ (when-not (:connection-manager connection-params)
             (errors/internal-error! (format "No connection manager created for [%s] in current application" app-name)))
+        _ (println (url-fn conn) method use-system-token? http-options)
 
         response (http-response->raw-response
                    (client/request
@@ -102,7 +103,8 @@
                              :throw-exceptions false}
                             (when use-system-token?
                               {:headers {config/token-header (config/echo-system-token)}})
-                            http-options)))]
+                            http-options)))
+        _ (println response)]
     (response-handler request response)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -93,7 +93,6 @@
         ;; Validate that a connection manager is always present. This can cause poor performance if not.
         _ (when-not (:connection-manager connection-params)
             (errors/internal-error! (format "No connection manager created for [%s] in current application" app-name)))
-        _ (println (url-fn conn) method use-system-token? http-options)
 
         response (http-response->raw-response
                    (client/request
@@ -103,8 +102,7 @@
                              :throw-exceptions false}
                             (when use-system-token?
                               {:headers {config/token-header (config/echo-system-token)}})
-                            http-options)))
-        _ (println response)]
+                            http-options)))]
     (response-handler request response)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
1. Current EMS usage data is reported with columns `Provider,Product,ProductVersion,Hosts` contrary to how the codebase and tests were using/anticipating `Provider,Product,Version,Hosts`.  This was changed sometime between 5 and 2 years ago.  The side-effect of this column renaming is that count-aggregations were done by short-name only.  Tests did not pick up this change because their dummy data still worked and there were no runtime errors because the endpoint was built in such a way as to handle a missing version column.
- All dummy data updated to reflect new column headers
- Reverted some changes in CMR-8138 that had removed references to the Version.
- Added an additional header validation to ensure that if the Version column changes in the future we'll be aware.
2. Version length is limited to 20 characters.  I'm not sure why that is, but it's part of the defined schema.  In the current community-usage-metrics, there are 6 products that have a version longer than 20 characters (all items share the same version.
```
PO DAAC,ASCATA-L2-25KM,Operational/Near-Real-Time,283
PO DAAC,ASCATA-L2-COASTAL,Operational/Near-Real-Time,201
PO DAAC,ASCATB-L2-25KM,Operational/Near-Real-Time,6023
PO DAAC,ASCATB-L2-COASTAL,Operational/Near-Real-Time,3980
PO DAAC,ASCATC-L2-25KM,Operational/Near-Real-Time,5943
PO DAAC,ASCATC-L2-COASTAL,Operational/Near-Real-Time,3796
```
- I made the decision that if an item has a Version longer than 20 characters, I would drop the version for that product.  This causes products that have versions longer than 20 characters to be summed over the entire product instead of by version.  The rankings will still work without the version.

4. Small bug fix from code change in CMR-8138.  If there were no humanizers stored in metadata-db, creating the first community-usage-metrics would fail because it tries to get the usage-metrics first then creates the new ones.
- Added `get-community-usage-metrics-or-empty-list` in `metrics_service.clj` - If no humanizer exists, an empty list is returned