### PR TITLE
Cmr 8605

### DIFF
--- a/cmr-exchange/service-bridge/project.clj
+++ b/cmr-exchange/service-bridge/project.clj
@@ -54,6 +54,7 @@
                  [org.clojure/java.classpath "0.3.0"]
                  [org.geotools/gt-geometry "24.6"]
                  [org.geotools/gt-referencing "24.6"]
+                 [org.yaml/snakeyaml "1.31"]
                  [ring/ring-core "1.7.1"]
                  [ring/ring-codec "1.1.2"]
                  [ring/ring-defaults "0.3.2"]

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -23,6 +23,7 @@
                  [org.elasticsearch/elasticsearch ~elastic-version]
                  [org.testcontainers/testcontainers "1.17.2"]
                  [potemkin "0.4.5"]]
+  :managed-dependencies [[org.yaml/snakeyaml "1.31"]]
   :plugins [[lein-shell "0.5.0"]
             [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -22,8 +22,8 @@
                  [org.clojure/clojure "1.10.0"]
                  [org.elasticsearch/elasticsearch ~elastic-version]
                  [org.testcontainers/testcontainers "1.17.2"]
+                 [org.yaml/snakeyaml "1.31"]
                  [potemkin "0.4.5"]]
-  :managed-dependencies [[org.yaml/snakeyaml "1.31"]]
   :plugins [[lein-shell "0.5.0"]
             [test2junit "1.3.3"]]
   :jvm-opts ^:replace ["-server"

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -34,8 +34,8 @@
                                            :suppression-file "resources/security/suppression.xml"}}
              :provided {:dependencies [[nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                                        [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-                                       [org.elasticsearch/elasticsearch "7.16.2"]]
-                        :managed-dependencies [[org.yaml/snakeyaml "1.31"]]}
+                                       [org.elasticsearch/elasticsearch "7.16.2"]
+                                       [org.yaml/snakeyaml "1.31"]]}
              :es-deps {:dependencies [[nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"
                                        ;; These exclusions will be provided by elasticsearch.
                                        :exclusions [[com.dadrox/quiet-slf4j]
@@ -69,8 +69,8 @@
                                   [org.elasticsearch/elasticsearch "7.16.2"]
                                   [org.clojars.gjahad/debug-repl "0.3.3"]
                                   [org.clojure/tools.nrepl "0.2.13"]
-                                  [org.clojure/tools.namespace "0.2.11"]]
-                   :managed-dependencies [[org.yaml/snakeyaml "1.31"]]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.yaml/snakeyaml "1.31"]]
                    :aot [cmr.elasticsearch.plugins.spatial.script.core
                          cmr.elasticsearch.plugins.spatial.factory.lfactory
                          cmr.elasticsearch.plugins.spatial.factory.core

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -34,7 +34,8 @@
                                            :suppression-file "resources/security/suppression.xml"}}
              :provided {:dependencies [[nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                                        [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-                                       [org.elasticsearch/elasticsearch "7.16.2"]]}
+                                       [org.elasticsearch/elasticsearch "7.16.2"]]
+                        :managed-dependencies [[org.yaml/snakeyaml "1.31"]]}
              :es-deps {:dependencies [[nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"
                                        ;; These exclusions will be provided by elasticsearch.
                                        :exclusions [[com.dadrox/quiet-slf4j]
@@ -69,6 +70,7 @@
                                   [org.clojars.gjahad/debug-repl "0.3.3"]
                                   [org.clojure/tools.nrepl "0.2.13"]
                                   [org.clojure/tools.namespace "0.2.11"]]
+                   :managed-dependencies [[org.yaml/snakeyaml "1.31"]]
                    :aot [cmr.elasticsearch.plugins.spatial.script.core
                          cmr.elasticsearch.plugins.spatial.factory.lfactory
                          cmr.elasticsearch.plugins.spatial.factory.core

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -34,6 +34,7 @@
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.quartz-scheduler/quartz "2.3.2"]
                  [org.slf4j/slf4j-api "1.7.30"]
+                 [org.yaml/snakeyaml "1.31"]
                  [potemkin "0.4.5"]
                  [ring/ring-codec "1.1.3"]
                  [ring/ring-core "1.9.2"]


### PR DESCRIPTION
Added explicit version of snakeyaml where dependencies have it as a sub-dependency (org.elasticsearch/elasticsearch and markdown-clj)