### PR TITLE
CMR-8619: Dynamically load generics

### DIFF
--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -11,6 +11,7 @@
    [cmr.common-app.services.search :as search]
    [cmr.common.cache :as cache]
    [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.generics :as common-generic]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as svc-errors]
@@ -373,7 +374,7 @@
 
 (def get-generics
   "Retrieve the generics which were dynamically loaded"
-  (mapv keyword (mapv inf/plural (keys (cfg/approved-pipeline-documents)))))
+  (mapv keyword (mapv inf/plural(common-generic/latest-approved-document-types))))
 
 (def join-generic-concepts
   "Combines the generic concepts to be a single string"

--- a/search-app/src/cmr/search/api/concepts_search.clj
+++ b/search-app/src/cmr/search/api/concepts_search.clj
@@ -378,7 +378,7 @@
 
 (def join-generic-concepts
   "Combines the generic concepts to be a single string"
-  (clojure.string/join "|" (mapv format-regex get-generics)))
+  (string/join "|" (mapv format-regex get-generics)))
 
 (def routes-regex
   "Appends the generic concepts dynamically loaded to the non-generic concepts to match possible routes general form: (?:(?:granules)|...(?:dataqualitysummaries)"

--- a/search-app/test/cmr/search/test/api/concepts_search.clj
+++ b/search-app/test/cmr/search/test/api/concepts_search.clj
@@ -1,29 +1,24 @@
-(ns cmr.search.test.api.concepts_search
-  "Tests to verify that the route building support functions are workign properly"
+(ns cmr.search.test.api.concepts-search
+  "Tests to verify that the route building support functions are working properly"
   (:require [clojure.test :refer :all]
-            [cmr.search.api.concepts-search :as concept_search]))
-
-(deftest plurlize-concept
-  (testing "Teseting taking a concept and making is plural"
-   (is (= :grids (concept_search/pluralize-concept :grid))))
-  (is (= :dataqualitysummaries (concept_search/pluralize-concept :dataqualitysummary))))
+            [cmr.search.api.concepts-search :as concept-search]))
 
 (deftest format-regex
   (testing "Testing that the regex is formatted for an individual concept"
-   (is (= "(?grid)" (concept_search/format-regex "grid")))))
+   (is (= "(?grid)" (concept-search/format-regex "grid")))))
 
 (deftest get-generics
-  (testing "Ensuring that retrieving the generics does not return :generic"
+  (testing "Ensuring that we retrieve the list of generics as keywords"
    (is (= [:grids
            :dataqualitysummaries
            :orderoptions
            :serviceentries
-           :serviceoptions] concept_search/get-generics)))
+           :serviceoptions] concept-search/get-generics)))
 
   (deftest join-generic-concepts
-    (testing "Ensuring that all generic concepts are joined together ")
-    (is (= "(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions)" concept_search/join-generic-concepts))))
+    (testing "Ensuring that all generic concepts are joined together")
+    (is (= "(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions)" concept-search/join-generic-concepts))))
 
 (deftest routes-regex
-  (testing "Ensuring that the regex is fully formed for the routes for all concepts. Note this must be comapred as a string"
-   (is (= (str #"(?:(?:granules)|(?:collections)|(?:variables)|(?:subscriptions)|(?:tools)|(?:services)|(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions))(?:\..+)?") (str concept_search/routes-regex)))))
+  (testing "Ensuring that the regex is fully formed for the routes for all concepts. Note this must be comapred as strings"
+   (is (= (str #"(?:(?:granules)|(?:collections)|(?:variables)|(?:subscriptions)|(?:tools)|(?:services)|(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions))(?:\..+)?") (str concept-search/routes-regex)))))

--- a/search-app/test/cmr/search/test/api/concepts_search.clj
+++ b/search-app/test/cmr/search/test/api/concepts_search.clj
@@ -1,0 +1,29 @@
+(ns cmr.search.test.api.concepts_search
+  "Tests to verify that the route building support functions are workign properly"
+  (:require [clojure.test :refer :all]
+            [cmr.search.api.concepts-search :as concept_search]))
+
+(deftest plurlize-concept
+  (testing "Teseting taking a concept and making is plural"
+   (is (= :grids (concept_search/pluralize-concept :grid))))
+  (is (= :dataqualitysummaries (concept_search/pluralize-concept :dataqualitysummary))))
+
+(deftest format-regex
+  (testing "Testing that the regex is formatted for an individual concept"
+   (is (= "(?grid)" (concept_search/format-regex "grid")))))
+
+(deftest get-generics
+  (testing "Ensuring that retrieving the generics does not return :generic"
+   (is (= [:grids
+           :dataqualitysummaries
+           :orderoptions
+           :serviceentries
+           :serviceoptions] concept_search/get-generics)))
+
+  (deftest join-generic-concepts
+    (testing "Ensuring that all generic concepts are joined together ")
+    (is (= "(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions)" concept_search/join-generic-concepts))))
+
+(deftest routes-regex
+  (testing "Ensuring that the regex is fully formed for the routes for all concepts. Note this must be comapred as a string"
+   (is (= (str #"(?:(?:granules)|(?:collections)|(?:variables)|(?:subscriptions)|(?:tools)|(?:services)|(?:grids)|(?:dataqualitysummaries)|(?:orderoptions)|(?:serviceentries)|(?:serviceoptions))(?:\..+)?") (str concept_search/routes-regex)))))


### PR DESCRIPTION
Generics were being hard-coded into the routes, changed so that they are being dynamically retrieved.