### PR TITLE
CMR-8766: Change CMR_GENERIC_DOCUMENTS DOCUMENT_NAME column size from 20 to 1020.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/migrations/087_update_generic_document_name_length.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/087_update_generic_document_name_length.clj
@@ -1,0 +1,16 @@
+(ns cmr.metadata-db.migrations.087-update-generic-document-name-length
+  (:require
+   [config.mdb-migrate-helper :as h]))
+
+(defn up
+  "Migrates the database up to version 87."
+  []
+  (println "cmr.metadata-db.migrations.087-update-generic-document-name-length up...")
+  (h/sql "alter table METADATA_DB.CMR_GENERIC_DOCUMENTS modify document_name VARCHAR(1020)"))
+
+
+(defn down
+  "Migrates the database down from version 87."
+  []
+  ;; do nothing as we don't want to truncate the document name
+  (println "cmr.metadata-db.migrations.087-update-generic-document-name-length down..."))


### PR DESCRIPTION
This change is needed for Legacy Services data migration as some of the legacy services generic documents (e.g. DataQualitySummary, ServiceEntry, etc) have names that can be 1020 characters long.