### PR TITLE
CMR-7857 Fix issue with community metrics CSV parsing

### DIFF
--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -97,7 +97,7 @@
   (let [access-count (read-csv-column csv-line hosts-col)]
     (if (seq access-count)
       (try
-        (long (bigdec  (str/replace access-count "," ""))) ; Remove commas in large ints
+        (Long/parseLong (str/replace access-count "," "")) ; Remove commas in large ints
         (catch java.lang.NumberFormatException e
           (errors/throw-service-error :invalid-data
                                       (format (str "Error parsing 'Hosts' CSV Data. "

--- a/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
+++ b/search-app/src/cmr/search/services/community_usage_metrics/metrics_service.clj
@@ -97,7 +97,7 @@
   (let [access-count (read-csv-column csv-line hosts-col)]
     (if (seq access-count)
       (try
-        (Integer/parseInt (str/replace access-count "," "")) ; Remove commas in large ints
+        (long (bigdec  (str/replace access-count "," ""))) ; Remove commas in large ints
         (catch java.lang.NumberFormatException e
           (errors/throw-service-error :invalid-data
                                       (format (str "Error parsing 'Hosts' CSV Data. "
@@ -159,7 +159,7 @@
   [context]
   (try
     (get-community-usage-metrics context)
-    (catch Exception e 
+    (catch Exception e
       (warn e)
       [])))
 

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/community_usage_metrics_test.clj
@@ -268,7 +268,12 @@
               :errors ["Error parsing 'Hosts' CSV Data. Hosts must be an integer. CSV line entry: [\"AMSR-L1A\" \"3\" \"x\"]"]}
              (humanizer-util/update-community-usage-metrics
               admin-update-token
-              "Product,ProductVersion,Hosts\nAMSR-L1A,3,x"))))))
+              "Product,ProductVersion,Hosts\nAMSR-L1A,3,x"))))
+    (testing "large integer value for hosts (access-count)"
+      (is (= {:concept-id "H1200000011-CMR", :revision-id 2, :status 200}
+             (humanizer-util/update-community-usage-metrics
+              admin-update-token
+              "Product,ProductVersion,Hosts\nAMSR-L1A,3,2147483648"))))))
 
 (def sample-aggregation-csv
   "Sample CSV to test aggregation of access counts in different CSV entries with the same short-name


### PR DESCRIPTION
The access counts are now parsed as a long in the community metrics file, handling the scenario of the access counts being too large for an integer.