### PR TITLE
CMR-8578: Removing 'bearer' prefix string; removing extra debug conso…

### DIFF
--- a/graph-db/serverless.yml
+++ b/graph-db/serverless.yml
@@ -25,6 +25,7 @@ provider:
     ENVIRONMENT: ${self:custom.variables.ENVIRONMENT}
     GREMLIN_URL: ${self:custom.variables.GREMLIN_URL}
     PAGE_SIZE: ${self:custom.variables.PAGE_SIZE}
+    CMR_TOKEN_KEY: ${self:custom.variables.CMR_TOKEN_KEY}
 
 configValidationMode: error
 plugins:
@@ -160,6 +161,7 @@ custom:
     ENVIRONMENT: ${self:provider.stage}
     GREMLIN_URL: ${env:GREMLIN_URL, 'wss://${cf:neptune-${opt:stage}.DBClusterEndpoint}:8182/gremlin'}
     PAGE_SIZE: ${env:PAGE_SIZE, '1000'}
+    CMR_TOKEN_KEY: ${env:CMR_TOKEN_KEY, 'CMR_ECHO_SYSTEM_TOKEN'}
 
   # Serverless Webpack configurations
   webpack:

--- a/graph-db/serverless/src/utils/cmr/__test__/fetchCmrCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/fetchCmrCollection.test.js
@@ -29,7 +29,7 @@ describe('fetchCmrCollection', () => {
     }
 
     nock(/local-cmr/)
-      .matchHeader('Authorization', 'Bearer mock_token')
+      .matchHeader('Authorization', 'mock_token')
       .get(/collections/)
       .reply(200, mockedBody)
 

--- a/graph-db/serverless/src/utils/cmr/fetchCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCmrCollection.js
@@ -10,7 +10,7 @@ export const fetchCmrCollection = async (conceptId, token) => {
   const requestHeaders = {}
 
   if (token) {
-    requestHeaders.Authorization = `Bearer ${token}`
+    requestHeaders.Authorization = token
   }
 
   let response

--- a/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
+++ b/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
@@ -65,7 +65,6 @@ export const fetchPageFromCMR = async ({
 
     if (chunkedItems.length > 0) {
       const { env: { IS_LOCAL } } = process
-      console.log('IS_Local', IS_LOCAL)
 
       await chunkedItems.forEachAsync(async (chunk) => {
         if (IS_LOCAL === 'true') {

--- a/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
+++ b/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
@@ -31,7 +31,7 @@ export const fetchPageFromCMR = async ({
   console.log(`Fetch collections from CMR, searchAfter #${searchAfterNum}`)
 
   if (token) {
-    requestHeaders.Authorization = `Bearer ${token}`
+    requestHeaders.Authorization = token
   }
 
   if (searchAfter) {
@@ -39,7 +39,6 @@ export const fetchPageFromCMR = async ({
   }
 
   let fetchUrl = `${process.env.CMR_ROOT}/search/collections.json?page_size=${process.env.PAGE_SIZE}`
-  console.log('CMR_ROOT', process.env.CMR_ROOT)
 
   if (providerId !== null) {
     fetchUrl += `&provider=${providerId}`


### PR DESCRIPTION
When indexing collections using the bootstrap function, the system token was not being parsed due to the bearer prefix. This removes the prefix; further actions will need to be taken under this PR to allow for all collections to be indexed as opposed to only public collections