### PR TITLE
CMR-8593: Removing references to Client Developer Forum

### DIFF
--- a/cmr-exchange/service-bridge/resources/config/slate/layout.erb
+++ b/cmr-exchange/service-bridge/resources/config/slate/layout.erb
@@ -73,7 +73,6 @@ under the License.
           <li><a href="https://cmr.sit.earthdata.nasa.gov/service-bridge/docs">Documentation</a></li>
 
 
-            <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner&#39;s Guide</a></li>
             <li><a href="https://github.com/nasa/Common-Metadata-Repository">Github</a></li>

--- a/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/1.0.0/rest-api/index.html
+++ b/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/1.0.0/rest-api/index.html
@@ -231,7 +231,6 @@
           <li><a href="https://cmr.sit.earthdata.nasa.gov/opendap/docs">Documentation</a></li>
 
 
-            <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner&#39;s Guide</a></li>
             <li><a href="https://github.com/nasa/Common-Metadata-Repository">Github</a></li>

--- a/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/1.5.0/rest-api/index.html
+++ b/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/1.5.0/rest-api/index.html
@@ -231,7 +231,6 @@
           <li><a href="https://cmr.sit.earthdata.nasa.gov/service-bridge/docs">Documentation</a></li>
 
 
-            <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner&#39;s Guide</a></li>
             <li><a href="https://github.com/nasa/Common-Metadata-Repository">Github</a></li>

--- a/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/current/rest-api/index.html
+++ b/cmr-exchange/service-bridge/resources/public/docs/service-bridge/docs/current/rest-api/index.html
@@ -231,7 +231,6 @@
           <li><a href="https://cmr.sit.earthdata.nasa.gov/service-bridge/docs">Documentation</a></li>
 
 
-            <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
             <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Partner+User+Guide">Client Partner&#39;s Guide</a></li>
             <li><a href="https://github.com/nasa/Common-Metadata-Repository">Github</a></li>

--- a/site-templates/resources/templates/base.html
+++ b/site-templates/resources/templates/base.html
@@ -11,7 +11,6 @@
     {% block app-nav %}
     {% endblock %}
     {% block common-nav %}
-    <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/CMR+Client+Developer+Forum">Forum</a></li>
     <li><a href="https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home">Wiki</a></li>
     <li><a href="{{ partner-url }}">{{ partner-text }}</a></li>
     <li><a href="https://github.com/nasa/Common-Metadata-Repository">GitHub</a></li>


### PR DESCRIPTION
Removing remaining references to the CMR Client Developer Forum. The CMR Client Developer Forum was retired in 2021. As a result, links to this forum in the API docs should be removed.