### PR TITLE
CMR-8839: Sanitize some of the search responses with user input

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
+++ b/common-app-lib/src/cmr/common_app/services/search/elastic_search_index.clj
@@ -197,9 +197,9 @@
            "with aggregations" (pr-str aggregations)
            "and highlights" (pr-str highlights))
     (when-let [scroll-id (:scroll-id query-map)]
-      (info "Using scroll-id" scroll-id))
+      (debug "Using scroll-id" scroll-id))
     (when-let [search-after (:search_after query-map)]
-      (info "Using search-after" search-after))
+      (debug "Using search-after" (pr-str search-after)))
     (let [response (send-query context index-info query-map)]
       ;; Replace the Elasticsearch field names with their query model field names within the results
       (update-in response [:hits :hits]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -26,6 +26,7 @@
                  [commons-codec/commons-codec "1.11"]
                  [compojure "1.6.1"]
                  [environ "1.1.0"]
+                 [hiccup "1.0.5"]
                  [inflections "0.13.0"]
                  [instaparse "1.4.10"]
                  [nasa-cmr/cmr-schemas "0.0.1-SNAPSHOT"]

--- a/common-lib/src/cmr/common/mime_types.clj
+++ b/common-lib/src/cmr/common/mime_types.clj
@@ -232,7 +232,7 @@
                          (format->mime-type (get extension-aliases extension-key extension-key)))]
        (if (and (some? valid-mime-types) (not (contains? valid-mime-types (base-mime-type-of mime-type))))
          (svc-errors/throw-service-error
-          :bad-request (format "The URL extension [%s] is not supported." extension))
+          :bad-request (format "The URL extension [%s] is not supported." (util/html-escape extension)))
          mime-type)))))
 
 (defn extract-header-mime-type
@@ -245,4 +245,4 @@
         (when validate?
           (svc-errors/throw-service-error
             :bad-request (format "The mime types specified in the %s header [%s] are not supported."
-                                 header header-value))))))
+                                 header (util/html-escape header-value)))))))

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -14,7 +14,8 @@
    [clojure.walk :as w]
    [cmr.common.config :as cfg]
    [cmr.common.log :refer (debug info warn error)]
-   [cmr.common.services.errors :as errors])
+   [cmr.common.services.errors :as errors]
+   [hiccup.util :as hp-util])
   (:import
    (java.text DecimalFormat)
    (java.util.zip GZIPInputStream GZIPOutputStream)
@@ -1067,3 +1068,8 @@
   (if (string? s)
     (read-string s)
     s))
+
+(defn html-escape
+  "Html escape the given string. it is used to deal with potential xss issues in user input."
+  [s]
+  (hp-util/escape-html s))

--- a/search-app/src/cmr/search/services/messages/attribute_messages.clj
+++ b/search-app/src/cmr/search/services/messages/attribute_messages.clj
@@ -1,5 +1,7 @@
 (ns cmr.search.services.messages.attribute-messages
-  "Contains messages for reporting responses to the user")
+  "Contains messages for reporting responses to the user"
+  (:require
+   [cmr.common.util :as util]))
 
 ;; Client error messages
 
@@ -10,11 +12,11 @@
 
 (defn invalid-type-msg
   [type]
-  (format "[%s] is an invalid type" (str type)))
+  (format "[%s] is an invalid type" (util/html-escape (str type))))
 
 (defn invalid-value-msg
   [type value]
-  (format "[%s] is an invalid value for type [%s]" (pr-str value) (name type)))
+  (format "[%s] is an invalid value for type [%s]" (util/html-escape (pr-str value)) (name type)))
 
 (defn invalid-name-msg
   [n]

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -563,10 +563,9 @@
         (reduce
          (fn [errors value]
            (if-not (valid-value-for-date-field? value date-field)
-             (conj errors (format (str "%s [%s] within [temporal_facet] is not a valid %s. "
+             (conj errors (format (str "%s within [temporal_facet] is not a valid %s. "
                                        "%ss must be between 1 and %d.")
                                   (s/capitalize (name date-field))
-                                  value
                                   (name date-field)
                                   (s/capitalize (name date-field))
                                   (max-value-for-date-field date-field)))

--- a/search-app/src/cmr/search/services/parameters/validation/util.clj
+++ b/search-app/src/cmr/search/services/parameters/validation/util.clj
@@ -2,7 +2,8 @@
   "Contains utility functions for validating parameters."
   (:require
    [camel-snake-kebab.core :as csk]
-   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]))
+   [cmr.common-app.services.search.parameters.converters.nested-field :as nf]
+   [cmr.common.util :as util]))
 
 (defn nested-field-validation-for-subfield
   "Validates that the provided subfield is valid for the given nested field."
@@ -17,7 +18,7 @@
               (if-not (some #{param} (nf/get-subfield-names field))
                 (conj errors (format (str "Parameter [%s] is not a valid [%s] search term. "
                                           "The valid search terms are %s.")
-                                     (name param)
+                                     (util/html-escape (name param))
                                      (csk/->snake_case_string field)
                                      (nf/get-printable-subfields field)))
                 errors))

--- a/system-int-test/test/cmr/system_int_test/search/collection_psa_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_psa_search_test.clj
@@ -1101,23 +1101,23 @@
 
     "Invalid int"
     {:additional_attribute_value {:type "int" :name "B" :value "1"}}
-    ["[\"1\"] is an invalid value for type [int]"]
+    ["[&quot;1&quot;] is an invalid value for type [int]"]
 
     "Invalid float"
     {:additional_attribute_value {:type "float" :name "B" :value "1.42"}}
-    ["[\"1.42\"] is an invalid value for type [float]"]
+    ["[&quot;1.42&quot;] is an invalid value for type [float]"]
 
     "Invalid datetime"
     {:additional_attribute_value {:type "datetime" :name "B" :value "2012-01-11 10:00:00"}}
-    ["[\"2012-01-11 10:00:00\"] is an invalid value for type [datetime]"]
+    ["[&quot;2012-01-11 10:00:00&quot;] is an invalid value for type [datetime]"]
 
     "Invalid date"
     {:additional_attribute_value {:type "date" :name "B" :value "10:00:00Z"}}
-    ["[\"10:00:00Z\"] is an invalid value for type [date]"]
+    ["[&quot;10:00:00Z&quot;] is an invalid value for type [date]"]
 
     "Invalid time"
     {:additional_attribute_value {:type "time" :name "B" :value "2012-01-11"}}
-    ["[\"2012-01-11\"] is an invalid value for type [time]"]
+    ["[&quot;2012-01-11&quot;] is an invalid value for type [time]"]
 
     "Invalid use of exclude-boundary"
     {:additional_attribute_value {:type "string" :name "a" :value "b" :exclude_boundary true}}
@@ -1161,8 +1161,8 @@
 
     "Multiple errors can be returned"
     {:additional_attribute_range {:type "float" :name "B" :min_value "1.42" :max_value "foo"}}
-    ["[\"foo\"] is an invalid value for type [float]"
-     "[\"1.42\"] is an invalid value for type [float]"]))
+    ["[&quot;foo&quot;] is an invalid value for type [float]"
+     "[&quot;1.42&quot;] is an invalid value for type [float]"]))
 
 (deftest dif-extended-metadata-test
   (let [dif9-coll (data-core/ingest-concept-with-metadata-file

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -1064,11 +1064,18 @@
 
 (deftest search-errors-in-json-or-xml-format
   (testing "invalid format"
-    (is (= {:errors ["The mime types specified in the accept header [application/echo11+xml] are not supported."],
-            :status 400}
+    (is (= {:status 400,
+            :errors ["The mime types specified in the accept header [application/echo11+xml] are not supported."]}
            (search/get-search-failure-xml-data
              (search/find-concepts-in-format
                "application/echo11+xml" :collection {})))))
+  
+  (testing "invalid format html escape"
+    (is (= {:status 400,
+            :errors ["The mime types specified in the accept header [application/html &quot;qss=&quot;QssAttrValue] are not supported."]}
+           (search/get-search-failure-xml-data
+            (search/find-concepts-in-format
+             "application/html \"qss=\"QssAttrValue" :collection {})))))
 
   (is (= {:status 400,
           :errors ["Parameter [unsupported] was not recognized."]}

--- a/system-int-test/test/cmr/system_int_test/search/granule_concept_retrieval_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_concept_retrieval_test.clj
@@ -131,4 +131,21 @@
             err-msg (first (:errors (json/decode (:body response) true)))]
         (is (= 400 (:status response)))
         (is (= "The URL extension [html] is not supported."
+               err-msg))))
+    (testing "unsupported formats with html escape"
+      (let [response (search/retrieve-concept
+                      gran-concept-id nil
+                      {:headers {transmit-config/token-header user1-token}
+                       :accept "application/html \"qss=\"QssAttrValue"})
+            err-msg (first (search/safe-parse-error-xml (:body response)))]
+        (is (= 400 (:status response)))
+        (is (= "The mime types specified in the accept header [application/html &quot;qss=&quot;QssAttrValue] are not supported."
+             err-msg)))
+      (let [response (search/retrieve-concept
+                      gran-concept-id nil
+                      {:headers {transmit-config/token-header user1-token}
+                       :url-extension "application/html \"qss=\"QssAttrValue"})
+            err-msg (first (search/safe-parse-error-xml (:body response)))]
+        (is (= 400 (:status response)))
+        (is (= "The URL extension [application/html &quot;qss=&quot;QssAttrValue] is not supported."
                err-msg))))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_temporal_facet_search_test.clj
@@ -106,10 +106,10 @@
             "The valid search terms are [\"year\" \"month\" \"day\"].")]
 
       "Invalid year" {"temporal_facet[0][year]" -3}
-      ["Year [-3] within [temporal_facet] is not a valid year. Years must be between 1 and 9999."]
+      ["Year within [temporal_facet] is not a valid year. Years must be between 1 and 9999."]
 
       "Invalid month" {"temporal_facet[0][month]" 13}
-      ["Month [13] within [temporal_facet] is not a valid month. Months must be between 1 and 12."]
+      ["Month within [temporal_facet] is not a valid month. Months must be between 1 and 12."]
 
       "Invalid day" {"temporal_facet[0][day]" 32}
-      ["Day [32] within [temporal_facet] is not a valid day. Days must be between 1 and 31."])))
+      ["Day within [temporal_facet] is not a valid day. Days must be between 1 and 31."])))


### PR DESCRIPTION
This PR sanitized some of the search responses with user input. We want to do a test scan to see how much this helps once deployed. 
Also updated logging message for search-after.