### PR TITLE
(Pipeline Feature Branch) CMR-8569 support distribution of EMFD Generic Document Schemas

### DIFF
--- a/Generics.md
+++ b/Generics.md
@@ -1,0 +1,81 @@
+# Generic Documents
+
+Generic documents are documents which conform to the "Generic" API in CMR. These are JSON documents validated against a known [schema][schema] file.
+
+
+## Configuration
+
+If adding a new document, you will need to update the defconf variable by either setting an ENV for global change, or by updating the default value in [/common-lib/src/cmr/common/config.clj](/common-lib/src/cmr/common/config.clj). The format for this value is either JSON for an ENV variable or a clojure map if setting directly in the default attribute of the defconfig like this:
+
+	(defconfig approved-pipeline-documents
+  		{:default {:grid ["0.0.1"]
+             :dataqualitysummary ["1.0.0"]
+             :orderoption ["1.0.0"]
+             :serviceentry ["1.0.0"]
+             :serviceoption ["1.0.0"]}
+   		:parser #(json/parse-string % true)})
+
+When setting in an ENV or in AWS, use the JSON format:
+
+	"{\"grid\": [\"0.0.1\"],
+    \"dataqualitysummary\": [\"1.0.0\"],
+    \"orderoption\": [\"1.0.0\"],
+    \"serviceentry\": [\"1.0.0\"],
+    \"serviceoption\": [\"1.0.0\"]}"
+
+Each setting consists of a key, which is the name for the Generic which must be unique, and a list of version numbers. These values *must* match parts of a file system path under "schemas". For example, the grid value must resolve to:
+
+	./{CMR-Root}/schemas/grid/v0.0.1/
+		README.md
+		index.json
+		metadata.json
+		schema.json
+		
+CMR will search for Generic definitions using the lower case value of the key (name) and the version number prefixed with a "v". Inside the directory there must be 4 files, three of which are directly read by CMR:
+
+* README.md - for humans
+* index.json - Search/Index configuration settings, must comply with [Index Schema][schema-index].
+* metadata.json - sample record, may be called by system-int-tests
+* schema.json - A schema document conforming to [JSON Schema][schema].
+
+### Running CMR
+
+Run CMR as normal, however if you wish to confirm which schemas are configured, look for the following in the logs:
+
+	Generic documents pipeline supports:
+
+Followed by a list of configured Generic Documents and the supported versions.
+
+## Adding/Updating New Documents
+
+Creating:
+
+1. Create a new directory in the [EMFD Generics][schema-other] repository.
+2. In the directory create a README.md file
+3. Create a `CHANGELOG.MD` file and populate like other formats do
+4. Create a directory with the symantic version number prefixed with the letter `v`
+	1. Version 1.0.0 would be `v1.0.0`.
+	2. Information on [Semantic Versioning][semver]
+5. Create at least a metadata.json and schema.json file inside the version number.
+6. Commit, Get approved, Merge
+7. Copy all files to the `schemas` directory under CMR
+8. call `cmr setup <action>`:
+	* `cmr setup dev` will update schemas
+	* `cmr setup schemas` to force copy to all projects and do no other action
+	* `(user/reset)` within the repl will also trigger a copy
+
+Updating is much the same as start, create a new version folder, populate it.
+
+DONT forget to update the change log!
+
+Commit and distribute to CMR as done in the addition steps.
+
+----
+
+Copyright © 2014-2022 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+
+
+[schema]: https://json-schema.org "JSON Schema definition"
+[schema-other]: https://git.earthdata.nasa.gov/scm/emfd/otherschemas.git "Generic Schema Repository"
+[schema-index]: https://git.earthdata.nasa.gov/projects/EMFD/repos/otherschemas/browse/Index "Index configuration definition"
+[semver]: https://semver.org "Information on semantic versioning"

--- a/bin/cmr
+++ b/bin/cmr
@@ -241,6 +241,9 @@ case "$COMMAND" in
             profile)
                 setup_profile
                 ;;
+            schemas)
+                setup_schemas
+                ;;
             *)
                 subcmd_not_found $COMMAND
                 exit 127

--- a/bin/functions/setup.sh
+++ b/bin/functions/setup.sh
@@ -80,11 +80,11 @@ function setup_schemas () {
     src=$(printf "%s/schemas/" "." $app)
     printf "Creating %s\n" $dest
     mkdir -p $CMR_DIR/$dest
-    for src_name in $(ls $CMR_DIR/schemas)
+    for src_name in $(ls $CMR_DIR/schemas | grep -v '.md')
     do
       src_name_lower=$(echo $src_name | awk '{print tolower($0)}')
       printf "\tCopy schemas/%s to %s/%s\n" ${src_name} ${dest} ${src_name_lower}
-      cp -r "${CMR_DIR}/schemas/${src_name}" "${CMR_DIR}/${dest}/${src_name_lower}"
+      cp -R "${CMR_DIR}/schemas/${src_name}/" "${CMR_DIR}/${dest}/${src_name_lower}"
     done
   done
 }

--- a/dev-system/dev/user.clj
+++ b/dev-system/dev/user.clj
@@ -121,22 +121,8 @@
   "A function that will copy the directory schemas in to all the necessary
    apps with schemas renamed to lowercase"
   []
-  (let [path (System/getProperty "user.dir")
-        apps ["search-app/resources"
-              "ingest-app/resources"
-              "indexer-app/resources"
-              "metadata-db-app/resources"
-              "system-int-test/resources"]
-        source (clojure.string/replace path #"dev-system" "schemas")
-        source-names (-> (:out (shell/sh "ls" source))
-                         (clojure.string/split #"\n"))]
-    (doseq [app apps]
-      (doseq [src-name source-names]
-        (if-not (clojure.string/ends-with? src-name ".md")
-          (let [dest-path (clojure.string/replace path #"dev-system" app)
-                dest-name (clojure.string/lower-case src-name)]
-            (shell/sh "mkdir" "-p" (format "%s/schemas" dest-path))
-            (shell/sh "cp" "-r" (format "%s/%s" source src-name) (format "%s/schemas/%s" dest-path dest-name))))))))
+  (println "Distributing schemas")
+  (shell/sh "cmr" "setup" "schemas"))
 
 (defn set-legacy
   "Passing `true` to this function will cause legacy configuration to be used

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -39,7 +39,7 @@
     (errors/throw-service-error
      :invalid-data
      (format "The [%s] schema on version [%s] is not an approved schema. This record cannot be ingested." schema version))
-    (if-some [schema-url (jio/resource (format "generics/%s/v%s/schema.json"
+    (if-some [schema-url (jio/resource (format "schemas/%s/v%s/schema.json"
                                                (name schema)
                                                version))]
       (let [schema-file (slurp schema-url)
@@ -52,7 +52,7 @@
 (defn get-sub-concept-type-concept-id-prefix
   "There are many concept types within generics. Read in the concept-id prefix for this specific one."
   [spec-key version]
-  (if-some [index-url (jio/resource (format "generics/%s/v%s/index.json"
+  (if-some [index-url (jio/resource (format "schemas/%s/v%s/index.json"
                                             (name spec-key)
                                             version))]
     (let [index-file-str (slurp index-url)

--- a/schemas/DataQualitySummary/v1.0.0/metadata.json
+++ b/schemas/DataQualitySummary/v1.0.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "Id":"8EA5CA1F-E339-8065-26D7-53B64074D7CC",
+  "Name":"CER-BDS_Terra",
+  "Summary":"Summary",
+  "MetadataSpecification": {
+    "Name": "DataQualitySummary",
+    "Version": "1.0.0",
+    "URL": "https://cdn.earthdata.nasa.gov/generics/dataqualitysummary/v1.0.0"
+  }
+}
+

--- a/schemas/DataQualitySummary/v1.0.0/schema.json
+++ b/schemas/DataQualitySummary/v1.0.0/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "DataQuailitySummary",
-  "description": "This schema descibes data quality summaries. Data quality summaries inform users about about a dataset and it's granules data quality. It is described in this record because that information is not suitable for metadata.",
+  "title": "DataQualitySummary",
+  "description": "Contains a human readable description of the quality of a set of data.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
@@ -10,13 +10,43 @@
       "type": "string"
     },
     "Name": {
-      "description": "The human-readable name associated with this definition.",
+      "description": "The name associated with the quality summary of the data set.",
       "type": "string"
     },
     "Summary": {
-      "description": "A textual representation of the data quality summary. This summary may contain HTML.",
+      "description": "Contains the human readable summary of the quality of the data set.",
       "type": "string"
+    },
+    "MetadataSpecification": {
+      "description": "Requires the client, or user, to add in schema information into every data quality summary record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
+      "$ref": "#/definitions/MetadataSpecificationType"
     }
   },
-  "required": ["Name", "Summary"]
+  "required": ["Name", "Summary", "MetadataSpecification"],
+
+  "definitions": {
+    "MetadataSpecificationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object requires any metadata record that is validated by this schema to provide information about the schema.",
+      "properties": {
+        "URL": {
+          "description": "This element represents the URL where the schema lives. The schema can be downloaded.",
+          "type": "string",
+          "enum": ["https://cdn.earthdata.nasa.gov/generics/dataqualitysummary/v1.0.0"]
+        },
+        "Name": {
+          "description": "This element represents the name of the schema.",
+          "type": "string",
+          "enum": ["DataQualitySummary"]
+        },
+        "Version": {
+          "description": "This element represents the version of the schema.",
+          "type": "string",
+          "enum": ["1.0.0"]
+        }
+      },
+      "required": ["URL", "Name", "Version"]
+    }
+  }
 }

--- a/schemas/Grid/v0.0.1/index.json
+++ b/schemas/Grid/v0.0.1/index.json
@@ -1,19 +1,84 @@
-{"MetadataSpecification": {
-		"URL": "https://cdn.earthdata.nasa.gov/generic/index/v0.0.1",
-		"Name": "Generic-Index",
-		"Version": "0.0.1"
-	},
-	"indexes" : [
-    {"field": ".dif.paleo.start",
-    	"type": "elastic",
-    	"name":"paleo-start",
-    	"indexer": "default",
-    	"config": {"format": "long"}},
-    {"field": ".dif.paleo.stop",
-    	"type": "elastic",
-    	"name": "paleo-stop",
-    	"indexer": "default",
-    	"config": {"format": "long"}
-    }
+{
+  "MetadataSpecification": {
+      "URL": "https://cdn.earthdata.nasa.gov/generic/index/v0.0.1",
+      "Name": "Generic-Index",
+      "Version": "0.0.1"
+  },
+  "SubConceptType": "GRD",
+  "Indexes":
+  [
+    {
+      "Description": "Long Name",
+      "Field": ".LongName",
+      "Name": "Long-Name",
+      "Mapping": "string"
+    },
+    {
+      "Description": "Type - maybe change",
+      "Field": ".GridDefinition.CoordinateReferenceSystemID.Type",
+      "Name": "CoordinateReferenceSystemID-Type",
+      "Mapping": "string"
+    },
+    {
+      "Description": "URL - maybe changee",
+      "Field": ".GridDefinition.CoordinateReferenceSystemID.URL",
+      "Name": "CoordinateReferenceSystemID-URL",
+      "Mapping": "string"
+    },
+    {
+      "Description": "Reference System",
+      "Field": ".GridDefinition.CoordinateReferenceSystemID",
+      "Name": "Grid-System",
+      "Mapping": "string",
+      "Indexer": "complex-field",
+      "Configuration": {"sub-fields": ["Type", "URL"]}
+    },
+    {
+      "Description": "Mock index for property field",
+      "Field": ".Name",
+      "Name": "Name",
+      "Type": "graph",
+      "Indexer": "property"
+  },
+  {
+      "Description": "Mock index for property field",
+      "Field": ".Version",
+      "Name": "Version",
+      "Type": "graph",
+      "Indexer": "property"
+  },
+  {
+      "Description": "Mock index for separate entity field",
+      "Field": ".GridDefinition.CoordinateReferenceSystemID",
+      "Name": "CoordinateReferenceSystem",
+      "Type": "graph",
+      "Indexer": "separate-node",
+      "Configuration": {
+          "properties": ["Type", "URL"],
+          "relationship": "DefinedBy"
+          }
+  },
+  {
+      "Description": "Mock index for separate entity field",
+      "Field": ".Organization",
+      "Name": "Organization",
+      "Type": "graph",
+      "Indexer": "separate-node",
+      "Configuration": {
+          "properties": ["ShortName"],
+          "relationship": "PublishedBy"
+          }
+  },
+  {
+      "Description": "Mock index for separate entity field",
+      "Field": ".RelatedURLs",
+      "Name": "URL",
+      "Type": "graph",
+      "Indexer": "separate-node",
+      "Configuration": {
+          "properties": ["URL", "URLContentType"],
+          "relationship": "RelatedTo"
+          }
+  }
   ]
 }

--- a/schemas/Grid/v0.0.1/metadata.json
+++ b/schemas/Grid/v0.0.1/metadata.json
@@ -11,7 +11,7 @@
     "GridDefinition": {
         "CoordinateReferenceSystemID": {
             "Type": "EPSG",
-			"Code": "EPSG:4326",
+			      "Code": "EPSG:4326",
             "Title": "WGS84 - World Geodetic System 1984, used in GPS - EPSG:4326",
             "URL": "https://epsg.io/4326"
         },
@@ -56,8 +56,7 @@
                 "0_360_DegreeProjection": true,
                 "Y-Dimension": 0,
                 "X-Dimension": 180
-                },
-                ]
+                }]
             },
 
         "Distortion": {
@@ -65,7 +64,7 @@
             "Percent": 31
         },
         "Uniform-Grid": true,
-        "Bounded-Grid": true,
+        "Bounded-Grid": true
     },
     "Organization": {
         "ShortName": "NASA/GSFC/SED/ESD/GCDC/GESDISC",
@@ -90,7 +89,7 @@
     "MetadataDate": {"Create": "2022-04-20T08:00:00Z"},
     "RelatedURLs": [
         {
-            "URL": "https://example.gov",
+            "URL": "https://example.gov/",
             "URLContentType": "C-Type",
             "Type": "Type"
         },{

--- a/schemas/Index/v0.0.1/metadata.json
+++ b/schemas/Index/v0.0.1/metadata.json
@@ -32,7 +32,7 @@
           "Field": ".GridDefinition.CoordinateReferenceSystemID.Type",
           "Name": "CoordinateReferenceSystemID-Type",
           "Indexer": "complex-field",
-          "Type": "graph",
+          "Type": "elastic",
           "Configuration": {"sub-fields": ["Type", "URL"]}
       }
 ]

--- a/schemas/OrderOption/v1.0.0/metadata.json
+++ b/schemas/OrderOption/v1.0.0/metadata.json
@@ -1,0 +1,14 @@
+{
+  "Id": "0AF0BB4E",
+  "Name": "With Browse",
+  "Description": "",
+  "Form": "<form xmlns=\"http://echo.nasa.gov/v9/echoforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <model> <instance> <ecs:options xmlns:ecs=\"http://ecs.nasa.gov/options\"> <!-- ECS distribution options example --> <ecs:distribution> <ecs:mediatype> <ecs:value>FtpPull</ecs:value> </ecs:mediatype> <ecs:mediaformat> <ecs:ftppull-format> <ecs:value>FILEFORMAT</ecs:value> </ecs:ftppull-format> </ecs:mediaformat> </ecs:distribution> <ecs:do-ancillaryprocessing>true</ecs:do-ancillaryprocessing> <ecs:ancillary> <ecs:orderBrowse/> </ecs:ancillary> </ecs:options> </instance> </model> <ui> <group id=\"mediaOptionsGroup\" label=\"Media Options\" ref=\"ecs:distribution\"> <output id=\"MediaTypeOutput\" label=\"Media Type:\" relevant=\"ecs:mediatype/ecs:value ='FtpPull'\" type=\"xsd:string\" value=\"'HTTPS Pull'\"/> <output id=\"FtpPullMediaFormatOutput\" label=\"Media Format:\" relevant=\"ecs:mediaformat/ecs:ftppull-format/ecs:value='FILEFORMAT'\" type=\"xsd:string\" value=\"'File'\"/> </group> <group id=\"checkancillaryoptions\" label=\"Additional file options:\" ref=\"ecs:ancillary\" relevant=\"//ecs:do-ancillaryprocessing = 'true'\"> <input label=\"Include associated Browse file in order\" ref=\"ecs:orderBrowse\" type=\"xsd:boolean\"/> </group> </ui> </form>",
+  "Scope":"PROVIDER",
+  "SortKey": "Name",
+  "Deprecated": false,
+  "MetadataSpecification": {
+    "Name": "OrderOption",
+    "Version": "1.0.0",
+    "URL": "https://cdn.earthdata.nasa.gov/generics/orderoption/v1.0.0"
+  }
+}

--- a/schemas/OrderOption/v1.0.0/schema.json
+++ b/schemas/OrderOption/v1.0.0/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OrderOption",
-  "description": "This schema describes order options. Order options are options that a user can choose when ordering data, such as how data can be accessed/distrbuted from the providers. These options are written in an XML format that must conform to the ECHO forms schema. The form will be used to display the option to the end users.",
+  "description": "This schema describes order options. Order options describe XML using some description language. This allows third parties to define parts of the API on CMR. Option Selections contain XML that must conform to the definition of the form in this. These are used during the ordering process to define how data can be accessed/distributed from the Providers.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
@@ -39,7 +39,7 @@
       "type": "boolean"
     },
     "MetadataSpecification": {
-      "description": "Requires the client, or user, to add in schema information into every order option record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
+      "description": "Requires the client, or user, to add in schema information into every data quality summary record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
       "$ref": "#/definitions/MetadataSpecificationType"
     }
   },

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,21 +1,29 @@
 # Non-UMM ESDIS Schema files
 
 Currently files used by the "Generic Documents" (working title) prototype in CMR
-Original Repository: https://git.earthdata.nasa.gov/projects/EMFD/repos/otherschemas
+Original Repository: [origin][origin].
 
 ## Projects
 
-| Schema | Implimentation | Notes |
-| ------ | -------------- | ----- |
-| Grid   | In progress    | Configuration files needed for hosting Grid documents |
-| Index  | In progress    | Configuration files needed for specifying indexes for Generic Documents |
-| OrderOption | In progress    | Configuration files needed for supporting Legacy Services migration
+| Schema             | Implementation | Notes |
+| ------------------ | -------------- | ----- |
+| Grid               | In progress    | Grid definitions |
+| Index              | In progress    | Configuration file for Schema used to specify indexes for Generic Documents |
+| OrderOption        | In progress    | Configuration files needed for supporting Legacy Services migration
 | DataQualitySummary | In progress    | Configuration files needed for supporting Legacy Services migration
-| ServiceEntry | In progress    | Configuration files needed for supporting Legacy Services migration
-| ServiceOption | In progress    | Configuration files needed for supporting Legacy Services migration
+| ServiceEntry       | In progress    | Configuration files needed for supporting Legacy Services migration
+| ServiceOption      | In progress    | Configuration files needed for supporting Legacy Services migration
+
+## Usage
+
+These files are to be copied to the [cmr][cmr] repository under the `schemas`
+directory when changed so that the files can be used by that software.
 
 ## License
 
 Copyright © 2022-2022 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration. All Rights
 Reserved.
+
+[origin]: https://git.earthdata.nasa.gov/projects/EMFD/repos/otherschemas "The repository for Generic Documents"
+[cmr]: https://github.com/nasa/Common-Metadata-Repository "CMR Git Repository"

--- a/schemas/ServiceEntry/v1.0.0/metadata.json
+++ b/schemas/ServiceEntry/v1.0.0/metadata.json
@@ -1,0 +1,13 @@
+{
+  "Id": "0AF0BB4E-7455-FBB2-15C7-B5B7DE43AA6D",
+  "Name": "Test Service",
+  "Description": "Testing Service",
+  "Type":"SERVICE_IMPLEMENTATION",
+  "InterfaceName":"EOSIDS Service Interface",
+  "URL":"www.example.com",
+  "MetadataSpecification": {
+    "Name": "ServiceEntry",
+    "Version": "1.0.0",
+    "URL": "https://cdn.earthdata.nasa.gov/generics/serviceentry/v1.0.0"
+  }
+}

--- a/schemas/ServiceEntry/v1.0.0/schema.json
+++ b/schemas/ServiceEntry/v1.0.0/schema.json
@@ -25,10 +25,14 @@
       "description": "The URL associated with the service.",
       "type": "string"
     },
-    "EntryType": {
+    "Type": {
       "description": "The type of the service.",
       "type": "string",
       "enum": ["ADVERTISEMENT", "SERVICE_INTERFACE", "SERVICE_IMPLEMENTATION", "GRAPHICAL_USER_INTERFACE"]
+    },
+    "InterfaceName": {
+      "description": "The name of the service interface.",
+      "type": "string"
     },
     "TagIds" :{
       "description": "The IDs of all the tags associated with this service entry.",
@@ -42,7 +46,7 @@
       "$ref": "#/definitions/MetadataSpecificationType"
     }
   },
-  "required": ["Name", "Description", "URL", "EntryType", "MetadataSpecification"],
+  "required": ["Name", "Description", "URL", "Type", "InterfaceName", "MetadataSpecification"],
   
   "definitions": {
     "MetadataSpecificationType": {

--- a/schemas/ServiceOption/v1.0.0/metadata.json
+++ b/schemas/ServiceOption/v1.0.0/metadata.json
@@ -1,0 +1,11 @@
+{
+  "Id": "1B41335E-82DD-8AAB-B8A9-546CC6DE6CBD",
+  "Name": "RangeSliderTest",
+  "Description": "Testing range slider - updated DEMO_PROV",
+  "Form": "<form></form>",
+  "MetadataSpecification": {
+    "Name": "ServiceOption",
+    "Version": "1.0.0",
+    "URL": "https://cdn.earthdata.nasa.gov/generics/serviceoption/v1.0.0"
+  }
+}

--- a/schemas/use-info.md
+++ b/schemas/use-info.md
@@ -1,12 +1,22 @@
+# Usage under CMR
+
 ## Implementation
-When a repl is created and the command `(reset)` is run, the entire schemas directory will be copied
-into the resources folders of the following applications:
+When a repl is created and the command `(user/reset)` is run, the entire schemas
+directory will be copied into the resources folders of the following applications:
+
 * indexer-app
 * ingest-app
 * metadata-db-app
 * search-app
 * system-int-test
 
-Each time `(reset)` is called, if a schemas folder already exists inside one of the above application's
-resources folder, that folder will be replaced by the source schemas folder and its contents.
-This will help each indiviudal application's resources stay up to date and reduce errors.
+Each time `(user/reset)` is called, if a schemas folder already exists inside
+one of the above application resources folders, that folder will be replaced by
+the source schemas folder with content. This will help each individual
+application resource directories stay up to date and reduce errors.
+
+## License
+
+Copyright © 2022-2022 United States Government as represented by the
+Administrator of the National Aeronautics and Space Administration. All Rights
+Reserved.

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -3,6 +3,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.string :as string]
+   [clojure.java.io :as jio]
    [cmr.common.config :as config]
    [cmr.common.generics :as gcfg]
    [cmr.common.util :as cutil]
@@ -16,41 +17,18 @@
   (:import
    [java.util UUID]))
 
-;; known issue, a provider needs to be created through a ficture
+;; TODO: Generic work: known issue, a provider needs to be created through a
+;; fixture, untill this is figured out, manually create a provider before testing
 (comment use-fixtures :each
   (join-fixtures
    [(ingest/reset-fixture
      {"provguid1" "PROV1"})]))
 
-;; This is as sample record, a minimalistic Grid to base tests on
-(def grid-good
-   {:MetadataSpecification {:URL "https://cdn.earthdata.nasa.gov/generic/grid/v0.0.1"
-                            :Name "Grid"
-                            :Version "0.0.1"}
-    :Name "Grid-A7-v1"
-    :LongName "Grid A-7 version 1.0"
-    :Version "v1.0"
-    :Description "A sample grid"
-    :GridDefinition {:CoordinateReferenceSystemID {:Type "EPSG:4326"
-                                                   :URL "https://epsg.io/4326"}
-                     :DimensionSize {:Height 3.14
-                                     :Width 3.14
-                                     :Time "12:00:00Z"
-                                     :Other {:Name "Other Dimension Size",
-                                             :Value "value here"}}
-                     :Resolution {:Unit "km"
-                                  :LongitudeResolution 64
-                                  :LatitudeResolution 32}
-                     :SpatialExtent {:BoundingRectangle {:0_360_DegreeProjection false,
-                                                         :NorthBoundingCoordinate -90.0,
-                                                         :EastBoundingCoordinate 180.0,
-                                                         :SouthBoundingCoordinate 90.0,
-                                                         :WestBoundingCoordinate -180.0}}}
-    :Organization {:ShortName "nasa.gov"}
-    :MetadataDate {:Create "2022-12-31T13:45:45Z"}
-    :AdditionalAttribute {:Name "name"
-                          :DataType "STRING"
-                          :Description "something"}})
+;; This is the sample record that comes with Grid
+(def grid-good (-> "schemas/grid/v0.0.1/metadata.json"
+                   (jio/resource)
+                   (slurp)
+                   (json/parse-string true)))
 
 (defn generic-request
   "This function will make a request to one of the generic URLs using the provided


### PR DESCRIPTION
Changes to support automatic updates of EMFD schemas if these schemas have been populated in the schemas directory. Developers must still update this directory, but once updated, `cmr setup dev` or `(user/reset)` will copy these files to all applications that need them.

Schema changes are in a separate commit, code changes are in the other(s).