### PR TITLE
CMR-8826: Fixed searching for generic concepts by native-id.

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/generic.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/generic.clj
@@ -6,8 +6,8 @@
    [camel-snake-kebab.core :as csk]
    [cheshire.core :as json]
    [clojure.java.io :as io]
+   [clojure.string :as string]
    [cmr.common.concepts :as concepts]
-   [cmr.common.mime-types :as mtype]
    [cmr.common.util :as util]
    [cmr.indexer.data.concepts.association-util :as assoc-util]
    [cmr.indexer.data.concept-parser :as c-parser]
@@ -100,7 +100,7 @@
          :user-id user-id
          :revision-date revision-date
          :native-id native-id
-         :native-id-lowercase native-id
+         :native-id-lowercase (string/lower-case native-id)
          :associations-gzip-b64 (assoc-util/associations->gzip-base64-str generic-associations concept-id)}
         configs (gen-util/only-elastic-preferences (:Indexes index-data))
         ;; now add the configured indexes

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -4506,11 +4506,11 @@ Access to service and service association is granted through the provider via th
 
 #### <a name="service-association"></a> Service Association
 
-A service identified by its concept id can be associated with collections through a list of collection concept revisions. The service association request normally returns status code 200 with a response that consists of a list of individual service association responses, one for each service association attempted to create. Each individual service association response has an `associated_item` field and either a `service_association` field with the service association concept id and revision id when the service association succeeded or an `errors` field with detailed error message when the service association failed. The `associated_item` field value has the collection concept id and the optional revision id that is used to identify the collection during service association. Service association requires that user has update permission on INGEST_MANAGEMENT_ACL for the collection's provider. Here is a sample service association request and its response:
+A service identified by its concept id can be associated with collections through a list of collection concept revisions and an optional data payload in JSON format. The service association request normally returns status code 200 with a response that consists of a list of individual service association responses, one for each service association attempted to create. Each individual service association response has an `associated_item` field and either a `service_association` field with the service association concept id and revision id when the service association succeeded or an `errors` field with detailed error message when the service association failed. The `associated_item` field value has the collection concept id and the optional revision id that is used to identify the collection during service association. Service association requires that user has update permission on INGEST_MANAGEMENT_ACL for the collection's provider. Here is a sample service association request and its response:
 
 ```
 curl -XPOST -i -H "Content-Type: application/json" -H "Authorization: Bearer XXXXX" %CMR-ENDPOINT%/services/S1200000008-PROV1/associations -d \
-'[{"concept_id": "C1200000005-PROV1"},
+'[{"concept_id": "C1200000005-PROV1", "data": {"order_option": "OO1200445588-PROV1"}},
   {"concept_id": "C1200000006-PROV1"}]'
 
 HTTP/1.1 400 BAD REQUEST
@@ -4533,14 +4533,6 @@ Content-Length: 168
     ],
     "associated_item":{
       "concept_id":"C1200000006-PROV1"
-    }
-  },
-  {
-    "errors":[
-      "User doesn't have update permission on INGEST_MANAGEMENT_ACL for provider of collection [C1200000007-PROV2] to make the association."
-    ],
-    "associated_item":{
-      "concept_id":"C1200000007-PROV2"
     }
   }
 ]

--- a/system-int-test/test/cmr/system_int_test/search/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/generics_test.clj
@@ -114,4 +114,11 @@
           (testing "Test that generics will work with concept and revision searches."
             (let [results (search-request (format "concepts/%s/%s" concept-id revision-id) "")
                   status (:status results)]
+              (is (= 200 status) "wrong http status")))
+          
+          (testing "Search generic concept by native-id"
+            (let [results (search-request plural-concept-type-name (str "native-id=" native-id))
+                  status (:status results)
+                  body (:body results)]
+              (is (string/includes? body concept-id) "record not found")
               (is (= 200 status) "wrong http status"))))))))


### PR DESCRIPTION
This is only a quick fix of the searching issue to unblock the Legacy migration work. It does not address the missing tests of searching generic concepts by other search parameters or attempt to refactor the existing tests which will be covered in CMR-8828.