### PR TITLE
CMR-7842 Geodetic rings in incorrect order will now result in a points ou…

### DIFF
--- a/spatial-lib/src/cmr/spatial/geodetic_ring.clj
+++ b/spatial-lib/src/cmr/spatial/geodetic_ring.clj
@@ -164,19 +164,22 @@
 
           contains-north-pole (or (some p/is-north-pole? points)
                                   (some a/crosses-north-pole? arcs)
-                                  (= :clockwise course-rotation-direction)
                                   (and (= :none course-rotation-direction)
                                        (= :counter-clockwise lon-rotation-direction)))
 
           contains-south-pole (or (some p/is-south-pole? points)
                                   (some a/crosses-south-pole? arcs)
-                                  (= :clockwise course-rotation-direction)
                                   (and (= :none course-rotation-direction)
                                        (= :clockwise lon-rotation-direction)))]
       (assoc ring
              :course-rotation-direction course-rotation-direction
              :contains-north-pole contains-north-pole
              :contains-south-pole contains-south-pole))))
+
+(defn ring->point-order
+  "Returns the direction of the arcs of a ring, either :clockwise, :counter-clockwise, or :none."
+  [^GeodeticRing ring]
+  (arcs->course-rotation-direction (ring->arcs ring)))
 
 (defn ring->mbr
   "Determines the mbr from the points in the ring."

--- a/spatial-lib/src/cmr/spatial/messages.clj
+++ b/spatial-lib/src/cmr/spatial/messages.clj
@@ -85,13 +85,11 @@
 
 (defn ring-contains-both-poles
   []
- "The polygon boundary contains both the North and South Poles. A polygon can contain at most one pole. Please check the order of your points.
- You may have provided them in the wrong order (clockwise vs counter-clockwise)")
+ "The polygon boundary contains both the North and South Poles. A polygon can contain at most one pole.")
 
 (defn ring-points-out-of-order
   []
-  (str "The polygon boundary points are listed in the wrong order (clockwise vs counter clockwise). "
-       "Please see the API documentation for the correct order."))
+  "The polygon boundary points are listed in the wrong order. Points must be provided in counter-clockwise order.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Polygon validation messages

--- a/spatial-lib/src/cmr/spatial/ring_validations.clj
+++ b/spatial-lib/src/cmr/spatial/ring_validations.clj
@@ -35,6 +35,12 @@
     (when (and (:contains-south-pole ring) (:contains-north-pole ring))
       [(msg/ring-contains-both-poles)])))
 
+(defn- ring-geo-point-order-validation
+  "Validates that a geodetic rings points are in counter clockwise order"
+  [ring]
+  (when (= (gr/ring->point-order ring) :clockwise)
+    [(msg/ring-points-out-of-order)]))
+
 (defn- ring-point-order-validation
   "Validates that a cartesian rings points are in counter clockwise order"
   [ring]
@@ -56,7 +62,8 @@
             ;; Advanced ring validation
             (let [ring (assoc ring :arcs (gr/ring->arcs ring))]
               (or (seq (ring-self-intersection-validation ring))
-                  (seq (ring-pole-validation ring)))))))
+                  (seq (ring-pole-validation ring))
+                  (seq (ring-geo-point-order-validation ring)))))))
 
   cmr.spatial.cartesian_ring.CartesianRing
   (validate

--- a/spatial-lib/test/cmr/spatial/test/geodetic_ring.clj
+++ b/spatial-lib/test/cmr/spatial/test/geodetic_ring.clj
@@ -96,7 +96,7 @@
          [(msg/ring-self-intersections [(p/point 1.5055573678910719 3.768366191776642)])]
 
          [0 0, 4 0, 6 5, 4.97 -1.77, 0 0]
-         [(msg/ring-contains-both-poles)])))
+         [(msg/ring-points-out-of-order)])))
 
 (declare ring-examples)
 


### PR DESCRIPTION
Originally, the function `ring-pole-validation` would always return the `ring-contains-both-poles` error message if the ring inputted was in clockwise order which could be misleading. Now there is a separate validation for the correct order of a geodetic ring and the error messages have been fixed to be more precise.