### PR TITLE
CMR-8446 Adds config toggle for CMR sid lookup

### DIFF
--- a/access-control-app/src/cmr/access_control/config.clj
+++ b/access-control-app/src/cmr/access_control/config.clj
@@ -38,6 +38,10 @@
    when determining SIDs."
   {:default false :type Boolean})
 
+(defconfig enable-cmr-group-sids
+  "Flag that indicates if we include CMR groups when looking up user SIDs."
+  {:default true :type Boolean})
+
 (defn queue-config
   "Returns the queue configuration for the application."
   []


### PR DESCRIPTION
For testing and verification purposes, we want to be able to verify EDL based SIDs are being properly used to enforce ACLs without CMR group SIDs being active, this toggle allows for this to be tested more easily.