### PR TITLE
CMR-8674 - Utility function for reading Service-Collection tag metadata out of the database

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -656,3 +656,15 @@
 (extend OracleStore
         concepts/ConceptsStore
         behaviour)
+
+(comment
+
+  (def db (get-in user/system [:apps :metadata-db :db]))
+  ;; Backdoor tool to read the encoded and zipped metadata column since this can
+  ;; not be done in a SQL query tool. All other columns are visible there.
+  (let [c (get-concept db :service-association "PROV1" "SA1200000040-CMR")
+        raw_meta_edn (:metadata c)
+        meta (read-string raw_meta_edn)]
+    meta)
+
+  )


### PR DESCRIPTION
CMR already supports putting a payload under the 'data' field as defined for tag association so no other code change were needed for this ticket. However this function was needed to prove the contents of the metadata column in the database. There is no easy way to read the metadata column from the SQL Query visualizer so this function gives us the ability to decode the compressed value.