### PR TITLE
CMR-8464: Make granule search by granule concept-id more efficient

### DIFF
--- a/search-app/src/cmr/search/services/aql/conversion.clj
+++ b/search-app/src/cmr/search/services/aql/conversion.clj
@@ -264,10 +264,11 @@
 (defmethod element->condition :granule-concept-id
   [concept-type element]
   (let [gran-condition (string-element->condition concept-type element)
-        provider-ids (->> element
-                          :content
-                          first
-                          :content
+        concept-id-elem (first (:content element))
+        concept-ids (if (= :value (:tag concept-id-elem))
+                      (:content concept-id-elem)
+                      (mapcat :content (:content concept-id-elem)))
+        provider-ids (->> concept-ids
                           (map (comp :provider-id cc/parse-concept-id))
                           distinct)
         coll-query-condition (qm/->CollectionQueryCondition

--- a/search-app/src/cmr/search/services/parameters/converters/collection_query.clj
+++ b/search-app/src/cmr/search/services/parameters/converters/collection_query.clj
@@ -1,10 +1,14 @@
 (ns cmr.search.services.parameters.converters.collection-query
   "Contains functions for converting query parameters to collection query condition"
-  (:require [clojure.set :as set]
-            [cmr.search.models.query :as qm]
-            [cmr.common-app.services.search.params :as p]))
+  (:require
+   [cmr.search.models.query :as qm]
+   [cmr.common-app.services.search.params :as p]))
 
 ;; Converts parameter and values into collection query condition
 (defmethod p/parameter->condition :collection-query
   [context concept-type param value options]
-  (qm/->CollectionQueryCondition (p/parameter->condition context :collection param value options)))
+  (let [param-name (if (= :collection-concept-id param)
+                     :concept-id
+                     param)]
+    (qm/->CollectionQueryCondition
+     (p/parameter->condition context :collection param-name value options))))

--- a/search-app/src/cmr/search/services/query_walkers/collection_query_resolver.clj
+++ b/search-app/src/cmr/search/services/query_walkers/collection_query_resolver.clj
@@ -98,6 +98,18 @@
    [:all (update-in query [:condition] #(second (resolve-collection-query % context)))])
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  cmr.common_app.services.search.query_model.NegatedCondition
+  (is-collection-query-cond? [_] false)
+
+  (merge-collection-queries
+   [query]
+   (update-in query [:condition] merge-collection-queries))
+
+  (resolve-collection-query
+   [query context]
+   [:all (update-in query [:condition] #(second (resolve-collection-query % context)))])
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   cmr.common_app.services.search.query_model.ConditionGroup
   (is-collection-query-cond? [_] false)
 

--- a/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/facets/granule_v2_facets_search_test.clj
@@ -28,21 +28,6 @@
       "umm_json")
     "umm_json"))
 
-(defn- search-and-return-v2-facets
-  "Returns only the facets from a v2 granule facets search request."
-  [search-params]
-  (let [query-params (merge {:page-size 0 :include-facets "v2"} search-params)]
-    (get-in (search/find-concepts-json :granule query-params) [:results :facets])))
-
-(deftest granule-facet-tests
-  (testing (str "Granule facets are returned when requesting V2 facets in JSON format for a single"
-                " collection concept ID.")
-    (let [facets (search-and-return-v2-facets {:collection-concept-id "C1-PROV1"})]
-      (is (= {:title "Browse Granules"
-              :type "group"
-              :has_children false}
-             facets)))))
-
 (defn- single-collection-test-setup
   "Ingests the collections and granules needed for the single collection validation test."
   []
@@ -75,6 +60,22 @@
     (ingest/ingest-concept gran2)
     (ingest/ingest-concept gran3)
     (index/wait-until-indexed)))
+
+(defn- search-and-return-v2-facets
+  "Returns only the facets from a v2 granule facets search request."
+  [search-params]
+  (let [query-params (merge {:page-size 0 :include-facets "v2"} search-params)]
+    (get-in (search/find-concepts-json :granule query-params) [:results :facets])))
+
+(deftest granule-facet-tests
+  (single-collection-test-setup)
+  (testing (str "Granule facets are returned when requesting V2 facets in JSON format for a single"
+                " collection concept ID.")
+    (let [facets (search-and-return-v2-facets {:collection-concept-id "C1-PROV1"})]
+      (is (= {:title "Browse Granules"
+              :type "group"
+              :has_children false}
+             facets)))))
 
 (deftest single-collection-validation-tests
   (single-collection-test-setup)
@@ -111,6 +112,7 @@
       "All granules query" {} "an undetermined number of")))
 
 (deftest granule-facets-parameter-validation-tests
+  (single-collection-test-setup)
   (testing "Only the json format supports V2 granule facets."
     (let [xml-error-string (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?><errors><error>"
                                 "V2 facets are only supported in the JSON format.</error></errors>")


### PR DESCRIPTION
This PR changed granule search by granule concept id to execute the search by narrowing down the target granule indices first by searching collections with the provider identified by the granule concept id, then searching for the granule matches within the identified granule indices rather than executing the search on all granule indices.
Since searching by parameter and searching by AQL query construct the query model differently, we need to make similar changes in both parameters to query model conversion and AQL query to query model conversion.