### PR TITLE
CMR-8712: cascading index issue

### DIFF
--- a/system-int-test/test/cmr/system_int_test/search/generic_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/generic_association_test.clj
@@ -838,27 +838,45 @@
               {:token "mock-echo-system-token"})
         coll-concept-id (:concept-id coll)
         coll-revision-id (:revision-id coll)
+
+        ;; Ingest a service
+        sv (service-util/ingest-service-with-attrs {:native-id "sv" :Name "service"})
+        sv-concept-id (:concept-id sv)
+
+        ;;Then ingest a tool
+        tl (tool-util/ingest-tool-with-attrs {:native-id "tl" :Name "tool"})
+        tl-concept-id (:concept-id tl)
         token (echo-util/login (system/context) "user1")
         _ (index/wait-until-indexed)
-        ;; associate grid and collection
+        ;; associate grid with collection,service and tool.
         _ (association-util/generic-associate-by-concept-ids-revision-ids
-           token grid-concept-id grid-revision-id [{:concept-id coll-concept-id :revision-id coll-revision-id}])
-        ;; search for the collection, the association should be there.
+           token grid-concept-id grid-revision-id [{:concept-id coll-concept-id :revision-id coll-revision-id}
+                                                   {:concept-id sv-concept-id}
+                                                   {:concept-id tl-concept-id}])
+        ;; search for the collection, service and tool, the association should be there.
         coll-search-result1 (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :grids true)
+        sv-search-result1 (get-associations-and-details "services.umm_json" "native_id=sv" :grids true)
+        tl-search-result1 (get-associations-and-details "tools.umm_json" "native_id=tl" :grids true)
 
         ;; delete the grid
         _ (gen-util/ingest-generic-document nil "PROV1" native-id :grid grid-doc :delete)
         _ (index/wait-until-indexed)
 
-        ;; search for the collection, the association shouldn't be there.
-        coll-search-result2 (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :grids true)]
+        ;; search for the collection,service and tool the association shouldn't be there.
+        coll-search-result2 (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :grids true)
+        sv-search-result2 (get-associations-and-details "services.umm-json" "native_id=sv" :grids true)
+        tl-search-result2 (get-associations-and-details "tools.umm-json" "native_id=tl" :grids true)]
     (is (= [grid-concept-id]
-           (:associations coll-search-result1)))
+           (:associations coll-search-result1)
+           (:associations sv-search-result1)
+           (:associations tl-search-result1)))
     (is (= nil
-           (:associations coll-search-result2)))))
+           (:associations coll-search-result2)
+           (:associations sv-search-result2)
+           (:associations tl-search-result2)))))
 
 (deftest test-cascading-association-deletion-for-collection
-  (let [;;First ingest a Grid concept
+  (let [;; Ingest a Grid concept
         native-id (format "Generic-Test-%s" (UUID/randomUUID))
         grid-doc gen-util/grid-good
         grid (gen-util/ingest-generic-document
@@ -866,7 +884,7 @@
         grid-concept-id (:concept-id grid)
         grid-revision-id (:revision-id grid)
 
-        ;;Then ingest a collection
+        ;;Ingest a collection
         coll (data-core/ingest-umm-spec-collection "PROV1"
               (data-umm-c/collection
                {:ShortName "coll1"
@@ -874,6 +892,10 @@
               {:token "mock-echo-system-token"})
         coll-concept-id (:concept-id coll)
         coll-revision-id (:revision-id coll)
+
+        ;; Ingest a service
+        sv (service-util/ingest-service-with-attrs {:native-id "sv" :Name "service"})
+        sv-concept-id (:concept-id sv)
 
         ;;Then ingest a tool
         tl (tool-util/ingest-tool-with-attrs {:native-id "tl" :Name "tool"})
@@ -885,28 +907,34 @@
         _ (association-util/generic-associate-by-concept-ids-revision-ids
            token grid-concept-id grid-revision-id [{:concept-id coll-concept-id :revision-id coll-revision-id}])
 
-        ;; associate tool and collection
+        ;; associate service and collection using the old association api (not allowed in the new api)
+        _ (association-util/associate-by-concept-ids
+           token sv-concept-id [{:concept-id coll-concept-id :revision-id coll-revision-id}])
+
+        ;; associate tool and collection using the old association api (not allowed in the new api)
         _ (association-util/associate-by-concept-ids
            token tl-concept-id [{:concept-id coll-concept-id :revision-id coll-revision-id}])
         
-        ;; search for the grid, the association should be there.
+        ;; search for the grid,service and tool, the association should be there.
         grid-search-result1 (get-associations-and-details "grids.json" "name=Grid-A7-v1" :collections false)
-
-        ;; search for the tool, the association should be there.
+        sv-search-result1 (get-associations-and-details "services.umm_json" "native_id=sv" :collections true)
         tl-search-result1 (get-associations-and-details "tools.umm_json" "native_id=tl" :collections true)
 
         ;; delete the collection
         _ (ingest/delete-concept (data-core/umm-c-collection->concept coll :echo10) {:accept-format :json :raw? true}) 
         _ (index/wait-until-indexed)
 
-        ;; search for the grid, the association shouldn't be there.
+        ;; search for the grid,service and tool, the association shouldn't be there.
         grid-search-result2 (get-associations-and-details "grids.json" "name=Grid-A7-v1" :collections false)
+        sv-search-result2 (get-associations-and-details "services.umm_json" "native_id=sv" :collections false)
         tl-search-result2 (get-associations-and-details "tools.umm_json" "native_id=tl" :collections false)]
     (is (= [coll-concept-id]
            (:associations grid-search-result1)
+           (:associations sv-search-result1)
            (:associations tl-search-result1)))
     (is (= nil
            (:associations grid-search-result2)
+           (:associations sv-search-result2)
            (:associations tl-search-result2)))))
 
 (deftest test-all-associations


### PR DESCRIPTION
Association delete events need to be published when collection is deleted.  Association delete events also need to be published when generic document is deleted. 