### PR TITLE
CMR-8564 - keeping tag associations is a feature not a bug

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -936,6 +936,11 @@
             (delete-associations context concept-type concept-id nil :tool-association)
             ;; delete the associated generic associations if applicable
             (delete-associations context concept-type concept-id nil :generic-association)
+
+            ;; Missing from this list is tag association, retain these records in case the
+            ;; concept is brought back to life (un-tombstoned). This is a feature not a bug
+            ;; backed up by tests in tag_association_test.clj
+
             ;; skip publication flag is set for tag association when its associated
             ;; collection revision is force deleted. In this case, the association is no longer
             ;; needed to be indexed, so we don't publish the deletion event.


### PR DESCRIPTION
researched this ticket, found tests to support the current behavior, decided to add a comment here to clearly define the behavior so that future tickets are not created and more time is spent on this because it took a lot of asking around to decide if this was expected behavior.