### PR TITLE
CMR-8216: UMM-Sub items should be migrated based on Accept header

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/core.clj
@@ -19,6 +19,7 @@
    [cmr.umm-spec.migration.version.granule]
    [cmr.umm-spec.migration.version.interface :as interface]
    [cmr.umm-spec.migration.version.service]
+   [cmr.umm-spec.migration.version.subscription]
    [cmr.umm-spec.migration.version.tool]
    [cmr.umm-spec.migration.version.variable]
    [cmr.umm-spec.spatial-conversion :as spatial-conversion]


### PR DESCRIPTION
Due to deployment differences between the dev and production systems, this import has been missing for some time (wasn't necessary due to only having 1 schema version).