### PR TITLE
CMR-8129: Added StandardProduct search parameter.

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -93,6 +93,7 @@ CMR Legacy Services' ECHO tokens will be deprecated soon. Please use EDL tokens 
     * [With/without granules Or OpenSearch](#c-has-granules-or-opensearch)
     * [OPeNDAP service URL](#c-has-opendap-url)
     * [Cloud Hosted](#c-cloud-hosted)
+    * [Standard Product](#c-standard-product)
   * [Sorting Collection Results](#sorting-collection-results)
   * [Retrieving all Revisions of a Collection](#retrieving-all-revisions-of-a-collection)
   * [Granule Search By Parameters](#granule-search-by-parameters)
@@ -2286,6 +2287,12 @@ The `has_granules_or_opensearch` parameter can be set to "true" or "false". When
 The `cloud_hosted` parameter can be set to "true" or "false". When true, the results will be restricted to collections that have a `DirectDistributionInformation` element or have been tagged with `gov.nasa.earthdatacloud.s3`.
 
     curl "%CMR-ENDPOINT%/collections?cloud_hosted=true"
+
+#### <a name="c-standard-product"></a> Find collections that are standard products.
+
+The `standard_product` parameter can be set to "true" or "false". When true, the results will be restricted to collections that have `StandardProduct` element being true or collections that don't have `StandardProduct` element set and have been tagged with `gov.nasa.eosdis.standardproduct`.
+
+    curl "%CMR-ENDPOINT%/collections?standard_product=true"
 
 #### <a name="sorting-collection-results"></a> Sorting Collection Results
 

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -48,6 +48,7 @@
    :has-granules-revised-at :multi-date-range
    :has-opendap-url :boolean
    :cloud-hosted :boolean
+   :standard-product :boolean
    :instrument :string
    :instrument-h :humanizer
    :keyword :keyword

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -634,7 +634,7 @@
   (let [bool-params (select-keys params [:downloadable :browsable :include-granule-counts
                                          :include-has-granules :has-granules :hierarchical-facets
                                          :include-highlights :all-revisions :has-opendap-url
-                                         :simplify-shapefile :cloud-hosted])]
+                                         :simplify-shapefile :cloud-hosted :standard-product])]
     (mapcat
       (fn [[param value]]
         (when-not (contains? #{"true" "false" "unset"} (when value (s/lower-case value)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_standard_product_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_standard_product_search_test.clj
@@ -1,0 +1,43 @@
+(ns cmr.system-int-test.search.collection-standard-product-search-test
+  "Integration tests for searching for records that are standard products."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.util :as util]
+   [cmr.mock-echo.client.echo-util :as echo]
+   [cmr.indexer.data.concepts.tag :as itag]
+   [cmr.system-int-test.data2.core :as data2]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.tag-util :as tags]))
+
+(use-fixtures :each tags/grant-all-tag-fixture)
+
+(deftest search-collections-that-are-standard-products
+  (ingest/create-provider {:provider-guid "provguid_consortium1" :provider-id "PROV1" :consortiums "eosdis"})
+
+  (let [coll1 (data2/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 1 {}))
+        coll2 (data2/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 2 {:StandardProduct false}))
+        coll3 (data2/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 3 {:StandardProduct true}))]
+    (index/wait-until-indexed)
+
+    (testing "Search by the StandardProduct flag only"
+      (util/are3
+       [expected items]
+       (data2/refs-match? items (search/find-refs :collection {:standard-product expected}))
+       "Found using metadata" true [coll3]
+       "Not found" false [coll1 coll2]))
+
+    (testing "Search for collections tagged as standard product"
+      (let [user1-token (echo/login (system/context) "user1")
+            tag1 (tags/make-tag {:tag-key itag/standard-product-tag})
+            tag_record (tags/save-tag user1-token tag1 [coll1 coll2])]
+        (index/wait-until-indexed)
+
+        (util/are3
+         [expected items]
+         (is (data2/refs-match? items (search/find-refs :collection {:standard-product expected})))
+         "Found using metadata or tags" true [coll1 coll3]
+         "Not found" false [coll2])))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_standard_product_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_standard_product_search_test.clj
@@ -13,9 +13,12 @@
    [cmr.system-int-test.utils.search-util :as search]
    [cmr.system-int-test.utils.tag-util :as tags]))
 
-(use-fixtures :each tags/grant-all-tag-fixture)
+(use-fixtures :each (join-fixtures
+                      [(ingest/reset-fixture {"provguid1" "PROV1"})
+                       tags/grant-all-tag-fixture]))
 
 (deftest search-collections-that-are-standard-products
+  (ingest/delete-provider "PROV1")  
   (ingest/create-provider {:provider-guid "provguid_consortium1" :provider-id "PROV1" :consortiums "eosdis"})
 
   (let [coll1 (data2/ingest-umm-spec-collection "PROV1" (data-umm-c/collection 1 {}))

--- a/umm-spec-lib/resources/xml-schemas/echo10/Collection.xsd
+++ b/umm-spec-lib/resources/xml-schemas/echo10/Collection.xsd
@@ -275,6 +275,12 @@ xmlns:xs="http://www.w3.org/2001/XMLSchema">
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
+      <xs:element name="StandardProduct" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The indication of whether this
+          collection is standard product.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="Orderable" type="xs:boolean" minOccurs="0">
         <xs:annotation>
           <xs:documentation>The indication of whether this

--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/echo10.clj
@@ -169,6 +169,7 @@
              [:Title (:Title assoc-doi)]
              [:Authority (:Authority assoc-doi)]])])
      [:CollectionDataType (:CollectionDataType c)]
+     [:StandardProduct (:StandardProduct c)]
      (when-let [revision-date (dates/metadata-update-date c)]
        [:RevisionDate (p/clj-time->date-time-str revision-date)])
      [:SuggestedUsage (util/trunc (:Purpose c) 4000)]

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10.clj
@@ -247,6 +247,7 @@
    :MetadataDates (parse-metadata-dates doc)
    :Abstract   (u/truncate (value-of doc "/Collection/Description") u/ABSTRACT_MAX sanitize?)
    :CollectionDataType (value-of doc "/Collection/CollectionDataType")
+   :StandardProduct (value-of doc "/Collection/StandardProduct") 
    :Purpose    (u/truncate (value-of doc "/Collection/SuggestedUsage") u/PURPOSE_MAX sanitize?)
    :CollectionProgress (get-umm-element/get-collection-progress
                          coll-progress-mapping


### PR DESCRIPTION
This PR included the fix for CMR-8132 because the ingest in this test needs to index the collection in echo10 format. If StandardProduct is not translated, it can't be indexed.