### PR TITLE
CMR-8764: Added logging when client still uses Echo-Token header.

### DIFF
--- a/other/cmr-exchange/authz/src/cmr/authz/token.clj
+++ b/other/cmr-exchange/authz/src/cmr/authz/token.clj
@@ -28,6 +28,8 @@
 (defn extract
   "Extract the value of `Authorization` or `Echo-Token` header that was passed in the request."
   [request]
+  (when (request/get-header request "echo-token")
+    (log/warn (format "Still using Echo-Token for authorization, client id: %s." (request/get-header request "client-id"))))
   (or (request/get-header request "authorization")
       (request/get-header request "echo-token")))
 


### PR DESCRIPTION
Currently, OUS will take token value from either the Authorization header or the Echo-Token header and pass it to CMR via the Authorization header. Since there is only one known client (EDSC) to OUS, it is not worth the effort to add a toggle configuration to not pass Echo-Token header value to CMR. Once ECHO Token generation is disabled in CMR, no one can get an Echo Token anyways. So the proposed solution is to simply log a message in OUS if the client is still using ECHO-Token header to pass in the token value and we can reach out to clients if any to tell them to use Authorization header instead. We can remove ECHO-Token header support from OUS all together once CMR completely retires ECHO token.