### PR TITLE
(feature branch) CMR-8591: remove old-style API endpoints from ingest-app, fix generic…

### DIFF
--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -250,8 +250,6 @@
            request
            (bulk/get-provider-tasks :granule provider-id request)))))))
 
-;; TODO: Generic work - should this change to be more dynamic, gen type in front?
-
 (def generate-generic-concept-types-reg-ex
   "This function creates a regular expresion for all of the generic concepts.  This is used to create the api endpoints.
    An example string that is return looks like: \"dataqualitysummary|orderoption|serviceoption\" "

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -252,13 +252,6 @@
 
 ;; TODO: Generic work - should this change to be more dynamic, gen type in front?
 
-(def generic-document-routes
-  (context "/generics/provider/:provider-id/:native-id" [provider-id native-id]
-    (POST "/" request (gen-doc/create-generic-document request))
-    (GET "/" request (gen-doc/read-generic-document request))
-    (PUT "/" request (gen-doc/update-generic-document request))
-    (DELETE "/" request (gen-doc/delete-generic-document request))))
-
 (def generate-generic-concept-types-reg-ex
   "This function creates a regular expresion for all of the generic concepts.  This is used to create the api endpoints.
    An example string that is return looks like: \"dataqualitysummary|orderoption|serviceoption\" "
@@ -267,7 +260,7 @@
               (clojure.string/replace #" " "|"))]
     rx))
 
-(def generic-document-routes-auxiliary
+(def generic-document-routes
  (routes
     (api-core/set-default-error-format
      :xml
@@ -291,7 +284,6 @@
 
       ;; add routes to create, update, read, and delete generic concepts
       generic-document-routes
-      generic-document-routes-auxiliary
 
       ;; db migration route
       db-migration-routes

--- a/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
@@ -49,8 +49,6 @@
                   transmit-config/token-header token}}
        (clj-http.client/request))))
 
-(def generic-request-with-echo-token (partial generic-request (transmit-config/echo-system-token)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; draft for eventually using with ingest-util/ingest-concept

--- a/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
@@ -45,7 +45,8 @@
         :connection-manager (sys/conn-mgr)
         :body (when document (json/generate-string document))
         :throw-exceptions false
-        :headers {transmit-config/token-header token}}
+        :headers {"Accept" "application/json"
+                  transmit-config/token-header token}}
        (clj-http.client/request))))
 
 (def generic-request-with-echo-token (partial generic-request (transmit-config/echo-system-token)))

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -16,10 +16,7 @@
   (:import
    [java.util UUID]))
 
-(use-fixtures :each
-  (join-fixtures
-   [(ingest/reset-fixture
-     {"provguid1" "PROV1"})]))
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
 (defn generic-request
   "This function will make a request to one of the generic URLs using the provided
@@ -87,7 +84,7 @@
    interface. Use the same native-id for all these steps"
 
   (let [native-id (format "Generic-Test-%s" (UUID/randomUUID))
-        generic-requester (partial gen-util/generic-request-with-echo-token "grid" "PROV1" native-id)
+        generic-requester (partial gen-util/generic-request (transmit-config/echo-system-token) "grid" "PROV1" native-id)
         good-generic-requester (partial generic-requester gen-util/grid-good)]
 
     (testing "send a good document with config set that does not include grid"

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -87,7 +87,7 @@
    interface. Use the same native-id for all these steps"
 
   (let [native-id (format "Generic-Test-%s" (UUID/randomUUID))
-        generic-requester (partial generic-request "grid" "PROV1" native-id)
+        generic-requester (partial gen-util/generic-request-with-echo-token "grid" "PROV1" native-id)
         good-generic-requester (partial generic-requester gen-util/grid-good)]
 
     (testing "send a good document with config set that does not include grid"


### PR DESCRIPTION
…s ingest system-int test fixture & convert it to use new API and to use generic ingest util