### PR TITLE
CMR-8617 - moving the fixed list of generics to a dynamic check in the case default

### DIFF
--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -3,21 +3,18 @@
   (:require [clojure.set :as cset]
             [clojure.string :as str]
             [cmr.common.util :as util]
+            [cmr.common.generics :as common-generic]
             [cmr.common.services.errors :as errors]))
 
-(def generic-concept-prefix->concept-type
-  "Maps a generic concept id prefix to the concept type."
-  {"X" :generic
-   ;; TODO: Generic work: Can I read a non common config file to read in the generics instead of coding them? This is primarily used for validation.
-   "DQS" :dataqualitysummary
-   "OO" :orderoption
-   "SO" :serviceoption
-   "SE" :serviceentry
-   "GRD" :grid})
-
 (def generic-concept-types->concept-prefix
-  "Gets an array of generic concept types."
-  (cset/map-invert generic-concept-prefix->concept-type))
+  "Gets an array of generic concept types.
+   Return {:generic \"X\" :grid \"GRD\"...}"
+  (merge {:generic "X"} (common-generic/approved-generic-concept-prefixes)))
+
+(def generic-concept-prefix->concept-type
+  "Maps a generic concept id prefix to the concept type.
+   Return: {\"X\" :generic \"GRD\" :grid...}"
+  (cset/map-invert generic-concept-types->concept-prefix))
 
 (defn get-generic-concept-types-array
   "Gets the array of generic concept types."
@@ -76,7 +73,7 @@
 (def concept-type->concept-prefix
   "Maps a concept type to the concept id prefix"
   (cset/map-invert concept-prefix->concept-type))
- 
+
 (def humanizer-native-id
   "The native id of the system level humanizer. There can only be one humanizer in CMR.
   We use just humanizer native id to enforce it."

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -1,14 +1,10 @@
 (ns cmr.indexer.data.index-set
   (:refer-clojure :exclude [update])
   (:require
-   [cheshire.core :as cheshire]
-   [clj-http.client :as client]
-   [clojure.string :as string]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as cs]
    [cmr.common.config :as cfg :refer [defconfig]]
-   [cmr.common.generics :as common-generic :refer [approved-generic?]]
-   [cmr.common.lifecycle :as lifecycle]
+   [cmr.common.generics :as common-generic]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.elastic-utils.index-util :as m :refer [defmapping defnestedmapping]]
@@ -995,16 +991,16 @@
                                       keys
                                       first
                                       name))]
-     (merge 
-      {:collection (get-concept-mapping-fn :collection) 
+     (merge
+      {:collection (get-concept-mapping-fn :collection)
        :granule (get-concept-mapping-fn :granule)
        :tag (get-concept-mapping-fn :tag)
        :variable (get-concept-mapping-fn :variable)
        :service (get-concept-mapping-fn :service)
        :tool (get-concept-mapping-fn :tool)
-       :subscription (get-concept-mapping-fn :subscription)} 
-      (into {} 
-            (map #(get-concept-mapping-types-for-generics % fetched-index-set) 
+       :subscription (get-concept-mapping-fn :subscription)}
+      (into {}
+            (map #(get-concept-mapping-types-for-generics % fetched-index-set)
                  (cs/get-generic-concept-types-array)))))))
 
 (defn fetch-rebalancing-collection-info
@@ -1117,22 +1113,17 @@
          [(get indexes :all-subscription-revisions)]
          [(get indexes (or target-index-key :subscriptions))])
 
-       ;; TODO Generic work: Figure out how to use cs/get-generic-concept-types-array or generic-concept?
-       (or :generic
-           :dataqualitysummary
-           :orderoption
-           :serviceoption
-           :serviceentry
-           :grid)
-       ;; Generics are a bunch of document types, find out which one to work with
-       ;; and return the index name for those
-       (if all-revisions-index?
-         [(get indexes (keyword (format "all-generic-%s-revisions" (name concept-type))))]
-         [(get indexes (keyword (format "generic-%s" (name concept-type))))])
-
        :granule
        (let [coll-concept-id (:parent-collection-id (:extra-fields concept))]
-         (get-granule-index-names-for-collection context coll-concept-id target-index-key))))))
+         (get-granule-index-names-for-collection context coll-concept-id target-index-key))
+
+       ;; Default
+       (if (some? (concept-type (common-generic/lattest-approved-documents)))
+         ;; Generics are a bunch of document types, find out which one to work with
+         ;; and return the index name for those
+         (if all-revisions-index?
+           [(get indexes (keyword (format "all-generic-%s-revisions" (name concept-type))))]
+           [(get indexes (keyword (format "generic-%s" (name concept-type))))]))))))
 
 (defn get-granule-index-names-for-provider
   "Return the granule index names for the input provider id"


### PR DESCRIPTION
Found a way to remove a fixed list of concept types by moving it to the default section of the case and doing a lookup there.