### PR TITLE
CMR-8379 - Create the Generic Document Table

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
@@ -1,59 +1,45 @@
 (ns cmr.metadata-db.migrations.080-add-generic-document-table
   (:require
-   [clojure.string :as string]
    [config.mdb-migrate-helper :as h]))
 
 (defn- create-generic-documents-table
   []
   (h/sql
-   (string/replace
-    (str "CREATE TABLE METADATA_DB.cmr_generic_documents (
-          id NUMBER,
-          concept_id VARCHAR(255) NOT NULL,
-          native_id VARCHAR(1030) NOT NULL,
-          provider_id VARCHAR(10) NOT NULL,
-          document_name VARCHAR(20) NOT NULL,
-          schema VARCHAR(255) NOT NULL,
-          format VARCHAR(255) NOT NULL,
-          mime_type VARCHAR(255) NOT NULL,
-          metadata BLOB NOT NULL,
-          revision_id INTEGER DEFAULT 1 NOT NULL,
-          revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
-          created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
-          deleted INTEGER DEFAULT 0 NOT NULL,
-          user_id VARCHAR(30),
-          transaction_id INTEGER DEFAULT 0 NOT NULL,
+   (str "CREATE TABLE METADATA_DB.cmr_generic_documents (
+         id NUMBER,
+         concept_id VARCHAR(255) NOT NULL,
+         native_id VARCHAR(1030) NOT NULL,
+         provider_id VARCHAR(10) NOT NULL,
+         document_name VARCHAR(20) NOT NULL,
+         schema VARCHAR(255) NOT NULL,
+         format VARCHAR(255) NOT NULL,
+         mime_type VARCHAR(255) NOT NULL,
+         metadata BLOB NOT NULL,
+         revision_id INTEGER DEFAULT 1 NOT NULL,
+         revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+         created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+         deleted INTEGER DEFAULT 0 NOT NULL,
+         user_id VARCHAR(30),
+         transaction_id INTEGER DEFAULT 0 NOT NULL,
 
-          CONSTRAINT generic_doc_pk PRIMARY KEY (id),
+         CONSTRAINT generic_doc_pk PRIMARY KEY (id),
 
-          CONSTRAINT gen_doc_cid_rev UNIQUE (concept_id, revision_id)
-          USING INDEX (create unique index generic_cri
-          ON cmr_generic_documents (concept_id, revision_id)))")
-    #"\s+" " ")))
+         CONSTRAINT gen_doc_cid_rev UNIQUE (concept_id, revision_id)
+         USING INDEX (create unique index generic_cri
+         ON cmr_generic_documents (concept_id, revision_id)))")))
 
 (defn- create-generic-document-indices
   []
   ;; Supports queries to find generic documents that have been deleted
   (h/sql
-   (string/replace
-    (str "CREATE INDEX generic_documents_crdi
-          ON METADATA_DB.cmr_generic_documents (concept_id, deleted)")
-    #"\s+" " "))
-
-  ;; Supports queries to find generic document by native id within one provider
-  (h/sql
-   (string/replace
-    (str "CREATE INDEX generic_documents_provider_native_id
-          ON METADATA_DB.cmr_generic_documents (provider_id, native_id)")
-    #"\s+" " "))
+   (str "CREATE INDEX generic_documents_crdi
+         ON METADATA_DB.cmr_generic_documents (concept_id, deleted)"))
 
   ;; Supports queries to find specific generic document matching a native id
   ;; and revision id within one provider
   (h/sql
-   (string/replace
-    (str "CREATE INDEX generic_documents_native_id_rev
-          ON METADATA_DB.cmr_generic_documents (provider_id, native_id, revision_id)")
-    #"\s+" " ")))
+   (str "CREATE INDEX generic_documents_native_id_rev
+         ON METADATA_DB.cmr_generic_documents (provider_id, native_id, revision_id)")))
 
 (defn- create-generic-document-sequence
   []

--- a/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
@@ -5,41 +5,41 @@
 (defn- create-generic-documents-table
   []
   (h/sql
-   (str "CREATE TABLE METADATA_DB.cmr_generic_documents (
-         id NUMBER,
-         concept_id VARCHAR(255) NOT NULL,
-         native_id VARCHAR(1030) NOT NULL,
-         provider_id VARCHAR(10) NOT NULL,
-         document_name VARCHAR(20) NOT NULL,
-         schema VARCHAR(255) NOT NULL,
-         format VARCHAR(255) NOT NULL,
-         mime_type VARCHAR(255) NOT NULL,
-         metadata BLOB NOT NULL,
-         revision_id INTEGER DEFAULT 1 NOT NULL,
-         revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
-         created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
-         deleted INTEGER DEFAULT 0 NOT NULL,
-         user_id VARCHAR(30),
-         transaction_id INTEGER DEFAULT 0 NOT NULL,
+   "CREATE TABLE METADATA_DB.cmr_generic_documents (
+    id NUMBER,
+    concept_id VARCHAR(255) NOT NULL,
+    native_id VARCHAR(1030) NOT NULL,
+    provider_id VARCHAR(10) NOT NULL,
+    document_name VARCHAR(20) NOT NULL,
+    schema VARCHAR(255) NOT NULL,
+    format VARCHAR(255) NOT NULL,
+    mime_type VARCHAR(255) NOT NULL,
+    metadata BLOB NOT NULL,
+    revision_id INTEGER DEFAULT 1 NOT NULL,
+    revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+    deleted INTEGER DEFAULT 0 NOT NULL,
+    user_id VARCHAR(30),
+    transaction_id INTEGER DEFAULT 0 NOT NULL,
 
-         CONSTRAINT generic_doc_pk PRIMARY KEY (id),
+    CONSTRAINT generic_doc_pk PRIMARY KEY (id),
 
-         CONSTRAINT gen_doc_cid_rev UNIQUE (concept_id, revision_id)
-         USING INDEX (create unique index generic_cri
-         ON cmr_generic_documents (concept_id, revision_id)))")))
+    CONSTRAINT gen_doc_cid_rev UNIQUE (concept_id, revision_id)
+    USING INDEX (create unique index generic_cri
+    ON cmr_generic_documents (concept_id, revision_id)))"))
 
 (defn- create-generic-document-indices
   []
   ;; Supports queries to find generic documents that have been deleted
   (h/sql
-   (str "CREATE INDEX generic_documents_crdi
-         ON METADATA_DB.cmr_generic_documents (concept_id, deleted)"))
-
+   "CREATE INDEX generic_documents_crdi
+    ON METADATA_DB.cmr_generic_documents (concept_id, deleted)")
+  
   ;; Supports queries to find specific generic document matching a native id
   ;; and revision id within one provider
   (h/sql
-   (str "CREATE INDEX generic_documents_native_id_rev
-         ON METADATA_DB.cmr_generic_documents (provider_id, native_id, revision_id)")))
+   "CREATE INDEX generic_documents_native_id_rev
+    ON METADATA_DB.cmr_generic_documents (provider_id, native_id, revision_id)"))
 
 (defn- create-generic-document-sequence
   []

--- a/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
@@ -1,11 +1,12 @@
 (ns cmr.metadata-db.migrations.080-add-generic-document-table
   (:require
+   [clojure.string :as string]
    [config.mdb-migrate-helper :as h]))
 
 (defn- create-generic-documents-table
   []
   (h/sql
-   (clojure.string/replace
+   (string/replace
     (str "CREATE TABLE METADATA_DB.cmr_generic_documents (
           id NUMBER,
           concept_id VARCHAR(255) NOT NULL,
@@ -32,18 +33,26 @@
 
 (defn- create-generic-document-indices
   []
-  ;; Supports queries to find generic document revisions that are deleted
+  ;; Supports queries to find generic documents that have been deleted
   (h/sql
-   (clojure.string/replace
+   (string/replace
     (str "CREATE INDEX generic_documents_crdi
-          ON METADATA_DB.cmr_generic_documents (concept_id, revision_id, deleted)")
+          ON METADATA_DB.cmr_generic_documents (concept_id, deleted)")
     #"\s+" " "))
 
   ;; Supports queries to find generic document by native id within one provider
   (h/sql
-   (clojure.string/replace
-    (str "CREATE INDEX generic_documents_native_id
-          ON METADATA_DB.cmr_generic_documents (native_id, provider_id)")
+   (string/replace
+    (str "CREATE INDEX generic_documents_provider_native_id
+          ON METADATA_DB.cmr_generic_documents (provider_id, native_id)")
+    #"\s+" " "))
+
+  ;; Supports queries to find specific generic document matching a native id
+  ;; and revision id within one provider
+  (h/sql
+   (string/replace
+    (str "CREATE INDEX generic_documents_native_id_rev
+          ON METADATA_DB.cmr_generic_documents (provider_id, native_id, revision_id)")
     #"\s+" " ")))
 
 (defn- create-generic-document-sequence

--- a/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/080_add_generic_document_table.clj
@@ -1,0 +1,65 @@
+(ns cmr.metadata-db.migrations.080-add-generic-document-table
+  (:require
+   [config.mdb-migrate-helper :as h]))
+
+(defn- create-generic-documents-table
+  []
+  (h/sql
+   (clojure.string/replace
+    (str "CREATE TABLE METADATA_DB.cmr_generic_documents (
+          id NUMBER,
+          concept_id VARCHAR(255) NOT NULL,
+          native_id VARCHAR(1030) NOT NULL,
+          provider_id VARCHAR(10) NOT NULL,
+          document_name VARCHAR(20) NOT NULL,
+          schema VARCHAR(255) NOT NULL,
+          format VARCHAR(255) NOT NULL,
+          mime_type VARCHAR(255) NOT NULL,
+          metadata BLOB NOT NULL,
+          revision_id INTEGER DEFAULT 1 NOT NULL,
+          revision_date TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+          created_at TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+          deleted INTEGER DEFAULT 0 NOT NULL,
+          user_id VARCHAR(30),
+          transaction_id INTEGER DEFAULT 0 NOT NULL,
+
+          CONSTRAINT generic_doc_pk PRIMARY KEY (id),
+
+          CONSTRAINT gen_doc_cid_rev UNIQUE (concept_id, revision_id)
+          USING INDEX (create unique index generic_cri
+          ON cmr_generic_documents (concept_id, revision_id)))")
+    #"\s+" " ")))
+
+(defn- create-generic-document-indices
+  []
+  ;; Supports queries to find generic document revisions that are deleted
+  (h/sql
+   (clojure.string/replace
+    (str "CREATE INDEX generic_documents_crdi
+          ON METADATA_DB.cmr_generic_documents (concept_id, revision_id, deleted)")
+    #"\s+" " "))
+
+  ;; Supports queries to find generic document by native id within one provider
+  (h/sql
+   (clojure.string/replace
+    (str "CREATE INDEX generic_documents_native_id
+          ON METADATA_DB.cmr_generic_documents (native_id, provider_id)")
+    #"\s+" " ")))
+
+(defn- create-generic-document-sequence
+  []
+  (h/sql "CREATE SEQUENCE cmr_generic_documents_seq"))
+
+(defn up
+  "Migrate the database up to version 80"
+  []
+  (println "cmr.metadata-db.migration.080_add_generic_document_table up...")
+  (create-generic-documents-table)
+  (create-generic-document-indices)
+  (create-generic-document-sequence))
+
+(defn down "Migrate the database down from version 80"
+  []
+  (println "cmr.metadata-db.migration.080_add_generic_document_table down...")
+  (h/sql "DROP SEQUENCE METADATA_DB.cmr_generic_documents_seq")
+  (h/sql "DROP TABLE METADATA_DB.cmr_generic_documents"))


### PR DESCRIPTION
* CMR-8379 - this change is a copy of the database table used by the generic system. This pull request is to get the database in master before all the other code so that the development team does not have to keep renaming the migration file every time another team makes a database change. This table is also needed by other efforts such as at the effort to create a simplified association table.

This table is much like other concept tables. Document name is to be made unique by code and may have rules that change for each document type.

Native-id is assumed to be unique by provider.