### PR TITLE
CMR-8800: Investigate re-indexing of old generic concept data to new indices

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -17,7 +17,7 @@ lein migrate
 ```
 
 You can use `lein migrate -version version` to restore the database to
-a given version. `lein migrate -version 0` will clean the datbase
+a given version. `lein migrate -version 0` will clean the database
 completely.
 
 3. Remove the user

--- a/system-int-test/src/cmr/system_int_test/utils/association_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/association_util.clj
@@ -23,7 +23,7 @@
      (ingest-util/parse-map-response response))))
 
 (defn generic-dissociate-by-concept-ids-revision-ids
-  "Associates a concept with the given concept id, revision id to a list of concept ids and revision ids."
+  "Disassociates a concept with the given concept id, revision id to a list of concept ids and revision ids."
   ([token concept-id revision-id concept-id-revision-id-list]
    (generic-dissociate-by-concept-ids-revision-ids token concept-id revision-id concept-id-revision-id-list nil))
   ([token concept-id revision-id concept-id-revision-id-list options]
@@ -56,7 +56,7 @@
      (ingest-util/parse-map-response response))))
 
 (defn associate-by-single-concept-id
-  "Associates a variable with a collection. This uses the single variable/collection assocation route."
+  "Associates a variable with a collection. This uses the single variable/collection association route."
   ([token concept-id coll-concept-id]
    (associate-by-single-concept-id token concept-id coll-concept-id nil))
   ([token concept-id coll-concept-id options]
@@ -67,7 +67,7 @@
      (ingest-util/parse-map-response response))))
 
 (defn dissociate-by-single-concept-id
-  "Dissociates a variable from a collection. This uses the single variable/collection dissocation route."
+  "Dissociates a variable from a collection. This uses the single variable/collection dissociation route."
   ([token concept-id coll-concept-id]
    (dissociate-by-single-concept-id token concept-id coll-concept-id nil))
   ([token concept-id coll-concept-id options]

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -179,7 +179,7 @@
   "Call the bootstrap app to bulk index a generic (either all of them, or just the
   ones for the given provider)."
   ([concept-type]
-   (bulk-index-generics concept-type {transmit-config/token-header (transmit-config/echo-system-token)}))
+   (bulk-index-generics concept-type nil {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([concept-type provider-id]
    (bulk-index-generics concept-type provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([concept-type provider-id headers]

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -154,11 +154,39 @@
    (bulk-index-grids nil {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([provider-id]
    (bulk-index-grids provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
-  ([provider-id headers] 
+  ([provider-id headers]
    (bulk-index-by-url
     (if (nil? provider-id)
       (url/bulk-index-grids-url)
       (url/bulk-index-grids-url provider-id))
+    headers)))
+
+(defn bulk-index-order-options
+  "Call the bootstrap app to bulk index order options (either all of them, or just the
+  ones for the given provider)."
+  ([]
+   (bulk-index-order-options nil {transmit-config/token-header (transmit-config/echo-system-token)}))
+  ([provider-id]
+   (bulk-index-order-options provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
+  ([provider-id headers]
+   (bulk-index-by-url
+    (if (nil? provider-id)
+      (url/bulk-index-order-options-url)
+      (url/bulk-index-order-options-url provider-id))
+    headers)))
+
+(defn bulk-index-generics
+  "Call the bootstrap app to bulk index a generic (either all of them, or just the
+  ones for the given provider)."
+  ([concept-type]
+   (bulk-index-grids concept-type {transmit-config/token-header (transmit-config/echo-system-token)}))
+  ([concept-type provider-id]
+   (bulk-index-grids concept-type provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
+  ([concept-type provider-id headers]
+   (bulk-index-by-url
+    (if (nil? provider-id)
+      (url/bulk-index-generics-url concept-type)
+      (url/bulk-index-generics-url concept-type provider-id))
     headers)))
 
 (defn bulk-index-provider

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -179,14 +179,14 @@
   "Call the bootstrap app to bulk index a generic (either all of them, or just the
   ones for the given provider)."
   ([concept-type]
-   (bulk-index-grids concept-type {transmit-config/token-header (transmit-config/echo-system-token)}))
+   (bulk-index-generics concept-type {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([concept-type provider-id]
-   (bulk-index-grids concept-type provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
+   (bulk-index-generics concept-type provider-id {transmit-config/token-header (transmit-config/echo-system-token)}))
   ([concept-type provider-id headers]
    (bulk-index-by-url
     (if (nil? provider-id)
-      (url/bulk-index-generics-url concept-type)
-      (url/bulk-index-generics-url concept-type provider-id))
+      (url/bulk-index-generics-url (name concept-type))
+      (url/bulk-index-generics-url (name concept-type) provider-id))
     headers)))
 
 (defn bulk-index-provider

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -11,8 +11,7 @@
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.queue :as queue]
    [cmr.system-int-test.utils.url-helper :as url]
-   [cmr.transmit.config :as transmit-config]
-   [cmr.system-int-test.utils.generic-util :as generic]))
+   [cmr.transmit.config :as transmit-config]))
 
 (defn refresh-elastic-index
   []

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -154,27 +154,6 @@
     (warn "Deleting index " index-name)
     (client/delete (format "%s/%s" (url/elastic-root) index-name)
                    {:connection-manager (s/conn-mgr)})))
-;
-; (defn delete-elasticsearch-index-generics
-;   "Helper to delete an elasticsearch index associated with a collection."
-;   ;; Pass the key for the generic and then pull out the name
-;   [generic]
-;   (let [index-name (string/replace (format "1_generic_%s" (string/lower-case (name generic)))
-;                                    #"-" "_")]
-;     (warn "Deleting index " index-name)
-;     (client/delete (format "%s/%s" (url/elastic-root) index-name)
-;                    {:connection-manager (s/conn-mgr)})))
-;
-;
-; (defn delete-elasticsearch-index-generics-all-revisions
-;   "Helper to delete an elasticsearch index associated with a generic document all revisions"
-;   ;; Pass the key for the generic and then pull out the name
-;   [generic]
-;   (let [index-name (string/replace (format "1_all_generic_%s" (str (string/lower-case (name generic)) "_revisions"))
-;                                    #"-" "_")]
-;     (warn "Deleting index " index-name)
-;     (client/delete (format "%s/%s" (url/elastic-root) index-name)
-;                    {:connection-manager (s/conn-mgr)})))
 
 (defn- query-for-granules-by-collection
   "Elasticsearch query to return all of the granules in a given collection."

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -11,7 +11,8 @@
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.queue :as queue]
    [cmr.system-int-test.utils.url-helper :as url]
-   [cmr.transmit.config :as transmit-config]))
+   [cmr.transmit.config :as transmit-config]
+   [cmr.system-int-test.utils.generic-util :as generic]))
 
 (defn refresh-elastic-index
   []
@@ -153,6 +154,27 @@
     (warn "Deleting index " index-name)
     (client/delete (format "%s/%s" (url/elastic-root) index-name)
                    {:connection-manager (s/conn-mgr)})))
+;
+; (defn delete-elasticsearch-index-generics
+;   "Helper to delete an elasticsearch index associated with a collection."
+;   ;; Pass the key for the generic and then pull out the name
+;   [generic]
+;   (let [index-name (string/replace (format "1_generic_%s" (string/lower-case (name generic)))
+;                                    #"-" "_")]
+;     (warn "Deleting index " index-name)
+;     (client/delete (format "%s/%s" (url/elastic-root) index-name)
+;                    {:connection-manager (s/conn-mgr)})))
+;
+;
+; (defn delete-elasticsearch-index-generics-all-revisions
+;   "Helper to delete an elasticsearch index associated with a generic document all revisions"
+;   ;; Pass the key for the generic and then pull out the name
+;   [generic]
+;   (let [index-name (string/replace (format "1_all_generic_%s" (str (string/lower-case (name generic)) "_revisions"))
+;                                    #"-" "_")]
+;     (warn "Deleting index " index-name)
+;     (client/delete (format "%s/%s" (url/elastic-root) index-name)
+;                    {:connection-manager (s/conn-mgr)})))
 
 (defn- query-for-granules-by-collection
   "Elasticsearch query to return all of the granules in a given collection."

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -536,6 +536,18 @@
   ([provider-id]
    (format "%s/%s" (bulk-index-grids-url) provider-id)))
 
+(defn bulk-index-order-options-url
+  ([]
+   (format "http://localhost:%s/bulk_index/order-options" (transmit-config/bootstrap-port)))
+  ([provider-id]
+   (format "%s/%s" (bulk-index-order-options-url) provider-id)))
+
+(defn bulk-index-generics-url
+  ([generic]
+   (format (str "http://localhost:%s/bulk_index/" generic) (transmit-config/bootstrap-port)))
+  ([generic provider-id]
+   (format "%s/%s" (bulk-index-generics-url generic) provider-id)))
+
 (defn bulk-index-collection-url
   []
   (format "http://localhost:%s/bulk_index/collections" (transmit-config/bootstrap-port)))

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -543,10 +543,10 @@
    (format "%s/%s" (bulk-index-order-options-url) provider-id)))
 
 (defn bulk-index-generics-url
-  ([generic]
-   (format (str "http://localhost:%s/bulk_index/" generic) (transmit-config/bootstrap-port)))
-  ([generic provider-id]
-   (format "%s/%s" (bulk-index-generics-url generic) provider-id)))
+  ([concept-type]
+   (format (str "http://localhost:%s/bulk_index/" (inf/plural concept-type)) (transmit-config/bootstrap-port)))
+  ([concept-type provider-id]
+   (format "%s/%s" (bulk-index-generics-url concept-type) provider-id)))
 
 (defn bulk-index-collection-url
   []

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
@@ -381,7 +381,7 @@
        (is (= 0 (:hits (search/find-refs :order-option {}))))
        ;; bulk index to create the indexes for the ingested grids
        (bootstrap/bulk-index-grids "PROV1")
-       (bootstrap/bulk-index-order-options "PROV1")
+       (bootstrap/bulk-index-generics :order-option "PROV1")
        (index/wait-until-indexed)
        ;; Grid and order-option should now be indexed
        (is (= 1 (:hits (search/find-refs :grid {}))))
@@ -397,7 +397,7 @@
          (is empty? (set (:association-details grid-search-pre-bulk))))
        ;; re-index the association since it was not there at the start of the test
        (bootstrap/bulk-index-grids)
-       (bootstrap/bulk-index-order-options "PROV1")
+       (bootstrap/bulk-index-generics :order-option "PROV1")
        (index/wait-until-indexed)
        ;; Should still have two indexes for both of the concepts
        (is (= 1 (:hits (search/find-refs :grid {}))))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
@@ -200,7 +200,7 @@
 (deftest ^:oracle bulk-index-generics-association
   (testing "Bulk index two grids which have been associated together and contain association details"
     (system/only-with-real-database
-    ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
       (core/disable-automatic-indexing)
       ;; Create two grids
       (let [token (echo-util/login (system/context) "user1")
@@ -240,9 +240,9 @@
 (deftest ^:oracle bulk-index-generics-association-json-endpoint
   (testing "Bulk index two grids which have been associated together and contain association details search on json endpoint"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
      (core/disable-automatic-indexing)
-  ;; Create two grids
+     ;; Create two grids
      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
@@ -281,9 +281,9 @@
 (deftest ^:oracle bulk-index-generics-multiple-associations
   (testing "Bulk index three grids multiple grids ensure associaions are returned"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
      (core/disable-automatic-indexing)
-  ;; Create two grids
+     ;; Create two grids
      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
@@ -324,9 +324,9 @@
 (deftest ^:oracle bulk-index-generics-specific-revision-id-association
   (testing "Bulk index two grids which have been associated together and contain association details between specific revisions"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
      (core/disable-automatic-indexing)
-  ;; Create two grids
+     ;; Create two grids
      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
@@ -366,9 +366,9 @@
 (deftest ^:oracle bulk-index-generics-different-concept-types
   (testing "bulk index two generic concepts which have been associated together and contain association details"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
      (core/disable-automatic-indexing)
-  ;; Create a grid and an order-option
+     ;; Create a grid and an order-option
      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            orderOption1 (generic/ingest-generic-document nil "PROV1" "oo1" :order-option generic/order-option :post)
@@ -414,9 +414,9 @@
 (deftest ^:oracle bulk-index-generics-different-providers
   (testing "bulk index two grids which have been associated together and contain association details but, belong to different providers"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      ;; Disable message publishing so items are not indexed but, they are ingested into the system.
      (core/disable-automatic-indexing)
-  ;; Create two grids
+     ;; Create two grids
      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)
@@ -454,9 +454,9 @@
 (deftest ^:oracle bulk-index-generics-different-providers-reindex-only-one
  (testing "Bulk index two grids reindex only one them"
    (system/only-with-real-database
- ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     ;; Disable message publishing so items are not indexed but, they are ingested into the system.
     (core/disable-automatic-indexing)
- ;; Create two grids of different providers
+    ;; Create two grids of different providers
     (let [token (echo-util/login (system/context) "user1")
           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
           grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)
@@ -496,9 +496,9 @@
 (deftest ^:oracle bulk-index-grids-service-association
  (testing "Bulk index a grid associated to a service verify association on the grid"
    (system/only-with-real-database
- ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     ;; Disable message publishing so items are not indexed but, they are ingested into the system.
     (core/disable-automatic-indexing)
- ;; Create two grids and a service
+    ;; Create two grids and a service
     (let [token (echo-util/login (system/context) "user1")
           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
           grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
@@ -200,10 +200,10 @@
 (deftest ^:oracle bulk-index-generics-association
   (testing "Bulk index two grids which have been associated together and contain association details"
     (system/only-with-real-database
-  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
-  (core/disable-automatic-indexing)
-  ;; Create two grids
-     (let [token (echo-util/login (system/context) "user1")
+    ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+      (core/disable-automatic-indexing)
+      ;; Create two grids
+      (let [token (echo-util/login (system/context) "user1")
            grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
            grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
            grid1-concept-id (:concept-id grid1)
@@ -261,7 +261,7 @@
        (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
                         token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data "some data" :revision-id grid2-revision-id}])
              _ (index/wait-until-indexed)
-             ;; Search using the
+             ;; Search the grid for associations
              grid-search-result (association-test/get-associations-and-details "grids.json" "native_id=tg1" :grids false)])
        ;; Associations in the index should be empty since they were not there when the record was re-indexed
        (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.json" "native_id=tg1" :grids false)]
@@ -381,7 +381,7 @@
        (is (= 0 (:hits (search/find-refs :order-option {}))))
        ;; bulk index to create the indexes for the ingested grids
        (bootstrap/bulk-index-grids "PROV1")
-       (bootstrap/bulk-index-generics :order-option "PROV1")
+       (bootstrap/bulk-index-generics :order-option)
        (index/wait-until-indexed)
        ;; Grid and order-option should now be indexed
        (is (= 1 (:hits (search/find-refs :grid {}))))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
@@ -6,15 +6,20 @@
    [cmr.system-int-test.bootstrap.bulk-index.core :as core]
    [cmr.system-int-test.data2.collection :as data-collection]
    [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.data2.umm-json :as data-umm-json]
+   [cmr.system-int-test.search.generic-association-test :as association-test]
    [cmr.system-int-test.system :as system]
-   [cmr.system-int-test.utils.association-util :as assoc-util]
+   [cmr.system-int-test.utils.association-util :as association-util]
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
    [cmr.system-int-test.utils.generic-util :as generic]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
+   [cmr.system-int-test.utils.service-util :as service-util]
+   [cmr.system-int-test.utils.tool-util :as tool-util]
    [cmr.system-int-test.utils.tool-util :as tool]
+   [cmr.system-int-test.utils.variable-util :as variable-util]
    [cmr.umm-spec.versioning :as umm-version]))
 
 (use-fixtures :each (join-fixtures
@@ -28,7 +33,7 @@
 (deftest ^:oracle bulk-index-grids-for-provider
   (testing "Bulk index grids for a single provider"
     (system/only-with-real-database
-     ;; Disable message publishing so items are not indexed.
+     ;; Disable message publishing so items are not indexed
      (core/disable-automatic-indexing)
      ;; The following is saved, but not indexed due to the above call
      (let [grid1 (generic/ingest-generic-document nil "PROV1" "Test-Native-Id-1" :grid generic/grid-good :post)
@@ -37,7 +42,7 @@
            grid2 (generic/ingest-generic-document nil "PROV2" "Test-Native-Id-1" :grid generic/grid-good :post)
            {:keys [status errors]} (bootstrap/bulk-index-grids "PROV1" nil)]
 
-       ;; The above bulk-index-grids call with nil headers has no token 
+       ;; The above bulk-index-grids call with nil headers has no token
        (is (= [401 ["You do not have permission to perform that action."]]
               [status errors]))
        (is (= 0 (:hits (search/find-refs :grid {}))))
@@ -59,10 +64,10 @@
                grid4 (generic/ingest-generic-document nil "PROV1" "Test-Native-Id-3" :grid generic/grid-good :post)
                grid5 (generic/ingest-generic-document nil "PROV1" "Test-Native-Id-4" :grid generic/grid-good :post)]
 
-          ;; The above three new grids are not indexed, only grid1 is indexed. 
+          ;; The above three new grids are not indexed, only grid1 is indexed.
           (is (= 1 (:hits (search/find-refs :grid {}))))
 
-          ;; bulk index again, all the grids in PROV1 should be indexed. 
+          ;; bulk index again, all the grids in PROV1 should be indexed.
           (bootstrap/bulk-index-grids "PROV1")
           (index/wait-until-indexed)
 
@@ -71,7 +76,7 @@
             (is (= 4 (count refs)))
             (is (= (set (map :id refs))
                    (set (map :concept-id [grid1, grid3, grid4, grid5]))))))))
-     
+
      ;; Re-enable message publishing.
      (core/reenable-automatic-indexing))))
 
@@ -115,7 +120,7 @@
                                      :user-id "user1"})
            grid1-3 (generic/ingest-generic-document nil "PROV1" "Test-Native-Id-1"
                                                     :grid generic/grid-good :put)
-           
+
            ;; Create, then update, then delete a grid for PROV2
            grid2-1 (generic/ingest-generic-document nil "PROV2" "Test-Native-Id-2"
                                                     :grid generic/grid-good :post)
@@ -126,7 +131,7 @@
                                     generic/grid-good
                                     {:deleted true
                                      :user-id "user1"})
-           
+
            ;; Create a grid for PROV3
            grid3 (generic/ingest-generic-document nil "PROV3" "Test-Native-Id-3"
                                                   :grid generic/grid-good :post)]
@@ -139,7 +144,6 @@
        ;; Just index PROV1
        (bootstrap/bulk-index-grids "PROV1")
        (index/wait-until-indexed)
-       ;;(println (search/find-concepts-umm-json :grid {:all-revisions true})) ;;REMOVEME
 
        (testing "After bulk indexing a provider, search found all grid revisions for that provider"
          (let [{:keys [status results]} (search/find-concepts-umm-json :grid {:all-revisions true})
@@ -151,30 +155,30 @@
                                 #(hash-map :concept-id (:concept-id %)
                                            :revision-id (:revision-id %))
                                 [grid1-1, grid1-2-tombstone, grid1-3])]
-           
+
            (is (= 200 status))
            (is (= 3 (:hits results)))))
 
        ;; Now index all grids
        (bootstrap/bulk-index-grids)
        (index/wait-until-indexed)
-       
-       (testing "After bulk indexing all grids, search for grids finds all revisions of all providers" 
+
+       (testing "After bulk indexing all grids, search for grids finds all revisions of all providers"
          (let [{:keys [status results]} (search/find-concepts-umm-json :grid {:all-revisions true})
                results-tuples (map
                                #(hash-map :concept-id (get-in % [:meta :concept-id])
                                           :revision-id (get-in % [:meta :revision-id]))
                                (:items results))
-               original-tuples (map 
-                                #(hash-map :concept-id (:concept-id %) 
-                                           :revision-id (:revision-id %)) 
-                                [grid1-1, grid1-2-tombstone, grid1-3, 
+               original-tuples (map
+                                #(hash-map :concept-id (:concept-id %)
+                                           :revision-id (:revision-id %))
+                                [grid1-1, grid1-2-tombstone, grid1-3,
                                  grid2-1, grid2-2, grid2-3-tombstone, grid3])]
            (is (= 200 status))
            (is (= 7 (:hits results)))
            (is (= (set results-tuples)
                   (set original-tuples)))))
-       
+
        (testing "The regular search does not include the deleted grids"
          (let [{:keys [status results]} (search/find-concepts-umm-json :grid {})
                results-tuples (map
@@ -192,3 +196,353 @@
 
        ;; Re-enable message publishing.
        (core/reenable-automatic-indexing)))))
+
+(deftest ^:oracle bulk-index-generics-association
+  (testing "Bulk index two grids which have been associated together and contain association details"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+  (core/disable-automatic-indexing)
+  ;; Create two grids
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
+           grid1-concept-id (:concept-id grid1)
+           grid2-concept-id (:concept-id grid2)
+           grid1-revision-id (:revision-id grid1)
+           grid2-revision-id (:revision-id grid2)]
+       ;; No index since they are disabled
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Grids should now be indexed
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; Associate the two grids
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data "some data" :revision-id grid2-revision-id}])
+             _ (index/wait-until-indexed)
+             grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)])
+       ;; Associations in the index should be empty since they were not there when the record was re-indexed
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for the grids
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; The association should still be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is (= (set [{:data "some data" :concept-id grid2-concept-id :revision-id grid2-revision-id}])
+                (set (:association-details grid-search-result2))))))
+    ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-association-json-endpoint
+  (testing "Bulk index two grids which have been associated together and contain association details search on json endpoint"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     (core/disable-automatic-indexing)
+  ;; Create two grids
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
+           grid1-concept-id (:concept-id grid1)
+           grid2-concept-id (:concept-id grid2)
+           grid1-revision-id (:revision-id grid1)
+           grid2-revision-id (:revision-id grid2)]
+       ;; No index since they are disabled
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Grids should now be indexed
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; Associate the two grids
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data "some data" :revision-id grid2-revision-id}])
+             _ (index/wait-until-indexed)
+             ;; Search using the
+             grid-search-result (association-test/get-associations-and-details "grids.json" "native_id=tg1" :grids false)])
+       ;; Associations in the index should be empty since they were not there when the record was re-indexed
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.json" "native_id=tg1" :grids false)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for the grids
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; The association should still be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.json" "native_id=tg1" :grids false)]
+         (is (= (set [{:data "some data", :concept-id grid2-concept-id :revision-id grid2-revision-id}])
+                (set (:association-details grid-search-result2))))))
+     ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-multiple-associations
+  (testing "Bulk index three grids multiple grids ensure associaions are returned"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     (core/disable-automatic-indexing)
+  ;; Create two grids
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
+           grid3 (generic/ingest-generic-document nil "PROV1" "tg3" :grid generic/grid-good :post)
+           grid1-concept-id (:concept-id grid1)
+           grid2-concept-id (:concept-id grid2)
+           grid3-concept-id (:concept-id grid3)
+           grid1-revision-id (:revision-id grid1)
+           grid2-revision-id (:revision-id grid2)
+           grid3-revision-id (:revision-id grid3)]
+       ;; No indicies since they are disabled
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; three Grids should now be indexed
+       (is (= 3 (:hits (search/find-refs :grid {}))))
+       ;; Associate the grids
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data "some data" :revision-id grid2-revision-id}, {:concept-id grid3-concept-id :data "some other data" :revision-id grid3-revision-id}])
+             _ (index/wait-until-indexed)
+             grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)])
+       ;; Associations in the index should be empty since they were not there when the record was re-indexed
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for the grids
+       (is (= 3 (:hits (search/find-refs :grid {}))))
+       ;; The association should still be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is (= (set [{:data "some data", :concept-id grid2-concept-id :revision-id grid2-revision-id}, {:data "some other data", :concept-id grid3-concept-id :revision-id grid3-revision-id}])
+                (set (:association-details grid-search-result2))))))
+     ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-specific-revision-id-association
+  (testing "Bulk index two grids which have been associated together and contain association details between specific revisions"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     (core/disable-automatic-indexing)
+  ;; Create two grids
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           grid2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
+           updated-grid-2 (generic/ingest-generic-document nil "PROV1" "tg2" :grid generic/grid-good :post)
+           grid1-concept-id (:concept-id grid1)
+           grid2-concept-id (:concept-id grid2)
+           grid1-revision-id (:revision-id grid1)
+           updated-grid-2-revision-id (:revision-id updated-grid-2)]
+       ;; No index since they are disabled
+       (is (= 2 updated-grid-2-revision-id))
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Grids should now be indexed
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; Associate the two grids
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data "some data" :revision-id 1}])
+             _ (index/wait-until-indexed)
+             grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)])
+       ;; Associations in the index should be empty since they were not there when the record was re-indexed
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids "PROV1")
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for the grids
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; The association should still be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is (= (set [{:data "some data", :concept-id grid2-concept-id :revision-id 1}])
+                (set (:association-details grid-search-result2))))))
+     ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-different-concept-types
+  (testing "bulk index two generic concepts which have been associated together and contain association details"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     (core/disable-automatic-indexing)
+  ;; Create a grid and an order-option
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           orderOption1 (generic/ingest-generic-document nil "PROV1" "oo1" :order-option generic/order-option :post)
+           grid1-concept-id (:concept-id grid1)
+           orderOption1-concept-id (:concept-id orderOption1)
+           grid1-revision-id (:revision-id grid1)
+           orderOption1-revision-id (:revision-id orderOption1)]
+       ;; No index since they are disabled
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       (is (= 0 (:hits (search/find-refs :order-option {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids "PROV1")
+       (bootstrap/bulk-index-order-options "PROV1")
+       (index/wait-until-indexed)
+       ;; Grid and order-option should now be indexed
+       (is (= 1 (:hits (search/find-refs :grid {}))))
+       (is (= 1 (:hits (search/find-refs :order-option {}))))
+       ;; Associate the the grid and the order-option
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id orderOption1-concept-id :data "some data" :revision-id orderOption1-revision-id}])
+             _ (index/wait-until-indexed)
+             grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :order-options true)]
+             (is (= 200 (:status response1))))
+       ;; Associations in the index should be empty since they were not there when the record was re-indexed
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :order-options true)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids)
+       (bootstrap/bulk-index-order-options "PROV1")
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for both of the concepts
+       (is (= 1 (:hits (search/find-refs :grid {}))))
+       (is (= 1 (:hits (search/find-refs :order-option {}))))
+       ;; The association should still be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :order-options true) order-option-search (association-test/get-associations-and-details "order-options.umm_json" "native_id=oo1" :grids true)]
+         (is (= (set [{:data "some data", :concept-id orderOption1-concept-id :revision-id orderOption1-revision-id}])
+                (set (:association-details grid-search-result2))))
+         (is (= (set [{:data "some data", :concept-id grid1-concept-id :revision-id grid1-revision-id}])
+                (set (:association-details order-option-search))))))
+      ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-different-providers
+  (testing "bulk index two grids which have been associated together and contain association details but, belong to different providers"
+    (system/only-with-real-database
+  ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+     (core/disable-automatic-indexing)
+  ;; Create two grids
+     (let [token (echo-util/login (system/context) "user1")
+           grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+           grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)
+           grid1-concept-id (:concept-id grid1)
+           grid2-concept-id (:concept-id grid2)
+           grid1-revision-id (:revision-id grid1)
+           grid2-revision-id (:revision-id grid2)]
+       ;; No index since they are disabled
+       (is (= 0 (:hits (search/find-refs :grid {}))))
+       ;; bulk index to create the indexes for the ingested grids
+       (bootstrap/bulk-index-grids)
+       (index/wait-until-indexed)
+       ;; Grids should now be indexed
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; Associate the two grids
+       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                        token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :revision-id grid2-revision-id}])
+             _ (index/wait-until-indexed)
+             grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is (= 200 (:status response1))))
+       (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is empty? (set (:association-details grid-search-pre-bulk))))
+       ;; re-index the association since it was not there at the start of the test
+       (bootstrap/bulk-index-grids)
+       (index/wait-until-indexed)
+       ;; Should still have two indexes for the grids
+       (is (= 2 (:hits (search/find-refs :grid {}))))
+       ;; The association should now be indexed
+       (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+         (is (= (set [{:data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :concept-id grid2-concept-id :revision-id grid2-revision-id}])
+                (set (:association-details grid-search-result2))))))
+     ;; Reenable message publishing
+     (core/reenable-automatic-indexing))))
+
+(deftest ^:oracle bulk-index-generics-different-providers-reindex-only-one
+ (testing "Bulk index two grids reindex only one them"
+   (system/only-with-real-database
+ ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+    (core/disable-automatic-indexing)
+ ;; Create two grids of different providers
+    (let [token (echo-util/login (system/context) "user1")
+          grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+          grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)
+          grid1-concept-id (:concept-id grid1)
+          grid2-concept-id (:concept-id grid2)
+          grid1-revision-id (:revision-id grid1)
+          grid2-revision-id (:revision-id grid2)]
+      ;; No index since they are disabled
+      (is (= 0 (:hits (search/find-refs :grid {}))))
+      ;; bulk index to create the indexes for the ingested grids
+      (bootstrap/bulk-index-grids)
+      (index/wait-until-indexed)
+      ;; Grids should now be indexed
+      (is (= 2 (:hits (search/find-refs :grid {}))))
+      ;; Associate the two grids
+      (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                       token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :revision-id grid2-revision-id}])
+            _ (index/wait-until-indexed)
+            grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)])
+      ;; Associations in the index should be empty since they were not there when the record was re-indexed
+      (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]
+        (is empty? (set (:association-details grid-search-pre-bulk))))
+      ;; re-index the association since it was not there at the start of the test
+      (bootstrap/bulk-index-grids "PROV2")
+      (index/wait-until-indexed)
+      ;; Should still have two indexes for the grids
+      (is (= 2 (:hits (search/find-refs :grid {}))))
+      ;; The association should be empty since it was not reindexed the PROV1 grid, but, since PROV2 was reindexed it should contain an assocaiation record
+      (let [grid-search-result-prov1 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true) grid-search-result-prov2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg2" :grids true)]
+        (is (= (set {})
+               (set (:association-details grid-search-result-prov1))))
+        (is (= (set [{:data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :concept-id grid1-concept-id :revision-id grid1-revision-id}])
+               (set (:association-details grid-search-result-prov2)))))))
+    ;; Reenable message publishing
+    (core/reenable-automatic-indexing)))
+
+(deftest ^:oracle bulk-index-grids-service-association
+ (testing "Bulk index a grid associated to a service verify association on the grid"
+   (system/only-with-real-database
+ ;; Disable message publishing so items are not indexed but, they are ingested into the system.
+    (core/disable-automatic-indexing)
+ ;; Create two grids and a service
+    (let [token (echo-util/login (system/context) "user1")
+          grid1 (generic/ingest-generic-document nil "PROV1" "tg1" :grid generic/grid-good :post)
+          grid2 (generic/ingest-generic-document nil "PROV2" "tg2" :grid generic/grid-good :post)
+          grid1-concept-id (:concept-id grid1)
+          grid2-concept-id (:concept-id grid2)
+          grid1-revision-id (:revision-id grid1)
+          grid2-revision-id (:revision-id grid2)
+          sv1 (service-util/ingest-service-with-attrs {:native-id "sv1"
+                                                       :Name "service1"})
+          sv1-concept-id (:concept-id sv1)
+          sv1-revision-id (:revision-id sv1)]
+      ;; No index since they are disabled
+      (is (= 0 (:hits (search/find-refs :grid {}))))
+      (is (= 0 (:hits (search/find-refs :service {}))))
+      ;; bulk index to create the indexes for the ingested grids and the service
+      (bootstrap/bulk-index-grids)
+      (bootstrap/bulk-index-services)
+      (index/wait-until-indexed)
+      ;; the Grids and the service should now be indexed
+      (is (= 2 (:hits (search/find-refs :grid {}))))
+      (is (= 1 (:hits (search/find-refs :service {}))))
+      ;; Associate the two grids and associate the service to one of the grids
+      (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
+                       token grid1-concept-id grid1-revision-id [{:concept-id grid2-concept-id :data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :revision-id grid2-revision-id}])
+            serviceAssociation  (association-util/generic-associate-by-concept-ids-revision-ids token sv1-concept-id sv1-revision-id [{:concept-id grid1-concept-id :data "Some data" :revision-id grid1-revision-id}])
+            _ (index/wait-until-indexed)
+            grid-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :services true)
+            service-search-result (association-test/get-associations-and-details "services.umm_json" "native_id=sv1" :grids true)]
+            (is (= 200 (:status serviceAssociation))))
+      ;; Associations in the index should be empty since they were not there when the record was re-indexed
+      (let [grid-search-pre-bulk (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :services true)]
+        (is empty? (set (:association-details grid-search-pre-bulk))))
+      ;; re-index the association since it was not there at the start of the test
+      (bootstrap/bulk-index-grids)
+      (bootstrap/bulk-index-services)
+      (index/wait-until-indexed)
+      ;; Should still have two indexes for the grids and one for the service
+      (is (= 2 (:hits (search/find-refs :grid {}))))
+      (is (= 1 (:hits (search/find-refs :service {}))))
+      ;; The association should exist for both the service-grid ns well as the grid-grids
+      (let [grid-service-assocaition-search-result (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :services true) grid-search-result-prov2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg2" :grids true)]
+        (is (= (set [{:concept-id sv1-concept-id :data "Some data" :revision-id sv1-revision-id}])
+               (set (:association-details grid-service-assocaition-search-result))))
+        (is (= (set [{:data {:convert-format {:XYZ "ZYX"} :allow-regridding "true"} :concept-id grid1-concept-id :revision-id grid1-revision-id}])
+               (set (:association-details grid-search-result-prov2)))))))
+    ;; Reenable message publishing
+    (core/reenable-automatic-indexing)))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj
@@ -312,7 +312,7 @@
        ;; re-index the association since it was not there at the start of the test
        (bootstrap/bulk-index-grids "PROV1")
        (index/wait-until-indexed)
-       ;; Should still have two indexes for the grids
+       ;; Should still have three indexes for the grids
        (is (= 3 (:hits (search/find-refs :grid {}))))
        ;; The association should still be indexed
        (let [grid-search-result2 (association-test/get-associations-and-details "grids.umm_json" "native_id=tg1" :grids true)]

--- a/system-int-test/test/cmr/system_int_test/search/generic_association_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/generic_association_test.clj
@@ -41,8 +41,8 @@
         :throw-exceptions false}
        (client/request))))
 
-(defn- get-associations-and-details
-  "Get the search result and extract asssociations and association-details."
+(defn get-associations-and-details
+  "Get the search result and extract associations and association-details."
   [concept-type-ext params concept-type-plural meta?]
   (let [search-result (search-request concept-type-ext params)
         search-body (json/parse-string (:body search-result) true)
@@ -88,8 +88,8 @@
         coll2-concept-id (:concept-id coll2)
         coll2-revision-id (:revision-id coll2)
         _ (index/wait-until-indexed)
-        tl1 (tool-util/ingest-tool-with-attrs {:native-id "tl1" :Name "tool1"}) 
-        tl2 (tool-util/ingest-tool-with-attrs {:native-id "tl2" :Name "tool2"}) 
+        tl1 (tool-util/ingest-tool-with-attrs {:native-id "tl1" :Name "tool1"})
+        tl2 (tool-util/ingest-tool-with-attrs {:native-id "tl2" :Name "tool2"})
         tl1-concept-id (:concept-id tl1)
         tl1-revision-id (:revision-id tl1)
         tl2-concept-id (:concept-id tl2)
@@ -129,8 +129,8 @@
              
     (testing "Associate tool with tool by concept-id and revision-ids"
       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
-                       token tl2-concept-id tl2-revision-id [{:concept-id tl1-concept-id  :revision-id tl1-revision-id}])
-            ;;Switch the position of tl1 and tl2 should return the same concept-id and revision-id is increased by 1.
+                       token tl2-concept-id tl2-revision-id [{:concept-id tl1-concept-id :revision-id tl1-revision-id}])
+            ;; Switch the position of tl1 and tl2 should return the same concept-id and revision-id is increased by 1.
             response2 (association-util/generic-associate-by-concept-ids-revision-ids
                        token tl1-concept-id tl1-revision-id [{:concept-id tl2-concept-id :revision-id tl2-revision-id}])
             ;;Try to associate tl1 with tl2 by concept-id only. This shouldn't be allowed.
@@ -196,17 +196,17 @@
             ;;Switch the position of grid and tool should return the same concept-id and revision-id is increased by 1.
             response2 (association-util/generic-associate-by-concept-ids-revision-ids
                        token tl1-concept-id tl1-revision-id [{:concept-id grid-concept-id :revision-id grid-revision-id}])
-            ;;Try to associate grid with tool by concept-id only. This shouldn't be allowed.
-            ;;Try to associate tool with grid by conept-id only,  This shouldn't be allowed.
-            ;;The following association is trying to do both of the above.
+            ;; Try to associate grid with tool by concept-id only. This shouldn't be allowed.
+            ;; Try to associate tool with grid by conept-id only,  This shouldn't be allowed.
+            ;; The following association is trying to do both of the above.
             response3 (association-util/generic-associate-by-concept-ids-revision-ids
                        token grid-concept-id nil [{:concept-id tl1-concept-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the grid, it should return the association
+            ;; Search for the grid, it should return the association
             grid-search-result (get-associations-and-details "grids.json" "name=Grid-A7-v1" :tools false)
 
-            ;;Search for the tool, it should return the association
+            ;; Search for the tool, it should return the association
             tl1-search-result (get-associations-and-details "tools.umm_json" "native_id=tl1" :grids true)
 
             ;;Update the tool and the grid, search for the grid and the tool, it should return the association.
@@ -216,15 +216,15 @@
 
             tl1-search-result-update (get-associations-and-details "tools.umm_json" "native_id=tl1" :grids true)
 
-            ;;Dissociate the association
+            ;; Dissociate the association
             response4 (association-util/generic-dissociate-by-concept-ids-revision-ids
                        token tl1-concept-id tl1-revision-id [{:concept-id grid-concept-id :revision-id grid-revision-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the grid again, it should NOT return the association
+            ;; Search for the grid again, it should NOT return the association
             grid-search-result1 (get-associations-and-details "grids.json" "name=Grid-A7-v1" :tools false)
 
-            ;;Search for the tool again, it should NOT return the association
+            ;; Search for the tool again, it should NOT return the association
             tl1-search-result1 (get-associations-and-details "tools.umm_json" "native_id=tl1" :grids true)]
         ;; The first and second associations are successful
         (is (= 200 (:status response1) (:status response2)))
@@ -279,7 +279,7 @@
         grid-concept-id (:concept-id grid)
         grid-revision-id (:revision-id grid)
 
-        ;;Then ingest two collections and two services 
+        ;; Then ingest two collections and two services
         coll1 (data-core/ingest-umm-spec-collection "PROV1"
                                                     (data-umm-c/collection
                                                      {:ShortName "coll1"
@@ -296,9 +296,9 @@
         coll2-revision-id (:revision-id coll2)
         _ (index/wait-until-indexed)
         sv1 (service-util/ingest-service-with-attrs {:native-id "sv1"
-                                                     :Name "service1"}) 
+                                                     :Name "service1"})
         sv2 (service-util/ingest-service-with-attrs {:native-id "sv2"
-                                                     :Name "service2"}) 
+                                                     :Name "service2"})
         sv1-concept-id (:concept-id sv1)
         sv1-revision-id (:revision-id sv1)
         sv2-concept-id (:concept-id sv2)
@@ -309,13 +309,13 @@
                        token sv1-concept-id [{:concept-id coll1-concept-id :revision-id coll1-revision-id}
                                              {:concept-id coll2-concept-id :data "some data"}])
             _ (index/wait-until-indexed)
-            ;;Search for the service sv1, it should return the association
+            ;; Search for the service sv1, it should return the association
             sv1-search-result (get-associations-and-details "services.umm_json" "native_id=sv1" :collections true)
 
-            ;;Search for the collection coll1, it should return the association
+            ;; Search for the collection coll1, it should return the association
             coll1-search-result (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :services true)
 
-            ;;Search for the collection coll2, it should return the association
+            ;; Search for the collection coll2, it should return the association
             coll2-search-result (get-associations-and-details "collections.umm-json" "entry_title=entry-title2" :services true)]
         (is (= 200 (:status response1)))
 
@@ -337,31 +337,31 @@
     (testing "Associate service with service by concept-id and revision-ids"
       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
                        token sv2-concept-id sv2-revision-id [{:concept-id sv1-concept-id  :revision-id sv1-revision-id}])
-            ;;Switch the position of sv1 and sv2 should return the same concept-id and revision-id is increased by 1.
+            ;; Switch the position of sv1 and sv2 should return the same concept-id and revision-id is increased by 1.
             response2 (association-util/generic-associate-by-concept-ids-revision-ids
                        token sv1-concept-id sv1-revision-id [{:concept-id sv2-concept-id :revision-id sv2-revision-id}])
-            ;;Try to associate sv1 with sv2 by concept-id only. This shouldn't be allowed.
-            ;;Try to associate sv2 with sv1 by conept-id only,  This shouldn't be allowed.
-            ;;The following association is trying to do both of the above.
+            ;; Try to associate sv1 with sv2 by concept-id only. This shouldn't be allowed.
+            ;; Try to associate sv2 with sv1 by conept-id only,  This shouldn't be allowed.
+            ;; The following association is trying to do both of the above.
             response3 (association-util/generic-associate-by-concept-ids-revision-ids
                        token sv2-concept-id nil [{:concept-id sv1-concept-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the service sv1, it should return the association
+            ;; Search for the service sv1, it should return the association
             sv1-search-result (get-associations-and-details "services.umm_json" "native_id=sv1" :services true)
 
-            ;;Search for the service sv2, it should return the association
+            ;; Search for the service sv2, it should return the association
             sv2-search-result (get-associations-and-details "services.umm_json" "native_id=sv2" :services true)
 
-            ;;Dissociate the association
+            ;; Dissociate the association
             response4 (association-util/generic-dissociate-by-concept-ids-revision-ids
                        token sv1-concept-id sv1-revision-id [{:concept-id sv2-concept-id :revision-id sv2-revision-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the service sv1 again, it should NOT return the association
+            ;; Search for the service sv1 again, it should NOT return the association
             sv1-search-result1 (get-associations-and-details "services.umm_json" "native_id=sv1" :services true)
 
-            ;;Search for the service sv2 again, it should NOT return the association
+            ;; Search for the service sv2 again, it should NOT return the association
             sv2-search-result1 (get-associations-and-details "services.umm_json" "native_id=sv2" :services true)]
         ;; The first and second associations are successful
         (is (= 200 (:status response1) (:status response2)))
@@ -663,21 +663,21 @@
                        token coll2-concept-id nil [{:concept-id coll1-concept-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the collection coll1, it should return the association
+            ;; Search for the collection coll1, it should return the association
             coll1-search-result (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :collections true)
 
-            ;;Search for the collection coll2, it should return the association
+            ;; Search for the collection coll2, it should return the association
             coll2-search-result (get-associations-and-details "collections.umm-json" "entry_title=entry-title2" :collections true)
 
-            ;;Dissociate the association
+            ;; Dissociate the association
             response4 (association-util/generic-dissociate-by-concept-ids-revision-ids
                        token coll1-concept-id coll1-revision-id [{:concept-id coll2-concept-id :revision-id coll2-revision-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the collection coll1 again, it should NOT return the association
+            ;; Search for the collection coll1 again, it should NOT return the association
             coll1-search-result1 (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :collections true)
 
-            ;;Search for the collection coll2 again, it should NOT return the association
+            ;; Search for the collection coll2 again, it should NOT return the association
             coll2-search-result1 (get-associations-and-details "collections.umm-json" "entry_title=entry-title2" :collections true)]
         ;; The first and second associations are successful
         (is (= 200 (:status response1) (:status response2)))
@@ -726,7 +726,7 @@
         grid-concept-id (:concept-id grid)
         grid-revision-id (:revision-id grid)
 
-        ;;Then ingest a collection
+        ;; Then ingest a collection
         coll (data-core/ingest-umm-spec-collection "PROV1"
               (data-umm-c/collection
                {:ShortName "coll1"
@@ -748,31 +748,31 @@
     (testing "Associate grid with collection by concept-id and revision-ids"
       (let [response1 (association-util/generic-associate-by-concept-ids-revision-ids
                        token grid-concept-id grid-revision-id [{:concept-id coll-concept-id :revision-id coll-revision-id}])
-            ;;Switch the position of grid and collection should return the same concept-id and revision-id is increased by 1.
+            ;; Switch the position of grid and collection should return the same concept-id and revision-id is increased by 1.
             response2 (association-util/generic-associate-by-concept-ids-revision-ids
                        token coll-concept-id coll-revision-id [{:concept-id grid-concept-id :revision-id grid-revision-id}])
-            ;;Try to associate grid with collection by concept-id only. This shouldn't be allowed.
-            ;;Try to associate collection with grid by conept-id only,  This shouldn't be allowed.
-            ;;The following association is trying to do both of the above.
+            ;; Try to associate grid with collection by concept-id only. This shouldn't be allowed.
+            ;; Try to associate collection with grid by conept-id only,  This shouldn't be allowed.
+            ;; The following association is trying to do both of the above.
             response3 (association-util/generic-associate-by-concept-ids-revision-ids
                        token grid-concept-id nil [{:concept-id coll-concept-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the grid, it should return the association
+            ;; Search for the grid, it should return the association
             grid-search-result (get-associations-and-details "grids.json" "name=Grid-A7-v1" :collections false)
 
-            ;;Search for the collection, it should return the association
+            ;; Search for the collection, it should return the association
             coll-search-result (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :grids true)
 
-            ;;Dissociate the association
+            ;; Dissociate the association
             response4 (association-util/generic-dissociate-by-concept-ids-revision-ids
                        token coll-concept-id coll-revision-id [{:concept-id grid-concept-id :revision-id grid-revision-id}])
             _ (index/wait-until-indexed)
 
-            ;;Search for the grid again, it should NOT return the association
+            ;; Search for the grid again, it should NOT return the association
             grid-search-result1 (get-associations-and-details "grids.json" "name=Grid-A7-v1" :collections false)
 
-            ;;Search for the collection again, it should NOT return the association
+            ;; Search for the collection again, it should NOT return the association
             coll-search-result1 (get-associations-and-details "collections.umm-json" "entry_title=entry-title1" :grids true)]
 
         ;; The first and second associations are successful
@@ -820,7 +820,7 @@
                (:associations coll-search-result1)))))))
 
 (deftest test-all-associations
-  (let [;; ingest two collections - the first for the test, and the second to put more assocation
+  (let [;; ingest two collections - the first for the test, and the second to put more association
         ;; data into the cmr_associations table.
         coll (data-core/ingest-umm-spec-collection "PROV1"
                                                    (data-umm-c/collection


### PR DESCRIPTION
* Adds some test coverage for associations and bulk indexing of generics
* Ticket CMR-8831 written to address some issues with re-indexing associations of non-generics
* Fixes some other minor things seen in related files most was on `system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/generics_test.clj`