### PR TITLE
CMR-8775: Control access to Generic API ingest interfaces with a new CMR configuration

### DIFF
--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -240,6 +240,14 @@
   {:default (approved-pipeline-documents)
    :parser #(json/parse-string % true)})
 
+(defconfig generic-ingest-disabled-list
+  "This is a toggle to disallow specified generic concepts from being ingested into CMR,
+   Should be an array of keys with the name of the schema to be disallowed from ingest
+   example [:grid :order-option], would disallow grids and order options from being ingested into CMR
+   if no concepts should be disalllowed set to an empty list"
+  {:default []
+   :parser #(json/parse-string % true)})
+
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.
   If any are unrecognized a warning message is logged. Usually this should be called at the start

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -21,6 +21,7 @@
 
 (defn disabled-for-ingest?
   "Determine if a generic schema is disallowed for ingest
+   Parameters:
    * schema, the keyword name of an approved generic"
   [schema]
   (some #{schema} (cfg/generic-ingest-disabled-list)))

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -26,17 +26,24 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Check the functions which validate generic metadata
+
+(deftest disabled-for-ingest?
+   (testing
+    "Test function for disabling ingest of specific concepts"
+    (with-redefs [config/generic-ingest-disabled-list (fn [] [:grid])]
+     (is (= :grid (gdocs/disabled-for-ingest? :grid)) "Grid is disabled in test and will be returned")
+     (is (= nil (gdocs/disabled-for-ingest? :order-option)) "order option is NOT disabled in test and returns nil"))))
+
 (deftest validate-json-test
   (testing
    "Test that approved-generic? approves configured Generic document types"
-    (with-redefs [config/approved-pipeline-documents (fn [] {:grids ["1.0.0"]})]
+    (with-redefs [config/approved-pipeline-documents (fn [] {:grids ["1.0.0"]}) config/generic-ingest-disabled-list (fn [] [])]
       (is (true? (gcfg/approved-generic? :grids "1.0.0")) "Grids should be an approved format")
       (is (not (gcfg/approved-generic? :grid "0.0.1")) "CMR is using default configuration")
       (is (not (gcfg/approved-generic? :fake "a.b.c")) "A fake type was incorectly approved")))
-
   (testing
    "Verify that a document can be validated as approved schema."
-    (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]})]
+    (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]}) config/generic-ingest-disabled-list (fn [] [])]
       (let [expected nil
             actual (gdocs/validate-json-against-schema
                     :grid
@@ -51,7 +58,17 @@
              clojure.lang.ExceptionInfo
              #"While validating the record against the \[:grid\] schema with version \[0.0.1\] the following error occurred: \[#: required key \[MetadataSpecification\] not found\]. The record cannot be ingested."
              (gdocs/validate-document-against-schema :grid "0.0.1" bad-json))
-            "Was not able to generate a schema exception")))))
+            "Was not able to generate a schema exception"))))
+  (testing
+   "Verify that if a schema is on the disabled on the ingest list, it is not ingested and an error message is returned."
+    (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]}) config/generic-ingest-disabled-list (fn [] [:grid])]
+       (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+             #"The :grid schema is currently disabled and cannot be ingested"
+            (gdocs/validate-json-against-schema
+             :grid
+             "0.0.1"
+             (json/generate-string gen-util/grid-good)))))))
 
 (deftest test-generic-CRUD
   (let [native-id "Generic-Test-CRUD"

--- a/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/generics_test.clj
@@ -60,7 +60,7 @@
              (gdocs/validate-document-against-schema :grid "0.0.1" bad-json))
             "Was not able to generate a schema exception"))))
   (testing
-   "Verify that if a schema is on the disabled on the ingest list, it is not ingested and an error message is returned."
+   "Verify that if a schema is on the disabled ingest list, it is not ingested and an error message is returned."
     (with-redefs [config/approved-pipeline-documents (fn [] {:grid ["0.0.1"]}) config/generic-ingest-disabled-list (fn [] [:grid])]
        (is (thrown-with-msg?
             clojure.lang.ExceptionInfo


### PR DESCRIPTION
* Adds a configuration to block specified concepts from being ingested into CMR