### PR TITLE
cmr-8569 config

### DIFF
--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -215,25 +215,24 @@
   {:default false
    :type Boolean})
 
-(def default-approved-pipeline-documents
-  "The default set of approved pipeline documents"
-  {:grid ["0.0.1"]
-   :dataqualitysummary ["1.0.0"]
-   :orderoption ["1.0.0"]
-   :serviceentry ["1.0.0"]
-   :serviceoption ["1.0.0"]})
-
 (defconfig approved-pipeline-documents
   "This is the feature toggle for the new document pipeline prototype, as well as serving as
-   the base truth list of approved document types.
-   This string should contain JSON that looks like:
-   {\"grid\": [\"0.0.1\"],
-    \"dataqualitysummary\": [\"1.0.0\"],
-    \"orderoption\": [\"1.0.0\"],
-    \"serviceentry\": [\"1.0.0\"],
-    \"serviceoption\": [\"1.0.0\"]}"
-  {:default default-approved-pipeline-documents
+   the base truth list of approved document types. For tests to process, grid is required,
+   but grid is not needed in any deployment envirnment. AWS should use JSON as those values
+   are passed through the parser and returned as if it was the default.
+   This string should contain a clojure map that looks something like:
+   {:grid [\"0.0.1\"],
+    :dataqualitysummary [\"1.0.0\"]
+    :orderoption [\"1.0.0\"]
+    :serviceentry [\"1.0.0\"]
+    :serviceoption [\"1.0.0\"]}"
+  {:default {:grid ["0.0.1"]
+             :dataqualitysummary ["1.0.0"]
+             :orderoption ["1.0.0"]
+             :serviceentry ["1.0.0"]
+             :serviceoption ["1.0.0"]}
    :parser #(json/parse-string % true)})
+
 
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.


### PR DESCRIPTION
Removing an unused configuration and setting the default to all the known generic types.