### PR TITLE
CMR-8376 : add new defconfig called approved-pipeline-documents, chan…

### DIFF
--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -23,3 +23,10 @@
   "Includes all the consortiums that opensearch contains."
   {:default ["CWIC" "FEDEO" "GEOSS" "CEOS" "EOSDIS"]
    :parser #(json/decode ^String %)})
+
+(defconfig approved-pipeline-documents
+  "This string should contain JSON that looks like:
+   {'grid': ['0.0.1'],
+    'variable': ['1.8.0']}"
+  {:default ""
+   :parser #(json/parse-string % true)})

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -9,6 +9,7 @@
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
+   [cmr.common-app.config :as common-config]
    [cmr.elastic-utils.index-util :as m :refer [defmapping defnestedmapping]]
    [cmr.indexer.data.index-set-generics :as index-set-gen]
    [cmr.indexer.data.index-set-elasticsearch :as index-set-es]
@@ -1114,7 +1115,7 @@
        ;; and return the index name for those
        (let [reported-type (clojure.string/lower-case (get-in concept [:MetadataSpecification :Name]))
               reported-version (get-in concept [:MetadataSpecification :Version])
-              approved (cmr.ingest.api.generic-documents/approved-generics reported-type reported-version)]
+              approved ((common-config/approved-pipeline-documents) reported-type reported-version)]
          (when approved
            (keyword (format "generic-%s" reported-type))
            (if all-revisions-index?

--- a/indexer-app/src/cmr/indexer/data/index_set_generics.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_generics.clj
@@ -10,6 +10,7 @@
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
+   [cmr.common-app.config :as common-config]
    [cmr.elastic-utils.index-util :as m :refer [defmapping defnestedmapping]]
    [cmr.indexer.data.concepts.generic-util :as gen-util]
    [cmr.indexer.data.index-set-elasticsearch :as index-set-es]
@@ -88,7 +89,7 @@
    "
   []
   (reduce (fn [data gen-name]
-            (let [gen-ver (last (gen-name ingest-generic/approved-generics))
+            (let [gen-ver (last (gen-name (common-config/approved-pipeline-documents)))
                   index-definition-str (-> "schemas/%s/v%s/index.json"
                                        (format (name gen-name) gen-ver)
                                        (clojure.java.io/resource)
@@ -109,4 +110,4 @@
                   (error (format "Could not parse schema %s version %s." (name gen-name) gen-ver))
                   data))))
           {}
-          (keys ingest-generic/approved-generics)))
+          (keys (common-config/approved-pipeline-documents))))

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -7,6 +7,7 @@
    [cmr.common.rebalancing-collections :as rebalancing-collections]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
+   [cmr.common-app.config :as common-config]
    [cmr.indexer.config :as config]
    [cmr.indexer.data.index-set-elasticsearch :as es]
    [cmr.indexer.services.messages :as m])
@@ -20,7 +21,7 @@
   [initial-list]
   (reduce (fn [data, item] (conj data (keyword (str "generic-" (name item)))))
           initial-list
-          (keys cmr.ingest.api.generic-documents/approved-generics)))
+          (keys (common-config/approved-pipeline-documents))))
 
 (def searchable-concept-types
   "Defines the concept types that are indexed in elasticsearch and thus searchable."

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -8,6 +8,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
+   [cmr.common-app.config :as common-config]
    [cmr.common-app.services.ingest.subscription-common :as sub-common]
    [cmr.common.log :refer [debug info warn error]]
    [cmr.common.services.errors :as errors]
@@ -37,7 +38,7 @@
 (defn approved-generic?
   "Check to see if a requested generic is on the approved list"
   [schema version]
-  (some #(= version %) (schema approved-generics)))
+  (some #(= version %) (schema (common-config/approved-pipeline-documents))))
 
 (defn validate-json-against-schema
   "validate a document, returns an array of errors if there are problems
@@ -108,4 +109,3 @@
 
  (defn delete-generic-document [request]
    (println "stub function: delete " request))
-


### PR DESCRIPTION
This is a change in how the list of approved generic documents for the new pipeline is stored, which also serves as a feature toggle for the new pipeline prototype. 

The code changes consist of 1) adding a new defconfig: cmr.common-app.config/approved-pipeline-documents, and 2) changing all calls to the previous source of truth for this information to use the new defconfig. The new defconfig is set to an empty string by default, which represents the normal 'non-prototype' mode which does not accept input to the new pipeline endpoints (eg does not accept ingesting or indexing grids). An environment variable can be set to turn on the prototype prior to booting, which triggers the creation of new pipeline elastic indices and allows the new pipeline endpoints to be used. 

Please note the environment variable should look like this:
CMR_APPROVED_PIPELINE_DOCUMENTS="{\"grid\": [\"0.0.1\"], \"variable\": [\"1.8.0\"]}"