### PR TITLE
Feature CMR-8774 - move provider parameter back to the URL path for generic ingest CRUD events

### DIFF
--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -24,9 +24,9 @@
    Expected usage is to pass in pluralize-concept-type."
   ([] (get-generic-concept-types-array identity))
   ([modifier-func]
-   (reduce (fn [coll, item] (conj coll (modifier-func item)))
+   (reduce (fn [coll, item] (conj coll (modifier-func (key item))))
            []
-           (keys generic-concept-types->concept-prefix))))
+           (common-generic/approved-generic-concept-prefixes))))
 
 (defn generic-concept?
   "Return true if the passed in concept is a generic concept"

--- a/common-lib/src/cmr/common/concepts.clj
+++ b/common-lib/src/cmr/common/concepts.clj
@@ -18,9 +18,15 @@
   (cset/map-invert generic-concept-types->concept-prefix))
 
 (defn get-generic-concept-types-array
-  "Gets the array of generic concept types."
-  []
-  (vec (keys generic-concept-types->concept-prefix)))
+  "Gets the array of generic concept types and optionally modify those values.
+   By default, no parameters will return the list as is, however if a function
+   is passed in that takes one value, this value will be changed in some way.
+   Expected usage is to pass in pluralize-concept-type."
+  ([] (get-generic-concept-types-array identity))
+  ([modifier-func]
+   (reduce (fn [coll, item] (conj coll (modifier-func item)))
+           []
+           (keys generic-concept-types->concept-prefix))))
 
 (defn generic-concept?
   "Return true if the passed in concept is a generic concept"
@@ -72,9 +78,16 @@
   (cset/map-invert concept-prefix->concept-type))
 
 (defn pluralize-concept-type
-  "Pluralizes the passed in concept keyword and returns it."
+  "Pluralizes the passed in concept keyword/string and returns it. The compliment
+   function is singularize-concept-type"
   [concept-key]
   (keyword (inf/plural (name concept-key))))
+
+(defn singularize-concept-type
+  "Singularize the passed in concept keyword/string and returns it. The compliment
+   function is pluralize-concept-type"
+  [concept-key]
+  (keyword (inf/singular (name concept-key))))
 
 (def humanizer-native-id
   "The native id of the system level humanizer. There can only be one humanizer in CMR.

--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -59,8 +59,7 @@
                (name generic-keyword)
                generic-version
                (format "schemas/%s/v%s/%s.json" (name generic-keyword) generic-version (name file-name))
-               (.getMessage e)))
-      (println "read-schema-file failed"))))
+               (.getMessage e))))))
 
 (defn read-schema-index
   "Return the schema index configuration file given the schema name and version

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -168,7 +168,7 @@
         concept-type (concept-type->singular route-params)]
     (api-core/delete-concept concept-type provider-id native-id request)))
 
-(defn validate-required-query-parameters
+(defn crud-generic-document
   "This function checks for required parameters. If they don't exist then throw an error, otherwise send the request
    on to the corresponding function."
   [request funct-str]

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -28,37 +28,18 @@
     (errors/throw-service-error
      :invalid-data
      (format "The [%s] schema on version [%s] is not an approved schema. This record cannot be ingested." schema version))
-    (if-some [schema-url (jio/resource (format "schemas/%s/v%s/schema.json"
-                                               (name schema)
-                                               version))]
-      (let [schema-file (slurp schema-url)
-            schema-obj (js-validater/json-string->json-schema schema-file)]
+    (if-some [schema-file (gconfig/read-schema-specification schema version)]
+      (let [schema-obj (js-validater/json-string->json-schema schema-file)]
         (js-validater/validate-json schema-obj raw-json true))
       (errors/throw-service-error
        :invalid-data
        (format "While the [%s] schema with version [%s] is approved, it cannot be found." schema version)))))
 
-(def required-query-parameters
-  "This defines in a map required parameters that are passed in and where they would be
-   located once the http request makes its way through compojure. If there is an error the error
-   messages goes into the cmr.ingest.services.messages.clj file."
-  {:provider messages/provider-does-not-exist})
-
-;; TODO: Generic work: This could be a candidate for a configuration file.
-(defn validate-required-parameter
-  "This function validates that the required parameters are present. If not then throw a service exception to let
-  the end users know what to do."
-  [required-param-to-check request]
-  (let [param-key (first required-param-to-check)
-        msg (second required-param-to-check)
-        value (get-in request [:params param-key])]
-    (when-not value
-      (errors/throw-service-error :invalid-data (msg)))))
-
-(defn validate-any-required-query-parameters
-  [request required-parameters]
-  (doseq [param required-parameters]
-    (validate-required-parameter param request)))
+(defn- concept-type->singular
+  "Common task to convert concepts from their public URL form to their internal
+   form. For example: grids -> grid"
+  [route-params]
+  (common-concepts/singularize-concept-type (:concept-type route-params)))
 
 (defn prepare-generic-document
   "Prepares a document to be ingested so that search can retrieve the contents.
@@ -68,7 +49,7 @@
         provider-id (or (:provider params)
                         (:provider-id route-params))
         native-id (:native-id route-params)
-        concept-type (keyword (:concept-type route-params))
+        concept-type (concept-type->singular route-params)
         _ (lt-validation/validate-launchpad-token request-context)
         _ (api-core/verify-provider-exists request-context provider-id)
         _ (acl/verify-ingest-management-permission
@@ -157,10 +138,10 @@
 (defn read-generic-document
   "Read a document from the Native ID and return that document"
   [request]
-  (let [{:keys [route-params request-context params]} request
-        provider-id (:provider params)
+  (let [{:keys [route-params request-context _params]} request
+        provider-id (:provider-id route-params)
         native-id (:native-id route-params)
-        concept-type (keyword (:concept-type route-params))
+        concept-type (concept-type->singular route-params)
         query-params (assoc {} :provider-id provider-id :native-id native-id)]
     (mdb2/find-concepts request-context query-params concept-type {:raw? true})))
 
@@ -170,7 +151,7 @@
   [request]
   (let [res (prepare-generic-document request)
         headers (:headers request)
-        {:keys [spec-key spec-version provider-id native-id request-context concept]} res
+        {:keys [spec-key spec-version _provider-id _native-id request-context concept]} res
         metadata (:metadata concept)]
     (validate-document-against-schema spec-key spec-version metadata)
     (ingest-document request-context concept headers)))
@@ -180,18 +161,17 @@
    if successful with the concept id and revision number. A 404 status is returned if the concept has
    already been deleted."
   [request]
-  (let [{:keys [route-params request-context headers params]} request
+  (let [{:keys [route-params _request-context _headers params]} request
         provider-id (or (:provider params)
                         (:provider-id route-params))
         native-id (:native-id route-params)
-        concept-type (:concept-type route-params)]
+        concept-type (concept-type->singular route-params)]
     (api-core/delete-concept concept-type provider-id native-id request)))
 
 (defn validate-required-query-parameters
   "This function checks for required parameters. If they don't exist then throw an error, otherwise send the request
    on to the corresponding function."
   [request funct-str]
-  (validate-any-required-query-parameters request required-query-parameters)
   (case funct-str
     :create (create-generic-document request)
     :read (read-generic-document request)

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -138,7 +138,7 @@
 (defn read-generic-document
   "Read a document from the Native ID and return that document"
   [request]
-  (let [{:keys [route-params request-context _params]} request
+  (let [{:keys [route-params request-context]} request
         provider-id (:provider-id route-params)
         native-id (:native-id route-params)
         concept-type (concept-type->singular route-params)
@@ -151,7 +151,7 @@
   [request]
   (let [res (prepare-generic-document request)
         headers (:headers request)
-        {:keys [spec-key spec-version _provider-id _native-id request-context concept]} res
+        {:keys [spec-key spec-version request-context concept]} res
         metadata (:metadata concept)]
     (validate-document-against-schema spec-key spec-version metadata)
     (ingest-document request-context concept headers)))
@@ -161,7 +161,7 @@
    if successful with the concept id and revision number. A 404 status is returned if the concept has
    already been deleted."
   [request]
-  (let [{:keys [route-params _request-context _headers params]} request
+  (let [{:keys [route-params params]} request
         provider-id (or (:provider params)
                         (:provider-id route-params))
         native-id (:native-id route-params)

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -241,10 +241,10 @@
        ;; Generic documents are by pattern: /providers/{prov_id}/{concept-type}/{native_id}
        (context ["/:concept-type" :concept-type generate-generic-concept-types-reg-ex] [concept-type]
          (context ["/:native-id" :native-id #".*$"] [native-id]
-           (POST "/" request (gen-doc/validate-required-query-parameters request :create))
-           (GET "/" request (gen-doc/validate-required-query-parameters request :read))
-           (PUT "/" request (gen-doc/validate-required-query-parameters request :update))
-           (DELETE "/" request (gen-doc/delete-generic-document request))))
+           (POST "/" request (gen-doc/crud-generic-document request :create))
+           (GET "/" request (gen-doc/crud-generic-document request :read))
+           (PUT "/" request (gen-doc/crud-generic-document request :update))
+           (DELETE "/" request (gen-doc/crud-generic-document request :delete))))
 
        ;; Bulk updates
        (context "/bulk-update/collections" []

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -102,6 +102,14 @@
            (jm/disable-email-subscription-processing-job ctx)
            {:status 200}))))
 
+(def generate-generic-concept-types-reg-ex
+  "This function creates a regular expresion for all of the generic concepts.  This is used to create the api endpoints.
+   An example string that is return looks like: \"dataqualitysummarys|orderoptions|serviceoptions\" "
+  (let [rx (-> (str (concepts/get-generic-concept-types-array concepts/pluralize-concept-type))
+               (clojure.string/replace #":|\]|\[" "")
+               (clojure.string/replace #" " "|"))]
+    (re-pattern rx)))
+
 (def ingest-routes
   (routes
     ;; variable ingest routes with association
@@ -229,6 +237,15 @@
            request
            (subscriptions/delete-subscription
             provider-id native-id request)))
+
+       ;; Generic documents are by pattern: /providers/{prov_id}/{concept-type}/{native_id}
+       (context ["/:concept-type" :concept-type generate-generic-concept-types-reg-ex] [concept-type]
+         (context ["/:native-id" :native-id #".*$"] [native-id]
+           (POST "/" request (gen-doc/validate-required-query-parameters request :create))
+           (GET "/" request (gen-doc/validate-required-query-parameters request :read))
+           (PUT "/" request (gen-doc/validate-required-query-parameters request :update))
+           (DELETE "/" request (gen-doc/delete-generic-document request))))
+
        ;; Bulk updates
        (context "/bulk-update/collections" []
          (POST "/"
@@ -250,25 +267,6 @@
            request
            (bulk/get-provider-tasks :granule provider-id request)))))))
 
-(def generate-generic-concept-types-reg-ex
-  "This function creates a regular expresion for all of the generic concepts.  This is used to create the api endpoints.
-   An example string that is return looks like: \"dataqualitysummary|orderoption|serviceoption\" "
-  (let [rx (-> (str (concepts/get-generic-concept-types-array))
-              (clojure.string/replace #":|\]|\[" "")
-              (clojure.string/replace #" " "|"))]
-    rx))
-
-(def generic-document-routes
- (routes
-    (api-core/set-default-error-format
-     :xml
-     (context ["/:concept-type" :concept-type (re-pattern generate-generic-concept-types-reg-ex)] [concept-type]
-       (context ["/:native-id" :native-id #".*$"] [native-id]
-         (POST "/" request (gen-doc/validate-required-query-parameters request :create))
-         (GET "/" request (gen-doc/validate-required-query-parameters request :read))
-         (PUT "/" request (gen-doc/validate-required-query-parameters request :update))
-         (DELETE "/" request (gen-doc/delete-generic-document request)))))))
-
 (defn build-routes [system]
   (routes
     (context (get-in system [:public-conf :relative-root-url]) []
@@ -279,9 +277,6 @@
 
       ;; Add routes to create, update, delete, & validate concepts
       ingest-routes
-
-      ;; add routes to create, update, read, and delete generic concepts
-      generic-document-routes
 
       ;; db migration route
       db-migration-routes

--- a/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
+++ b/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
@@ -5,7 +5,7 @@
    [cmr.common.util :as u :refer [are3]]
    [cmr.ingest.api.generic-documents :as gendoc]))
 
-(deftest required-query-parameters-test
+(comment deftest required-query-parameters-test
   "Tests the required query parameters functionality works."
   (are3 [expected request required-query-parameters]
         (try

--- a/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
+++ b/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
@@ -1,6 +1,0 @@
-(ns cmr.ingest.test.api.generic-documents
-  "This tests functions in generic documents."
-  (:require
-   [clojure.test :refer :all]
-   [cmr.common.util :as u :refer [are3]]
-   [cmr.ingest.api.generic-documents :as gendoc]))

--- a/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
+++ b/ingest-app/test/cmr/ingest/test/api/generic_documents.clj
@@ -4,36 +4,3 @@
    [clojure.test :refer :all]
    [cmr.common.util :as u :refer [are3]]
    [cmr.ingest.api.generic-documents :as gendoc]))
-
-(comment deftest required-query-parameters-test
-  "Tests the required query parameters functionality works."
-  (are3 [expected request required-query-parameters]
-        (try
-          (let [actual (gendoc/validate-any-required-query-parameters request required-query-parameters)]
-            (is (= expected (first actual))))
-          (catch Exception e
-            (is (= expected (str (.getMessage e))))))
-
-        "Test that the required query parameter exists"
-        nil
-        {:params {:provider "PROV2"}}
-        {:provider cmr.ingest.services.messages/provider-does-not-exist}
-
-        "Test that the required query parameter doesn't exist"
-        (cmr.ingest.services.messages/provider-does-not-exist)
-        {:params {:provider1 "PROV2"}}
-        {:provider cmr.ingest.services.messages/provider-does-not-exist}
-
-        "Test that more than 1 required query parameter works."
-        nil
-        {:params {:provider "PROV2"
-                  :provider2 "PROV3"}}
-        {:provider cmr.ingest.services.messages/provider-does-not-exist
-         :provider2 cmr.ingest.services.messages/provider-does-not-exist}
-
-        "Test when more than 1 required query parameter exists and 1 fails."
-        (cmr.ingest.services.messages/provider-does-not-exist)
-        {:params {:provider "PROV2"
-                  :provider3 "PROV3"}}
-        {:provider cmr.ingest.services.messages/provider-does-not-exist
-         :provider2 cmr.ingest.services.messages/provider-does-not-exist}))

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -704,8 +704,9 @@
 (defn ingest-generic-crud-url
   "Get the URL for Creating a Generic Document"
   [concept-type provider-id native-id]
-  (format "http://localhost:%s/%s/%s?provider=%s"
+  ;; /providers/<provider-id>/<concept-type>/<native-id>
+  (format "http://localhost:%s/providers/%s/%s/%s"
           (transmit-config/ingest-port)
+          provider-id
           concept-type
-          native-id
-          provider-id))
+          native-id))

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -4,6 +4,7 @@
    [cmr.common.config :as config]
    [cmr.elastic-utils.config :as es-config]
    [cmr.transmit.config :as transmit-config]
+   [inflections.core :as inf]
    [ring.util.codec :as codec])
   (:import (java.net URL)))
 
@@ -705,8 +706,9 @@
   "Get the URL for Creating a Generic Document"
   [concept-type provider-id native-id]
   ;; /providers/<provider-id>/<concept-type>/<native-id>
+  ;; NOTE: concept-type must be "plural"
   (format "http://localhost:%s/providers/%s/%s/%s"
           (transmit-config/ingest-port)
           provider-id
-          concept-type
+          (inf/plural concept-type)
           native-id))

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -56,7 +56,7 @@
 (deftest test-generic-CRUD
   (let [native-id "Generic-Test-CRUD"
         generic-tokened-request (partial gen-util/generic-request nil "PROV1" native-id)
-        generic-requester (partial generic-tokened-request "grids")]
+        generic-requester (partial generic-tokened-request "grid")]
 
     (testing "send a good document with config set that does not include grid"
       (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]})]

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -56,7 +56,7 @@
 (deftest test-generic-CRUD
   (let [native-id "Generic-Test-CRUD"
         generic-tokened-request (partial gen-util/generic-request nil "PROV1" native-id)
-        generic-requester (partial generic-tokened-request "grid")]
+        generic-requester (partial generic-tokened-request "grids")]
 
     (testing "send a good document with config set that does not include grid"
       (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]})]


### PR DESCRIPTION
move "provider=PROV1" back to the URL for CRUD events. 

NOTE: documentation of these URL changes is dependent on CMR-8649 and will be completed in a following ticket.