### PR TITLE
CMR-7735 Adds EDL SIDs lookup

### DIFF
--- a/access-control-app/src/cmr/access_control/config.clj
+++ b/access-control-app/src/cmr/access_control/config.clj
@@ -33,6 +33,11 @@
   {:default 100
    :type Long})
 
+(defconfig enable-edl-groups
+  "Flag that indicates if we accept EDL Group Names as group_id identifiers and that they will be used.
+   when determining SIDs."
+  {:default false :type Boolean})
+
 (defn queue-config
   "Returns the queue configuration for the application."
   []

--- a/access-control-app/src/cmr/access_control/services/acl_validation.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_validation.clj
@@ -1,16 +1,17 @@
 (ns cmr.access-control.services.acl-validation
   (:require
-    [clj-time.core :as t]
-    [cmr.access-control.data.acls :as acls]
-    [cmr.access-control.services.group-service :as group-service]
-    [cmr.access-control.services.messages :as msg]
-    [cmr.acl.core :as acl]
-    [cmr.common.config :as cfg :refer [defconfig]]
-    [cmr.common.date-time-parser :as dtp]
-    [cmr.common.validations.core :as v]
-    [cmr.common.concepts :as concepts]
-    [cmr.transmit.metadata-db :as mdb1]
-    [cmr.transmit.metadata-db2 :as mdb]))
+   [clj-time.core :as t]
+   [cmr.access-control.config :as access-control-config]
+   [cmr.access-control.data.acls :as acls]
+   [cmr.access-control.services.group-service :as group-service]
+   [cmr.access-control.services.messages :as msg]
+   [cmr.acl.core :as acl]
+   [cmr.common.concepts :as concepts]
+   [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.date-time-parser :as dtp]
+   [cmr.common.validations.core :as v]
+   [cmr.transmit.metadata-db :as mdb1]
+   [cmr.transmit.metadata-db2 :as mdb]))
 
 (def ^:private c "create")
 (def ^:private r "read")
@@ -86,10 +87,6 @@
       (println "|" target "|" (clojure.string/join ", " permissions) "|"))
     (println)))
 
-(defconfig allow-edl-groups
-  "Flag that indicates if we accept EDL Group Names as group_id identifiers."
-  {:default false :type Boolean})
-
 (defn- get-identity-type
   [acl]
   (cond
@@ -102,7 +99,7 @@
   "Validates if group-ids are valid CMR concept-ids"
   [key-path group-id]
   (let [regex #"^AG\d+-\S+$"]
-    (when-not (or (allow-edl-groups) (re-matches regex group-id))
+    (when-not (or (access-control-config/enable-edl-groups) (re-matches regex group-id))
       {key-path [(format "[%s] is not a valid group concept-id" group-id)]})))
 
 (defn- make-group-permissions-validation

--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -60,6 +60,33 @@
                           </body>
                         </html>"}))
 
+(defn get-groups
+  "Returns mock URS groups for a user"
+  [context user-id]
+  (if-not (= "null" user-id)
+    (if (= "user1" user-id)
+      {:status 200 :body [{:description "cmr test group",
+                           :name "cmr_test_group",
+                           :shared_user_group false,
+                           :app_uid "mock_test_application",
+                           :client_id "cmr",
+                           :tag nil,
+                           :created_by "mock_test_application"}
+                          {:description "cmr test group",
+                           :name "cmr_test_group2",
+                           :shared_user_group false,
+                           :app_uid "mock_test_application",
+                           :client_id "cmr",
+                           :tag nil,
+                           :created_by "mock_test_application"}]}
+
+      {:status 200 :body []})
+    {:status 500 :body "<!DOCTYPE html>
+                          <body>
+                            <p> There has been an error processing your request. </p>
+                          </body>
+                        </html>"}))
+
 (defn parse-create-user-xml
   "Parses a create user request into a map of user fields"
   [body]
@@ -162,6 +189,11 @@
         ;; we only need the email address to fill in for the subscription concept.
         (GET "/:user-id" {{:keys [user-id]} :params}
           (get-user-info user-id)))
+
+      (context "/api/user_groups" []
+        (GET "/search" {:keys [request-context params] :as request}
+          (assert-bearer-token request)
+          (get-groups request-context (:user_ids params))))
 
       (context "/users" []
         ;; Create a bunch of users all at once

--- a/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
+++ b/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
@@ -1,16 +1,28 @@
 (ns cmr.system-int-test.access-control.edl-group-test
   (:require
    [cheshire.core :as json]
-   [clj-http.client :as client]
+   [clojure.string :as string]
    [clojure.test :refer :all]
-   [cmr.access-control.services.acl-validation :as acl-validation]
+   [cmr.access-control.config :as access-control-config]
+   [cmr.access-control.test.util :as u]
+   [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-   [cmr.system-int-test.utils.ingest-util :as ingest]))
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.transmit.access-control :as ac]
+   [cmr.transmit.config :as transmit-config]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
                                            "provguid2" "PROV2"
-                                           "provguid3" "PROV3"}))
+                                           "provguid3" "PROV3"}
+                                          {:grant-all-search? false
+                                           :grant-all-ingest? false
+                                           :grant-all-access-control? true}))
+
+
+(defn create-acl
+  [acl]
+  (ac/create-acl (u/conn-context) acl {:token (transmit-config/echo-system-token)}))
 
 (deftest create-acl-with-edl-id
   (let [acl {:group_permissions [{:group_id "EDLGroupName1"
@@ -21,11 +33,156 @@
                                      :collection_applicable true}}]
 
     (testing "Can make an ACL with an EDL group ID when toggle set true"
-      (dev-sys-util/eval-in-dev-sys `(acl-validation/set-allow-edl-groups! true))
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (is (= 200 (:status (data-core/create-acl acl)))))
 
     (testing "Error returned when try to ingest ACL with an EDL group ID when toggle set false"
-      (dev-sys-util/eval-in-dev-sys `(acl-validation/set-allow-edl-groups! false))
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! false))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"clj-http: status 400"
                             (data-core/create-acl acl))))))
+
+(defn get-permissions
+  "Helper to get permissions with the current context and the specified username string or user type keyword and concept ids."
+  [user & concept-ids]
+  (json/parse-string
+    (ac/get-permissions
+      (u/conn-context)
+      (merge {:concept_id concept-ids}
+             (if (keyword? user)
+               {:user_type (name user)}
+               {:user_id user})))))
+
+(deftest collection-simple-catalog-item-identity-permission-check-test
+  (let [token (e/login (u/conn-context) "user1" ["group-create-group"])
+        save-prov1-collection #(u/save-collection {:provider-id "PROV1"
+                                                   :entry-title (str % " entry title")
+                                                   :native-id %
+                                                   :short-name %})
+        coll1 (save-prov1-collection "coll1")
+        get-collection-permissions #(get-permissions %1 coll1)
+        fixture-acls (:items (u/search-for-acls (transmit-config/echo-system-token) {:target "INGEST_MANAGEMENT_ACL"}))
+        _ (doseq [fixture-acl fixture-acls]
+            (e/ungrant (u/conn-context) (:concept_id fixture-acl)))]
+
+      (testing "acls granting collection catalog-item-identity access to edl groups"
+        (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
+        (create-acl {:group_permissions [{:permissions [:read :order]
+                                          :group_id "cmr_test_group"}]
+                     :catalog_item_identity {:name "coll1 read and order"
+                                             :collection_applicable true
+                                             :provider_id "PROV1"}})
+
+        (are [user permissions]
+          (= {coll1 permissions}
+             (get-collection-permissions user))
+          :guest []
+          :registered []
+          "user1" ["read" "order"]
+          "user2" []))))
+
+(deftest granule-permissions-test
+  (let [token (e/login (u/conn-context) "user1" ["group-create-group"])
+        save-prov1-collection #(u/save-collection {:provider-id "PROV1"
+                                                   :entry-title (str % " entry title")
+                                                   :native-id %
+                                                   :short-name %})
+        coll1 (save-prov1-collection "coll1")
+        gran1 (u/save-granule coll1)]
+    (testing "permissions granted to a edl group"
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
+      (create-acl {:group_permissions [{:permissions [:read]
+                                        :group_id "cmr_test_group"}]
+                   :catalog_item_identity {:name "prov1 granule read"
+                                           :granule_applicable true
+                                           :provider_id "PROV1"}})
+
+      (are [user permissions]
+        (= {gran1 permissions}
+           (get-permissions user gran1))
+        :guest []
+        :registered []
+        "user1" ["read"]))))
+
+(deftest collection-provider-level-permission-check-test
+  (let [token (e/login (u/conn-context) "user1" ["group-create-group"])
+        coll1 (u/save-collection {:provider-id "PROV1"
+                                  :entry-title "coll1"
+                                  :native-id "coll1"
+                                  :short-name "coll1"})
+        get-coll1-permissions #(get-permissions % coll1)
+        fixture-acls (:items (u/search-for-acls (transmit-config/echo-system-token) {:target "INGEST_MANAGEMENT_ACL"}))
+        _ (doseq [fixture-acl fixture-acls]
+            (e/ungrant (u/conn-context) (:concept_id fixture-acl)))]
+
+    (testing "granted to edl groups"
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
+      (create-acl {:group_permissions [{:permissions [:update]
+                                        :group_id "cmr_test_group"}]
+                   :provider_identity {:provider_id "PROV1"
+                                       :target "INGEST_MANAGEMENT_ACL"}})
+
+      (are [user permissions]
+        (= {coll1 permissions}
+           (get-coll1-permissions user))
+        :guest []
+        :registered []
+        "user1" ["update" "delete"]
+        "user2" []))))
+
+(deftest system-provider-object-permission-check
+  (let [token (e/login (u/conn-context) "user1" ["group-create-group"])
+        get-system-permissions (fn [user system-object]
+                                 (json/parse-string
+                                  (ac/get-permissions
+                                   (u/conn-context)
+                                   (merge {:system_object system-object}
+                                          (if (keyword? user)
+                                            {:user_type (name user)}
+                                            {:user_id user})))))
+        get-provider-permissions (fn [user provider-id provider-object]
+                                   (json/parse-string
+                                    (ac/get-permissions
+                                     (u/conn-context)
+                                     (merge {:target provider-object
+                                             :provider provider-id}
+                                            (if (keyword? user)
+                                              {:user_type (name user)}
+                                              {:user_id user})))))]
+
+    (testing "provider object permissions granted to edl groups"
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
+      (create-acl {:group_permissions [{:permissions [:create :read :update :delete]
+                                        :group_id "cmr_test_group"}]
+                   :provider_identity {:provider_id "PROV1"
+                                       :target "PROVIDER_OBJECT_ACL"}})
+
+      (are [user permissions]
+        (= {"PROVIDER_OBJECT_ACL" (set permissions)}
+           (update (get-provider-permissions user "PROV1" "PROVIDER_OBJECT_ACL") "PROVIDER_OBJECT_ACL" set))
+        :guest []
+        :registered []
+        "user1" ["create" "read" "update" "delete"]
+        "user2" []))
+
+    (testing "system permissions granted to edl groups"
+      (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
+      (let [concept-id (e/grant
+                        (u/conn-context)
+                        [{:permissions [:read]
+                          :group_id "cmr_test_group"}]
+                        :system_identity {:target "GROUP"})]
+        (ac/update-acl (u/conn-context)
+                       concept-id
+                       {:group_permissions [{:permissions [:read]
+                                             :group_id "cmr_test_group"}]
+                        :system_identity {:target "GROUP"}}
+                       {:token (transmit-config/echo-system-token)}))
+
+      (are [user permissions]
+        (= {"GROUP" permissions}
+           (get-system-permissions user "GROUP"))
+        :guest []
+        :registered []
+        "user1" ["read"]
+        "user2" []))))

--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -93,7 +93,6 @@
         ;; Validate that a connection manager is always present. This can cause poor performance if not.
         _ (when-not (:connection-manager connection-params)
             (errors/internal-error! (format "No connection manager created for [%s] in current application" app-name)))
-
         response (http-response->raw-response
                    (client/request
                      (merge connection-params

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -22,6 +22,10 @@
   [conn username]
   (format "%s/api/users/%s" (conn/root-url conn) username))
 
+(defn- group-search-url
+  [conn]
+  (format "%s/api/user_groups/search" (conn/root-url conn)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Request functions
 
@@ -84,6 +88,27 @@
   "Returns URS email associated with a username"
   [context user]
   (:email_address (get-user-info context user)))
+
+(defn get-edl-groups-by-username
+  "Returns groups associated with a username"
+  [context user-id]
+  (let [{:keys [status body]} (request-with-auth context {:url-fn #(group-search-url %)
+                                                          :method :get
+                                                          :raw? true
+                                                          :http-options {:query-params
+                                                                         {:user_ids
+                                                                          user-id}}})]
+    (info "DEBUGz1" status)
+    (info "DEBUGz2" (pr-str body))
+    (info "DEBUGz3" user-id)
+    (when-not (= 200 status)
+      (info (format "Cannot get group info for username [%s] in URS. Failed with status code [%d].
+        EDL error message: [%s]" user-id status (pr-str body)))
+      (errors/throw-service-error
+        :unauthorized
+        (format "Cannot get group info for username [%s] in URS. Failed with status code [%d]."
+                user-id status)))
+    (map #(get % :name) body)))
 
 
 (comment

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -75,7 +75,7 @@
                                                           :method :get
                                                           :raw? true})]
     (when-not (= 200 status)
-      (info (format "Cannot get info for username [%s] in URS. Failed with status code [%d].
+      (error (format "Cannot get info for username [%s] in URS. Failed with status code [%d].
         EDL error message: [%s]" user status (pr-str body)))
       (errors/throw-service-error
         :unauthorized
@@ -98,11 +98,8 @@
                                                           :http-options {:query-params
                                                                          {:user_ids
                                                                           user-id}}})]
-    (info "DEBUGz1" status)
-    (info "DEBUGz2" (pr-str body))
-    (info "DEBUGz3" user-id)
     (when-not (= 200 status)
-      (info (format "Cannot get group info for username [%s] in URS. Failed with status code [%d].
+      (error (format "Cannot get group info for username [%s] in URS. Failed with status code [%d].
         EDL error message: [%s]" user-id status (pr-str body)))
       (errors/throw-service-error
         :unauthorized


### PR DESCRIPTION
This PR allows user groups in EDL to be used as SIDs for CMR permissions.