### PR TITLE
CMR-8775-01: Control access to Generic API ingest interfaces with a n…

### DIFF
--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -237,10 +237,10 @@
 (defconfig generic-ingest-disabled-list
   "This is a toggle to prevent specified generic concepts from being ingested into CMR,
    Should be an array of keys with the name of the schema to be blocked from ingest.
-   Example [\"grid\",\"order-option\"], would prevent grids and order options from being ingested into CMR
+   Example  \"grid,order-option\", would prevent grids and order options from being ingested into CMR
    if no concepts should be blocked from ingest set to an empty array"
   {:default []
-   :parser #(vec (map (fn [item] (keyword item)) (json/parse-string %)))})
+   :parser #(vec (map (fn [item] (keyword item)) (str/split % #",")))})
 
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -240,7 +240,7 @@
    Example  \"grid,order-option\", would prevent grids and order options from being ingested into CMR
    if no concepts should be blocked from ingest set to an empty array"
   {:default []
-   :parser #(vec (map (fn [item] (keyword item)) (str/split % #",")))})
+   :parser #(vec (map (fn [item] (keyword (str/trim item))) (str/split % #",")))})
 
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -240,7 +240,7 @@
    Example  \"grid,order-option\", would prevent grids and order options from being ingested into CMR
    if no concepts should be blocked from ingest set to an empty array"
   {:default []
-   :parser #(vec (map (fn [item] (keyword (str/trim item))) (str/split % #",")))})
+   :parser #(map (fn [item] (keyword (str/trim item))) (str/split % #","))})
 
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -240,7 +240,7 @@
    Example  \"grid,order-option\", would prevent grids and order options from being ingested into CMR
    if no concepts should be blocked from ingest set to an empty array"
   {:default []
-   :parser #(map (fn [item] (keyword (str/trim item))) (str/split % #","))})
+   :parser #(map (comp keyword str/trim) (str/split % #","))})
 
 (defn check-env-vars
   "Checks any environment variables starting with CMR_ are recognized as known environment variables.


### PR DESCRIPTION
* Simplify the defconfig env variable to a simple string and parse it so that there can be no ambiguity in how it is set on parameter store vs en variable
* Tested an upstream build from this on Friday deployed into SIT, it was working as expected