### PR TITLE
CMR-8279-2 Added subscription-type to be returned from JSON response enhancement

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/subscription.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/subscription.clj
@@ -11,7 +11,9 @@
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields created-at]} concept
         {:keys [subscription-name subscriber-id collection-concept-id]} extra-fields
-        type (:Type parsed-concept)
+        type (if deleted
+               (:subscription-type parsed-concept)
+               (:Type parsed-concept))
         doc-for-deleted
          {:concept-id concept-id
           :revision-id revision-id

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -5052,6 +5052,7 @@ The JSON response includes the following fields.
   * revision_id
   * provider_id
   * native_id
+  * type
   * name
   * subscriber_id
   * collection_concept_id
@@ -5073,6 +5074,7 @@ Content-Length: 944
     "revision_id" : 1,
     "provider_id" : "PROV1",
     "native_id" : "subscription-1",
+    "type" : "granule",
     "name" : "someSub1",
     "subscriber-id" : "someSubId1",
     "collection-concept-id" : "C1200000001-PROV1"
@@ -5081,9 +5083,9 @@ Content-Length: 944
     "revision_id" : 1,
     "provider_id" : "PROV1",
     "native_id" : "subscription-2",
+    "type" : "collection",
     "name" : "someSub2",
     "subscriber-id" : "someSubId2",
-    "collection-concept-id" : "C1200000001-PROV1"
   } ]
 }
 ```


### PR DESCRIPTION
CMR-8279-2 is an enhancement to [CMR-8279](https://github.com/nasa/Common-Metadata-Repository/pull/1582) to fix the `type` field for deleted subscriptions and update the API docs to reflect the new field.