### PR TITLE
CMR-8502

### DIFF
--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -116,6 +116,11 @@
   "Defines the password that is sent from the CMR to URS to authenticate the CMR."
   {})
 
+(defconfig local-edl-verification
+  "Controls when cmr uses the EDL public key to locally verify JWT tokens."
+  {:type Boolean
+   :default true})
+
 (defconfig edl-public-key
   "Defines the EDL public key which is used to validate EDL JWT tokens locally.  Default is set to
    a locally generated EDL test jwk and is used in token unit tests"

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -101,7 +101,8 @@
   (if (transmit-config/echo-system-token? token)
     ;; Short circuit a lookup when we already know who this is.
     (transmit-config/echo-system-username)
-    (if (common-util/is-jwt-token? token)
+    (if (and (common-util/is-jwt-token? token)
+             (transmit-config/local-edl-verification))
       (verify-edl-token-locally token)
       (let [[status parsed body] (r/rest-post context "/tokens/get_token_info"
                                               {:headers {"Accept" mt/json


### PR DESCRIPTION
Fixes issue where Bearer wasn't being stripped prior to doing EDL local verification, Adds env config to turn local verification on or off.