### PR TITLE
CMR-8614: Remove the mime-type from the SQL database, have Generic code treat mime-types in a standard way

### DIFF
--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -103,8 +103,7 @@
                        :native-id native-id
                        :user-id (api-core/get-user-id request-context headers)
                        :extra-fields {:document-name (:Name document)
-                                      :schema spec-key
-                                      :mime-type (str "application/vnd.nasa.cmr.umm+json;version=" spec-version)}
+                                      :schema spec-key}
                        :concept-sub-type concept-sub-type)
        :spec-key spec-key
        :spec-version spec-version

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/generic_documents.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/generic_documents.clj
@@ -23,8 +23,7 @@
                     provider_id
                     user_id
                     document_name
-                    schema
-                    mime_type]} result]
+                    schema]} result]
         (util/remove-nil-keys {:concept-type concept-type
                                :native-id native_id
                                :concept-id concept_id
@@ -39,17 +38,16 @@
                                :transaction-id transaction_id
                                :user-id user_id
                                :extra-fields {:document-name document_name
-                                              :schema schema
-                                              :mime-type mime_type}})))))
+                                              :schema schema}})))))
 
 (defn- concept->insert-args
   [concept]
-  (let [{{:keys [document-name schema mime-type]} :extra-fields
+  (let [{{:keys [document-name schema]} :extra-fields
          user-id :user-id
          provider-id :provider-id} concept
         [cols values] (c/concept->common-insert-args concept)]
-    [(concat cols ["provider_id" "user_id" "document_name" "schema" "mime_type"])
-     (concat values [provider-id user-id document-name schema mime-type])]))
+    [(concat cols ["provider_id" "user_id" "document_name" "schema"])
+     (concat values [provider-id user-id document-name schema])]))
 
 (doseq [doseq-concept-type (cc/get-generic-concept-types-array)]
   (defmethod c/concept->insert-args [doseq-concept-type false]

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -61,8 +61,8 @@
    :generic-association (into common-columns
                                [:associated_concept_id :associated_revision_id
                                 :source_concept_identifier :source_revision_id :user_id])}
-   (zipmap (cc/get-generic-concept-types-array) 
-           (repeat (into common-columns [:provider_id :document_name :schema :mime_type :user_id :created_at])))))
+   (zipmap (cc/get-generic-concept-types-array)
+           (repeat (into common-columns [:provider_id :document_name :schema :user_id :created_at])))))
 
 (def single-table-with-providers-concept-type?
   "The set of concept types that are stored in a single table with a provider column. These concept

--- a/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
@@ -1,0 +1,20 @@
+(ns cmr.metadata-db.migrations.086-remove-mimetype-generics-table
+   (:require
+   [cheshire.core :as json]
+   [cmr.common.util :as util]
+   [cmr.common-app.services.ingest.subscription-common :as sub-common]
+   [config.mdb-migrate-helper :as h]))
+
+(defn up
+  "Migrates the database up to version 86."
+  []
+  (println "cmr.metadata-db.migrations.086-remove-mimetype-generics-table up...")
+  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS ADD MIME_TYPE VARCHAR(255)")
+  ;;Retrieve the version # from the format column and prepdend that to the restored MIME_TYPE column value for each row
+  (h/sql "UPDATE CMR_GENERIC_DOCUMENTS SET MIME_TYPE = CONCAT('application/vnd.nasa.cmr.umm+json;', SUBSTR(FORMAT, -5))"))
+
+(defn down
+  "Migrates the database down from version 86."
+  []
+  (println "cmr.metadata-db.migrations.086-remove-mimetype-generics-table down...")
+  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS DROP COLUMN MIME_TYPE"))

--- a/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
@@ -1,8 +1,5 @@
 (ns cmr.metadata-db.migrations.086-remove-mimetype-generics-table
    (:require
-   [cheshire.core :as json]
-   [cmr.common.util :as util]
-   [cmr.common-app.services.ingest.subscription-common :as sub-common]
    [config.mdb-migrate-helper :as h]))
 
 (defn up
@@ -10,7 +7,7 @@
   []
   (println "cmr.metadata-db.migrations.086-remove-mimetype-generics-table up...")
   (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS ADD MIME_TYPE VARCHAR(255)")
-  ;;Retrieve the version # from the format column and prepdend that to the restored MIME_TYPE column value for each row
+  ;;Retrieve the version # from the format column and append that to the restored MIME_TYPE column value for each row
   (h/sql "UPDATE CMR_GENERIC_DOCUMENTS SET MIME_TYPE = CONCAT('application/vnd.nasa.cmr.umm+json;', SUBSTR(FORMAT, -5))"))
 
 (defn down

--- a/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/086_remove_mimetype_generics_table.clj
@@ -6,12 +6,12 @@
   "Migrates the database up to version 86."
   []
   (println "cmr.metadata-db.migrations.086-remove-mimetype-generics-table up...")
-  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS ADD MIME_TYPE VARCHAR(255)")
-  ;;Retrieve the version # from the format column and append that to the restored MIME_TYPE column value for each row
-  (h/sql "UPDATE CMR_GENERIC_DOCUMENTS SET MIME_TYPE = CONCAT('application/vnd.nasa.cmr.umm+json;', SUBSTR(FORMAT, -5))"))
+  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS DROP COLUMN MIME_TYPE"))
 
 (defn down
   "Migrates the database down from version 86."
   []
   (println "cmr.metadata-db.migrations.086-remove-mimetype-generics-table down...")
-  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS DROP COLUMN MIME_TYPE"))
+  (h/sql "ALTER TABLE CMR_GENERIC_DOCUMENTS ADD MIME_TYPE VARCHAR(255)")
+  ;;Retrieve the version # from the format column and append that to the restored MIME_TYPE column value for each row
+  (h/sql "UPDATE CMR_GENERIC_DOCUMENTS SET MIME_TYPE = CONCAT('application/vnd.nasa.cmr.umm+json;', SUBSTR(FORMAT, -5))"))

--- a/schemas/resources/schemas/grid/v0.0.1/schema.json
+++ b/schemas/resources/schemas/grid/v0.0.1/schema.json
@@ -499,6 +499,12 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 80
+        },
+        "MimeType": {
+          "description": "The multi-purpose internet mail extensions indicates the nature and format of the data that is accessed through the URL. The controlled vocabulary for MimeTypes is maintained in the Keyword Management System (KMS): https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/MimeType?gtm_scheme=MimeType",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
         }
       },
       "required": [

--- a/schemas/resources/schemas/grid/v0.0.1/schema.json
+++ b/schemas/resources/schemas/grid/v0.0.1/schema.json
@@ -499,12 +499,6 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 80
-        },
-        "MimeType": {
-          "description": "The multi-purpose internet mail extensions indicates the nature and format of the data that is accessed through the URL. The controlled vocabulary for MimeTypes is maintained in the Keyword Management System (KMS): https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/MimeType?gtm_scheme=MimeType",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 80
         }
       },
       "required": [

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -88,8 +88,7 @@
                         :revision-id 1
                         :concept-type "grid"
                         :extra-fields {:document-name "Grid-A7-v1"
-                                       :schema "grid"
-                                       :mime-type "application/vnd.nasa.cmr.umm+json;version=0.0.1"}
+                                       :schema "grid"}
                         :metadata gen-util/grid-good}
 
               create-result (generic-requester gen-util/grid-good :post)


### PR DESCRIPTION
This is to remove the mimetype from the SQL database with a migration as well as remove instances of the mime_type field being used in generics