### PR TITLE
CMR-8642 and CMR-8617 -  Removing fixed lists of generic document types

### DIFF
--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -27,6 +27,7 @@
                  [compojure "1.6.1"]
                  [environ "1.1.0"]
                  [instaparse "1.4.10"]
+                 [nasa-cmr/cmr-schemas "0.0.1-SNAPSHOT"]
                  [nasa-cmr/cmr-schema-validation-lib "0.1.0-SNAPSHOT"]
                  [net.jpountz.lz4/lz4 "1.3.0"]
                  [org.clojure/clojure "1.10.0"]

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -8,12 +8,12 @@
 
 (def generic-concept-types->concept-prefix
   "Gets an array of generic concept types.
-   Return {:generic \"X\" :grid \"GRD\"...}"
+   Return {:generic (str X) :grid (str GRD)...}"
   (merge {:generic "X"} (common-generic/approved-generic-concept-prefixes)))
 
 (def generic-concept-prefix->concept-type
   "Maps a generic concept id prefix to the concept type.
-   Return: {\"X\" :generic \"GRD\" :grid...}"
+   Return: {(str X) :generic (str GRD) :grid...}"
   (cset/map-invert generic-concept-types->concept-prefix))
 
 (defn get-generic-concept-types-array

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -129,11 +129,6 @@
   (let [prefix (concept-type->concept-prefix concept-type)]
     (format "%s%d-%s" prefix sequence-number provider-id)))
 
-(defn build-generic-concept-id
-  "Converts a map of concept-type sequence-number and provider-id to a concept-id for generic concept types."
-  [{:keys [concept-type sequence-number provider-id]}]
-  (format "%s%d-%s" concept-type sequence-number provider-id))
-
 (defn concept-id->type
   "Returns concept type for the given concept-id"
   [concept-id]

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -6,14 +6,15 @@
             [cmr.common.generics :as common-generic]
             [cmr.common.services.errors :as errors]))
 
-;; Gets an array of generic concept types.
-;; Return {:generic (str X) :grid (str GRD)...}
+
 (def generic-concept-types->concept-prefix
+  "Gets an array of generic concept types.
+   Return {:generic (str X) :grid (str GRD)...}"
   (merge {:generic "X"} (common-generic/approved-generic-concept-prefixes)))
 
-;; Maps a generic concept id prefix to the concept type.
-;; Return: {(str X) :generic (str GRD) :grid...}
 (def generic-concept-prefix->concept-type
+  "Maps a generic concept id prefix to the concept type.
+   Return: {(str X) :generic (str GRD) :grid...}"
   (cset/map-invert generic-concept-types->concept-prefix))
 
 (defn get-generic-concept-types-array

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -6,14 +6,14 @@
             [cmr.common.generics :as common-generic]
             [cmr.common.services.errors :as errors]))
 
+;; Gets an array of generic concept types.
+;; Return {:generic (str X) :grid (str GRD)...}
 (def generic-concept-types->concept-prefix
-  "Gets an array of generic concept types.
-   Return {:generic (str X) :grid (str GRD)...}"
   (merge {:generic "X"} (common-generic/approved-generic-concept-prefixes)))
 
+;; Maps a generic concept id prefix to the concept type.
+;; Return: {(str X) :generic (str GRD) :grid...}
 (def generic-concept-prefix->concept-type
-  "Maps a generic concept id prefix to the concept type.
-   Return: {(str X) :generic (str GRD) :grid...}"
   (cset/map-invert generic-concept-types->concept-prefix))
 
 (defn get-generic-concept-types-array
@@ -28,7 +28,7 @@
 
 (def concept-types
   "This is the set of the types of concepts in the CMR."
-  #{:access-group
+  (into #{:access-group
     :acl
     :collection
     :granule
@@ -43,12 +43,8 @@
     :variable-association
     :subscription
     :generic
-    :dataqualitysummary
-    :orderoption
-    :serviceoption
-    :serviceentry
-    :grid
-    :generic-association})
+    :generic-association}
+    (keys generic-concept-types->concept-prefix)))
 
 (def concept-prefix->concept-type
   "Maps a concept id prefix to the concept type"

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -21,7 +21,7 @@
 (defn latest-approved-documents
   "Return a map of all the configured approved generics and the latest version
    string for each one.
-   Return {:doc-type \"1.2.3"}"
+   Return {:doc-type \"1.2.3\"}"
   []
   (reduce (fn [data item]
             (assoc data (first item) (last (second item))))

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -21,7 +21,7 @@
 (defn latest-approved-documents
   "Return a map of all the configured approved generics and the latest version
    string for each one.
-   Return {:doc-type \"ver.ion.string\"}"
+   Return {:doc-type \"1.2.3"}"
   []
   (reduce (fn [data item]
             (assoc data (first item) (last (second item))))

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -1,10 +1,116 @@
 (ns cmr.common.generics
-  "Defines utilities for new generic document pipeline"
-  (:require 
-   [cmr.common.config :as cfg]))
+  "Defines utilities for new generic document pipeline. Most functions will deal
+   with either returning generic config files, or lists of approved generics."
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [cmr.common.config :as cfg]
+   [cmr.common.log :as log :refer (error)]
+   [cmr.schema-validation.json-schema :as js-validater]))
 
 (defn approved-generic?
-  "Check to see if a requested generic is on the approved list"
+  "Check to see if a requested generic is on the approved list.
+   Parameters:
+   * schema: schema keyword like :grid
+   * version: string like 0.0.1
+   Returns: true if schema and version are supported, nil otherwise"
   [schema version]
   (when (and schema version)
     (some #(= version %) (schema (cfg/approved-pipeline-documents)))))
+
+(defn lattest-approved-documents
+  "Return a map of all the configured approved generics and the lattest version
+   string for each one.
+   Return {:doc-type \"ver.ion.string\"}"
+  []
+  (reduce (fn [data item]
+            (assoc data (first item) (last (second item))))
+          {}
+          (cfg/approved-pipeline-documents)))
+
+(defn lattest-approved-document-types
+  "Return a list of configured approved generic keywords
+   Returns: (:grid :dataqualitysummary ...)"
+  []
+  (keys (lattest-approved-documents)))
+
+(defn read-schema-file
+  "Return the specific schema given the schema keyword name and version number.
+   Throw an error if the file can't be read.
+   Parameters:
+   * file-name: [metadata | index | schema]
+   * generic-keyword: [:grid | ...]
+   * generic-version: 0.0.1
+   Returns: string"
+  [file-name generic-keyword generic-version]
+  (try
+    (-> "schemas/%s/v%s/%s.json"
+        (format (name generic-keyword) generic-version (name file-name))
+        (io/resource)
+        (slurp))
+    (catch Exception e
+      (error
+       (format (str "The %s.json file for schema [%s] version [%s] cannot be found."
+                    "Please make sure that it exists. %s")
+               (name file-name)
+               (name generic-keyword)
+               generic-version
+               (.getMessage e))))))
+
+(defn read-schema-index
+  "Return the schema index configuration file given the schema name and version
+   number. Throw an error if the file can't be read.
+   Parameters:
+   * generic-keyword: [:grid | ...]
+   * generic-version: 0.0.1
+   Returns: string"
+  [generic-keyword generic-version]
+  (read-schema-file "index" generic-keyword generic-version))
+
+(defn read-schema-specification
+  "Return the schema specification file given the schema name and version number.
+   Throw an error if the file can't be read.
+   Parameters:
+   * generic-keyword: [:grid | ...]
+   * generic-version: 0.0.1
+   Returns: string"
+  [generic-keyword generic-version]
+  (read-schema-file "schema" generic-keyword generic-version))
+
+(defn read-schema-example
+  "Return the schema example metadata file given the schema name and version
+   number. Throw an error if the file can't be read.
+   Parameters:
+   * generic-keyword: [:grid | ...]
+   * generic-version: 0.0.1
+   Returns: string"
+  [generic-keyword generic-version]
+  (read-schema-file "metadata" generic-keyword generic-version))
+
+(defn validate-index-against-schema
+  "Validate a document, returns an array of errors if there are problems
+   Parameters:
+   * raw-json, json as a string to validate
+   Returns: list of errors or nil"
+  [raw-json]
+  (let [schema-file (read-schema-file :schema :index "0.0.1")
+        schema-obj (js-validater/json-string->json-schema schema-file)]
+    (js-validater/validate-json schema-obj raw-json)))
+
+(defn approved-generic-concept-prefixes
+  "Return the active list of approved generic content types with the defined
+   prefix in the :SubConceptType field found in the index.json file. If field is
+   not defined, then X is used.
+   Parameters: none, based off approved-documents?
+   Return: {doc-type \"concept-prefix\"}"
+  []
+  (reduce (fn [data item]
+            (let [generic-keyword (first item)
+                  index-raw (read-schema-index generic-keyword (second item))
+                  parse-errors (validate-index-against-schema index-raw)]
+              (when-not (some? parse-errors)
+                (assoc data
+                       generic-keyword
+                       (get (json/parse-string index-raw true) :SubConceptType "X")))))
+          {}
+          (lattest-approved-documents)))

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -50,12 +50,15 @@
         (slurp))
     (catch Exception e
       (error
-       (format (str "The %s.json file for schema [%s] version [%s] cannot be found."
+       (format (str "The %s.json file for schema [%s] version [%s] cannot be found. "
+                    " - [%s] - "
                     "Please make sure that it exists. %s")
                (name file-name)
                (name generic-keyword)
                generic-version
-               (.getMessage e))))))
+               (format "schemas/%s/v%s/%s.json" (name generic-keyword) generic-version (name file-name))
+               (.getMessage e)))
+      (println "read-schema-file failed"))))
 
 (defn read-schema-index
   "Return the schema index configuration file given the schema name and version

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -18,8 +18,8 @@
   (when (and schema version)
     (some #(= version %) (schema (cfg/approved-pipeline-documents)))))
 
-(defn lattest-approved-documents
-  "Return a map of all the configured approved generics and the lattest version
+(defn latest-approved-documents
+  "Return a map of all the configured approved generics and the latest version
    string for each one.
    Return {:doc-type \"ver.ion.string\"}"
   []
@@ -28,11 +28,11 @@
           {}
           (cfg/approved-pipeline-documents)))
 
-(defn lattest-approved-document-types
+(defn latest-approved-document-types
   "Return a list of configured approved generic keywords
    Returns: (:grid :dataqualitysummary ...)"
   []
-  (keys (lattest-approved-documents)))
+  (keys (latest-approved-documents)))
 
 (defn read-schema-file
   "Return the specific schema given the schema keyword name and version number.
@@ -113,4 +113,4 @@
                        generic-keyword
                        (get (json/parse-string index-raw true) :SubConceptType "X")))))
           {}
-          (lattest-approved-documents)))
+          (latest-approved-documents)))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -1118,7 +1118,7 @@
          (get-granule-index-names-for-collection context coll-concept-id target-index-key))
 
        ;; Default
-       (if (some? (concept-type (common-generic/lattest-approved-documents)))
+       (if (some? (concept-type (common-generic/latest-approved-documents)))
          ;; Generics are a bunch of document types, find out which one to work with
          ;; and return the index name for those
          (if all-revisions-index?

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -178,15 +178,8 @@
         provider-id (:provider params)
         native-id (:native-id route-params)
         concept-type (keyword (:concept-type route-params))
-        query-params (assoc {} :provider-id provider-id :native-id native-id)
-        found-concepts (mdb2/find-concepts request-context query-params concept-type {:raw? true})
-        ;; in memory database is inserting these values, where as the sql is not
-        body (-> found-concepts
-                 :body
-                 last
-                 (dissoc :concept-sub-type :user-id)
-                 list)]
-    (assoc found-concepts :body body)))
+        query-params (assoc {} :provider-id provider-id :native-id native-id)]
+    (mdb2/find-concepts request-context query-params concept-type {:raw? true})))
 
 (defn update-generic-document
   [request]

--- a/metadata-db-app/src/cmr/metadata_db/api/routes.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/routes.clj
@@ -1,14 +1,12 @@
 (ns cmr.metadata-db.api.routes
   "Defines the HTTP URL routes for the application."
   (:require
-   [cheshire.core :as json]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common.api.context :as context]
    [cmr.common.api.errors :as errors]
    [cmr.common.cache :as cache]
-   [cmr.common.jobs :as jobs]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.metadata-db.api.concepts :as concepts-api]
    [cmr.metadata-db.api.provider :as provider-api]

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -429,10 +429,10 @@
          ;; Set the created-at time to the current timekeeper time for concepts which have
          ;; the created-at field and do not already have a :created-at time set.
          ;; :generic is included for undeclared generic documents which may not specify one
-         ;; of the types in lattest-approved-document-types.
+         ;; of the types in latest-approved-document-types.
          concepts-with-created-at
          (into [:collection :granule :service :tool :variable :subscription :generic]
-               (common-generic/lattest-approved-document-types))
+               (common-generic/latest-approved-document-types))
          concept (if (some #{concept-type} concepts-with-created-at)
                    (update-in concept
                               [:created-at]

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -80,7 +80,7 @@
           (is (string/starts-with? (:body result) "<!DOCTYPE html>") "The body is not correct"))))
 
     (testing "CREATE a document with a valid config set that includes grid"
-      (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]})] 
+      (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]})]
         (let [expected {:native-id native-id
                         :deleted false
                         :provider-id "PROV1"
@@ -93,7 +93,7 @@
                         :metadata gen-util/grid-good}
 
               create-result (generic-requester gen-util/grid-good :post)
-              create-response (:body create-result) 
+              create-response (:body create-result)
 
               read-result (generic-requester)
               read-response (:body read-result)
@@ -101,7 +101,8 @@
               actual (first (json/parse-string read-response true))
               concept-id (get actual :concept-id)
               ;; these fields are complicated to test, do so another way
-              normalised (dissoc actual :concept-id :revision-date :created-at :transaction-id)
+              normalised (dissoc actual :concept-id :revision-date :created-at :transaction-id
+                                 :user-id :concept-sub-type)
               expected-pattern (re-pattern "\\{\"concept-id\":\"GRD[0-9]+-PROV1\",\"revision-id\":1,\"warnings\":null,\"existing-errors\":null\\}")]
           ;; test that the create was a success
           (is (= 201 (:status create-result)) "The HTTP status code from create is not correct")
@@ -133,9 +134,9 @@
               update-body (:body update-result)
 
               read-result (generic-requester)
-              read-body (:body read-result) 
-              read-json (->> (json/parse-string read-body true) 
-                             (filter #(= 2 (:revision-id %))) 
+              read-body (:body read-result)
+              read-json (->> (json/parse-string read-body true)
+                             (filter #(= 2 (:revision-id %)))
                              (first))
               metadata (:metadata read-json)
               actual (get (json/parse-string metadata true) :Description)


### PR DESCRIPTION
both tickets deal with removing fixed lists of generic document types. Primary work was in common-lib/src/cmr/common/generics.clj to create some util functions and then use those functions in the ingest and metadata services to remove fixed lists.