### PR TITLE
CMR-8269

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -42,9 +42,9 @@ Join the [CMR Client Developer Forum](https://wiki.earthdata.nasa.gov/display/CM
         * [PUT - Create or update a tool.](#create-update-tool)
         * [DELETE - Delete a tool.](#delete-tool)
 * Subscriptions
-    * /providers/\<provider-id>/subscriptions
+    * /subscriptions
         *  [POST - Create a subscription without specifying a native-id.](#create-subscription)
-      * /providers/\<provider-id>/subscriptions/\<native-id>
+    * /subscriptions/\<native-id>
         * [POST - Create a subscription with a provided native-id.](#create-subscription)
         * [PUT - Create or Update a subscription.](#update-subscription)
         * [DELETE - Delete a subscription.](#delete-subscription)
@@ -788,6 +788,8 @@ Tool metadata can be deleted by sending an HTTP DELETE to the URL `%CMR-ENDPOINT
 
 ### <a name="create-subscription"></a> Create a Subscription
 
+NOTE: The `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions` API routes for subscription ingest are deprecated. Please switch to the new `%CMR-ENDPOINT%/subscriptions` API routes. All the examples below are using the new routes.
+
 Subscription allows a user to register some query conditions in CMR and be notified via email when collections/granules matching the conditions are created or updated in CMR. There are two types of subscriptions (identified by the `Type` field of the subscription):
 
 - collection subscription for users to be notified when collections are created/updated.
@@ -795,7 +797,7 @@ Subscription allows a user to register some query conditions in CMR and be notif
 
 Subscription metadata is in JSON format and conforms to [UMM-Sub Schema](https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/subscription). There is a background job that processes the subscriptions periodically (configurable), to see if there are any collections/granules that are created/updated since the last time the subscription has been processed and notify the subscription user with any matches.
 
-Subscription concepts can be created by sending an HTTP POST or PUT with the metadata sent as data to the URL `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) ,the [revision id](#revision-id), and a [native-id](#native-id).
+Subscription concepts can be created by sending an HTTP POST or PUT with the metadata sent as data to the URL `%CMR-ENDPOINT%/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) ,the [revision id](#revision-id), and a [native-id](#native-id).
 
 `Type` is a required field in subscription request body. The valid values of `Type` are: `"collection"` or `"granule"`. It indicates if the subscription is a collection subscription or granule subscription. Subscriptions of type granule must supply a requisite CollectionConceptId, and subscriptions of type collection cannot have a CollectionConceptId field.
 
@@ -807,10 +809,10 @@ If a SubscriberId is not provided, then the user ID associated with the token us
 EmailAddress was previously a required field, but this field is now deprecated. Instead, the email address associated with the SubscriberId's EarthData Login (URS) account will be used as the EmailAddress. If an EmailAddress is specified at subscription creation it will be ignored.
 
 POST only may be used without a native-id at the following URL.
-`%CMR-ENDPOINT%/providers/<provider-id>/subscriptions`
+`%CMR-ENDPOINT%/subscriptions`
 
 POST or PUT may be used with the following URL.
-`%CMR-ENDPOINT%/providers/<provider-id>/subscriptions/<native-id>`
+`%CMR-ENDPOINT%/subscriptions/<native-id>`
 
 Query values should not be URL encoded. Instead, the query should consist of standard granule search parameters, separated by '&'. For example, a valid query string might look like:
 
@@ -820,7 +822,7 @@ If the query provided is invalid for granule searching, subscription creation wi
 
 ### <a name="update-subscription"></a> Update a Subscription
 
-Subscription concept can be updated by sending an HTTP POST or PUT with the metadata sent as data to the URL `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
+Subscription concept can be updated by sending an HTTP POST or PUT with the metadata sent as data to the URL `%CMR-ENDPOINT%/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id).
 
 If a native-id is provided in a POST, and a subscription already exists for that provider with the given native-id, the request will be rejected.
 
@@ -830,7 +832,7 @@ PUT requests should be used for updating subscriptions. Creation of subscription
 curl -i -XPUT \
   -H "Content-type: application/vnd.nasa.cmr.umm+json" \
   -H "Echo-Token: XXXX" \
-  %CMR-ENDPOINT%/providers/PROV1/subscriptions/subscription123 \
+  %CMR-ENDPOINT%/subscriptions/subscription123 \
   -d \
 "{\"Name\": \"someSubscription\",  \"SubscriberId\": \"someSubscriberId\",  \"CollectionConceptId\": \"C1234-PROV1.\",  \"Query\": \"polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78\"}"
 ```
@@ -839,7 +841,7 @@ curl -i -XPUT \
 curl -i -XPOST \
   -H "Content-type: application/vnd.nasa.cmr.umm+json" \
   -H "Echo-Token: XXXX" \
-  %CMR-ENDPOINT%/providers/PROV1/subscriptions \
+  %CMR-ENDPOINT%/subscriptions \
   -d \
 "{\"Name\": \"someSubscription\",  \"SubscriberId\": \"someSubscriberId\",  \"CollectionConceptId\": \"C1234-PROV1.\",  \"Query\": \"polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78\"}"
 ```
@@ -863,12 +865,12 @@ get a JSON response:
 
 ### <a name="delete-subscription"></a> Delete a Subscription
 
-Subscription metadata can be deleted by sending an HTTP DELETE to the URL `%CMR-ENDPOINT%/providers/<provider-id>/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id) of the tombstone.
+Subscription metadata can be deleted by sending an HTTP DELETE to the URL `%CMR-ENDPOINT%/subscriptions/<native-id>`. The response will include the [concept id](#concept-id) and the [revision id](#revision-id) of the tombstone.
 
 ```
 curl -i -X DELETE \
   -H "Echo-Token: XXXX" \
-  %CMR-ENDPOINT%/providers/PROV1/subscriptions/subscription123
+  %CMR-ENDPOINT%/subscriptions/subscription123
 ```
 
 #### Successful Response in XML
@@ -887,7 +889,9 @@ curl -i -X DELETE \
 
 ### <a name="subscription-access-control"></a> Subscription Access Control
 
-Ingest permissions for subscriptions are granted through the provider via the INGEST_MANAGEMENT_ACL and SUBSCRIPTION_MANAGEMENT. In order to ingest/update/delete a subscription for a given provider, update permission has to be granted to the user through both INGEST_MANAGEMENT_ACL and SUBSCRIPTION_MANAGEMENT ACLs for the provider.
+Ingest permissions for granule subscriptions are granted through the provider via the INGEST_MANAGEMENT_ACL and SUBSCRIPTION_MANAGEMENT. In order to ingest/update/delete a subscription for a given provider, update permission has to be granted to the user through both INGEST_MANAGEMENT_ACL and SUBSCRIPTION_MANAGEMENT ACLs for the provider.
+
+For lack of a better ACL, ingest permissions for collection subscription are granted through the SYSTEM OBJECT TAG_GROUP ACL update permission.
 
 ## <a name="translate-collection"></a> Translate Collection Metadata
 

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -108,15 +108,32 @@
      (context "/collections/:coll-concept-id" [coll-concept-id]
        (context "/:coll-revision-id" [coll-revision-id]
          (context "/variables/:native-id" [native-id]
-          (PUT "/"
-           request
-           (variables/ingest-variable
-             nil native-id request coll-concept-id coll-revision-id))))
+           (PUT "/"
+             request
+             (variables/ingest-variable
+              nil native-id request coll-concept-id coll-revision-id))))
        (context "/variables/:native-id" [native-id]
          (PUT "/"
            request
            (variables/ingest-variable
-             nil native-id request coll-concept-id nil)))))
+            nil native-id request coll-concept-id nil)))))
+    ;; Subscriptions
+    (api-core/set-default-error-format
+     :xml
+     (context ["/subscriptions"] []
+       (POST "/"
+         request
+         (subscriptions/create-subscription request))
+       (context ["/:native-id" :native-id #".*$"] [native-id]
+         (POST "/"
+           request
+           (subscriptions/create-subscription-with-native-id native-id request))
+         (PUT "/"
+           request
+           (subscriptions/create-or-update-subscription-with-native-id native-id request))
+         (DELETE "/"
+           request
+           (subscriptions/delete-subscription native-id request)))))
     ;; granule bulk update status route
     (api-core/set-default-error-format
      :json

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/delete_test.clj
@@ -22,8 +22,15 @@
 
 (deftest delete-concepts-test
   (doseq [concept-type [:collection :granule :service
-                        :service-association :subscription :tool :tool-association]]
+                        :service-association :tool :tool-association]]
    (cd-spec/general-delete-test concept-type ["REG_PROV" "SMAL_PROV"])))
+
+;; subscription does not allow the same native-id across different providers, so we separate the tests
+(deftest subscription-delete-concepts-reg-test
+  (cd-spec/general-delete-test :subscription ["REG_PROV"]))
+
+(deftest subscription-delete-concepts-small-test
+  (cd-spec/general-delete-test :subscription ["SMAL_PROV"]))
 
 (deftest delete-variable-and-association-concepts-test
   (cd-spec/general-delete-variable-and-association-test ["REG_PROV" "SMAL_PROV"]))

--- a/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/subscription_save_test.clj
+++ b/metadata-db-app/int-test/cmr/metadata_db/int_test/concepts/subscription_save_test.clj
@@ -14,8 +14,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (use-fixtures :each (util/reset-database-fixture
-                     {:provider-id "PROV1" :small false}
-                     {:provider-id "PROV2" :small false}))
+                     {:provider-id "PROV1" :small false}))
 
 (defmethod c-spec/gen-concept :subscription
   [_ provider-id uniq-num attributes]
@@ -26,7 +25,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest save-subscription
-  (c-spec/general-save-concept-test :subscription ["PROV1" "PROV2"]))
+  (c-spec/general-save-concept-test :subscription ["PROV1"]))
 
 (deftest save-subscription-with-missing-required-parameters
   (c-spec/save-test-with-missing-required-parameters

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -125,6 +125,28 @@
   [concept]
   [(:concept-id concept) (:revision-id concept)])
 
+(defmulti find-existing-concept
+  "Returns the existing concept in db that matches the given concept-id or native-id."
+  (fn [db concept-type provider-id concept-id native-id]
+    concept-type))
+
+(defmethod find-existing-concept :subscription
+  [db concept-type provider-id concept-id native-id]
+  (->> @(:concepts-atom db)
+       (filter #(= concept-type (:concept-type %)))
+       (filter #(or (= concept-id (:concept-id %))
+                    (= native-id (:native-id %))))
+       first))
+
+(defmethod find-existing-concept :default
+  [db concept-type provider-id concept-id native-id]
+  (->> @(:concepts-atom db)
+       (filter #(= concept-type (:concept-type %)))
+       (filter #(= provider-id (:provider-id %)))
+       (filter #(or (= concept-id (:concept-id %))
+                    (= native-id (:native-id %))))
+       first))
+
 (defn validate-concept-id-native-id-not-changing
   "Validates that the concept-id native-id pair for a concept being saved is not changing. This
   should be done within a save transaction to avoid race conditions where we might miss it.
@@ -132,12 +154,8 @@
   [db provider concept]
   (let [{:keys [concept-id native-id concept-type provider-id]} concept
         {existing-concept-id :concept-id
-         existing-native-id :native-id} (->> @(:concepts-atom db)
-                                             (filter #(= concept-type (:concept-type %)))
-                                             (filter #(= provider-id (:provider-id %)))
-                                             (filter #(or (= concept-id (:concept-id %))
-                                                          (= native-id (:native-id %))))
-                                             first)]
+         existing-native-id :native-id} (find-existing-concept
+                                         db concept-type provider-id concept-id native-id)]
     (when (and (and existing-concept-id existing-native-id)
                (or (not= existing-concept-id concept-id)
                    (not= existing-native-id native-id)))
@@ -258,18 +276,24 @@
   [db providers params]
   ;; XXX Looking at search-with-params, seems like it might need to be
   ;;     in a utility ns for use by all impls
-  (let [found-concepts (mapcat #(concepts/search-with-params
+  (let [is-subscription? (= :subscription (:concept-type params))
+        found-concepts (mapcat #(concepts/search-with-params
                                  @(:concepts-atom db)
-                                 (assoc params :provider-id (:provider-id %)))
-                              providers)]
+                                 (if is-subscription?
+                                   params
+                                   (assoc params :provider-id (:provider-id %))))
+                               providers)]
     (concepts->find-result found-concepts params)))
 
 (defn find-latest-concepts
   [db provider params]
   (let [latest-concepts (latest-revisions @(:concepts-atom db))
+        params  (if (= :subscription (:concept-type params))
+                  params
+                  (assoc params :provider-id (:provider-id provider)))
         found-concepts (concepts/search-with-params
                         latest-concepts
-                        (assoc params :provider-id (:provider-id provider)))]
+                        params)]
     (concepts->find-result found-concepts params)))
 
 (def concept-search-behaviour

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -212,15 +212,24 @@
   [db provider concept]
   (let [{:keys [concept-type provider-id concept-id native-id]} concept
         table (tables/get-table-name provider concept-type)
-        {:keys [concept_id native_id]} (or (su/find-one
-                                             db (select [:concept-id :native-id]
-                                                  (from table)
-                                                  (where (by-provider
-                                                           concept-type provider `(= :native-id
-                                                                                     ~native-id)))))
-                                           (su/find-one db (select [:concept-id :native-id]
-                                                             (from table)
-                                                             (where `(= :concept-id ~concept-id)))))]
+        {:keys [concept_id native_id]} (if (= :subscription concept-type)
+                                         (or (su/find-one
+                                              db (select [:concept-id :native-id]
+                                                         (from table)
+                                                         (where `(= :native-id ~native-id))))
+                                             (su/find-one db (select [:concept-id :native-id]
+                                                                     (from table)
+                                                                     (where `(= :concept-id ~concept-id)))))
+                                         ;; concepts other than subscription
+                                         (or (su/find-one
+                                              db (select [:concept-id :native-id]
+                                                         (from table)
+                                                         (where (by-provider
+                                                                 concept-type provider `(= :native-id
+                                                                                           ~native-id)))))
+                                             (su/find-one db (select [:concept-id :native-id]
+                                                                     (from table)
+                                                                     (where `(= :concept-id ~concept-id))))))]
     (when (and (and concept_id native_id)
                (or (not= concept_id concept-id) (not= native_id native-id)))
       {:error :concept-id-concept-conflict

--- a/metadata-db-app/src/cmr/metadata_db/migrations/079_update_subscription_constraint.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/079_update_subscription_constraint.clj
@@ -1,0 +1,19 @@
+(ns cmr.metadata-db.migrations.079-update-subscription-constraint
+  (:require
+   [config.mdb-migrate-helper :as h]))
+
+(defn up
+  "Migrates the database up to version 79."
+  []
+  (println "cmr.metadata-db.migrations.079-update-subscription-constraint up...")
+  (h/sql "ALTER TABLE cmr_subscriptions DROP CONSTRAINT subscriptions_con_npr")
+  (h/sql "ALTER TABLE cmr_subscriptions ADD CONSTRAINT subscriptions_nid_rid UNIQUE (native_id, revision_id)
+  USING INDEX (create unique index subscriptions_unri ON cmr_subscriptions (native_id, revision_id))"))
+
+(defn down
+  "Migrates the database down from version 79."
+  []
+  (println "cmr.metadata-db.migrations.079-update-subscription-constraint down...")
+  (h/sql "ALTER TABLE cmr_subscriptions DROP CONSTRAINT subscriptions_nid_rid")
+  (h/sql "ALTER TABLE cmr_subscriptions ADD CONSTRAINT subscriptions_con_npr UNIQUE (native_id, revision_id, provider_id)
+  USING INDEX (create unique index subscriptions_idx_npr ON cmr_subscriptions (native_id, revision_id, provider_id))"))

--- a/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/search_service.clj
@@ -86,7 +86,10 @@
   (if-let [provider-id (:provider-id params)]
     (when-let [provider (provider-service/get-provider-by-id context provider-id)]
       [provider])
-    (provider-service/get-providers context)))
+    (let [providers (provider-service/get-providers context)]
+      (if (= :subscription (:concept-type params))
+        (concat [{:provider-id "CMR"}] providers)
+        providers))))
 
 (defn- find-cmr-concepts
   "Find tags or tag associations with specific parameters"

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -372,17 +372,22 @@
          :system_identity
          {:target tag-acl}))
 
+(defn grant-system-ingest-management
+  "Creates an ACL in mock echo granting system Ingest Management ACL for guests and registered users."
+  [context guest-permissions registered-permissions]
+  (grant context
+         [{:permissions registered-permissions
+           :user_type :registered}
+          {:permissions guest-permissions
+           :user_type :guest}]
+         :system_identity
+         {:target ingest-management-acl}))
+
 (defn grant-all-variable
   "Creates an ACL in mock echo granting registered users ability to do all
   variable related operations"
   [context]
-  (grant context
-         [{:permissions [:read :update]
-           :user_type :registered}
-          {:permissions [:read :update]
-           :user_type :guest}]
-         :system_identity
-         {:target ingest-management-acl}))
+  (grant-system-ingest-management context [:read :update] [:read :update]))
 
 (def grant-all-service
   "Creates an ACL in mock echo granting registered users ability to do all

--- a/search-app/src/cmr/search/services/acls/acl_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_helper.clj
@@ -21,3 +21,9 @@
         esm-acls (filter #(= "SUBSCRIPTION_MANAGEMENT" (get-in % [:provider-identity :target])) acls)
         sids (util/lazy-get context :sids)]
     (filter (partial acl/acl-matches-sids-and-permission? sids :read) esm-acls)))
+
+(defn has-system-read-permission?
+  "Returns true if the current user has system Ingest Management read permission
+  which is needed to see all collection subscriptions."
+  [context]
+  (acl/has-ingest-management-permission? context :read :system-object nil))

--- a/search-app/src/cmr/search/services/acls/subscription_acls.clj
+++ b/search-app/src/cmr/search/services/acls/subscription_acls.clj
@@ -26,6 +26,9 @@
           provider-ids (if (seq sm-acls)
                          (map #(get-in % [:provider-identity :provider-id]) sm-acls)
                          ["non-existing-provider-id"])
+          provider-ids (if (acl-helper/has-system-read-permission? context)
+                         (concat provider-ids ["CMR"])
+                         provider-ids)
           acl-cond (gc/or-conds [(qm/string-conditions :provider-id provider-ids true)
                                  subscriber-cond])]
       (update-in query [:condition] #(gc/and-conds [acl-cond %])))))

--- a/system-int-test/src/cmr/system_int_test/data2/core.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/core.clj
@@ -149,8 +149,9 @@
    (ingest-umm-spec-collection provider-id item nil))
   ([provider-id item options]
    (let [format-key (get options :format :echo10)
+         umm-concept (umm-c-collection->concept (assoc item :provider-id provider-id) format-key)
          response (ingest/ingest-concept
-                    (umm-c-collection->concept (assoc item :provider-id provider-id) format-key)
+                    (assoc umm-concept :provider-id provider-id)
                     (select-keys options [:token
                                           :client-id
                                           :user-id

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -388,6 +388,56 @@
          params (merge params (when accept-format {:accept accept-format}))]
      (parse-ingest-response (client/request params) options))))
 
+;; Temporary function, will be removed in CMR-8270
+(defn ingest-subscription-concept
+  "Ingest a concept and return a map with status, concept-id, and revision-id"
+  ([concept]
+   (ingest-subscription-concept concept {}))
+  ([concept options]
+   (let [{:keys [metadata format concept-type concept-id revision-id native-id]} concept
+         {:keys [token client-id user-id validate-keywords validate-umm-c cmr-request-id x-request-id test-existing-errors]} options
+         accept-format (:accept-format options)
+         method (get options :method :put)
+         headers (util/remove-nil-keys {"Cmr-Concept-id" concept-id
+                                        "Cmr-Revision-id" revision-id
+                                        "Cmr-Validate-Keywords" validate-keywords
+                                        "Cmr-Validate-Umm-C" validate-umm-c
+                                        "Cmr-Test-Existing-Errors" test-existing-errors
+                                        "Authorization" token
+                                        "User-Id" user-id
+                                        "Client-Id" client-id
+                                        "CMR-Request-Id" cmr-request-id
+                                        "X-Request-Id" x-request-id})
+         params {:method method
+                 :url (url/ingest-subscription-url native-id)
+                 :body  metadata
+                 :content-type format
+                 :headers headers
+                 :throw-exceptions false
+                 :connection-manager (s/conn-mgr)}
+         params (merge params (when accept-format {:accept accept-format}))]
+     (parse-ingest-response (client/request params) options))))
+
+(defn delete-subscription-concept
+  "Delete a given concept."
+  ([concept]
+   (delete-subscription-concept concept {}))
+  ([concept options]
+   (let [{:keys [concept-type native-id]} concept
+         {:keys [token client-id accept-format revision-id user-id]} options
+         headers (util/remove-nil-keys {"Authorization" token
+                                        "Client-Id" client-id
+                                        "User-Id" user-id
+                                        "Cmr-Revision-id" revision-id})
+         params {:method :delete
+                 :url (url/ingest-subscription-url native-id)
+                 :headers headers
+                 :accept accept-format
+                 :throw-exceptions false
+                 :connection-manager (s/conn-mgr)}
+         params (merge params (when accept-format {:accept accept-format}))]
+     (parse-ingest-response (client/request params) options))))
+
 (defn delete-concept
   "Delete a given concept."
   ([concept]

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -388,7 +388,7 @@
          params (merge params (when accept-format {:accept accept-format}))]
      (parse-ingest-response (client/request params) options))))
 
-;; Temporary function, will be removed in CMR-8270
+;; Temporary function, this calls the subscription routes under the ingest root url, will be removed in CMR-8270
 (defn ingest-subscription-concept
   "Ingest a concept and return a map with status, concept-id, and revision-id"
   ([concept]

--- a/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
@@ -47,7 +47,7 @@
   [providers guest-permissions registered-permissions]
   (fn [f]
     ;; grant INGEST_MANAGEMENT_ACL permission.
-    (echo-util/grant-all-subscription-ima (s/context))
+    (echo-util/grant-system-ingest-management (s/context) guest-permissions registered-permissions)
     (let [providers (for [[provider-guid provider-id] providers]
                       {:provider-guid provider-guid
                        :provider-id provider-id})]

--- a/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/subscription_util.clj
@@ -206,7 +206,9 @@
      (merge subscription
             {:name (extract-name-from-metadata subscription)
              :subscriber-id (extract-subscriber-id-from-metadata subscription)}
-            (when (not (= subscription-type "collection")) {:collection-concept-id (extract-collection-concept-id-from-metadata subscription)}))
+            (if (= subscription-type "collection")
+              {:provider-id "CMR"}
+              {:collection-concept-id (extract-collection-concept-id-from-metadata subscription)}))
      json-field-names)))
 
 (defn assert-subscription-search

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -201,10 +201,24 @@
   ([provider-id concept-type]
    (ingest-url provider-id concept-type nil))
   ([provider-id concept-type native-id]
-   (let [url (format "http://localhost:%s/providers/%s/%ss"
+   (let [url (if (and (nil? provider-id)
+                      (= :subscription concept-type))
+               (format "http://localhost:%s/subscriptions"
+                     (transmit-config/ingest-port))
+               (format "http://localhost:%s/providers/%s/%ss"
                      (transmit-config/ingest-port)
                      (codec/url-encode provider-id)
-                     (name concept-type))]
+                     (name concept-type)))]
+     (if native-id
+       (str url "/" (codec/url-encode native-id))
+       url))))
+
+(defn ingest-subscription-url
+  ([]
+   (ingest-subscription-url nil))
+  ([native-id]
+   (let [url (format "http://localhost:%s/subscriptions"
+                     (transmit-config/ingest-port))]
      (if native-id
        (str url "/" (codec/url-encode native-id))
        url))))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
@@ -201,6 +201,12 @@
            coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "E1"
                                                                                :ShortName "S1"
                                                                                :Version "V1"}))
+           coll2 (d/ingest-umm-spec-collection "PROV2" (data-umm-c/collection {:EntryTitle "E2"
+                                                                               :ShortName "S2"
+                                                                               :Version "V2"}))
+           coll3 (d/ingest-umm-spec-collection "PROV3" (data-umm-c/collection {:EntryTitle "E3"
+                                                                               :ShortName "S3"
+                                                                               :Version "V3"}))
            sub1-concept (subscription/make-subscription-concept {:native-id "SUB1"
                                                                  :Name "Sub1"
                                                                  :SubscriberId "user1"
@@ -210,19 +216,19 @@
            sub2-concept (subscription/make-subscription-concept {:native-id "SUB2"
                                                                  :Name "Sub2"
                                                                  :SubscriberId "user1"
-                                                                 :CollectionConceptId (:concept-id coll1)
+                                                                 :CollectionConceptId (:concept-id coll2)
                                                                  :Query "platform=NOAA-9"
                                                                  :provider-id "PROV2"})
            sub2-2-concept (subscription/make-subscription-concept {:native-id "SUB2"
                                                                    :Name "Sub2-2"
                                                                    :SubscriberId "user1"
-                                                                   :CollectionConceptId (:concept-id coll1)
+                                                                   :CollectionConceptId (:concept-id coll2)
                                                                    :Query "platform=NOAA-10"
                                                                    :provider-id "PROV2"})
            sub3-concept (subscription/make-subscription-concept {:native-id "SUB3"
                                                                  :Name "Sub1"
                                                                  :SubscriberId "user1"
-                                                                 :CollectionConceptId (:concept-id coll1)
+                                                                 :CollectionConceptId (:concept-id coll3)
                                                                  :Query "platform=NOAA-11"
                                                                  :provider-id "PROV3"})
            sub1-1 (subscription/ingest-subscription sub1-concept)

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
@@ -27,7 +27,7 @@
                                     (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV1"}
                                                                   [:read :update]
                                                                   [:read :update])
-                                    (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV2"}
+                                    (subscription-util/grant-all-subscription-fixture {"provguid2" "PROV2"}
                                                                   [:read]
                                                                   [:read])
                                     (dev-system/freeze-resume-time-fixture)]))
@@ -286,7 +286,7 @@
             "another-prov-admin-token can't ingest"
             another-prov-admin-token
             "provider-admin-read-token can't ingest"
-            provider-admin-read-token)
+            provider-admin-read-token))
 
      ;; Ingest and delete of subscriptions are controlled by both INGEST_MANAGEMENT_ACL and SUBSCRIPTION+MANAGEMENT ACLs.
      ;; subscriptoin-np is ingested on PROV2, which has no SUBSCRIPTION_MANAGEMENT permission to ingest. so, even though
@@ -312,7 +312,7 @@
             "provider-admin-read-update token can not delete"
             provider-admin-read-update-token
             "provider-admin-update-delete token can not delete"
-            provider-admin-update-delete-token)))
+            provider-admin-update-delete-token))
 
     ;; The assert-ingest-succeeded tests below are identical to the tests above,
     ;; except that the subscription is on PROV1, which has both the INGEST and SUBSCRIPTION ACL permissions.

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_permissions_test.clj
@@ -44,6 +44,12 @@
   (let [status (:status response)]
     (is (= 401 status))))
 
+(defn- assert-ingest-not-found
+  "Succeeds if provided token returns 404 NOT FOUND error."
+  [response]
+  (let [status (:status response)]
+    (is (= 404 status))))
+
 (deftest ingest-provider-management-permissions-test
   (let [_ (mock-urs/create-users (s/context) [{:username "someSubId" :password "Password"}])
         prov-admin-read-group-concept-id (echo-util/get-or-create-group
@@ -151,6 +157,10 @@
                     "PROV1"
                     (data-umm-c/collection {})
                     {:token provider-admin-update-token})
+        coll2 (d/ingest-umm-spec-collection
+                    "PROV2"
+                    (data-umm-c/collection {})
+                    {:token provider-admin-update-token})
         ingested-concept (mdb/get-concept (:concept-id collection))
 
         granule (d/item->concept
@@ -160,7 +170,8 @@
         subscription (subscription-util/make-subscription-concept {:CollectionConceptId (:concept-id collection)})
         ;; create a subscription on PROV2, which doesn't have SUBSCRIPTION_MANAGEMENT permission
         ;; to ingest. So all the ingests should fail.
-        subscription-np (subscription-util/make-subscription-concept {:provider-id "PROV2"})
+        subscription-np (subscription-util/make-subscription-concept {:CollectionConceptId (:concept-id coll2)
+                                                                      :provider-id "PROV2"} {} 1)
         tool (tool-util/make-tool-concept)]
 
     (testing "ingest granule update permissions"
@@ -304,7 +315,7 @@
             provider-admin-update-delete-token)
 
       (are3 [token]
-            (assert-ingest-no-permission
+            (assert-ingest-not-found
              (ingest/delete-concept subscription-np {:token token
                                                      :allow-failure? true}))
             "provider-admin-update-token can not delete"
@@ -330,17 +341,6 @@
             "provider-admin-read-update token can ingest"
             provider-admin-read-update-token
             "provider-admin-update-delete token can ingest"
-            provider-admin-update-delete-token)
-
-      (are3 [token]
-            (assert-ingest-succeeded
-             (ingest/delete-concept subscription {:token token
-                                                  :allow-failure? true}))
-            "provider-admin-update-token can delete"
-            provider-admin-update-token
-            "provider-admin-read-update token can delete"
-            provider-admin-read-update-token
-            "provider-admin-update-delete token can delete"
             provider-admin-update-delete-token)
 
       (are3 [token]
@@ -371,7 +371,18 @@
             "another-prov-admin-token can't delete"
             another-prov-admin-token
             "provider-admin-read-token can't delete"
-            provider-admin-read-token))
+            provider-admin-read-token)
+
+      (are3 [token]
+            (assert-ingest-succeeded
+             (ingest/delete-concept subscription {:token token
+                                                  :allow-failure? true}))
+            "provider-admin-update-token can delete"
+            provider-admin-update-token
+            "provider-admin-read-update token can delete"
+            provider-admin-read-update-token
+            "provider-admin-update-delete token can delete"
+            provider-admin-update-delete-token))
 
     (testing "token expiration"
       ;; 29 days after token creation is OK since the token expires in 30 days

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
@@ -102,7 +102,7 @@
 
             "- two consortiums with an underscore"
             "PROV11" "S11" true true "Group2_1 Group2_3"
-            
+
             "- consortiums with only spaces"
             "PROV12" nil nil nil "    "
 
@@ -292,7 +292,7 @@
                                                               :Name "sub2"
                                                               :SubscriberId "user1"
                                                               :Query "platform=NOAA-9"
-                                                              :CollectionConceptId (:concept-id coll1)
+                                                              :CollectionConceptId (:concept-id coll3)
                                                               :provider-id "PROV2"})
           _ (index/wait-until-indexed)
           svc-association1 (au/make-service-association

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_permission_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_permission_test.clj
@@ -2,76 +2,239 @@
   "CMR subscription ingest permission integration tests.
   For some granule subscription permissions tests, see `provider-ingest-permissions-test`."
   (:require
-   [cheshire.core :as json]
-   [clojure.java.io :as io]
-   [clojure.string :as string]
    [clojure.test :refer :all]
    [cmr.access-control.test.util :as ac-util]
-   [cmr.common.util :refer [are3]]
-   [cmr.common-app.test.side-api :as side]
-   [cmr.ingest.services.subscriptions-helper :as jobsub]
    [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.mock-echo.client.mock-urs-client :as mock-urs]
    [cmr.system-int-test.data2.core :as data-core]
-   [cmr.system-int-test.data2.granule :as data-granule]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as system]
-   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
-   [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
-   [cmr.system-int-test.utils.subscription-util :as subscription-util]
-   [cmr.transmit.access-control :as access-control]
-   [cmr.transmit.config :as transmit-config]
-   [cmr.transmit.metadata-db :as mdb2]
-   [cmr.mock-echo.client.mock-urs-client :as mock-urs]))
+   [cmr.system-int-test.utils.subscription-util :as subscription-util]))
 
 (use-fixtures :each
-  (join-fixtures
-   [(ingest/reset-fixture
-     {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"})
-    (subscription-util/grant-all-subscription-fixture
-     {"provguid1" "PROV1" "provguid2" "PROV2"}
-     [:read]
-     [:read :update])
-    (dev-sys-util/freeze-resume-time-fixture)
-    (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
-                                                      [:read]
-                                                      [:read :update])]))
+              (join-fixtures
+               [(ingest/reset-fixture
+                 {"provguid1" "PROV1" "provguid2" "PROV2"})]))
 
-(deftest delete-collection-subscription-ingest-test
+(deftest subscription-ingest-permission-test
   (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])
-  (testing "delete a collection subscription"
-    (let [coll1 (data-core/ingest-umm-spec-collection
-                 "PROV1"
-                 (data-umm-c/collection
-                  {:ShortName "coll1"
-                   :EntryTitle "entry-title1"})
-                 {:token "mock-echo-system-token"})
-          user1-token (echo-util/login (system/context) "user1")
-          guest-token (echo-util/login-guest (system/context))
-          concept (subscription-util/make-subscription-concept
-                   {:Type "collection"}
+  (let [reg-user-group (echo-util/get-or-create-group (system/context) "some-group-guid")
+        user1-token (echo-util/login (system/context) "user1" [reg-user-group])
+        guest-token (echo-util/login-guest (system/context))
+        coll-sub-group (echo-util/get-or-create-group (system/context) "coll-sub-group")
+        coll-sub-token (echo-util/login (system/context) "coll-sub-user" [coll-sub-group])
+        _ (echo-util/grant-group-tag (system/context) coll-sub-group :update)
+        coll1 (data-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})
+        coll2 (data-core/ingest-umm-spec-collection
+               "PROV2"
+               (data-umm-c/collection
+                {:ShortName "coll2"
+                 :EntryTitle "entry-title2"})
+               {:token user1-token})
+
+        gran-sub1 (subscription-util/make-subscription-concept
+                   {:Type "granule"
+                    :CollectionConceptId (:concept-id coll1)}
                    {}
-                   "coll-sub")]
-      (ingest/ingest-concept concept {:token user1-token})
-      (testing "delete without permission, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
-        (let [{:keys [status errors]} (ingest/delete-concept concept
-                                                             {:token guest-token})]
+                   "gran-sub1")
+        gran-sub2 (subscription-util/make-subscription-concept
+                   {:Type "granule"
+                    :CollectionConceptId (:concept-id coll2)}
+                   {}
+                   "gran-sub2")
+        coll-sub (subscription-util/make-subscription-concept
+                  {:Type "collection"}
+                  {}
+                  "coll-sub")]
+
+    (testing "create a granule subscription without permission"
+      (let [{:keys [status errors]} (ingest/ingest-concept gran-sub1 {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "create a granule subscription with permission on PROV1"
+      ;; grant registered user permission to PROV1
+      (echo-util/grant-all-subscription-sm (system/context)
+                                           "PROV1"
+                                           [:read]
+                                           [:read :update])
+      (ac-util/wait-until-indexed)
+      (ingest/clear-caches)
+      (let [{:keys [status errors]} (ingest/ingest-concept gran-sub1 {:token user1-token})]
+        (is (= 201 status))
+        (is (nil? errors)))
+
+      (testing "create a granule subscription on PROV2 still doesn't work as no permission is granted on PROV2"
+        (let [{:keys [status errors]} (ingest/ingest-concept gran-sub2 {:token user1-token})]
           (is (= 401 status))
-          (is (= ["You do not have permission to perform that action."] errors))))
-      (testing "delete a collection subscription with permission"
-        (let [{:keys [status concept-id revision-id]} (ingest/delete-concept concept
-                                                                             {:token user1-token})
-              fetched (mdb/get-concept concept-id revision-id)]
-          (is (= 200 status))
-          (is (= 2 revision-id))
-          (is (= (:native-id concept)
-                 (:native-id fetched)))
-          (is (:deleted fetched))
-          (testing "delete a deleted collection subscription"
-            (let [{:keys [status errors]} (ingest/delete-concept concept
-                                                                 {:token user1-token})]
-              (is (= 404 status))
-              (is (= [(format "Subscription with native-id [%s] has already been deleted."
-                              (:native-id concept))]
-                     errors)))))))))
+          (is (= ["You do not have permission to perform that action."] errors)))))
+
+    (testing "delete without permission, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
+      (let [{:keys [status errors]} (ingest/delete-concept gran-sub1
+                                                           {:token guest-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "delete with permission"
+      (let [{:keys [status concept-id revision-id]} (ingest/delete-concept gran-sub1
+                                                                           {:token user1-token})
+            fetched (mdb/get-concept concept-id revision-id)]
+        (is (= 200 status))
+        (is (= 2 revision-id))
+        (is (= (:native-id gran-sub1)
+               (:native-id fetched)))
+        (is (:deleted fetched)))
+
+      (testing "delete a granule subscription on PROV2 still doesn't work as no permission is granted on PROV2"
+        (let [{:keys [status errors]} (ingest/ingest-concept gran-sub2 {:token user1-token})]
+          (is (= 401 status))
+          (is (= ["You do not have permission to perform that action."] errors)))))
+
+    (testing "create collection subscription using a token that can create granule subscription does not work"
+      (let [{:keys [status errors]} (ingest/ingest-concept coll-sub {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "create collection subscription with permission"
+      (let [{:keys [status errors]} (ingest/ingest-concept coll-sub {:token coll-sub-token})]
+        (is (= 201 status))
+        (is (nil? errors))))
+
+    (testing "delete collection subscription without permission, using a token that can create granule subscription does not work"
+      (let [{:keys [status errors]} (ingest/delete-concept coll-sub
+                                                           {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "delete with permission"
+      (let [{:keys [status concept-id revision-id]} (ingest/delete-concept coll-sub
+                                                                           {:token coll-sub-token})
+            fetched (mdb/get-concept concept-id revision-id)]
+        (is (= 200 status))
+        (is (= 2 revision-id))
+        (is (= (:native-id coll-sub)
+               (:native-id fetched)))
+        (is (:deleted fetched))))))
+
+;; This tests the subscription routes in ingest root url, will be removed in CMR-8270
+(deftest subscription-ingest-permission-temporary-test
+  (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])
+  (let [reg-user-group (echo-util/get-or-create-group (system/context) "some-group-guid")
+        user1-token (echo-util/login (system/context) "user1" [reg-user-group])
+        guest-token (echo-util/login-guest (system/context))
+        coll-sub-group (echo-util/get-or-create-group (system/context) "coll-sub-group")
+        coll-sub-token (echo-util/login (system/context) "coll-sub-user" [coll-sub-group])
+        _ (echo-util/grant-group-tag (system/context) coll-sub-group :update)
+        coll1 (data-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})
+        coll2 (data-core/ingest-umm-spec-collection
+               "PROV2"
+               (data-umm-c/collection
+                {:ShortName "coll2"
+                 :EntryTitle "entry-title2"})
+               {:token user1-token})
+
+        gran-sub1 (subscription-util/make-subscription-concept
+                   {:Type "granule"
+                    :CollectionConceptId (:concept-id coll1)}
+                   {}
+                   "gran-sub1")
+        gran-sub2 (subscription-util/make-subscription-concept
+                   {:Type "granule"
+                    :CollectionConceptId (:concept-id coll2)}
+                   {}
+                   "gran-sub2")
+        coll-sub (subscription-util/make-subscription-concept
+                  {:Type "collection"}
+                  {}
+                  "coll-sub")]
+
+    (testing "create a granule subscription without permission"
+      (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                     gran-sub1 {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "create a granule subscription with permission on PROV1"
+      ;; grant registered user permission to PROV1
+      (echo-util/grant-all-subscription-sm (system/context)
+                                           "PROV1"
+                                           [:read]
+                                           [:read :update])
+      (ac-util/wait-until-indexed)
+      (ingest/clear-caches)
+      (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                     gran-sub1 {:token user1-token})]
+        (is (= 201 status))
+        (is (nil? errors)))
+
+      (testing "create a granule subscription on PROV2 still doesn't work as no permission is granted on PROV2"
+        (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                       gran-sub2 {:token user1-token})]
+          (is (= 401 status))
+          (is (= ["You do not have permission to perform that action."] errors)))))
+
+    (testing "delete without permission, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
+      (let [{:keys [status errors]} (ingest/delete-subscription-concept
+                                     gran-sub1
+                                     {:token guest-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "delete with permission"
+      (let [{:keys [status concept-id revision-id]} (ingest/delete-subscription-concept
+                                                     gran-sub1
+                                                     {:token user1-token})
+            fetched (mdb/get-concept concept-id revision-id)]
+        (is (= 200 status))
+        (is (= 2 revision-id))
+        (is (= (:native-id gran-sub1)
+               (:native-id fetched)))
+        (is (:deleted fetched)))
+
+      (testing "delete a granule subscription on PROV2 still doesn't work as no permission is granted on PROV2"
+        (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                       gran-sub2 {:token user1-token})]
+          (is (= 401 status))
+          (is (= ["You do not have permission to perform that action."] errors)))))
+
+    (testing "create collection subscription using a token that can create granule subscription does not work"
+      (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                     coll-sub {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "create collection subscription with permission"
+      (let [{:keys [status errors]} (ingest/ingest-subscription-concept
+                                     coll-sub {:token coll-sub-token})]
+        (is (= 201 status))
+        (is (nil? errors))))
+
+    (testing "delete collection subscription without permission, using a token that can create granule subscription does not work"
+      (let [{:keys [status errors]} (ingest/delete-subscription-concept
+                                     coll-sub
+                                     {:token user1-token})]
+        (is (= 401 status))
+        (is (= ["You do not have permission to perform that action."] errors))))
+
+    (testing "delete with permission"
+      (let [{:keys [status concept-id revision-id]} (ingest/delete-subscription-concept
+                                                     coll-sub
+                                                     {:token coll-sub-token})
+            fetched (mdb/get-concept concept-id revision-id)]
+        (is (= 200 status))
+        (is (= 2 revision-id))
+        (is (= (:native-id coll-sub)
+               (:native-id fetched)))
+        (is (:deleted fetched))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_permission_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_permission_test.clj
@@ -1,0 +1,77 @@
+(ns cmr.system-int-test.ingest.subscription-ingest-permission-test
+  "CMR subscription ingest permission integration tests.
+  For some granule subscription permissions tests, see `provider-ingest-permissions-test`."
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.access-control.test.util :as ac-util]
+   [cmr.common.util :refer [are3]]
+   [cmr.common-app.test.side-api :as side]
+   [cmr.ingest.services.subscriptions-helper :as jobsub]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.granule :as data-granule]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.subscription-util :as subscription-util]
+   [cmr.transmit.access-control :as access-control]
+   [cmr.transmit.config :as transmit-config]
+   [cmr.transmit.metadata-db :as mdb2]
+   [cmr.mock-echo.client.mock-urs-client :as mock-urs]))
+
+(use-fixtures :each
+  (join-fixtures
+   [(ingest/reset-fixture
+     {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"})
+    (subscription-util/grant-all-subscription-fixture
+     {"provguid1" "PROV1" "provguid2" "PROV2"}
+     [:read]
+     [:read :update])
+    (dev-sys-util/freeze-resume-time-fixture)
+    (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
+                                                      [:read]
+                                                      [:read :update])]))
+
+(deftest delete-collection-subscription-ingest-test
+  (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])
+  (testing "delete a collection subscription"
+    (let [coll1 (data-core/ingest-umm-spec-collection
+                 "PROV1"
+                 (data-umm-c/collection
+                  {:ShortName "coll1"
+                   :EntryTitle "entry-title1"})
+                 {:token "mock-echo-system-token"})
+          user1-token (echo-util/login (system/context) "user1")
+          guest-token (echo-util/login-guest (system/context))
+          concept (subscription-util/make-subscription-concept
+                   {:Type "collection"}
+                   {}
+                   "coll-sub")]
+      (ingest/ingest-concept concept {:token user1-token})
+      (testing "delete without permission, guest is not granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
+        (let [{:keys [status errors]} (ingest/delete-concept concept
+                                                             {:token guest-token})]
+          (is (= 401 status))
+          (is (= ["You do not have permission to perform that action."] errors))))
+      (testing "delete a collection subscription with permission"
+        (let [{:keys [status concept-id revision-id]} (ingest/delete-concept concept
+                                                                             {:token user1-token})
+              fetched (mdb/get-concept concept-id revision-id)]
+          (is (= 200 status))
+          (is (= 2 revision-id))
+          (is (= (:native-id concept)
+                 (:native-id fetched)))
+          (is (:deleted fetched))
+          (testing "delete a deleted collection subscription"
+            (let [{:keys [status errors]} (ingest/delete-concept concept
+                                                                 {:token user1-token})]
+              (is (= 404 status))
+              (is (= [(format "Subscription with native-id [%s] has already been deleted."
+                              (:native-id concept))]
+                     errors)))))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_temporary_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_ingest_temporary_test.clj
@@ -10,12 +10,12 @@
    [clojure.string :as string]
    [clojure.test :refer :all]
    [cmr.access-control.test.util :as ac-util]
-   [cmr.common.util :refer [are3]]
    [cmr.common-app.test.side-api :as side]
+   [cmr.common.util :refer [are3]]
    [cmr.ingest.services.subscriptions-helper :as jobsub]
    [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.mock-echo.client.mock-urs-client :as mock-urs]
    [cmr.system-int-test.data2.core :as data-core]
-   [cmr.system-int-test.data2.granule :as data-granule]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as system]
    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
@@ -23,23 +23,22 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
    [cmr.system-int-test.utils.subscription-util :as subscription-util]
-   [cmr.transmit.access-control :as access-control]
-   [cmr.transmit.config :as transmit-config]
-   [cmr.transmit.metadata-db :as mdb2]
-   [cmr.mock-echo.client.mock-urs-client :as mock-urs]))
+   [cmr.system-int-test.utils.tag-util :as tags]
+   [cmr.transmit.config :as transmit-config]))
 
 (use-fixtures :each
-  (join-fixtures
-   [(ingest/reset-fixture
-     {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"})
-    (subscription-util/grant-all-subscription-fixture
-     {"provguid1" "PROV1" "provguid2" "PROV2"}
-     [:read :update]
-     [:read :update])
-    (dev-sys-util/freeze-resume-time-fixture)
-    (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
-                                                      [:read]
-                                                      [:read :update])]))
+              (join-fixtures
+               [(ingest/reset-fixture
+                 {"provguid1" "PROV1" "provguid2" "PROV2" "provguid3" "PROV3"})
+                (subscription-util/grant-all-subscription-fixture
+                 {"provguid1" "PROV1" "provguid2" "PROV2"}
+                 [:read :update]
+                 [:read :update])
+                (dev-sys-util/freeze-resume-time-fixture)
+                (subscription-util/grant-all-subscription-fixture {"provguid1" "PROV3"}
+                                                                  [:read]
+                                                                  [:read :update])
+                tags/grant-all-tag-fixture]))
 
 (deftest subscription-count-exceeds-limit-test
   (side/eval-form `(jobsub/set-subscriptions-limit! 1))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription_processing_test.clj
@@ -342,7 +342,7 @@
                                                                    {:token "mock-echo-system-token"})
              _              (subscription-util/ingest-subscription (subscription-util/make-subscription-concept
                                                                     {:provider-id         "PROV2"
-                                                                     :Name                "test_sub_prov1"
+                                                                     :Name                "test_sub_prov2"
                                                                      :SubscriberId        "user1"
                                                                      :Type                "granule"
                                                                      :EmailAddress        "user1@nasa.gov"

--- a/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/concept_retrieval_test.clj
@@ -118,7 +118,7 @@
 (deftest retrieve-subscription-by-concept-id-various-read-permission
   ;; We support UMM JSON format; No format and any format are also accepted.
   (let [_ (mock-urs/create-users (s/context) [{:username "someSubId" :password "Password"}])
-        coll1 (data-core/ingest-umm-spec-collection "PROV1"
+        coll1 (data-core/ingest-umm-spec-collection "PROV2"
                (data-umm-c/collection
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_revisions_search_test.clj
@@ -30,6 +30,12 @@
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
+        coll2 (d/ingest-umm-spec-collection
+               "PROV2"
+               (data-umm-c/collection
+                {:ShortName "coll2"
+                 :EntryTitle "entry-title2"})
+               {:token "mock-echo-system-token"})
         subscription1 {:native-id "SUB1"
                        :Name "Sub1"
                        :Query "platform=NOAA-7"
@@ -37,7 +43,7 @@
                        :provider-id "PROV1"}
         subscription2 {:native-id "SUB2"
                        :Query "platform=NOAA-9"
-                       :CollectionConceptId (:concept-id coll1)
+                       :CollectionConceptId (:concept-id coll2)
                        :Name "Sub2"
                        :provider-id "PROV2"}
         subscription1s (doall (for [n (range 2)]
@@ -72,6 +78,12 @@
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
+        coll2 (d/ingest-umm-spec-collection
+               "PROV2"
+               (data-umm-c/collection
+                {:ShortName "coll2"
+                 :EntryTitle "entry-title2"})
+               {:token "mock-echo-system-token"})
         sub1-concept (subscription/make-subscription-concept {:native-id "SUB1"
                                                               :Query "platform=NOAA-7"
                                                               :CollectionConceptId (:concept-id coll1)
@@ -89,7 +101,7 @@
                                                                 :provider-id "PROV1"})
         sub3-concept (subscription/make-subscription-concept {:native-id "SUB3"
                                                               :Query "platform=NOAA-11"
-                                                              :CollectionConceptId (:concept-id coll1)
+                                                              :CollectionConceptId (:concept-id coll2)
                                                               :Name "Subscription1"
                                                               :provider-id "PROV2"})
         sub1-1 (subscription/ingest-subscription sub1-concept)

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
@@ -1,13 +1,14 @@
 (ns cmr.system-int-test.search.subscription.subscription-search-test
   "This tests searching subscriptions."
   (:require
-   [clojure.test :refer :all]
    [clojure.string :as string]
+   [clojure.test :refer :all]
    [cmr.access-control.test.util :as ac-util]
    [cmr.common.date-time-parser :as dt-parser]
    [cmr.common.mime-types :as mime-types]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.mock-echo.client.mock-urs-client :as mock-urs]
    [cmr.system-int-test.data2.core :as data2-core]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.system :as system]
@@ -15,7 +16,7 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
    [cmr.system-int-test.utils.subscription-util :as subscriptions]
-   [cmr.mock-echo.client.mock-urs-client :as mock-urs]))
+   [cmr.system-int-test.utils.tag-util :as tags]))
 
 (use-fixtures :each
               (join-fixtures
@@ -30,7 +31,8 @@
                   {"provguid3" "PROV3"} [:update] [:read :update])
                 ;; No read permission granted for any user_types for PROV4.
                 (subscriptions/grant-all-subscription-fixture
-                  {"provguid4" "PROV4"} [:update] [:update])]))
+                  {"provguid4" "PROV4"} [:update] [:update])
+                tags/grant-all-tag-fixture]))
 
 (deftest search-for-subscriptions-test-with-subscriber
   (echo-util/ungrant-by-search (system/context)
@@ -207,13 +209,13 @@
   (let [_ (mock-urs/create-users (system/context) [{:username "SubId1" :password "Password"}
                                                    {:username "SubId2" :password "Password"}])
         coll1 (data2-core/ingest-umm-spec-collection
-               "PROV4"
+               "PROV1"
                (data-umm-c/collection
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
         coll2 (data2-core/ingest-umm-spec-collection
-               "PROV4"
+               "PROV2"
                (data-umm-c/collection
                 {:ShortName "coll2"
                  :EntryTitle "entry-title2"})
@@ -265,7 +267,7 @@
 
       "Combination of params"
       [subscription4]
-      {:type "collection" :provider "*2" "options[provider][pattern]" true})))
+      {:type "collection" :name  "Sub*4" "options[name][pattern]" true})))
 
 (deftest search-for-subscriptions-test
   (let [_ (mock-urs/create-users (system/context) [{:username "SubId1" :password "Password"}
@@ -273,19 +275,19 @@
                                                    {:username "SubId3" :password "Password"}
                                                    {:username "SubId4" :password "Password"}])
         coll1 (data2-core/ingest-umm-spec-collection
-               "PROV4"
+               "PROV1"
                (data-umm-c/collection
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
         coll2 (data2-core/ingest-umm-spec-collection
-               "PROV4"
+               "PROV1"
                (data-umm-c/collection
                 {:ShortName "coll2"
                  :EntryTitle "entry-title2"})
                {:token "mock-echo-system-token"})
         coll3 (data2-core/ingest-umm-spec-collection
-               "PROV1"
+               "PROV2"
                (data-umm-c/collection
                 {:ShortName "coll3"
                  :EntryTitle "entry-title3"})
@@ -305,7 +307,7 @@
         subscription3 (subscriptions/ingest-subscription-with-attrs {:native-id "sub3"
                                                                      :Name "Subscrition3"
                                                                      :Query "platform=NOAA-8"
-                                                                     :CollectionConceptId (:concept-id coll1)
+                                                                     :CollectionConceptId (:concept-id coll3)
                                                                      :SubscriberId "SubId3"
                                                                      :provider-id "PROV2"})
         subscription4 (subscriptions/ingest-subscription-with-attrs {:native-id "sb4"
@@ -408,11 +410,11 @@
       ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
       ;; collection-concept-id Param
       "By name case sensitive - exact match"
-      [subscription1 subscription3]
+      [subscription1]
       {:collection-concept-id (:concept-id coll1)}
 
       "By collection-concept-id case sensitive, default ignore-case true"
-      [subscription1 subscription3]
+      [subscription1]
       {:collection-concept-id (string/lower-case (:concept-id coll1))}
 
       "By collection-concept-id ignore case false"
@@ -420,7 +422,7 @@
       {:collection-concept-id (string/lower-case (:concept-id coll1)) "options[collection-concept-id][ignore-case]" false}
 
       "By collection-concept-id ignore case true"
-      [subscription1 subscription3]
+      [subscription1]
       {:collection-concept-id (string/lower-case (:concept-id coll1)) "options[collection-concept-id][ignore-case]" true}
 
       "By collection-concept-id Pattern, default false"
@@ -428,7 +430,7 @@
       {:collection-concept-id  "*PROV1"}
 
       "By collection-concept-id Pattern true"
-      [subscription4]
+      prov1-subscriptions
       {:collection-concept-id "*PROV1" "options[collection-concept-id][pattern]" true}
 
       "By collection-concept-id Pattern false"
@@ -436,12 +438,12 @@
       {:collection-concept-id "*PROV1" "options[collection-concept-id][pattern]" false}
 
       "By multiple collection-concept-ids"
-      [subscription1 subscription2 subscription3]
+      [subscription1 subscription2]
       {:collection-concept-id [(:concept-id coll1) (:concept-id coll2)]}
 
       "By multiple collection-concept-ids with options"
       [subscription1 subscription3 subscription4]
-      {:collection-concept-id [(:concept-id coll1) "*PROV1"] "options[collection-concept-id][pattern]" true}
+      {:collection-concept-id [(:concept-id coll1) "*PROV2"] "options[collection-concept-id][pattern]" true}
 
       ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
       ;; provider Param
@@ -538,53 +540,64 @@
 (deftest subscription-umm-json-search-results
   (let [_ (mock-urs/create-users (system/context) [{:username "SubId1" :password "Password"}])
         coll1 (data2-core/ingest-umm-spec-collection
-               "PROV4"
+               "PROV1"
                (data-umm-c/collection
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
-        _sub1 (subscriptions/ingest-subscription-with-attrs {:native-id "Sub1"
-                                                                     :Name "Subscription1"
-                                                                     :SubscriberId "SubId1"
-                                                                     :Query "platform=NOAA-6"
-                                                                     :CollectionConceptId (:concept-id coll1)
-                                                                     :provider-id "PROV1"})]
+        sub1 (subscriptions/ingest-subscription-with-attrs {:native-id "Sub1"
+                                                            :Name "Subscription1"
+                                                            :SubscriberId "SubId1"
+                                                            :Query "platform=NOAA-6"
+                                                            :CollectionConceptId (:concept-id coll1)
+                                                            :provider-id "PROV1"})]
     (index/wait-until-indexed)
     (testing "subscription-umm-json-results contains valid creation-date"
       (let [{json-umm-status :status json-umm-results :results} (search/find-concepts-umm-json
-                                                         :subscription {})
+                                                                 :subscription {})
             creation-date (-> json-umm-results :items first :meta :creation-date)
             parsed-creation-date (dt-parser/parse-datetime creation-date)]
         (is (= 200 json-umm-status))
         (is (some? parsed-creation-date))))))
 
 (deftest subscription-search-sort
-  (let [_ (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])
-        coll1 (data2-core/ingest-umm-spec-collection "PROV4"
+  (mock-urs/create-users (system/context) [{:username "someSubId" :password "Password"}])
+  (let [coll1 (data2-core/ingest-umm-spec-collection
+               "PROV1"
                (data-umm-c/collection
                 {:ShortName "coll1"
                  :EntryTitle "entry-title1"})
                {:token "mock-echo-system-token"})
-        subscription1 (subscriptions/ingest-subscription-with-attrs {:native-id "sub1"
-                                                                     :Name "subscription"
-                                                                     :Query "platform=NOAA-7"
-                                                                     :CollectionConceptId (:concept-id coll1)
-                                                                     :provider-id "PROV2"})
-        subscription2 (subscriptions/ingest-subscription-with-attrs {:native-id "sub2"
-                                                                     :Name "Subscription 2"
-                                                                     :Query "platform=NOAA-4"
-                                                                     :CollectionConceptId (:concept-id coll1)
-                                                                     :provider-id "PROV1"})
-        subscription3 (subscriptions/ingest-subscription-with-attrs {:native-id "sub3"
-                                                                     :Name "a subscription"
-                                                                     :Query "platform=NOAA-5"
-                                                                     :CollectionConceptId (:concept-id coll1)
-                                                                     :provider-id "PROV1"})
-        subscription4 (subscriptions/ingest-subscription-with-attrs {:native-id "sub4"
-                                                                     :Name "subscription"
-                                                                     :Query "platform=NOAA-6"
-                                                                     :CollectionConceptId (:concept-id coll1)
-                                                                     :provider-id "PROV1"})]
+        coll2 (data2-core/ingest-umm-spec-collection
+               "PROV2"
+               (data-umm-c/collection
+                {:ShortName "coll2"
+                 :EntryTitle "entry-title2"})
+               {:token "mock-echo-system-token"})
+        subscription1 (subscriptions/ingest-subscription-with-attrs
+                       {:native-id "sub1"
+                        :Name "subscription"
+                        :Query "platform=NOAA-7"
+                        :CollectionConceptId (:concept-id coll2)
+                        :provider-id "PROV2"})
+        subscription2 (subscriptions/ingest-subscription-with-attrs
+                       {:native-id "sub2"
+                        :Name "Subscription 2"
+                        :Query "platform=NOAA-4"
+                        :CollectionConceptId (:concept-id coll1)
+                        :provider-id "PROV1"})
+        subscription3 (subscriptions/ingest-subscription-with-attrs
+                       {:native-id "sub3"
+                        :Name "a subscription"
+                        :Query "platform=NOAA-5"
+                        :CollectionConceptId (:concept-id coll1)
+                        :provider-id "PROV1"})
+        subscription4 (subscriptions/ingest-subscription-with-attrs
+                       {:native-id "sub4"
+                        :Name "subscription"
+                        :Query "platform=NOAA-6"
+                        :CollectionConceptId (:concept-id coll1)
+                        :provider-id "PROV1"})]
     (index/wait-until-indexed)
 
     (are3 [sort-key expected-subscriptions]


### PR DESCRIPTION
This PR adds the subscription Ingest routes to the Ingest root level. The provider level subscription routes are kept for backwards compatibility and will be remove once all clients have switched over to the new routes.

Changes in the PR:

1. Added subscription ingest API routes on ingest root url. The old subscription ingest API with provider is kept for backwards compatibility and will be removed once all clients have moved to the new routes.
2. Changed collection subscription ingest ACL check to be on System Object TAG_GROUP ACL UPDATE permission.
3. Changed native-id uniqueness to be across CMR rather than on individual providers which does not make sense for collection subscriptions.
  - Added db migration to change subscription table unique constraint for native-id and revision-id, dropping provider-id.
  - Updated in memory db and oracle referential integrity checks for subscription concepts.
4. Fixed subscription deletion bug where tombstones are used for referential integrity checks.
5. Fixed collection subscription search bug where wrong ACL is used.
6. Fixed bugs in utility classes.
7. Fixed wrong tests, added and updated tests.
8. Updated ingest API doc.