### PR TITLE
CMR-8376: Add feature toggle from new generic document pipeline

### DIFF
--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -3,6 +3,7 @@
   through an environment variable. Configuration items should be added using the defconfig macro."
   (:require
    [camel-snake-kebab.core :as csk]
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -234,3 +235,10 @@
                (pr-str unknown-vars))
          true)
        false))))
+
+(defconfig approved-pipeline-documents
+  "This string should contain JSON that looks like:
+   {'grid': ['0.0.1'],
+    'variable': ['1.8.0']}"
+  {:default ""
+   :parser #(json/parse-string % true)})

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -221,7 +221,6 @@
    the base truth list of approved document types.
    This string should contain JSON that looks like:
    {\"grid\": [\"0.0.1\"],
-    \"variable\": [\"1.8.0\"],
     \"dataqualitysummary\": [\"1.0.0\"],
     \"orderoption\": [\"1.0.0\"],
     \"serviceentry\": [\"1.0.0\"],

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -3,6 +3,7 @@
   through an environment variable. Configuration items should be added using the defconfig macro."
   (:require
    [camel-snake-kebab.core :as csk]
+   [cmr.common.log :as log :refer [debug info warn error]]
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.set :as set]
@@ -215,6 +216,15 @@
   {:default false
    :type Boolean})
 
+(defconfig approved-pipeline-documents
+  "This is the feature toggle for the new document pipeline prototype, as well as serving as
+   the base truth list of approved document types.
+   This string should contain JSON that looks like:
+   {'grid': ['0.0.1'],
+    'variable': ['1.8.0']}"
+  {:default ""
+   :parser #(json/parse-string % true)})
+
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.
   If any are unrecognized a warning message is logged. Usually this should be called at the start
@@ -236,9 +246,5 @@
          true)
        false))))
 
-(defconfig approved-pipeline-documents
-  "This string should contain JSON that looks like:
-   {'grid': ['0.0.1'],
-    'variable': ['1.8.0']}"
-  {:default ""
-   :parser #(json/parse-string % true)})
+(when (seq (approved-pipeline-documents))
+  (info "Prototype feature toggle detected"))

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -220,8 +220,12 @@
   "This is the feature toggle for the new document pipeline prototype, as well as serving as
    the base truth list of approved document types.
    This string should contain JSON that looks like:
-   {'grid': ['0.0.1'],
-    'variable': ['1.8.0']}"
+   {\"grid\": [\"0.0.1\"],
+    \"variable\": [\"1.8.0\"],
+    \"dataqualitysummary\": [\"1.0.0\"],
+    \"orderoption\": [\"1.0.0\"],
+    \"serviceentry\": [\"1.0.0\"],
+    \"serviceoption\": [\"1.0.0\"]}"
   {:default ""
    :parser #(json/parse-string % true)})
 

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -247,4 +247,4 @@
        false))))
 
 (when (seq (approved-pipeline-documents))
-  (info "Prototype feature toggle detected"))
+  (info (format "Generic documents pipeline supports: %s" (approved-pipeline-documents))))

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -1,0 +1,9 @@
+(ns cmr.common.generics
+  "Defines utilities for new generic document pipeline"
+  (:require 
+   [cmr.common.config :as cfg]))
+
+(defn approved-generic?
+  "Check to see if a requested generic is on the approved list"
+  [schema version]
+  (some #(= version %) (schema (cfg/approved-pipeline-documents))))


### PR DESCRIPTION
These changes include just the feature toggle from the new document pipeline prototype, which is set by an environment variable that also serves as the list of approved document types. Also in these changes is a log info line that is activated when the environment variable is set. (If not set, it should default to an empty string and thus not trigger the log.)