### PR TITLE
CMR-8334 Updates CMR to take EDL group tags into account.

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -66,28 +66,28 @@
   (if-not (= "null" user-id)
     (case user-id
       "edl-group-user1"
-      {:status 200 :body [{:description "cmr test group",
-                           :name "cmr_test_group",
-                           :shared_user_group false,
-                           :app_uid "mock_test_application",
-                           :client_id "cmr",
-                           :tag nil,
+      {:status 200 :body [{:description "cmr test group"
+                           :name "cmr_test_group"
+                           :shared_user_group false
+                           :app_uid "mock_test_application"
+                           :client_id "cmr"
+                           :tag "PROV1"
                            :created_by "mock_test_application"}
-                          {:description "cmr test group",
-                           :name "cmr_test_group2",
-                           :shared_user_group false,
-                           :app_uid "mock_test_application",
-                           :client_id "cmr",
-                           :tag nil,
+                          {:description "cmr test group"
+                           :name "cmr_test_group2"
+                           :shared_user_group false
+                           :app_uid "mock_test_application"
+                           :client_id "cmr"
+                           :tag nil
                            :created_by "mock_test_application"}]}
 
       "edl-group-user3"
-      {:status 200 :body [{:description "cmr test group",
-                           :name "cmr_test_group3",
-                           :shared_user_group false,
-                           :app_uid "mock_test_application",
-                           :client_id "cmr",
-                           :tag nil,
+      {:status 200 :body [{:description "cmr test group"
+                           :name "cmr_test_group3"
+                           :shared_user_group false
+                           :app_uid "mock_test_application"
+                           :client_id "cmr"
+                           :tag "PROV1"
                            :created_by "mock_test_application"}]}
 
       {:status 200 :body []})

--- a/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
+++ b/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
@@ -67,7 +67,7 @@
     (testing "acls granting collection catalog-item-identity access to edl groups"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (create-acl {:group_permissions [{:permissions [:read :order]
-                                        :group_id "cmr_test_group"}]
+                                        :group_id "cmr_test_group:PROV1"}]
                    :catalog_item_identity {:name "coll1 read and order"
                                            :collection_applicable true
                                            :provider_id "PROV1"}})
@@ -90,7 +90,7 @@
     (testing "permissions granted to a edl group"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (create-acl {:group_permissions [{:permissions [:read]
-                                        :group_id "cmr_test_group"}]
+                                        :group_id "cmr_test_group:PROV1"}]
                    :catalog_item_identity {:name "prov1 granule read"
                                            :granule_applicable true
                                            :provider_id "PROV1"}})
@@ -115,7 +115,7 @@
     (testing "granted to edl groups"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (create-acl {:group_permissions [{:permissions [:update]
-                                        :group_id "cmr_test_group"}]
+                                        :group_id "cmr_test_group:PROV1"}]
                    :provider_identity {:provider_id "PROV1"
                                        :target "INGEST_MANAGEMENT_ACL"}})
 
@@ -149,7 +149,7 @@
     (testing "provider object permissions granted to edl groups"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (create-acl {:group_permissions [{:permissions [:create :read :update :delete]
-                                        :group_id "cmr_test_group"}]
+                                        :group_id "cmr_test_group:PROV1"}]
                    :provider_identity {:provider_id "PROV1"
                                        :target "PROVIDER_OBJECT_ACL"}})
 
@@ -166,12 +166,12 @@
       (let [concept-id (e/grant
                         (u/conn-context)
                         [{:permissions [:read]
-                          :group_id "cmr_test_group"}]
+                          :group_id "cmr_test_group:PROV1"}]
                         :system_identity {:target "GROUP"})]
         (ac/update-acl (u/conn-context)
                        concept-id
                        {:group_permissions [{:permissions [:read]
-                                             :group_id "cmr_test_group"}]
+                                             :group_id "cmr_test_group:PROV1"}]
                         :system_identity {:target "GROUP"}}
                        {:token (transmit-config/echo-system-token)}))
 
@@ -192,14 +192,14 @@
     (testing "initial search find fixture ACLs"
       ;; search by permitted group
       (let [{:keys [hits items]} (ac/search-for-acls
-                                  test-context {:permitted-group ["cmr_test_group"]})]
+                                  test-context {:permitted-group ["cmr_test_group:PROV1"]})]
         (is (= 0 hits))
         (is (= [] (map :name items))))
 
       ; search by group permission
       (let [{:keys [hits items]} (ac/search-for-acls
                                   test-context
-                                  {:group-permission {:0 {:permitted-group ["cmr_test_group"]}}})]
+                                  {:group-permission {:0 {:permitted-group ["cmr_test_group:PROV1"]}}})]
         (is (= 0 hits))
         (is (= [] (map :name items))))
 
@@ -211,16 +211,16 @@
 
     (testing "search ACLs with EDL group"
       (create-acl {:group_permissions [{:permissions [:read :order]
-                                        :group_id "cmr_test_group"}]
+                                        :group_id "cmr_test_group:PROV1"}]
                    :catalog_item_identity {:name "group1 read and order"
                                            :collection_applicable true
                                            :provider_id "PROV1"}})
       (create-acl {:group_permissions [{:permissions [:update]
-                                        :group_id "cmr_test_group2"}]
+                                        :group_id "cmr_test_group2:"}]
                    :provider_identity {:provider_id "PROV1"
                                        :target "INGEST_MANAGEMENT_ACL"}})
       (create-acl {:group_permissions [{:permissions [:read :order]
-                                        :group_id "cmr_test_group3"}]
+                                        :group_id "cmr_test_group3:PROV1"}]
                    :catalog_item_identity {:name "group3 read and order"
                                            :collection_applicable true
                                            :provider_id "PROV1"}})
@@ -233,7 +233,7 @@
           (is (= expected-names (map :name items))))
 
         "search by EDL group, found"
-        ["cmr_test_group"]
+        ["cmr_test_group:PROV1"]
         1
         ["group1 read and order"]
 
@@ -243,7 +243,7 @@
         []
 
         "search by multiple EDL groups"
-        ["cmr_test_group" "non_existent_group" "cmr_test_group2"]
+        ["cmr_test_group:PROV1" "non_existent_group" "cmr_test_group2:"]
         2
         ["group1 read and order" "Provider - PROV1 - INGEST_MANAGEMENT_ACL"])
 
@@ -256,7 +256,7 @@
           (is (= (set expected-names) (set (map :name items)))))
 
         "search by EDL group, found"
-        ["cmr_test_group"]
+        ["cmr_test_group:PROV1"]
         1
         ["group1 read and order"]
 
@@ -266,7 +266,7 @@
         []
 
         "search by multiple EDL groups"
-        ["cmr_test_group" "non_existent_group" "cmr_test_group2"]
+        ["cmr_test_group:PROV1" "non_existent_group" "cmr_test_group2:"]
         2
         ["group1 read and order" "Provider - PROV1 - INGEST_MANAGEMENT_ACL"])
 

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -105,8 +105,12 @@
         :unauthorized
         (format "Cannot get group info for username [%s] in URS. Failed with status code [%d]."
                 user-id status)))
-    (map #(get % :name) body)))
-
+    (map  (fn [group]
+            (str (get group :name)
+                 ":"
+                 (when-let [tag (get group :tag)]
+                   tag)))
+         body)))
 
 (comment
  ;; Use this code to test with URS. Replace XXXX with real values


### PR DESCRIPTION
Currently EDL groups are unique via the combination of name and tag, so when saving them to ACLs we need to concat both around a ":".   Grabbing SIDs therefore must also assume this convention.