### PR TITLE
CMR-8279 Added subscription-type to be returned from JSON response

### DIFF
--- a/search-app/src/cmr/search/results_handlers/subscriptions_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/subscriptions_json_results_handler.clj
@@ -11,7 +11,7 @@
 (defmethod elastic-search-index/concept-type+result-format->fields [:subscription :json]
   [concept-type query]
   ["concept-id" "revision-id" "deleted" "provider-id" "native-id" "subscription-name"
-   "subscriber-id" "collection-concept-id"])
+   "subscriber-id" "collection-concept-id"  "subscription-type"])
 
 (defmethod elastic-results/elastic-result->query-result-item [:subscription :json]
   [context query elastic-result]
@@ -21,6 +21,7 @@
           deleted :deleted
           provider-id :provider-id
           native-id :native-id
+          subscription-type :subscription-type
           concept-id :concept-id} :_source} elastic-result
         revision-id (elastic-results/get-revision-id-from-elastic-result :service elastic-result)
         result-item (util/remove-nil-keys
@@ -28,6 +29,7 @@
                       :revision_id revision-id
                       :provider_id provider-id
                       :native_id native-id
+                      :subscription-type subscription-type
                       :name subscription-name
                       :subscriber_id subscriber-id
                       :collection_concept_id collection-concept-id})]

--- a/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/subscription/subscription_search_test.clj
@@ -205,6 +205,32 @@
             (search/find-concepts-in-format
              nil :subscription {} {:url-extension "atom"}))))))
 
+(deftest search-for-subscription-type-field
+  (let [_ (mock-urs/create-users (system/context) [{:username "SubId" :password "Password"}])
+        coll1 (data2-core/ingest-umm-spec-collection
+               "PROV1"
+               (data-umm-c/collection
+                {:ShortName "coll1"
+                 :EntryTitle "entry-title1"})
+               {:token "mock-echo-system-token"})
+        subscription1 (subscriptions/ingest-subscription-with-attrs {:native-id "sub1"
+                                                                     :Name "Subscription1"
+                                                                     :SubscriberId "SubId"
+                                                                     :Query "platform=NOAA-6"
+                                                                     :CollectionConceptId (:concept-id coll1)
+                                                                     :provider-id "PROV1"})
+        subscription2 (subscriptions/ingest-subscription-with-attrs {:native-id "sub2"
+                                                                     :Name "Subscription2"
+                                                                     :SubscriberId "SubId"
+                                                                     :Type "collection"
+                                                                     :provider-id "PROV1"})]
+    (index/wait-until-indexed)
+    (testing "JSON response contains Type field"
+      (testing "collection subscription type"
+        (is (= 1 (:hits (subscriptions/search-refs {:type "collection"})))))
+      (testing "granule subscription type"
+        (is (= 1 (:hits (subscriptions/search-refs {:type "granule"}))))))))
+
 (deftest search-for-subscription-by-type-test
   (let [_ (mock-urs/create-users (system/context) [{:username "SubId1" :password "Password"}
                                                    {:username "SubId2" :password "Password"}])


### PR DESCRIPTION
With the introduction of Collection subscriptions, we want to include subscription Type in the subscription search JSON response. e.g. 
```
{
  "hits" : 3,
  "took" : 11,
  "items" : [ {
    "concept_id" : "SUB1200425213-CMR",
    "revision_id" : 1,
    "type" : "collection",
    "provider_id" : "CMR",
    "native_id" : "coll_subscription_v_1._1_1c7b71bf-8cc0-4d08-a549-ef6ee0e72dc6",
    "name" : "coll_subscription_v1.1",
    "subscriber_id" : "yliu10"
  } ]
}
```
This change is intended to verify a `type` field is added to subscription search JSON response with the value being the subscription's subscription Type.