### PR TITLE
CMR-8541: As a CMR operator, I would like to bulk index a collection with a start_index parameter.

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -107,6 +107,8 @@ This should return the granule including the echo-10 xml.
 
 NOTE from CMR-1908 that when reindexing a provider the collections are not reindexed in the all revisions index. The workaround here is to use the indexer endpoint for reindexing collections.
 
+Operator can use the `start_index` parameter to index concepts with sequence number larger than the `start_index` value. This parameter is used to recover from a prematurely terminated bulk index request.
+
 ### Bulk index all providers
 
     curl -i -XPOST http://localhost:3006/bulk_index/providers/all
@@ -116,6 +118,8 @@ Bulk indexing all collections and granules for all providers. Similar to the bul
 ### Bulk index a single collection
 
     curl -i -XPOST  -H "Content-Type: application/json" -d '{"provider_id": "FIX_PROV1", "collection_id":"C123-FIX_PROV1"}' http://localhost:3006/bulk_index/collections
+
+Operator can use the `start_index` parameter to index concepts with sequence number larger than the `start_index` value. This parameter is used to recover from a prematurely terminated bulk index request.
 
 ### Bulk index concepts by concept-id - for indexing multiple specific items
 

--- a/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
@@ -33,9 +33,10 @@
   (let [dispatcher (api-util/get-dispatcher context params :index-collection)
         provider-id (get provider-id-collection-map "provider_id")
         collection-id (get provider-id-collection-map "collection_id")
+        start-index (Long/parseLong (get params :start_index "0"))
         _ (service/validate-collection context provider-id collection-id)
         result (service/index-collection
-                context dispatcher provider-id collection-id)]
+                context dispatcher provider-id collection-id {:start-index start-index})]
     {:status 202
      :body {:message (msg/index-collection params result collection-id)}}))
 

--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -60,14 +60,15 @@
 
 (defn index-granules-for-collection
   "Index the granules for the given collection."
-  [system provider-id collection-id {:keys [target-index-key completion-message rebalancing-collection?]}]
+  [system provider-id collection-id {:keys [start-index target-index-key completion-message rebalancing-collection?]}]
   (info "Indexing granule data for collection" collection-id)
   (let [db (helper/get-metadata-db-db system)
         provider (p/get-provider db provider-id)
         params {:concept-type :granule
                 :provider-id provider-id
                 :parent-collection-id collection-id}
-        concept-batches (db/find-concepts-in-batches db provider params (:db-batch-size system))
+        start-index (or start-index 0)
+        concept-batches (db/find-concepts-in-batches db provider params (:db-batch-size system) start-index)
         num-granules (index/bulk-index {:system (helper/get-indexer system)}
                                        concept-batches
                                        {:target-index-key target-index-key})]

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -87,10 +87,8 @@
 
 (defn index-collection
   "Bulk index all the granules in a collection"
-  ([context dispatcher provider-id collection-id]
-   (index-collection context dispatcher provider-id collection-id nil))
-  ([context dispatcher provider-id collection-id options]
-   (dispatch/index-collection dispatcher context provider-id collection-id options)))
+  [context dispatcher provider-id collection-id options]
+  (dispatch/index-collection dispatcher context provider-id collection-id options))
 
 (defn index-system-concepts
   "Bulk index all the tags, acls, and access-groups."


### PR DESCRIPTION
This PR provides the ability to resume a prematurely terminated bulk index collection request from where it left off rather than have to always start from the very beginning.