### PR TITLE
CMR-8727: Reducing access control Errors when indexing collections into graphDb

### DIFF
--- a/graph-db/README.md
+++ b/graph-db/README.md
@@ -84,7 +84,7 @@ npm install
 ```
 
 ### Test
-To run the test suite one time run
+To run the test suite one time run (Note: to run all tests you must have the gremlin-sever docker container running)
 ```
 npm run test
 ```

--- a/graph-db/package-lock.json
+++ b/graph-db/package-lock.json
@@ -1247,14 +1247,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
       "dev": true,
@@ -3659,14 +3651,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
       "bin": {
         "fxparser": "src/cli/cli.js"
+      },
+      "dependencies": {
+        "strnum": "^1.0.5"
       },
       "funding": {
         "type": "paypal",
@@ -14420,14 +14412,14 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
       "bin": {
         "fxparser": "src/cli/cli.js"
+      },
+      "dependencies": {
+        "strnum": "^1.0.5"
       },
       "funding": {
         "type": "paypal",
@@ -14643,14 +14635,14 @@
       "license": "MIT"
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
       "bin": {
         "fxparser": "src/cli/cli.js"
+      },
+      "dependencies": {
+        "strnum": "^1.0.5"
       },
       "funding": {
         "type": "paypal",
@@ -15547,19 +15539,20 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.19.0",
-      "dev": true,
+      "version": "4.1.2",
       "license": "MIT",
-      "peer": true,
-      "bin": {
-        "xml2js": "cli.js"
-      },
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dev": true,
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "funding": {
         "type": "paypal",
         "url": "https://paypal.me/naturalintelligence"
+      },
+      "bin": {
+        "xml2js": "cli.js"
       }
     },
     "node_modules/adm-zip": {
@@ -16548,6 +16541,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-hex-encoding": {
@@ -18188,8 +18189,15 @@
             "@aws-sdk/util-user-agent-node": "3.226.0",
             "@aws-sdk/util-utf8-browser": "3.188.0",
             "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
+            "fast-xml-parser": "4.1.2",
             "tslib": "^2.3.1"
+          },
+          "dependencies": {
+            "fast-xml-parser": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+              "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+            }
           }
         },
         "@aws-sdk/config-resolver": {
@@ -18718,9 +18726,9 @@
           }
         },
         "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
           "requires": {
             "strnum": "^1.0.5"
           }
@@ -18784,8 +18792,15 @@
         "@aws-sdk/util-waiter": "3.78.0",
         "@aws-sdk/xml-builder": "3.55.0",
         "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+        }
       }
     },
     "@aws-sdk/client-sqs": {
@@ -18829,7 +18844,7 @@
         "@aws-sdk/util-user-agent-node": "3.224.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -19417,9 +19432,9 @@
           }
         },
         "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
           "requires": {
             "strnum": "^1.0.5"
           }
@@ -19557,8 +19572,15 @@
             "@aws-sdk/util-user-agent-node": "3.224.0",
             "@aws-sdk/util-utf8-browser": "3.188.0",
             "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
+            "fast-xml-parser": "4.1.2",
             "tslib": "^2.3.1"
+          },
+          "dependencies": {
+            "fast-xml-parser": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+              "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+            }
           }
         },
         "@aws-sdk/config-resolver": {
@@ -20046,9 +20068,9 @@
           }
         },
         "fast-xml-parser": {
-          "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
           "requires": {
             "strnum": "^1.0.5"
           }
@@ -20554,8 +20576,15 @@
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+        }
       }
     },
     "@aws-sdk/config-resolver": {
@@ -25662,9 +25691,13 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.19.0",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -25713,6 +25746,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
     },
     "filename-reserved-regex": {
       "version": "2.0.0"

--- a/graph-db/package-lock.json
+++ b/graph-db/package-lock.json
@@ -18,9 +18,9 @@
         "gremlin": "~3.4.10",
         "lodash": "^4.17.21",
         "serverless": "^3.24.1",
-        "serverless-offline": "^12.0.3",
+        "serverless-offline": "^12.0.4",
         "serverless-webpack": "^5.9.0",
-        "webpack": "^5.9.0",
+        "webpack": "^5.73.0",
         "webpack-node-externals": "^3.0.0"
       },
       "devDependencies": {
@@ -2251,9 +2251,9 @@
       "license": "MIT"
     },
     "node_modules/luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": ">=12"
       }
@@ -4993,10 +4993,10 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.15.0",
+      "version": "3.16.0",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -8226,8 +8226,10 @@
       }
     },
     "node_modules/cron-parser/node_modules/luxon": {
-      "version": "1.28.0",
+      "version": "1.28.1",
       "license": "MIT",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": "*"
       }
@@ -23307,7 +23309,7 @@
         "node-fetch": "^2.6.7",
         "open": "^7.4.2",
         "semver": "^7.3.7",
-        "simple-git": "3.15.0",
+        "simple-git": "3.16.0",
         "type": "^2.6.0",
         "uuid": "^8.3.2",
         "yamljs": "^0.3.0"
@@ -23329,9 +23331,9 @@
           }
         },
         "simple-git": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-          "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg=="
+          "version": "3.16.0",
+          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+          "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw=="
         }
       }
     },
@@ -24724,11 +24726,13 @@
       "version": "3.5.0",
       "requires": {
         "is-nan": "^1.3.2",
-        "luxon": "^1.26.0"
+        "luxon": "1.28.1"
       },
       "dependencies": {
         "luxon": {
-          "version": "1.28.0"
+          "version": "1.28.1",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
         }
       }
     },
@@ -27856,9 +27860,9 @@
       }
     },
     "luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -28961,7 +28965,7 @@
         "jsonpath-plus": "^7.2.0",
         "jsonschema": "^1.4.1",
         "jszip": "^3.10.1",
-        "luxon": "^3.2.0",
+        "luxon": "1.28.1",
         "node-fetch": "^3.3.0",
         "node-schedule": "^2.1.0",
         "object.hasown": "^1.1.2",
@@ -29011,6 +29015,11 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
           "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        },
+        "luxon": {
+          "version": "1.28.1",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
         },
         "mimic-fn": {
           "version": "4.0.0",
@@ -29110,9 +29119,9 @@
       "version": "3.0.7"
     },
     "simple-git": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",

--- a/graph-db/package-lock.json
+++ b/graph-db/package-lock.json
@@ -18,7 +18,7 @@
         "gremlin": "~3.4.10",
         "lodash": "^4.17.21",
         "serverless": "^3.24.1",
-        "serverless-offline": "^8.8.1",
+        "serverless-offline": "^12.0.3",
         "serverless-webpack": "^5.9.0",
         "webpack": "^5.9.0",
         "webpack-node-externals": "^3.0.0"
@@ -101,13 +101,6 @@
         "@webassemblyjs/ieee754": "1.11.1",
         "@webassemblyjs/leb128": "1.11.1",
         "@webassemblyjs/utf8": "1.11.1"
-      }
-    },
-    "node_modules/p-reflect": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/propagate": {
@@ -285,15 +278,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/jwa": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/expect": {
       "version": "27.5.1",
       "dev": true,
@@ -355,6 +339,22 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "license": "MIT",
@@ -404,10 +404,11 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "license": "MIT",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.1.3",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -432,11 +433,12 @@
       }
     },
     "node_modules/@hapi/validate": {
-      "version": "1.1.3",
-      "license": "BSD-3-Clause",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
       }
     },
     "node_modules/zip-stream": {
@@ -466,14 +468,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/boxen/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-node": {
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
@@ -485,6 +479,11 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@hapi/somever/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
@@ -587,8 +586,9 @@
       "license": "0BSD"
     },
     "node_modules/@hapi/file": {
-      "version": "2.0.0",
-      "license": "BSD-3-Clause"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -723,6 +723,26 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.245.0.tgz",
+      "integrity": "sha512-Dwv8zmRLTDLeEkGrK/sLNFZSC+ahXZxr07CuID054QKACIdUEvkqYlnalRiTeXngiHGQ54u8wU7f0D32R2oL0g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.245.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.245.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.0",
       "dev": true,
@@ -739,14 +759,18 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.2",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "dependencies": {
-        "@types/retry": "0.12.0",
+        "@types/retry": "0.12.1",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-jest/node_modules/supports-color": {
@@ -765,6 +789,11 @@
       "dev": true,
       "license": "0BSD",
       "peer": true
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/jest-matcher-utils/node_modules/has-flag": {
       "version": "4.0.0",
@@ -981,6 +1010,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/serverless/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -1012,10 +1049,6 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
-    },
-    "node_modules/cuid": {
-      "version": "2.1.8",
-      "license": "MIT"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
@@ -1215,9 +1248,9 @@
       }
     },
     "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=4"
       }
@@ -1372,12 +1405,13 @@
       "license": "MIT"
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1404,6 +1438,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/protocol-http": {
@@ -1797,10 +1853,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "license": "MIT"
-    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "license": "MIT",
@@ -1820,11 +1872,11 @@
       }
     },
     "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2092,6 +2144,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -2183,8 +2251,9 @@
       "license": "MIT"
     },
     "node_modules/luxon": {
-      "version": "2.4.0",
-      "license": "MIT",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
       "engines": {
         "node": ">=12"
       }
@@ -2200,9 +2269,31 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "license": "MIT"
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -2273,6 +2364,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/node-fetch": {
@@ -2350,6 +2455,18 @@
         "node": ">=7.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/log": {
       "version": "6.3.1",
       "license": "ISC",
@@ -2394,6 +2511,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/minizlib": {
@@ -2517,12 +2646,24 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@hapi/somever": {
-      "version": "3.0.1",
-      "license": "BSD-3-Clause",
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dependencies": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
+      "dependencies": {
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@serverless/utils/node_modules/supports-color": {
@@ -2602,17 +2743,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/boxen/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/object.entries": {
       "version": "1.1.5",
       "dev": true,
@@ -2627,13 +2757,14 @@
       }
     },
     "node_modules/@hapi/catbox": {
-      "version": "11.1.1",
-      "license": "BSD-3-Clause",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
+      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
@@ -2656,11 +2787,38 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
@@ -2730,6 +2888,14 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/array-unflat-js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
+      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -3067,6 +3233,18 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
       "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -3165,8 +3343,9 @@
       }
     },
     "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "license": "MIT"
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -3437,6 +3616,21 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "license": "MIT",
@@ -3564,8 +3758,9 @@
       "license": "ISC"
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "license": "MIT",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3574,14 +3769,15 @@
       }
     },
     "node_modules/@hapi/iron": {
-      "version": "6.0.0",
-      "license": "BSD-3-Clause",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
       "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/velocityjs": {
@@ -3637,10 +3833,11 @@
       }
     },
     "node_modules/@hapi/vise": {
-      "version": "4.0.0",
-      "license": "BSD-3-Clause",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/@serverless/utils": {
@@ -3709,30 +3906,31 @@
       }
     },
     "node_modules/@hapi/hapi": {
-      "version": "20.2.2",
-      "license": "BSD-3-Clause",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
+      "integrity": "sha512-het7j9yLXZMVU1IvtN2JXkPkn/UcU1j8gsZxMS0Mu1q7791IQeyhT37tpRPUhqerOtL6L0E8Z8CvVVFOYxoN6w==",
       "dependencies": {
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/accept": "^5.0.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/accept": "^6.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.15.0"
       }
     },
     "node_modules/lazystream/node_modules/string_decoder": {
@@ -3865,6 +4063,16 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -4031,6 +4239,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.18.2",
       "dev": true,
@@ -4150,11 +4370,12 @@
       }
     },
     "node_modules/@hapi/bounce": {
-      "version": "2.0.0",
-      "license": "BSD-3-Clause",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
@@ -4222,6 +4443,49 @@
         "which": "bin/which"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.245.0.tgz",
+      "integrity": "sha512-dxzRwRo55ZNQ4hQigC+cishxLSWlBrbr3iszG0FLviavLDOlnVG5UUxWpOIGvwr8pYiSfM4jnfMxiwYwiCLg1g==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@babel/plugin-transform-parameters": {
       "version": "7.17.12",
       "dev": true,
@@ -4281,19 +4545,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/semver": {
-      "version": "7.3.7",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4376,16 +4627,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/serverless-offline/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.17.12",
       "dev": true,
@@ -4398,6 +4639,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-TI2hnvT6dPUnn/jARFCJBKL1eeabAfLnKZ2lmW5Uh317s1Ii2IMroL1yMciEk/G+OETykVzlsH6x/L4q/avhgw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -4415,6 +4668,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
@@ -4459,10 +4723,11 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "license": "BSD-3-Clause",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/babel-jest": {
@@ -4708,6 +4973,18 @@
       "version": "0.0.51",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "license": "MIT",
@@ -4771,6 +5048,14 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@aws-sdk/util-retry/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-message-util/node_modules/color-name": {
       "version": "1.1.4",
       "dev": true,
@@ -4818,10 +5103,11 @@
       }
     },
     "node_modules/@hapi/ammo": {
-      "version": "5.0.1",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/got": {
@@ -4845,6 +5131,21 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/environment": {
@@ -4981,6 +5282,23 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
@@ -5045,6 +5363,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/serverless-offline/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.16.7",
       "dev": true,
@@ -5102,6 +5431,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5243,6 +5573,53 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.245.0.tgz",
+      "integrity": "sha512-E+7v2sy34TLni/Dmz6bTU20NWvbHYH9sVUHKQ9kHhmFopUWrs4Nt77f85PbuiKJz/irjUh9ppT5q1odJNRKRVQ==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "fast-xml-parser": "4.0.11",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
@@ -5322,6 +5699,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -5345,13 +5734,6 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.18.2",
@@ -5381,6 +5763,27 @@
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.224.0",
         "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -5515,6 +5918,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.18.0",
       "dev": true,
@@ -5633,6 +6050,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -5738,16 +6156,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5772,6 +6190,17 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -5827,6 +6256,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "license": "MIT",
@@ -5845,6 +6286,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-builder": {
@@ -5871,6 +6326,58 @@
       "engines": {
         "node": ">=7.0.0"
       }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.245.0.tgz",
+      "integrity": "sha512-vhC9MPWclA3/qMUzOMu6Xc3sQ1iJJFQ+h7kbnYMbQFDQWIN24O/HqmdLJ3iGcIYLd8vw3jpz6dQB/OCKSPIPVg==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/client-sts": "3.245.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/@aws-sdk/config-resolver": {
       "version": "3.80.0",
@@ -5936,6 +6443,17 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "dev": true,
@@ -5987,11 +6505,11 @@
       }
     },
     "node_modules/boxen/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6199,6 +6717,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT"
@@ -6362,12 +6885,13 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "17.2.0",
-      "license": "BSD-3-Clause",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/superagent/node_modules/string_decoder": {
@@ -6389,10 +6913,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -6516,20 +7036,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/p-settle": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.2",
-        "p-reflect": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "dev": true,
@@ -6617,6 +7123,28 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
@@ -6893,14 +7421,15 @@
       }
     },
     "node_modules/@hapi/nigel": {
-      "version": "4.0.2",
-      "license": "BSD-3-Clause",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@serverless/dashboard-plugin": {
@@ -6996,13 +7525,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
       "dev": true,
@@ -7071,13 +7593,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/p-settle/node_modules/p-try": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/find-requires": {
       "version": "1.0.0",
       "license": "ISC",
@@ -7090,8 +7605,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "license": "MIT",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -7162,6 +7678,17 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "node_modules/p-memoize/node_modules/type-fest": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+      "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "27.5.1",
       "dev": true,
@@ -7219,10 +7746,11 @@
       }
     },
     "node_modules/@hapi/b64": {
-      "version": "5.0.0",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/untildify": {
@@ -7238,7 +7766,8 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
         "node": ">= 4"
       }
@@ -7251,21 +7780,21 @@
       }
     },
     "node_modules/boxen": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
+      "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
       "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7288,10 +7817,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "license": "MIT"
     },
     "node_modules/unbzip2-stream/node_modules/buffer": {
       "version": "5.7.1",
@@ -7391,6 +7916,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7469,10 +8005,11 @@
       }
     },
     "node_modules/@hapi/teamwork": {
-      "version": "5.1.1",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/fs-extra": {
@@ -7513,11 +8050,12 @@
       }
     },
     "node_modules/@hapi/accept": {
-      "version": "5.0.2",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/@types/prettier": {
@@ -7615,6 +8153,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.truncate": {
@@ -7777,10 +8326,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "dev": true,
@@ -7858,10 +8403,11 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "5.1.0",
-      "license": "MIT",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/process-utils": {
@@ -7915,6 +8461,22 @@
     "node_modules/serverless/node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/serverless-webpack/node_modules/semver": {
       "version": "7.3.8",
@@ -8035,13 +8597,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "dev": true,
@@ -8110,9 +8665,9 @@
       }
     },
     "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=4"
       }
@@ -8194,6 +8749,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-config/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -8211,31 +8779,41 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "license": "MIT",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
       "dependencies": {
+        "gopd": "^1.0.1",
         "regexp.prototype.flags": "^1.4.3",
         "object-keys": "^1.1.1",
-        "internal-slot": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "is-array-buffer": "^3.0.0",
+        "es-set-tostringtag": "^2.0.0",
+        "internal-slot": "^1.0.4",
         "function-bind": "^1.1.1",
         "es-to-primitive": "^1.2.1",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.3",
         "is-weakref": "^1.0.2",
-        "is-callable": "^1.2.4",
-        "string.prototype.trimend": "^1.0.5",
+        "is-callable": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
         "is-shared-array-buffer": "^1.0.2",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "is-regex": "^1.1.4",
+        "is-typed-array": "^1.1.10",
         "has-symbols": "^1.0.3",
         "get-symbol-description": "^1.0.0",
+        "safe-regex-test": "^1.0.0",
         "unbox-primitive": "^1.0.2",
         "is-string": "^1.0.7",
         "call-bind": "^1.0.2",
         "function.prototype.name": "^1.1.5",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "has": "^1.0.3",
+        "globalthis": "^1.0.3",
+        "typed-array-length": "^1.0.4",
+        "which-typed-array": "^1.1.9",
         "has-property-descriptors": "^1.0.0",
-        "string.prototype.trimstart": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.6",
         "is-negative-zero": "^2.0.2"
       },
       "engines": {
@@ -8257,10 +8835,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -8622,14 +9196,17 @@
       }
     },
     "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
       "dependencies": {
-        "string-width": "^4.0.0"
+        "string-width": "^5.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
@@ -8666,6 +9243,17 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-middleware": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
@@ -8683,16 +9271,6 @@
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
-      }
-    },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/minipass": {
@@ -8831,6 +9409,7 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -8958,11 +9537,12 @@
       "license": "MIT"
     },
     "node_modules/@hapi/call": {
-      "version": "8.0.1",
-      "license": "BSD-3-Clause",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/path2": {
@@ -9081,6 +9661,49 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.245.0.tgz",
+      "integrity": "sha512-0pGPA00kEsu2Yq1Ul+OwftHxws5YVllm4iZrPtGnqmXr7wmf6B9lOtrMQF44y7Tfw53po6+bKz08OKTEWkkjUA==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -9093,6 +9716,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/node-fetch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/child-process-ext/node_modules/shebang-command": {
@@ -9118,6 +9774,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/regexpp": {
@@ -9197,16 +9865,30 @@
       }
     },
     "node_modules/@hapi/h2o2": {
-      "version": "9.1.0",
-      "license": "BSD-3-Clause",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
+      "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0",
+        "@hapi/wreck": "^18.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/run-async": {
@@ -9229,8 +9911,9 @@
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "license": "BSD-3-Clause"
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
     },
     "node_modules/webpack/node_modules/acorn": {
       "version": "8.7.1",
@@ -9387,45 +10070,81 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.245.0.tgz",
+      "integrity": "sha512-txWrJc0WNBhXMi7q+twjx7cs/qzgTfbQ+vbag5idRmdoUeiR8rfLvihCab2NaGg50xhh+TaoUCXrgJp3E/XjYQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.245.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.245.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "license": "MIT"
     },
     "node_modules/serverless-offline": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.8.1.tgz",
-      "integrity": "sha512-tpvAEGMf6qB9jGSDrpLQSYljqiIxOfjpsWq6q9ol3goqbcxXasvGR9nVX5cXq1MNBRXsJQE1PdHxtxivng2Lrw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
+      "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
       "dependencies": {
-        "@hapi/h2o2": "^9.1.0",
-        "semver": "^7.3.7",
-        "p-retry": "^4.6.2",
-        "jsonwebtoken": "^8.5.1",
-        "p-memoize": "^4.0.4",
-        "jszip": "^3.9.1",
-        "execa": "^5.1.1",
-        "fs-extra": "^10.1.0",
+        "@hapi/h2o2": "^10.0.0",
+        "p-retry": "^5.1.2",
+        "array-unflat-js": "^0.1.3",
+        "p-memoize": "^7.1.1",
+        "is-wsl": "^2.2.0",
+        "jszip": "^3.10.1",
+        "execa": "^6.1.0",
+        "fs-extra": "^11.1.0",
         "java-invoke-local": "0.0.6",
-        "boxen": "^5.1.2",
+        "boxen": "^7.0.1",
         "js-string-escape": "^1.0.1",
         "velocityjs": "^2.0.6",
-        "luxon": "^2.4.0",
-        "node-fetch": "^2.6.7",
-        "chalk": "^4.1.2",
-        "p-queue": "^6.6.2",
-        "cuid": "^2.1.8",
-        "@hapi/boom": "^9.1.4",
-        "jsonpath-plus": "^5.1.0",
-        "aws-sdk": "^2.1136.0",
-        "jsonschema": "^1.4.0",
-        "@hapi/hapi": "^20.2.2",
-        "ws": "^7.5.7",
-        "node-schedule": "^2.1.0"
+        "desm": "^1.3.0",
+        "luxon": "^3.2.0",
+        "node-fetch": "^3.3.0",
+        "object.hasown": "^1.1.2",
+        "chalk": "^5.2.0",
+        "@aws-sdk/client-lambda": "^3.241.0",
+        "jose": "^4.11.2",
+        "@hapi/boom": "^10.0.0",
+        "jsonpath-plus": "^7.2.0",
+        "jsonschema": "^1.4.1",
+        "@hapi/hapi": "^21.1.0",
+        "ws": "^8.11.0",
+        "node-schedule": "^2.1.0",
+        "@serverless/utils": "^6.8.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.18.0"
       },
       "peerDependencies": {
-        "serverless": "^1.60.0 || 2 || 3"
+        "serverless": "^3.2.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
@@ -9451,6 +10170,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/json5": {
@@ -9501,9 +10238,24 @@
         "node": ">=8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "license": "MIT"
+    "node_modules/serverless-offline/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@aws-sdk/smithy-client": {
       "version": "3.99.0",
@@ -9615,6 +10367,7 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -9788,6 +10541,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.245.0.tgz",
+      "integrity": "sha512-m/spXR/vEXGb+zMqRUMQYVMwFZSTdK5RkddYqamYkNhIoLm60EYeRu57JsMMs5djKi8dBRSKiXwVHx0l2rXMjg==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.245.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
@@ -9937,10 +10705,11 @@
       }
     },
     "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/jest-cli/node_modules/color-convert": {
@@ -10072,19 +10841,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/serverless-offline/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "dev": true,
@@ -10113,14 +10869,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -10170,9 +10918,9 @@
       "license": "0BSD"
     },
     "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10189,10 +10937,11 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "5.0.2",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "node_modules/@serverless/utils/node_modules/js-yaml": {
@@ -10650,6 +11399,19 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "license": "MIT",
@@ -10677,15 +11439,16 @@
       }
     },
     "node_modules/serverless-offline/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "license": "MIT",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
@@ -10696,6 +11459,17 @@
         "@aws-sdk/types": "3.224.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -10712,6 +11486,17 @@
       "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
       "dependencies": {
         "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -10767,14 +11552,11 @@
       }
     },
     "node_modules/serverless-offline/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -10884,11 +11666,12 @@
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "5.0.1",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/child-process-ext/node_modules/cross-spawn": {
@@ -11050,15 +11833,23 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -11267,18 +12058,25 @@
       }
     },
     "node_modules/boxen/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -11492,11 +12290,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/boxen/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "node_modules/@jest/fake-timers": {
       "version": "27.5.1",
       "dev": true,
@@ -11637,16 +12430,17 @@
       }
     },
     "node_modules/@hapi/statehood": {
-      "version": "7.0.4",
-      "license": "BSD-3-Clause",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -11683,21 +12477,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/serverless-offline/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/decompress-unzip": {
@@ -11736,6 +12521,22 @@
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/aws-sdk/node_modules/querystring": {
@@ -11778,6 +12579,25 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.245.0.tgz",
+      "integrity": "sha512-1SjfVc5Wg0lLRUvwMrfjGgFkl+zfxn74gnkPr6by1QyMAoTzmeUkalPLAIqd+uHtFom9e3K633BQtX7zVPZ5XQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.245.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
@@ -11785,6 +12605,19 @@
       "dependencies": {
         "@aws-sdk/protocol-http": "3.224.0",
         "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -11818,10 +12651,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "license": "MIT"
     },
     "node_modules/jest-junit": {
       "version": "12.3.0",
@@ -12102,20 +12931,6 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "node_modules/p-queue": {
-      "version": "6.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "license": "MIT"
@@ -12197,26 +13012,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
       }
     },
     "node_modules/type": {
@@ -12324,9 +13119,18 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "license": "BSD-3-Clause"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "node_modules/@aws-sdk/util-base64-node": {
       "version": "3.55.0",
@@ -12436,6 +13240,14 @@
         "seek-table": "bin/seek-bzip-table"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "2.6.9",
       "dev": true,
@@ -12443,10 +13255,6 @@
       "dependencies": {
         "ms": "2.0.0"
       }
-    },
-    "node_modules/serverless-offline/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
     },
     "node_modules/@jest/types/node_modules/color-convert": {
       "version": "2.0.1",
@@ -12604,6 +13412,18 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/clone-response": {
       "version": "1.0.2",
       "license": "MIT",
@@ -12650,6 +13470,20 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -12861,6 +13695,17 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@types/keyv": {
@@ -13108,6 +13953,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/serverless-offline/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@serverless/utils/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -13144,6 +14003,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
@@ -13159,6 +14039,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/formidable": {
@@ -13429,9 +14319,9 @@
       }
     },
     "node_modules/decompress-tar/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=4"
       }
@@ -13499,6 +14389,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "license": "MIT",
@@ -13563,8 +14466,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.10.0",
-      "license": "(MIT OR GPL-3.0-or-later)",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -13673,6 +14577,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/hash-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-jasmine2/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -13723,6 +14640,21 @@
       "version": "4.14.182",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.16.7",
       "dev": true,
@@ -13740,6 +14672,20 @@
         "log": "^6.0.0",
         "split2": "^3.1.1",
         "stream-promise": "^3.2.0"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/is-retry-allowed": {
@@ -13905,6 +14851,20 @@
         }
       }
     },
+    "node_modules/serverless-offline/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
       "funding": [
@@ -14006,6 +14966,19 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
       "version": "3.0.0",
       "license": "MIT",
@@ -14045,14 +15018,11 @@
       }
     },
     "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -14165,11 +15135,11 @@
       }
     },
     "node_modules/boxen/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14280,15 +15250,15 @@
       }
     },
     "node_modules/p-memoize": {
-      "version": "4.0.4",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
+      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
       "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0",
-        "p-settle": "^4.1.1"
+        "mimic-fn": "^4.0.0",
+        "type-fest": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
@@ -14390,6 +15360,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/fetch-http-handler": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
@@ -14400,6 +15382,19 @@
         "@aws-sdk/types": "3.224.0",
         "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/sinon": {
@@ -14488,9 +15483,9 @@
       }
     },
     "node_modules/@serverless/utils/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=10"
       },
@@ -14675,11 +15670,12 @@
       }
     },
     "node_modules/@hapi/shot": {
-      "version": "5.0.5",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/sinon/node_modules/has-flag": {
@@ -14703,6 +15699,18 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/property-provider": {
@@ -14820,6 +15828,18 @@
         "xmlbuilder": "~9.0.1"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-worker/node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
@@ -14873,9 +15893,9 @@
       "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
     },
     "node_modules/archive-type/node_modules/file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "engines": {
         "node": ">=4"
       }
@@ -14911,13 +15931,14 @@
       }
     },
     "node_modules/@hapi/cryptiles": {
-      "version": "5.1.0",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -14928,11 +15949,12 @@
       }
     },
     "node_modules/@hapi/mimos": {
-      "version": "6.0.0",
-      "license": "BSD-3-Clause",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
       }
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/hash-node": {
@@ -15053,6 +16075,19 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
       "license": "MIT",
@@ -15110,12 +16145,13 @@
       }
     },
     "node_modules/@hapi/heavy": {
-      "version": "7.0.1",
-      "license": "BSD-3-Clause",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/essentials": {
@@ -15188,10 +16224,11 @@
       }
     },
     "node_modules/serverless-offline/node_modules/ws": {
-      "version": "7.5.8",
-      "license": "MIT",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -15309,6 +16346,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "dev": true,
@@ -15338,6 +16388,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/stream-promise/node_modules/is-stream": {
@@ -15384,16 +16445,17 @@
       "license": "MIT"
     },
     "node_modules/@hapi/subtext": {
-      "version": "7.0.3",
-      "license": "BSD-3-Clause",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
       }
     },
     "node_modules/cli-sprintf-format": {
@@ -15448,6 +16510,22 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "license": "Apache-2.0",
@@ -15468,6 +16546,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -15538,15 +16627,27 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
@@ -15620,6 +16721,11 @@
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "license": "MIT"
+    },
+    "node_modules/desm": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
+      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
@@ -15707,6 +16813,20 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/parse5": {
@@ -15898,6 +17018,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15929,12 +17050,13 @@
       }
     },
     "node_modules/@hapi/podium": {
-      "version": "4.1.3",
-      "license": "BSD-3-Clause",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/pkg-dir/node_modules/path-exists": {
@@ -16057,6 +17179,18 @@
         }
       }
     },
+    "node_modules/object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-defaults-mode-node": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
@@ -16074,12 +17208,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "license": "MIT",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -16218,6 +17353,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "dev": true,
@@ -16280,6 +17430,15 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.224.0",
@@ -16444,14 +17603,15 @@
       }
     },
     "node_modules/@hapi/pez": {
-      "version": "5.0.3",
-      "license": "BSD-3-Clause",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
       }
     },
     "node_modules/text-table": {
@@ -16501,30 +17661,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/p-settle/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
@@ -16535,10 +17671,14 @@
       }
     },
     "node_modules/p-memoize/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-name-validator": {
@@ -16871,6 +18011,718 @@
       "requires": {
         "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-lambda": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.245.0.tgz",
+      "integrity": "sha512-vhC9MPWclA3/qMUzOMu6Xc3sQ1iJJFQ+h7kbnYMbQFDQWIN24O/HqmdLJ3iGcIYLd8vw3jpz6dQB/OCKSPIPVg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.245.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.245.0.tgz",
+          "integrity": "sha512-dxzRwRo55ZNQ4hQigC+cishxLSWlBrbr3iszG0FLviavLDOlnVG5UUxWpOIGvwr8pYiSfM4jnfMxiwYwiCLg1g==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.245.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.245.0.tgz",
+          "integrity": "sha512-0pGPA00kEsu2Yq1Ul+OwftHxws5YVllm4iZrPtGnqmXr7wmf6B9lOtrMQF44y7Tfw53po6+bKz08OKTEWkkjUA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.245.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.245.0.tgz",
+          "integrity": "sha512-E+7v2sy34TLni/Dmz6bTU20NWvbHYH9sVUHKQ9kHhmFopUWrs4Nt77f85PbuiKJz/irjUh9ppT5q1odJNRKRVQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-node": "3.245.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-sdk-sts": "3.226.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.245.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+          "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+          "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.245.0.tgz",
+          "integrity": "sha512-1SjfVc5Wg0lLRUvwMrfjGgFkl+zfxn74gnkPr6by1QyMAoTzmeUkalPLAIqd+uHtFom9e3K633BQtX7zVPZ5XQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.245.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.245.0.tgz",
+          "integrity": "sha512-Dwv8zmRLTDLeEkGrK/sLNFZSC+ahXZxr07CuID054QKACIdUEvkqYlnalRiTeXngiHGQ54u8wU7f0D32R2oL0g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-ini": "3.245.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.245.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+          "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.245.0.tgz",
+          "integrity": "sha512-txWrJc0WNBhXMi7q+twjx7cs/qzgTfbQ+vbag5idRmdoUeiR8rfLvihCab2NaGg50xhh+TaoUCXrgJp3E/XjYQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.245.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/token-providers": "3.245.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+          "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+          "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+          "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+          "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+          "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+          "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+          "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+          "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.235.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/service-error-classification": "3.229.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+          "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+          "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+          "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+          "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.245.0.tgz",
+          "integrity": "sha512-m/spXR/vEXGb+zMqRUMQYVMwFZSTdK5RkddYqamYkNhIoLm60EYeRu57JsMMs5djKi8dBRSKiXwVHx0l2rXMjg==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.245.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+          "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+          "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+          "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+          "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+          "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/client-s3": {
@@ -19547,6 +21399,22 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+        }
+      }
+    },
     "@aws-sdk/util-stream-browser": {
       "version": "3.78.0",
       "dev": true,
@@ -20587,229 +22455,296 @@
       }
     },
     "@hapi/accept": {
-      "version": "5.0.2",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/ammo": {
-      "version": "5.0.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/b64": {
-      "version": "5.0.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/boom": {
-      "version": "9.1.4",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "10.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/bourne": {
-      "version": "2.1.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "@hapi/call": {
-      "version": "8.0.1",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/catbox": {
-      "version": "11.1.1",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
+      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "5.0.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/content": {
-      "version": "5.0.2",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "@hapi/cryptiles": {
-      "version": "5.1.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "@hapi/file": {
-      "version": "2.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "@hapi/h2o2": {
-      "version": "9.1.0",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
+      "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0",
+        "@hapi/wreck": "^18.0.0"
       }
     },
     "@hapi/hapi": {
-      "version": "20.2.2",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
+      "integrity": "sha512-het7j9yLXZMVU1IvtN2JXkPkn/UcU1j8gsZxMS0Mu1q7791IQeyhT37tpRPUhqerOtL6L0E8Z8CvVVFOYxoN6w==",
       "requires": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/accept": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/heavy": {
-      "version": "7.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/hoek": {
-      "version": "9.3.0"
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
     },
     "@hapi/iron": {
-      "version": "6.0.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/mimos": {
-      "version": "6.0.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
       }
     },
     "@hapi/nigel": {
-      "version": "4.0.2",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "requires": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "5.0.3",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
       }
     },
     "@hapi/podium": {
-      "version": "4.1.3",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/shot": {
-      "version": "5.0.5",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/somever": {
-      "version": "3.0.1",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
       "requires": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        }
       }
     },
     "@hapi/statehood": {
-      "version": "7.0.4",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "@hapi/subtext": {
-      "version": "7.0.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
       }
     },
     "@hapi/teamwork": {
-      "version": "5.1.1"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A=="
     },
     "@hapi/topo": {
-      "version": "5.1.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
       "requires": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/validate": {
-      "version": "1.1.3",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
       }
     },
     "@hapi/vise": {
-      "version": "4.0.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/wreck": {
-      "version": "17.2.0",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -21459,7 +23394,7 @@
         "event-emitter": "^0.3.5",
         "ext": "^1.7.0",
         "ext-name": "^5.0.0",
-        "file-type": "17.1.3",
+        "file-type": "16.5.4",
         "filenamify": "^4.3.0",
         "get-stream": "^6.0.1",
         "got": "^11.8.5",
@@ -21517,9 +23452,9 @@
           "version": "1.1.4"
         },
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
           "requires": {
             "readable-web-to-node-stream": "^3.0.0",
             "strtok3": "^6.2.4",
@@ -21744,7 +23679,9 @@
       }
     },
     "@types/retry": {
-      "version": "0.12.0"
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@types/sinon": {
       "version": "10.0.10",
@@ -21978,13 +23915,13 @@
     "archive-type": {
       "version": "4.0.0",
       "requires": {
-        "file-type": "17.1.3"
+        "file-type": "16.5.4"
       },
       "dependencies": {
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
         }
       }
     },
@@ -22060,6 +23997,11 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
+    },
+    "array-unflat-js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
+      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw=="
     },
     "array-union": {
       "version": "2.1.0"
@@ -22308,72 +24250,77 @@
       "version": "2.11.0"
     },
     "boxen": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
+      "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
       "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
         "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
         },
         "camelcase": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+          "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw=="
         },
         "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
           "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
           }
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
+            "ansi-regex": "^6.0.1"
           }
         },
         "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        },
+        "wrap-ansi": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
+          "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
         }
       }
     },
@@ -22431,9 +24378,6 @@
     },
     "buffer-crc32": {
       "version": "0.2.13"
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1"
     },
     "buffer-fill": {
       "version": "1.0.0"
@@ -22589,9 +24533,9 @@
       "dev": true
     },
     "cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
     },
     "cli-color": {
       "version": "2.0.2",
@@ -22813,9 +24757,6 @@
         }
       }
     },
-    "cuid": {
-      "version": "2.1.8"
-    },
     "d": {
       "version": "1.0.1",
       "requires": {
@@ -22827,6 +24768,11 @@
           "version": "1.2.0"
         }
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -22892,7 +24838,7 @@
     "decompress-tar": {
       "version": "4.1.1",
       "requires": {
-        "file-type": "17.1.3",
+        "file-type": "16.5.4",
         "is-stream": "^1.1.0",
         "tar-stream": "^1.5.2"
       },
@@ -22905,9 +24851,9 @@
           }
         },
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -22948,16 +24894,16 @@
       "version": "4.1.1",
       "requires": {
         "decompress-tar": "^4.1.0",
-        "file-type": "17.1.3",
+        "file-type": "16.5.4",
         "is-stream": "^1.1.0",
         "seek-bzip": "^1.0.5",
         "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -22968,14 +24914,14 @@
       "version": "4.1.1",
       "requires": {
         "decompress-tar": "^4.1.1",
-        "file-type": "17.1.3",
+        "file-type": "16.5.4",
         "is-stream": "^1.1.0"
       },
       "dependencies": {
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -22985,16 +24931,16 @@
     "decompress-unzip": {
       "version": "4.0.1",
       "requires": {
-        "file-type": "17.1.3",
+        "file-type": "16.5.4",
         "get-stream": "^2.2.0",
         "pify": "^2.3.0",
         "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
         },
         "get-stream": {
           "version": "2.3.1",
@@ -23053,6 +24999,11 @@
     "delayed-stream": {
       "version": "1.0.0"
     },
+    "desm": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
+      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "dev": true
@@ -23108,11 +25059,10 @@
         "es5-ext": "~0.10.46"
       }
     },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "electron-to-chromium": {
       "version": "1.4.150"
@@ -23157,35 +25107,56 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.1",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
       "requires": {
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.0",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.0",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       }
     },
     "es-module-lexer": {
       "version": "0.9.3"
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -23600,14 +25571,12 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "eventemitter3": {
-      "version": "4.0.7"
-    },
     "events": {
       "version": "1.1.1"
     },
     "execa": {
       "version": "5.1.1",
+      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -23717,6 +25686,15 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -23811,6 +25789,14 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
     "formidable": {
       "version": "1.2.6"
     },
@@ -23886,7 +25872,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -23934,6 +25922,14 @@
       "version": "11.12.0",
       "dev": true
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "requires": {
@@ -23948,6 +25944,14 @@
         "ignore": {
           "version": "5.2.0"
         }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "got": {
@@ -23999,6 +26003,11 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+    },
     "has-symbols": {
       "version": "1.0.3"
     },
@@ -24046,7 +26055,8 @@
       }
     },
     "human-signals": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -24161,9 +26171,11 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.1.3",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
@@ -24175,6 +26187,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-TI2hnvT6dPUnn/jARFCJBKL1eeabAfLnKZ2lmW5Uh317s1Ii2IMroL1yMciEk/G+OETykVzlsH6x/L4q/avhgw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "is-arrayish": {
@@ -24209,7 +26230,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.4"
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -24307,7 +26330,8 @@
       }
     },
     "is-stream": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -24322,14 +26346,14 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
     },
@@ -25461,6 +27485,11 @@
     "jmespath": {
       "version": "0.16.0"
     },
+    "jose": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
+    },
     "js-string-escape": {
       "version": "1.0.1"
     },
@@ -25567,33 +27596,17 @@
       }
     },
     "jsonpath-plus": {
-      "version": "5.1.0"
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
     },
     "jsonschema": {
       "version": "1.4.1"
     },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1"
-        }
-      }
-    },
     "jszip": {
-      "version": "3.10.0",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -25626,21 +27639,6 @@
     "just-extend": {
       "version": "4.2.1",
       "dev": true
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "jwt-decode": {
       "version": "2.2.0"
@@ -25735,30 +27733,12 @@
       "version": "4.4.2",
       "dev": true
     },
-    "lodash.includes": {
-      "version": "4.3.0"
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3"
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4"
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3"
-    },
     "lodash.isplainobject": {
       "version": "4.0.6"
-    },
-    "lodash.isstring": {
-      "version": "4.0.1"
     },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
-    },
-    "lodash.once": {
-      "version": "4.1.1"
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -25876,7 +27856,9 @@
       }
     },
     "luxon": {
-      "version": "2.4.0"
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -25893,12 +27875,6 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
-      }
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "requires": {
-        "p-defer": "^1.0.0"
       }
     },
     "memoizee": {
@@ -26042,6 +28018,11 @@
         "minimatch": "^3.0.2"
       }
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
       "version": "2.6.7",
       "requires": {
@@ -26106,6 +28087,7 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
+      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       }
@@ -26129,11 +28111,13 @@
       "version": "1.1.1"
     },
     "object.assign": {
-      "version": "4.1.2",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -26144,6 +28128,15 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "object.values": {
@@ -26255,9 +28248,6 @@
     "p-cancelable": {
       "version": "2.1.1"
     },
-    "p-defer": {
-      "version": "1.0.0"
-    },
     "p-event": {
       "version": "4.2.0",
       "requires": {
@@ -26282,51 +28272,33 @@
       }
     },
     "p-memoize": {
-      "version": "4.0.4",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
+      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
       "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0",
-        "p-settle": "^4.1.1"
+        "mimic-fn": "^4.0.0",
+        "type-fest": "^3.0.0"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "3.1.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+        },
+        "type-fest": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.1.tgz",
+          "integrity": "sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA=="
         }
       }
-    },
-    "p-queue": {
-      "version": "6.6.2",
-      "requires": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      }
-    },
-    "p-reflect": {
-      "version": "2.1.0"
     },
     "p-retry": {
-      "version": "4.6.2",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "requires": {
-        "@types/retry": "0.12.0",
+        "@types/retry": "0.12.1",
         "retry": "^0.13.1"
-      }
-    },
-    "p-settle": {
-      "version": "4.1.1",
-      "requires": {
-        "p-limit": "^2.2.2",
-        "p-reflect": "^2.1.0"
-      },
-      "dependencies": {
-        "p-limit": {
-          "version": "2.3.0",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0"
-        }
       }
     },
     "p-timeout": {
@@ -26718,7 +28690,9 @@
       }
     },
     "retry": {
-      "version": "0.13.1"
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4"
@@ -26757,6 +28731,16 @@
     },
     "safe-buffer": {
       "version": "5.1.2"
+    },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2"
@@ -26955,83 +28939,124 @@
       }
     },
     "serverless-offline": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.8.1.tgz",
-      "integrity": "sha512-tpvAEGMf6qB9jGSDrpLQSYljqiIxOfjpsWq6q9ol3goqbcxXasvGR9nVX5cXq1MNBRXsJQE1PdHxtxivng2Lrw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
+      "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
       "requires": {
-        "@hapi/boom": "^9.1.4",
-        "@hapi/h2o2": "^9.1.0",
-        "@hapi/hapi": "^20.2.2",
-        "aws-sdk": "^2.1136.0",
-        "boxen": "^5.1.2",
-        "chalk": "^4.1.2",
-        "cuid": "^2.1.8",
-        "execa": "^5.1.1",
-        "fs-extra": "^10.1.0",
+        "@aws-sdk/client-lambda": "^3.241.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/h2o2": "^10.0.0",
+        "@hapi/hapi": "^21.1.0",
+        "@serverless/utils": "^6.8.2",
+        "array-unflat-js": "^0.1.3",
+        "boxen": "^7.0.1",
+        "chalk": "^5.2.0",
+        "desm": "^1.3.0",
+        "execa": "^6.1.0",
+        "fs-extra": "^11.1.0",
+        "is-wsl": "^2.2.0",
         "java-invoke-local": "0.0.6",
+        "jose": "^4.11.2",
         "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^5.1.0",
-        "jsonschema": "^1.4.0",
-        "jsonwebtoken": "^8.5.1",
-        "jszip": "^3.9.1",
-        "luxon": "^2.4.0",
-        "node-fetch": "^2.6.7",
+        "jsonpath-plus": "^7.2.0",
+        "jsonschema": "^1.4.1",
+        "jszip": "^3.10.1",
+        "luxon": "^3.2.0",
+        "node-fetch": "^3.3.0",
         "node-schedule": "^2.1.0",
-        "p-memoize": "^4.0.4",
-        "p-queue": "^6.6.2",
-        "p-retry": "^4.6.2",
-        "semver": "^7.3.7",
+        "object.hasown": "^1.1.2",
+        "p-memoize": "^7.1.1",
+        "p-retry": "^5.1.2",
         "velocityjs": "^2.0.6",
-        "ws": "^7.5.7"
+        "ws": "^8.11.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
         },
-        "color-convert": {
-          "version": "2.0.1",
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
           "requires": {
-            "color-name": "~1.1.4"
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
           }
-        },
-        "color-name": {
-          "version": "1.1.4"
         },
         "fs-extra": {
-          "version": "10.1.0",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0"
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
         },
-        "semver": {
-          "version": "7.3.7",
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+        },
+        "node-fetch": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
           "requires": {
-            "lru-cache": "^6.0.0"
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
           "requires": {
-            "has-flag": "^4.0.0"
+            "path-key": "^4.0.0"
           }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
         },
         "ws": {
-          "version": "7.5.8"
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
         }
       }
     },
@@ -27244,19 +29269,23 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "string_decoder": {
@@ -27287,7 +29316,8 @@
       }
     },
     "strip-final-newline": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -27659,6 +29689,16 @@
     "type-fest": {
       "version": "0.21.3"
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -27839,6 +29879,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "dev": true
@@ -27926,24 +29971,54 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       }
     },
     "widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
       "requires": {
-        "string-width": "^4.0.0"
+        "string-width": "^5.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
       }
     },
     "word-wrap": {

--- a/graph-db/package-lock.json
+++ b/graph-db/package-lock.json
@@ -14,12 +14,13 @@
         "@aws-sdk/client-ssm": "^3.211.0",
         "array-foreach-async": "^1.0.1",
         "axios": "^0.24.0",
+        "axios-retry": "^3.3.1",
         "gremlin": "~3.4.10",
         "lodash": "^4.17.21",
         "serverless": "^3.24.1",
-        "serverless-offline": "^12.0.4",
+        "serverless-offline": "^8.8.1",
         "serverless-webpack": "^5.9.0",
-        "webpack": "^5.73.0",
+        "webpack": "^5.9.0",
         "webpack-node-externals": "^3.0.0"
       },
       "devDependencies": {
@@ -102,6 +103,13 @@
         "@webassemblyjs/utf8": "1.11.1"
       }
     },
+    "node_modules/p-reflect": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "dev": true,
@@ -138,18 +146,18 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.224.0.tgz",
-      "integrity": "sha512-QeyGmKipZsbVkezI5OKe0Xad7u1JPkZWNm1m7uqjd9vTK3A+/fw7eNxOWYVdSKs/kHyAWr9PG+fASBtr3gesPA==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/ajv-keywords": {
@@ -172,6 +180,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+      "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
@@ -208,17 +229,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.224.0.tgz",
-      "integrity": "sha512-S9a3fvF0Lv/NnXKbh0cbqhzfVcCOU1pPeGKuDB/p7AWCoql/KSG52MGBU6jKcevCtWVUKpSkgJfs+xkKmSiXIA==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/crc32-stream": {
@@ -239,7 +259,8 @@
     },
     "node_modules/terser": {
       "version": "5.14.2",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -264,6 +285,15 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/expect": {
       "version": "27.5.1",
       "dev": true,
@@ -279,9 +309,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1286.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1286.0.tgz",
-      "integrity": "sha512-CvkCD1+NSk2MPOutD2hEPhXDET/79w/gd9a359QWb9Ja0Fd4vVFXPkhlm1DTGzuwqFKGinpCMxDP4md7QPsVvw==",
+      "version": "2.1250.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1250.0.tgz",
+      "integrity": "sha512-/fZno2UC2elau/VUOepMvqwKGXmk+dXx1tmahdy1DaAJmELXShg/XWWrtCVg346iLD/XC8eJFR8kQb5ffat0Fw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -298,6 +328,20 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
+      "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@jest/types/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -310,22 +354,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
@@ -353,14 +381,26 @@
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "version": "3.58.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+      "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/internal-slot": {
@@ -392,12 +432,11 @@
       }
     },
     "node_modules/@hapi/validate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
-      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "version": "1.1.3",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/topo": "^6.0.0"
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
       }
     },
     "node_modules/zip-stream": {
@@ -427,10 +466,25 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@hapi/somever/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/boxen/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
@@ -533,9 +587,8 @@
       "license": "0BSD"
     },
     "node_modules/@hapi/file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
+      "version": "2.0.0",
+      "license": "BSD-3-Clause"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -592,6 +645,19 @@
         "node": ">=7.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+      "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/escodegen/node_modules/estraverse": {
       "version": "5.3.0",
       "dev": true,
@@ -601,16 +667,15 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "version": "3.55.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/make-dir": {
@@ -658,26 +723,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.241.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/table": {
       "version": "6.8.0",
       "dev": true,
@@ -694,18 +739,14 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "version": "4.6.2",
+      "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.1",
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/babel-jest/node_modules/supports-color": {
@@ -721,15 +762,9 @@
     },
     "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
+      "license": "0BSD",
       "peer": true
-    },
-    "node_modules/boxen/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/jest-matcher-utils/node_modules/has-flag": {
       "version": "4.0.0",
@@ -763,6 +798,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+      "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/chardet": {
@@ -800,6 +848,17 @@
       },
       "engines": {
         "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/core/node_modules/supports-color": {
@@ -863,15 +922,16 @@
       }
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
-      "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/ts-node": {
@@ -921,14 +981,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/serverless/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -961,6 +1013,10 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/cuid": {
+      "version": "2.1.8",
+      "license": "MIT"
+    },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "license": "Apache-2.0"
@@ -981,9 +1037,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
-      "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1004,49 +1060,50 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
-      "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
         "tslib": "^2.3.1",
         "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/middleware-sdk-sts": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
-        "@aws-sdk/credential-provider-node": "3.224.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/credential-provider-node": "3.105.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "fast-xml-parser": "4.0.11",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0",
-        "@aws-sdk/middleware-signing": "3.224.0"
+        "fast-xml-parser": "3.19.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "entities": "2.2.0",
+        "@aws-sdk/middleware-signing": "3.78.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/yargs-parser": {
@@ -1077,16 +1134,17 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
-      "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
@@ -1094,6 +1152,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/jest-util/node_modules/color-convert": {
@@ -1146,9 +1215,9 @@
       }
     },
     "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
       "engines": {
         "node": ">=4"
       }
@@ -1212,69 +1281,68 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.224.0.tgz",
-      "integrity": "sha512-CPU1sG4xr+fJ+OFpqz9Oum7cJwas0mA9YFvPLkgKLvNC2rhmmn0kbjwawtc6GUDu6xygeV8koBL2gz7OJHQ7fQ==",
+      "version": "3.107.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-expect-continue": "3.224.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/middleware-ssec": "3.224.0",
-        "@aws-sdk/util-stream-node": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/util-stream-browser": "3.224.0",
-        "@aws-sdk/middleware-sdk-s3": "3.224.0",
-        "@aws-sdk/client-sts": "3.224.0",
-        "@aws-sdk/eventstream-serde-browser": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
-        "@aws-sdk/util-waiter": "3.224.0",
+        "@aws-sdk/middleware-expect-continue": "3.78.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/middleware-ssec": "3.78.0",
+        "@aws-sdk/util-stream-node": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/util-stream-browser": "3.78.0",
+        "@aws-sdk/middleware-sdk-s3": "3.105.0",
+        "@aws-sdk/client-sts": "3.105.0",
+        "@aws-sdk/eventstream-serde-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/util-waiter": "3.78.0",
         "tslib": "^2.3.1",
         "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/eventstream-serde-node": "3.224.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "@aws-sdk/signature-v4-multi-region": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/eventstream-serde-node": "3.78.0",
+        "@aws-sdk/xml-builder": "3.55.0",
+        "@aws-sdk/signature-v4-multi-region": "3.88.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-crypto/sha1-browser": "2.0.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/hash-blob-browser": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/md5-js": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
-        "@aws-sdk/credential-provider-node": "3.224.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/hash-blob-browser": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/md5-js": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/credential-provider-node": "3.105.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/middleware-location-constraint": "3.224.0",
-        "fast-xml-parser": "4.0.11",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/hash-stream-node": "3.224.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.224.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0",
-        "@aws-sdk/middleware-signing": "3.224.0"
+        "@aws-sdk/middleware-location-constraint": "3.78.0",
+        "fast-xml-parser": "3.19.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/hash-stream-node": "3.78.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.80.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "entities": "2.2.0",
+        "@aws-sdk/middleware-signing": "3.78.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jest-cli/node_modules/has-flag": {
@@ -1304,13 +1372,12 @@
       "license": "MIT"
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.5",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1339,26 +1406,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
       "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -1378,6 +1435,27 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+      "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -1415,9 +1493,8 @@
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
@@ -1519,6 +1596,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/is-builtin-module": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
@@ -1554,16 +1643,28 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
-      "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/service-error-classification": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1596,6 +1697,22 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
+      "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/decompress-tar/node_modules/bl": {
       "version": "1.2.3",
       "license": "MIT",
@@ -1605,16 +1722,15 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "version": "3.55.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/dotenv-expand": {
@@ -1630,6 +1746,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/hash-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+      "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
@@ -1668,6 +1797,10 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "license": "MIT"
+    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "license": "MIT",
@@ -1687,22 +1820,23 @@
       }
     },
     "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
-      "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -1742,15 +1876,31 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
-      "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+      "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+      "dependencies": {
         "@aws-sdk/signature-v4": "3.224.0",
         "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1778,17 +1928,16 @@
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.224.0.tgz",
-      "integrity": "sha512-5RDwzB2C4Zjn4M2kZYntkc2LJdqe8CH9xmudu3ZYESkZToN5Rd3JyqobW9KPbm//R43VR4ml2qUhYHFzK6jvgg==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@types/yargs-parser": {
@@ -1810,8 +1959,7 @@
     },
     "node_modules/buffer": {
       "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -1842,6 +1990,19 @@
         "node": ">= 0.6.3"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.224.0.tgz",
+      "integrity": "sha512-+SNItYzUSPa8PV1iWwOi3637ztlczJNa2pZ/R1nWf2N8sAmk0BXzGJISv/GKvzPDyAz+uOpT549e8P6rRLZedA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
       "license": "BSD-3-Clause",
@@ -1864,16 +2025,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
-      "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/strip-dirs": {
@@ -1930,28 +2092,23 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/child-process-ext/node_modules/shebang-regex": {
@@ -2026,35 +2183,34 @@
       "license": "MIT"
     },
     "node_modules/luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "version": "2.4.0",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
       "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/object-keys": {
@@ -2080,15 +2236,16 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
-      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -2116,20 +2273,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/node-fetch": {
@@ -2207,18 +2350,6 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/log": {
       "version": "6.3.1",
       "license": "ISC",
@@ -2263,18 +2394,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/minizlib": {
@@ -2328,19 +2447,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
-      "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -2388,13 +2507,22 @@
         }
       }
     },
-    "node_modules/@hapi/somever": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
-      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/url-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
       "dependencies": {
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/hoek": "^9.0.0"
+        "@aws-sdk/querystring-parser": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@serverless/utils/node_modules/supports-color": {
@@ -2411,14 +2539,15 @@
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-validate/node_modules/has-flag": {
@@ -2427,6 +2556,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/mimic-fn": {
@@ -2462,6 +2602,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/boxen/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object.entries": {
       "version": "1.1.5",
       "dev": true,
@@ -2476,14 +2627,13 @@
       }
     },
     "node_modules/@hapi/catbox": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
-      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
+      "version": "11.1.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
@@ -2502,27 +2652,8 @@
     },
     "node_modules/url/node_modules/querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/boxen/node_modules/wrap-ansi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loader-runner": {
@@ -2532,28 +2663,18 @@
         "node": ">=6.11.5"
       }
     },
-    "node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
-      "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/at-least-node": {
@@ -2571,11 +2692,23 @@
       }
     },
     "node_modules/filesize": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.6.tgz",
-      "integrity": "sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.5.tgz",
+      "integrity": "sha512-qrzyt8gLh86nsyYiC3ibI5KyIYRCWg2yqIklYrWF4a0qNfekik4OQfn7AoPJG2hRrPMSlH6fET4VEITweZAzjA==",
       "engines": {
-        "node": ">= 10.4.0"
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -2597,14 +2730,6 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/array-unflat-js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
-      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -2732,6 +2857,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+      "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/d/node_modules/type": {
       "version": "1.2.0",
       "license": "ISC"
@@ -2768,12 +2908,99 @@
       "version": "0.1.1",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+      "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
+      "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/util-defaults-mode-node": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/util-user-agent-browser": "3.224.0",
+        "@aws-sdk/middleware-host-header": "3.224.0",
+        "@aws-sdk/middleware-content-length": "3.224.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.224.0",
+        "@aws-sdk/middleware-retry": "3.224.0",
+        "@aws-sdk/fetch-http-handler": "3.224.0",
+        "@aws-sdk/middleware-user-agent": "3.224.0",
+        "@aws-sdk/node-http-handler": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/util-endpoints": "3.224.0",
+        "@aws-sdk/hash-node": "3.224.0",
+        "@aws-sdk/smithy-client": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.224.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/invalid-dependency": "3.224.0",
+        "@aws-sdk/middleware-logger": "3.224.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/util-user-agent-node": "3.224.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-endpoint": "3.224.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+      "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/supports-color": {
@@ -2836,9 +3063,9 @@
       "license": "MIT"
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2938,9 +3165,8 @@
       }
     },
     "node_modules/@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "version": "0.12.0",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -2959,6 +3185,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+      "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
@@ -2995,6 +3236,19 @@
       "version": "4.4.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+      "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3040,14 +3294,15 @@
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.58.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -3099,6 +3354,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
+      "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/token-providers": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/lodash.isplainobject": {
@@ -3166,21 +3437,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "license": "MIT",
@@ -3206,6 +3462,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
@@ -3263,6 +3534,20 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+      "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -3279,9 +3564,8 @@
       "license": "ISC"
     },
     "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "version": "1.2.4",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3290,15 +3574,14 @@
       }
     },
     "node_modules/@hapi/iron": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
-      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+      "version": "6.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/b64": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/velocityjs": {
@@ -3314,10 +3597,17 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "4.2.0",
+      "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -3347,11 +3637,10 @@
       }
     },
     "node_modules/@hapi/vise": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
-      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
+      "version": "4.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@serverless/utils": {
@@ -3420,31 +3709,30 @@
       }
     },
     "node_modules/@hapi/hapi": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
-      "integrity": "sha512-het7j9yLXZMVU1IvtN2JXkPkn/UcU1j8gsZxMS0Mu1q7791IQeyhT37tpRPUhqerOtL6L0E8Z8CvVVFOYxoN6w==",
+      "version": "20.2.2",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/catbox-memory": "^6.0.0",
-        "@hapi/heavy": "^8.0.0",
-        "@hapi/subtext": "^8.0.0",
-        "@hapi/mimos": "^7.0.0",
-        "@hapi/call": "^9.0.0",
-        "@hapi/somever": "^4.1.0",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/statehood": "^8.0.0",
-        "@hapi/accept": "^6.0.0",
-        "@hapi/shot": "^6.0.0",
-        "@hapi/ammo": "^6.0.0",
-        "@hapi/topo": "^6.0.0",
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/catbox": "^12.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/statehood": "^7.0.4",
+        "@hapi/accept": "^5.0.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/teamwork": "^5.1.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/validate": "^1.1.1"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/lazystream/node_modules/string_decoder": {
@@ -3522,9 +3810,8 @@
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
@@ -3533,15 +3820,14 @@
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.224.0.tgz",
-      "integrity": "sha512-nUBRZzxbq6mU8FIK6OizC5jIeRkVn5tB2ZYxPd7P2IDhh1OVod6gXkq9EKTf3kecNvYgWUVHcOezZF1qLMDLHg==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.188.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/chunked-blob-reader": "3.55.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -3579,16 +3865,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -3638,14 +3914,15 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
-      "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/querystring-builder": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
@@ -3727,8 +4004,7 @@
     },
     "node_modules/serverless/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -3755,18 +4031,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.18.2",
       "dev": true,
@@ -3780,6 +4044,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/nice-try": {
@@ -3875,27 +4150,27 @@
       }
     },
     "node_modules/@hapi/bounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
+      "version": "2.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
-      "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+      "version": "3.94.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/querystring-builder": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/builtin-modules": {
@@ -3922,6 +4197,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
@@ -3937,49 +4220,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
-      "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "tslib": "^2.3.1",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
@@ -4043,6 +4283,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/serverless-offline/node_modules/semver": {
+      "version": "7.3.7",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "dev": true,
@@ -4061,6 +4314,76 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+      "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+      "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+      "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
+      "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/supports-color": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
@@ -4094,28 +4417,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/serverless-offline/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
-      "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-message-util/node_modules/has-flag": {
@@ -4132,8 +4445,7 @@
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4147,11 +4459,10 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "version": "9.1.4",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "10.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/babel-jest": {
@@ -4369,11 +4680,22 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.224.0.tgz",
-      "integrity": "sha512-FpgKNGzImgmHTbz4Hjc41GEH4/dASxz6sTtn5T+kFDsT1j7o21tpWlS6psoazTz9Yi3ichBo2yzYUaY3QxOFew==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
       "dependencies": {
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
@@ -4386,18 +4708,6 @@
       "version": "0.0.51",
       "license": "MIT"
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/property-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "license": "MIT",
@@ -4406,10 +4716,10 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.16.0",
+      "version": "3.15.0",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
-      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
+      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -4461,14 +4771,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@aws-sdk/util-retry/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/jest-message-util/node_modules/color-name": {
       "version": "1.1.4",
       "dev": true,
@@ -4496,6 +4798,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "license": "MIT",
@@ -4504,17 +4818,15 @@
       }
     },
     "node_modules/@hapi/ammo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
-      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
+      "version": "5.0.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "11.8.5",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -4533,21 +4845,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/environment": {
@@ -4638,18 +4935,47 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.235.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
+      "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/util-defaults-mode-node": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/util-user-agent-browser": "3.224.0",
+        "@aws-sdk/middleware-host-header": "3.224.0",
+        "@aws-sdk/middleware-content-length": "3.224.0",
         "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.224.0",
+        "@aws-sdk/middleware-retry": "3.224.0",
+        "@aws-sdk/fetch-http-handler": "3.224.0",
+        "@aws-sdk/middleware-user-agent": "3.224.0",
+        "@aws-sdk/node-http-handler": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/util-endpoints": "3.224.0",
+        "@aws-sdk/hash-node": "3.224.0",
+        "@aws-sdk/smithy-client": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.224.0",
+        "@aws-sdk/middleware-sdk-sts": "3.224.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/invalid-dependency": "3.224.0",
+        "@aws-sdk/middleware-logger": "3.224.0",
+        "@aws-sdk/credential-provider-node": "3.224.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "fast-xml-parser": "4.0.11",
+        "@aws-sdk/util-user-agent-node": "3.224.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-endpoint": "3.224.0",
+        "@aws-sdk/middleware-signing": "3.224.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4670,6 +4996,15 @@
         "es5-ext": "^0.10.12"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+      "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "license": "MIT",
@@ -4682,15 +5017,16 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
-      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
@@ -4707,17 +5043,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
@@ -4777,7 +5102,6 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4810,6 +5134,22 @@
         "superagent": "^3.8.3"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+      "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/service-error-classification": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.2.0",
       "license": "MIT",
@@ -4824,19 +5164,20 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
-      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.224.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -4856,6 +5197,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/parent-module": {
@@ -4894,51 +5243,20 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+      "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
       "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "tslib": "^2.3.1",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "fast-xml-parser": "4.0.11",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0"
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@jest/console/node_modules/color-name": {
@@ -4973,6 +5291,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
+      "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/credential-provider-sso": "3.224.0",
+        "@aws-sdk/credential-provider-web-identity": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/color-name": {
       "version": "1.1.3",
       "dev": true,
@@ -4984,18 +5320,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
@@ -5022,6 +5346,13 @@
       "version": "1.2.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.18.2",
       "dev": true,
@@ -5043,21 +5374,57 @@
         "node": ">=6"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+      "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
+      "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/credential-provider-env": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/credential-provider-ini": "3.224.0",
+        "@aws-sdk/credential-provider-process": "3.224.0",
+        "@aws-sdk/credential-provider-sso": "3.224.0",
+        "@aws-sdk/credential-provider-web-identity": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
+      "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -5201,6 +5568,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/url-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
       "version": "8.1.0",
       "dev": true,
@@ -5256,7 +5633,6 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -5347,33 +5723,31 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.224.0.tgz",
-      "integrity": "sha512-SDyFandByU9UBQOxqFk8TCE0e9FPA/nr0FRjANxkIm24/zxk2yZbk3OUx/Zr7ibo28b5BqcQV69IClBOukPiEw==",
+      "version": "3.105.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
+      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "is-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5399,17 +5773,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.7",
       "license": "MIT",
@@ -5424,15 +5787,16 @@
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/nise": {
@@ -5447,12 +5811,16 @@
         "path-to-regexp": "^1.7.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
+      "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/client-sso": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/token-providers": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -5479,18 +5847,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+      "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "bowser": "^2.11.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/console/node_modules/color-convert": {
@@ -5505,71 +5872,20 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.241.0.tgz",
-      "integrity": "sha512-Hb2/SE9nVEjTaLFitz36vU4/c0HhPNw/clQNQW4soVJjxBadQ8Yce03QjdEvphCFk3rQWSebhc9L+UZ3qw7Qdw==",
-      "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/client-sts": "3.241.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "tslib": "^2.3.1",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
-      "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -5578,6 +5894,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+      "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
@@ -5612,17 +5936,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/boxen/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "dev": true,
@@ -5653,6 +5966,18 @@
         "@webassemblyjs/wasm-parser": "1.11.1"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
       "dev": true,
@@ -5662,11 +5987,11 @@
       }
     },
     "node_modules/boxen/node_modules/camelcase": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5693,6 +6018,29 @@
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -5739,14 +6087,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+      "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.7.3",
+      "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "bin": {
@@ -5839,11 +6198,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6008,13 +6362,12 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
-      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
+      "version": "17.2.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/superagent/node_modules/string_decoder": {
@@ -6036,6 +6389,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -6159,6 +6516,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/p-settle": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.2",
+        "p-reflect": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "dev": true,
@@ -6203,18 +6574,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.224.0.tgz",
-      "integrity": "sha512-xgihNtu5dXzRqL0QrOuMLmSoji7BsKJ+rCXjW+X+Z1flYFV5UDY5PI0dgAlgWQDWZDyu17n4R5IIZUzb/aAI1g==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-header-default": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-resolve/node_modules/chalk": {
@@ -6246,28 +6617,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/execa": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^3.0.1",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
@@ -6305,6 +6654,22 @@
       "version": "0.6.6",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
+      "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.5",
       "dev": true,
@@ -6341,6 +6706,18 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/char-regex": {
@@ -6504,16 +6881,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/@hapi/nigel": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
-      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/vise": "^5.0.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/nigel": {
+      "version": "4.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@serverless/dashboard-plugin": {
@@ -6564,16 +6951,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
-      "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@types/babel__traverse": {
@@ -6608,6 +6996,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
       "dev": true,
@@ -6616,9 +7011,37 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+      "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.41",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+      "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/service-error-classification": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/serverless/node_modules/supports-color": {
       "version": "8.1.1",
@@ -6648,6 +7071,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/p-settle/node_modules/p-try": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/find-requires": {
       "version": "1.0.0",
       "license": "ISC",
@@ -6660,9 +7090,8 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.1.2",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6682,10 +7111,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
-      "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+      "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -6718,17 +7160,6 @@
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/p-memoize/node_modules/type-fest": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.0.tgz",
-      "integrity": "sha512-bI3zRmZC8K0tUz1HjbIOAGQwR2CoPQG68N5IF7gm0LBl8QSNXzkmaWnkWccCUL5uG9mCsp4sBwC8SBrNSISWew==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
@@ -6788,11 +7219,10 @@
       }
     },
     "node_modules/@hapi/b64": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
-      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "version": "5.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/untildify": {
@@ -6808,8 +7238,7 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -6822,21 +7251,21 @@
       }
     },
     "node_modules/boxen": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
-      "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
       "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^7.0.0",
-        "chalk": "^5.0.1",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^5.1.2",
-        "type-fest": "^2.13.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.0.1"
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6859,6 +7288,10 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "license": "MIT"
     },
     "node_modules/unbzip2-stream/node_modules/buffer": {
       "version": "5.7.1",
@@ -6883,15 +7316,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
-      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/run-parallel-limit": {
@@ -6916,10 +7350,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "version": "1.0.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -6996,21 +7429,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-http-handler": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
-      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+      "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
       "dependencies": {
+        "@aws-sdk/abort-controller": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+      "license": "MIT"
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -7021,11 +7469,10 @@
       }
     },
     "node_modules/@hapi/teamwork": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
-      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "version": "5.1.1",
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fs-extra": {
@@ -7054,13 +7501,23 @@
         "node": ">=6"
       }
     },
-    "node_modules/@hapi/accept": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
-      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/accept": {
+      "version": "5.0.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@types/prettier": {
@@ -7094,12 +7551,29 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/service-error-classification": {
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/signature-v4": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
-      "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
@@ -7143,35 +7617,25 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/serverless-offline/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
-      "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+      "version": "3.81.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/regjsgen": {
@@ -7213,24 +7677,35 @@
       }
     },
     "node_modules/cron-parser/node_modules/luxon": {
-      "version": "1.28.1",
+      "version": "1.28.0",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": "*"
       }
     },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
-      "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/table/node_modules/ajv": {
@@ -7254,10 +7729,28 @@
     },
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
+      "license": "0BSD",
       "peer": true
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+      "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.17.12",
@@ -7284,6 +7777,10 @@
         "node": ">= 6"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "dev": true,
@@ -7293,30 +7790,30 @@
       }
     },
     "node_modules/serverless": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.26.0.tgz",
-      "integrity": "sha512-drVr4akkQwm2Pj7ZN9boh5PoI2nKvlXmy+Cb8Hh1Zv8ybsf47ZUQE6t7dakGA4irYf4SQCbVc72nKqISfarMCQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.24.1.tgz",
+      "integrity": "sha512-v7WTprSqj0jFoKOY0BU4a7P7bOYHPsvhhxpZt8OJqYrnqyAQbnhM6GXbDimRMibsH3CNvMVWEKD+WWeimXzcHw==",
       "hasInstallScript": true,
       "dependencies": {
         "get-stdin": "^8.0.0",
         "d": "^1.0.1",
         "js-yaml": "^4.1.0",
-        "got": "^11.8.6",
+        "got": "^11.8.5",
         "semver": "^7.3.8",
         "child-process-ext": "^2.1.1",
         "globby": "^11.1.0",
         "dotenv": "^16.0.3",
-        "dayjs": "^1.11.7",
+        "dayjs": "^1.11.6",
         "strip-ansi": "^6.0.1",
         "path2": "^0.1.0",
         "lodash": "^4.17.21",
         "yaml-ast-parser": "0.0.43",
-        "tar": "^6.1.13",
+        "tar": "^6.1.12",
         "npm-registry-utilities": "^1.0.0",
         "signal-exit": "^3.0.7",
         "is-docker": "^2.2.1",
         "essentials": "^1.2.0",
-        "filesize": "^10.0.6",
+        "filesize": "^10.0.5",
         "ajv-formats": "^2.1.1",
         "fs-extra": "^10.1.0",
         "require-from-string": "^2.0.2",
@@ -7335,11 +7832,11 @@
         "supports-color": "^8.1.1",
         "chalk": "^4.1.2",
         "dotenv-expand": "^9.0.0",
-        "ajv": "^8.11.2",
+        "ajv": "^8.11.0",
         "https-proxy-agent": "^5.0.1",
         "type": "^2.7.2",
         "untildify": "^4.0.0",
-        "aws-sdk": "^2.1280.0",
+        "aws-sdk": "^2.1247.0",
         "@serverless/dashboard-plugin": "^6.2.2",
         "json-refs": "^3.0.15",
         "process-utils": "^4.0.0",
@@ -7349,7 +7846,7 @@
         "@serverless/utils": "^6.8.2",
         "@serverless/platform-client": "^4.3.2",
         "graceful-fs": "^4.2.10",
-        "ci-info": "^3.7.0",
+        "ci-info": "^3.5.0",
         "micromatch": "^4.0.5"
       },
       "bin": {
@@ -7361,11 +7858,10 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "5.1.0",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/process-utils": {
@@ -7420,22 +7916,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/serverless-webpack/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -7451,21 +7931,20 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.224.0.tgz",
-      "integrity": "sha512-8umP3a1YNg5+sowQgzKNiq//vSVC53iTBzg8/oszstwIMYE9aNf4RKd/X/H9biBF/G05xdTjqNAQrAh54UbKrQ==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7532,9 +8011,36 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/cookiejar": {
       "version": "2.1.3",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -7556,6 +8062,18 @@
     "node_modules/ieee754": {
       "version": "1.1.13",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/decompress-tar/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -7580,20 +8098,21 @@
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
       "engines": {
         "node": ">=4"
       }
@@ -7637,17 +8156,12 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.224.0.tgz",
-      "integrity": "sha512-JS+C8CyxVFMQ69P4QIDTrzkhseEFCVFy2YHZYlCx3M5P+L1/PQHebTETYFMmO9ThY8TRXmYZDJHv79guvV+saQ==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -7680,32 +8194,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.224.0.tgz",
-      "integrity": "sha512-p8DePCwvgrrlYK7r3euI5aX/VVxrCl+DClHy0TV6/Eq8WCgWqYfZ5TSl5kbrxIc4U7pDlNIBkTiQMIl/ilEiQg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -7714,35 +8202,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+      "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.20.1",
+      "license": "MIT",
       "dependencies": {
-        "gopd": "^1.0.1",
         "regexp.prototype.flags": "^1.4.3",
         "object-keys": "^1.1.1",
         "internal-slot": "^1.0.3",
         "function-bind": "^1.1.1",
         "es-to-primitive": "^1.2.1",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.1.1",
         "is-weakref": "^1.0.2",
-        "is-callable": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
+        "is-callable": "^1.2.4",
+        "string.prototype.trimend": "^1.0.5",
         "is-shared-array-buffer": "^1.0.2",
-        "object.assign": "^4.1.4",
+        "object.assign": "^4.1.2",
         "is-regex": "^1.1.4",
         "has-symbols": "^1.0.3",
         "get-symbol-description": "^1.0.0",
-        "safe-regex-test": "^1.0.0",
         "unbox-primitive": "^1.0.2",
         "is-string": "^1.0.7",
         "call-bind": "^1.0.2",
         "function.prototype.name": "^1.1.5",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.5",
         "is-negative-zero": "^2.0.2"
       },
       "engines": {
@@ -7764,6 +8257,10 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -7968,6 +8465,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+      "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.17.12",
       "dev": true,
@@ -8016,12 +8522,37 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+      "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/property-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ora/node_modules/ansi-styles": {
@@ -8050,6 +8581,24 @@
         "es5-ext": "^0.10.53"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
+      "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/credential-provider-sso": "3.224.0",
+        "@aws-sdk/credential-provider-web-identity": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -8073,17 +8622,14 @@
       }
     },
     "node_modules/widest-line": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dependencies": {
-        "string-width": "^5.0.1"
+        "string-width": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
@@ -8109,6 +8655,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+      "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -8117,10 +8685,20 @@
         "color-name": "1.1.3"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minipass": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
-      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -8128,17 +8706,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/middleware-content-length": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
-      "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-serializer": {
@@ -8209,6 +8796,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.0.1",
       "dev": true,
@@ -8220,9 +8818,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -8268,8 +8876,6 @@
     },
     "node_modules/token-types/node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -8283,27 +8889,21 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
-      "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
@@ -8319,6 +8919,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -8350,12 +8958,11 @@
       "license": "MIT"
     },
     "node_modules/@hapi/call": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
-      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
+      "version": "8.0.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/path2": {
@@ -8378,6 +8985,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+      "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/is-number-object": {
@@ -8453,49 +9081,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
-      "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "tslib": "^2.3.1",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -8508,39 +9093,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/child-process-ext/node_modules/shebang-command": {
@@ -8608,42 +9160,53 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@aws-sdk/util-body-length-node": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-buffer-from": {
       "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@hapi/h2o2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
-      "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0",
-        "@hapi/wreck": "^18.0.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+    "node_modules/@aws-sdk/eventstream-marshaller": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@hapi/h2o2": {
+      "version": "9.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x",
+        "@hapi/wreck": "17.x.x"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/run-async": {
@@ -8666,9 +9229,8 @@
       }
     },
     "node_modules/@hapi/hoek": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
-      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+      "version": "9.3.0",
+      "license": "BSD-3-Clause"
     },
     "node_modules/webpack/node_modules/acorn": {
       "version": "8.7.1",
@@ -8762,6 +9324,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
+      "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
@@ -8778,9 +9356,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+      "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+      "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -8790,81 +9387,63 @@
         "node": ">=4"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.241.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "license": "MIT"
     },
     "node_modules/serverless-offline": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
-      "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.8.1.tgz",
+      "integrity": "sha512-tpvAEGMf6qB9jGSDrpLQSYljqiIxOfjpsWq6q9ol3goqbcxXasvGR9nVX5cXq1MNBRXsJQE1PdHxtxivng2Lrw==",
       "dependencies": {
-        "@hapi/h2o2": "^10.0.0",
-        "p-retry": "^5.1.2",
-        "array-unflat-js": "^0.1.3",
-        "p-memoize": "^7.1.1",
-        "is-wsl": "^2.2.0",
-        "jszip": "^3.10.1",
-        "execa": "^6.1.0",
-        "fs-extra": "^11.1.0",
+        "@hapi/h2o2": "^9.1.0",
+        "semver": "^7.3.7",
+        "p-retry": "^4.6.2",
+        "jsonwebtoken": "^8.5.1",
+        "p-memoize": "^4.0.4",
+        "jszip": "^3.9.1",
+        "execa": "^5.1.1",
+        "fs-extra": "^10.1.0",
         "java-invoke-local": "0.0.6",
-        "boxen": "^7.0.1",
+        "boxen": "^5.1.2",
         "js-string-escape": "^1.0.1",
         "velocityjs": "^2.0.6",
-        "desm": "^1.3.0",
-        "luxon": "^3.2.0",
-        "node-fetch": "^3.3.0",
-        "object.hasown": "^1.1.2",
-        "chalk": "^5.2.0",
-        "@aws-sdk/client-lambda": "^3.241.0",
-        "jose": "^4.11.2",
-        "@hapi/boom": "^10.0.0",
-        "jsonpath-plus": "^7.2.0",
-        "jsonschema": "^1.4.1",
-        "@hapi/hapi": "^21.1.0",
-        "ws": "^8.11.0",
-        "node-schedule": "^2.1.0",
-        "@serverless/utils": "^6.8.2"
+        "luxon": "^2.4.0",
+        "node-fetch": "^2.6.7",
+        "chalk": "^4.1.2",
+        "p-queue": "^6.6.2",
+        "cuid": "^2.1.8",
+        "@hapi/boom": "^9.1.4",
+        "jsonpath-plus": "^5.1.0",
+        "aws-sdk": "^2.1136.0",
+        "jsonschema": "^1.4.0",
+        "@hapi/hapi": "^20.2.2",
+        "ws": "^7.5.7",
+        "node-schedule": "^2.1.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "serverless": "^3.2.0"
+        "serverless": "^1.60.0 || 2 || 3"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+      "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
       "engines": {
-        "node": ">=10.5.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@serverless/utils/node_modules/has-flag": {
@@ -8874,29 +9453,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "version": "2.2.1",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8941,31 +9501,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/serverless-offline/node_modules/human-signals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
-      "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+      "version": "3.99.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+      "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "dependencies": {
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
@@ -8973,9 +9548,20 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "license": "MIT"
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+      "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
@@ -8999,9 +9585,36 @@
         "node": ">=7.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+      "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-header-default": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -9077,6 +9690,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/url-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.18.2",
       "dev": true,
@@ -9095,6 +9718,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.58.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/traverse": {
@@ -9126,17 +9758,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
-      "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
@@ -9155,19 +9788,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@nodelib/fs.stat": {
@@ -9219,6 +9845,18 @@
       "version": "2.2.0",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "license": "MIT"
@@ -9243,14 +9881,15 @@
       "license": "ISC"
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
@@ -9298,11 +9937,10 @@
       }
     },
     "node_modules/@hapi/topo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
-      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "version": "5.1.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/jest-cli/node_modules/color-convert": {
@@ -9400,19 +10038,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
-      "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/token-providers": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/client-sso": "3.105.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/fb-watchman": {
@@ -9434,6 +10072,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/serverless-offline/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "dev": true,
@@ -9451,9 +10102,8 @@
       }
     },
     "node_modules/serverless/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.11.0",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9463,6 +10113,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9478,9 +10136,8 @@
     },
     "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
+      "license": "0BSD",
       "peer": true
     },
     "node_modules/neo-async": {
@@ -9513,9 +10170,9 @@
       "license": "0BSD"
     },
     "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9532,11 +10189,10 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "5.0.2",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0"
+        "@hapi/boom": "9.x.x"
       }
     },
     "node_modules/@serverless/utils/node_modules/js-yaml": {
@@ -9601,7 +10257,6 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -9863,8 +10518,7 @@
     },
     "node_modules/sax": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+      "license": "ISC"
     },
     "node_modules/whatwg-url": {
       "version": "8.7.0",
@@ -9927,15 +10581,29 @@
       }
     },
     "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+      "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -9982,19 +10650,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "license": "MIT",
@@ -10022,27 +10677,25 @@
       }
     },
     "node_modules/serverless-offline/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "version": "10.1.0",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=12"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+      "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
       "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "bowser": "^2.11.0",
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -10053,11 +10706,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
       "dependencies": {
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -10113,11 +10767,14 @@
       }
     },
     "node_modules/serverless-offline/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "4.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -10163,45 +10820,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
-      "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
         "tslib": "^2.3.1",
         "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0"
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/types": "3.78.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/bl/node_modules/buffer": {
@@ -10227,12 +10884,11 @@
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
-      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
+      "version": "5.0.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/child-process-ext/node_modules/cross-spawn": {
@@ -10389,29 +11045,20 @@
     },
     "node_modules/xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
+      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -10474,7 +11121,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.18.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -10484,16 +11130,22 @@
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "version": "3.55.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/types": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
       "version": "3.224.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
       "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
@@ -10530,8 +11182,7 @@
     },
     "node_modules/strtok3": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -10616,25 +11267,18 @@
       }
     },
     "node_modules/boxen/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -10651,6 +11295,17 @@
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.16.7",
@@ -10732,14 +11387,54 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.224.0.tgz",
-      "integrity": "sha512-zl8YUa+JZV9Dj304pc2HovMuUsz3qzo8HHj+FjIHxVsNfFL4U/NX/eDhkiWNUwVMlQIWvjksoJZ75kIzDyWGKQ==",
-      "dev": true,
-      "peer": true,
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+      "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
       "dependencies": {
         "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+      "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -10796,6 +11491,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/boxen/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@jest/fake-timers": {
       "version": "27.5.1",
@@ -10901,10 +11601,29 @@
     },
     "node_modules/jmespath": {
       "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/esrecurse": {
@@ -10918,17 +11637,16 @@
       }
     },
     "node_modules/@hapi/statehood": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
-      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
+      "version": "7.0.4",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/iron": "^7.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -10950,6 +11668,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+      "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/serverless-offline/node_modules/has-flag": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/decompress-unzip": {
@@ -10990,27 +11738,8 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/aws-sdk/node_modules/querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -11049,32 +11778,26 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+      "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+      "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -11096,6 +11819,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "license": "MIT"
+    },
     "node_modules/jest-junit": {
       "version": "12.3.0",
       "dev": true,
@@ -11114,6 +11841,18 @@
       "version": "1.14.1",
       "license": "0BSD"
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "license": "MIT",
@@ -11124,6 +11863,29 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
@@ -11185,6 +11947,17 @@
         "@webassemblyjs/wast-printer": "1.11.1"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
       "license": "MIT",
@@ -11207,6 +11980,52 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
+      "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/util-defaults-mode-node": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/util-user-agent-browser": "3.224.0",
+        "@aws-sdk/middleware-host-header": "3.224.0",
+        "@aws-sdk/middleware-content-length": "3.224.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.224.0",
+        "@aws-sdk/middleware-retry": "3.224.0",
+        "@aws-sdk/fetch-http-handler": "3.224.0",
+        "@aws-sdk/middleware-user-agent": "3.224.0",
+        "@aws-sdk/node-http-handler": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/util-endpoints": "3.224.0",
+        "@aws-sdk/hash-node": "3.224.0",
+        "@aws-sdk/smithy-client": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.224.0",
+        "@aws-sdk/middleware-sdk-sts": "3.224.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/invalid-dependency": "3.224.0",
+        "@aws-sdk/middleware-logger": "3.224.0",
+        "@aws-sdk/credential-provider-node": "3.224.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "fast-xml-parser": "4.0.11",
+        "@aws-sdk/util-user-agent-node": "3.224.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-endpoint": "3.224.0",
+        "@aws-sdk/middleware-signing": "3.224.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -11244,6 +12063,18 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-runner/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -11271,10 +12102,23 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "license": "MIT"
     },
     "node_modules/decompress-tarbz2/node_modules/is-stream": {
       "version": "1.1.0",
@@ -11291,19 +12135,31 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-universal": {
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.224.0.tgz",
-      "integrity": "sha512-sI9WKnaKfpVamLCESHDOg8SkMtkjjYX3awny5PJC3/Jx9zOFN9AnvGtnIJrOGFxs5kBmQNj7c4sKCAPiTCcITw==",
-      "dev": true,
-      "peer": true,
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
+      "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
       "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -11343,6 +12199,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
     "node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
@@ -11350,8 +12226,7 @@
     },
     "node_modules/readable-web-to-node-stream": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^3.6.0"
       },
@@ -11421,21 +12296,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
-      "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/credential-provider-sso": "3.224.0",
-        "@aws-sdk/credential-provider-web-identity": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.105.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/cliui": {
@@ -11448,18 +12324,22 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@hapi/bourne": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
+      "version": "2.1.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -11467,15 +12347,16 @@
       "license": "MIT"
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
-      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/is-generator-fn": {
@@ -11563,6 +12444,10 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/serverless-offline/node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
     "node_modules/@jest/types/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11634,16 +12519,17 @@
       "license": "MIT"
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.224.0.tgz",
-      "integrity": "sha512-+SNItYzUSPa8PV1iWwOi3637ztlczJNa2pZ/R1nWf2N8sAmk0BXzGJISv/GKvzPDyAz+uOpT549e8P6rRLZedA==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/inquirer/node_modules/color-name": {
@@ -11718,23 +12604,22 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/md5-js": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.224.0.tgz",
+      "integrity": "sha512-DT9hKzBYJUcPvGxTXwoug5Ac4zJ7q5pwOVF/PFCsN3TiXHHfDAIA0/GJjA6pZwPEi/qVy0iNhGKQK8/0i5JeWw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -11765,20 +12650,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -11823,6 +12694,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -11913,6 +12795,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@serverless/utils/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -11935,8 +12828,7 @@
     },
     "node_modules/events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -12076,6 +12968,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+      "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-jasmine2/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -12129,6 +13035,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "license": "MIT",
@@ -12142,6 +13060,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/nwsapi": {
@@ -12179,23 +13108,25 @@
         "node": ">=8"
       }
     },
-    "node_modules/serverless-offline/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@serverless/utils/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -12213,27 +13144,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "license": "MIT",
@@ -12249,16 +13159,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/url-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/formidable": {
@@ -12335,16 +13235,17 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
-      "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/jest-resolve-dependencies": {
@@ -12358,6 +13259,17 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/types/node_modules/supports-color": {
@@ -12399,9 +13311,8 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "version": "3.55.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -12487,6 +13398,20 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+      "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@jest/console": {
       "version": "27.5.1",
       "dev": true,
@@ -12504,11 +13429,48 @@
       }
     },
     "node_modules/decompress-tar/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+      "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+      "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@webassemblyjs/helper-buffer": {
@@ -12537,19 +13499,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "license": "MIT",
@@ -12565,19 +13514,47 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
-      "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/credential-provider-ini": "3.224.0",
-        "@aws-sdk/credential-provider-process": "3.224.0",
-        "@aws-sdk/credential-provider-sso": "3.224.0",
-        "@aws-sdk/credential-provider-web-identity": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.105.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.105.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.105.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/property-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "dependencies": {
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
@@ -12586,9 +13563,8 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "version": "3.10.0",
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -12613,6 +13589,18 @@
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dependencies": {
         "type": "^2.7.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -12657,15 +13645,15 @@
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
-      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/fs-constants": {
@@ -12683,19 +13671,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/hash-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/jest-jasmine2/node_modules/has-flag": {
@@ -12767,18 +13742,15 @@
         "stream-promise": "^3.2.0"
       }
     },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
@@ -12854,9 +13826,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1068.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1068.0.tgz",
-      "integrity": "sha512-lVXp7yDTp9oznGDs9W4vMtY271smJ5wukB8g6gdLYRcNAozrN70kbvZGvBFELxdWdVak2qa+ut5AyIVHZ8XUew==",
+      "version": "1.1056.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1056.0.tgz",
+      "integrity": "sha512-Ny9dHfI6SgNHfh6HbRgtMN0MKUH0QhIcWYbw24t5GM0qejoMSEQSJv9kDzrIQLRd0OBBlZAba5EEPRiSafrxmQ==",
       "dev": true,
       "bin": {
         "snyk": "bin/snyk"
@@ -12879,6 +13851,28 @@
         "timers-ext": "^0.1.7"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/url-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-snapshot/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -12887,54 +13881,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.224.0.tgz",
-      "integrity": "sha512-xOW8rtEH2Rcadr+CFfiISZwcbf4jPdc4OvL6OiPsv+arndOhxk+4ZaRT2xic1FrVdYQypmSToRITYlZc9N7PjQ==",
+      "version": "3.88.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/signature-v4-crt": "^3.118.0"
+        "@aws-sdk/signature-v4-crt": "^3.79.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/signature-v4-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/serverless-offline/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/follow-redirects": {
@@ -12975,6 +13943,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
+      "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -13019,24 +14000,10 @@
     },
     "node_modules/url": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-waiter": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
@@ -13078,11 +14045,14 @@
       }
     },
     "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -13104,6 +14074,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/hash-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+      "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/content-disposition": {
@@ -13182,11 +14165,11 @@
       }
     },
     "node_modules/boxen/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13297,15 +14280,15 @@
       }
     },
     "node_modules/p-memoize": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
-      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
+      "version": "4.0.4",
+      "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0",
+        "p-settle": "^4.1.1"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
@@ -13340,6 +14323,32 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+      "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+      "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-mock": {
       "version": "27.5.1",
       "dev": true,
@@ -13366,29 +14375,31 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+      "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+      "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/sinon": {
@@ -13463,20 +14474,17 @@
       "version": "5.1.2",
       "license": "MIT"
     },
-    "node_modules/@serverless/utils/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "engines": {
-        "node": ">=10"
-      },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+      "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
       "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -13526,11 +14534,12 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "3.19.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "bin": {
-        "fxparser": "src/cli/cli.js"
+        "xml2js": "cli.js"
       },
       "dependencies": {
         "strnum": "^1.0.5"
@@ -13560,6 +14569,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+      "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/querystring-builder": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
       "license": "MIT"
@@ -13578,6 +14599,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+      "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jest/core": {
@@ -13627,12 +14659,11 @@
       }
     },
     "node_modules/@hapi/shot": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
-      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
+      "version": "5.0.5",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "node_modules/sinon/node_modules/has-flag": {
@@ -13644,29 +14675,30 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
-      "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+      "version": "3.80.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/property-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "dependencies": {
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
@@ -13681,20 +14713,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.224.0.tgz",
-      "integrity": "sha512-cAmrSmVjBCENM9ojUBRhIsuQ2mPH4WxnqE5wxloHdP8BD7usNE/dMtGMhot3Dnf8WZEFpTMfhtrZrmSTCaANTQ==",
+      "version": "3.80.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/import-fresh": {
@@ -13710,6 +14741,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/decompress": {
@@ -13756,23 +14798,10 @@
     },
     "node_modules/xml2js": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/jest-worker/node_modules/has-flag": {
@@ -13783,11 +14812,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
-      "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
@@ -13822,17 +14852,14 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-      "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
-      "engines": {
-        "node": ">=8"
-      }
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
     },
     "node_modules/archive-type/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
       "engines": {
         "node": ">=4"
       }
@@ -13868,14 +14895,13 @@
       }
     },
     "node_modules/@hapi/cryptiles": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
-      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+      "version": "5.1.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0"
+        "@hapi/boom": "9.x.x"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -13886,12 +14912,24 @@
       }
     },
     "node_modules/@hapi/mimos": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
-      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
+      "version": "6.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0",
-        "mime-db": "^1.52.0"
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/hash-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+      "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -13930,12 +14968,26 @@
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
-      "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+      "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
         "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -13961,15 +15013,16 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
-      "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+      "version": "3.99.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -14041,13 +15094,12 @@
       }
     },
     "node_modules/@hapi/heavy": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
-      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "version": "7.0.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "node_modules/essentials": {
@@ -14120,11 +15172,10 @@
       }
     },
     "node_modules/serverless-offline/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "7.5.8",
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=8.3.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -14217,6 +15268,17 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -14229,19 +15291,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-parse": {
@@ -14273,17 +15322,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/stream-promise/node_modules/is-stream": {
@@ -14330,17 +15368,16 @@
       "license": "MIT"
     },
     "node_modules/@hapi/subtext": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
-      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
+      "version": "7.0.3",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/file": "^3.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/pez": "^6.0.0",
-        "@hapi/wreck": "^18.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "node_modules/cli-sprintf-format": {
@@ -14395,22 +15432,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/boxen/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "license": "Apache-2.0",
@@ -14431,6 +15452,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "17.1.3",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/tslib": {
@@ -14468,8 +15506,7 @@
     },
     "node_modules/aws-sdk/node_modules/uuid": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14502,16 +15539,57 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.5",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
+      "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+      "dependencies": {
+        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/util-defaults-mode-node": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.224.0",
+        "@aws-sdk/util-user-agent-browser": "3.224.0",
+        "@aws-sdk/middleware-host-header": "3.224.0",
+        "@aws-sdk/middleware-content-length": "3.224.0",
+        "tslib": "^2.3.1",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-sdk/middleware-serde": "3.224.0",
+        "@aws-sdk/middleware-retry": "3.224.0",
+        "@aws-sdk/fetch-http-handler": "3.224.0",
+        "@aws-sdk/middleware-user-agent": "3.224.0",
+        "@aws-sdk/node-http-handler": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/util-endpoints": "3.224.0",
+        "@aws-sdk/hash-node": "3.224.0",
+        "@aws-sdk/smithy-client": "3.224.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.224.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/invalid-dependency": "3.224.0",
+        "@aws-sdk/middleware-logger": "3.224.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/util-user-agent-node": "3.224.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-endpoint": "3.224.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/isarray": {
@@ -14525,14 +15603,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+      "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/desm": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
-      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
@@ -14622,20 +15710,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "dev": true,
@@ -14643,9 +15717,8 @@
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
@@ -14657,25 +15730,33 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.224.0.tgz",
-      "integrity": "sha512-ztvZHJJg9/BwUrKnSz3jV6T8oOdxA1MRypK2zqTdjoPU9u/8CFQ2p0gszBApMjyxCnLWo1oM5oiMwzz1ufDrlA==",
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/xml": {
       "version": "1.0.1",
@@ -14687,6 +15768,26 @@
       "license": "MIT",
       "bin": {
         "java-invoke-local": "lib/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
+      "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/credential-provider-ini": "3.224.0",
+        "@aws-sdk/credential-provider-process": "3.224.0",
+        "@aws-sdk/credential-provider-sso": "3.224.0",
+        "@aws-sdk/credential-provider-web-identity": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/shared-ini-file-loader": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/json5": {
@@ -14731,12 +15832,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
-      "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+      "version": "3.99.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -14745,12 +15847,13 @@
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
-      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -14796,13 +15899,27 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+      "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/url-parser": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/lowercase-keys": {
@@ -14813,13 +15930,12 @@
       }
     },
     "node_modules/@hapi/podium": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
-      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "version": "4.1.3",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "node_modules/pkg-dir/node_modules/path-exists": {
@@ -14846,15 +15962,16 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
@@ -14941,26 +16058,29 @@
         }
       }
     },
-    "node_modules/object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+      "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "@aws-sdk/config-resolver": "3.224.0",
+        "@aws-sdk/credential-provider-imds": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.2",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -14971,13 +16091,14 @@
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.224.0.tgz",
-      "integrity": "sha512-DT9hKzBYJUcPvGxTXwoug5Ac4zJ7q5pwOVF/PFCsN3TiXHHfDAIA0/GJjA6pZwPEi/qVy0iNhGKQK8/0i5JeWw==",
+      "version": "3.78.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
@@ -15025,13 +16146,13 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.12.tgz",
+      "integrity": "sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^3.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -15098,21 +16219,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "dev": true,
@@ -15126,9 +16232,10 @@
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "version": "3.55.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -15142,6 +16249,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/property-provider": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/jest-watcher/node_modules/chalk": {
@@ -15163,13 +16282,16 @@
       "version": "2.20.3",
       "license": "MIT"
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+      "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -15213,6 +16335,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
+      "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.224.0",
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/signature-v4": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/log-node/node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
@@ -15245,6 +16383,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
+      "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/v8-to-istanbul/node_modules/source-map": {
@@ -15294,21 +16445,31 @@
       }
     },
     "node_modules/@hapi/pez": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
-      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
+      "version": "5.0.3",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/b64": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/nigel": "^5.0.0"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
       }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.17.7",
@@ -15341,6 +16502,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/p-settle/node_modules/p-limit": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
@@ -15351,14 +16536,10 @@
       }
     },
     "node_modules/p-memoize/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "version": "3.1.0",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -15409,6 +16590,23 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
+      "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
@@ -15462,17 +16660,41 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/@aws-sdk/eventstream-serde-node": {
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-retry": {
       "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.224.0.tgz",
-      "integrity": "sha512-o0PXQwyyqeBk+kkn9wIPVIdzwp28EmRt2UqEH/UO6XzpmZTghuY4ZWkQTx9n+vMZ0e/EbqIlh2BPAhELwYzMug==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+      "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.224.0",
+        "@aws-sdk/service-error-classification": "3.224.0",
+        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/util-middleware": "3.224.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.78.0",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.224.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+      "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15508,8 +16730,6 @@
     },
     "@aws-crypto/crc32": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -15520,8 +16740,6 @@
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true,
           "peer": true
         }
@@ -15529,8 +16747,6 @@
     },
     "@aws-crypto/crc32c": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -15541,8 +16757,6 @@
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true,
           "peer": true
         }
@@ -15561,8 +16775,6 @@
     },
     "@aws-crypto/sha1-browser": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -15576,8 +16788,6 @@
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true,
           "peer": true
         }
@@ -15639,18 +16849,16 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
-      "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "version": "3.55.0",
       "dev": true,
       "peer": true,
       "requires": {
@@ -15658,721 +16866,73 @@
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "version": "3.58.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-lambda": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.241.0.tgz",
-      "integrity": "sha512-Hb2/SE9nVEjTaLFitz36vU4/c0HhPNw/clQNQW4soVJjxBadQ8Yce03QjdEvphCFk3rQWSebhc9L+UZ3qw7Qdw==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.241.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-          "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-          "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-          "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/credential-provider-node": "3.241.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-sdk-sts": "3.226.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-signing": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
-          },
-          "dependencies": {
-            "fast-xml-parser": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-              "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
-            }
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-          "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-          "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-          "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.241.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-          "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-ini": "3.241.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.241.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-          "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-          "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.241.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/token-providers": "3.241.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-          "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/querystring-builder": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-          "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-          "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-          "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-          "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-          "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-          "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-          "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.235.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/service-error-classification": "3.229.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-          "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-          "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-          "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-          "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/querystring-builder": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.229.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-          "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.241.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-          "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-          "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-          "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-          "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-          "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-waiter": {
-          "version": "3.226.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-          "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.224.0.tgz",
-      "integrity": "sha512-CPU1sG4xr+fJ+OFpqz9Oum7cJwas0mA9YFvPLkgKLvNC2rhmmn0kbjwawtc6GUDu6xygeV8koBL2gz7OJHQ7fQ==",
+      "version": "3.107.0",
       "dev": true,
       "peer": true,
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.224.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/credential-provider-node": "3.224.0",
-        "@aws-sdk/eventstream-serde-browser": "3.224.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.224.0",
-        "@aws-sdk/eventstream-serde-node": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/hash-blob-browser": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/hash-stream-node": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/md5-js": "3.224.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0",
-        "@aws-sdk/middleware-expect-continue": "3.224.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-location-constraint": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/middleware-sdk-s3": "3.224.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-signing": "3.224.0",
-        "@aws-sdk/middleware-ssec": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4-multi-region": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/util-stream-browser": "3.224.0",
-        "@aws-sdk/util-stream-node": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.224.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "fast-xml-parser": "4.1.2",
+        "@aws-sdk/client-sts": "3.105.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.105.0",
+        "@aws-sdk/eventstream-serde-browser": "3.78.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
+        "@aws-sdk/eventstream-serde-node": "3.78.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-blob-browser": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/hash-stream-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/md5-js": "3.78.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.80.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-expect-continue": "3.78.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-location-constraint": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-s3": "3.105.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-ssec": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4-multi-region": "3.88.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-stream-browser": "3.78.0",
+        "@aws-sdk/util-stream-node": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/util-waiter": "3.78.0",
+        "@aws-sdk/xml-builder": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "fast-xml-parser": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
-        }
       }
     },
     "@aws-sdk/client-sqs": {
@@ -16416,14 +16976,600 @@
         "@aws-sdk/util-user-agent-node": "3.224.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.1.2",
+        "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+          "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
+          "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/fetch-http-handler": "3.224.0",
+            "@aws-sdk/hash-node": "3.224.0",
+            "@aws-sdk/invalid-dependency": "3.224.0",
+            "@aws-sdk/middleware-content-length": "3.224.0",
+            "@aws-sdk/middleware-endpoint": "3.224.0",
+            "@aws-sdk/middleware-host-header": "3.224.0",
+            "@aws-sdk/middleware-logger": "3.224.0",
+            "@aws-sdk/middleware-recursion-detection": "3.224.0",
+            "@aws-sdk/middleware-retry": "3.224.0",
+            "@aws-sdk/middleware-serde": "3.224.0",
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/middleware-user-agent": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/node-http-handler": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/smithy-client": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+            "@aws-sdk/util-defaults-mode-node": "3.224.0",
+            "@aws-sdk/util-endpoints": "3.224.0",
+            "@aws-sdk/util-user-agent-browser": "3.224.0",
+            "@aws-sdk/util-user-agent-node": "3.224.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
+          "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/credential-provider-node": "3.224.0",
+            "@aws-sdk/fetch-http-handler": "3.224.0",
+            "@aws-sdk/hash-node": "3.224.0",
+            "@aws-sdk/invalid-dependency": "3.224.0",
+            "@aws-sdk/middleware-content-length": "3.224.0",
+            "@aws-sdk/middleware-endpoint": "3.224.0",
+            "@aws-sdk/middleware-host-header": "3.224.0",
+            "@aws-sdk/middleware-logger": "3.224.0",
+            "@aws-sdk/middleware-recursion-detection": "3.224.0",
+            "@aws-sdk/middleware-retry": "3.224.0",
+            "@aws-sdk/middleware-sdk-sts": "3.224.0",
+            "@aws-sdk/middleware-serde": "3.224.0",
+            "@aws-sdk/middleware-signing": "3.224.0",
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/middleware-user-agent": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/node-http-handler": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/smithy-client": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+            "@aws-sdk/util-defaults-mode-node": "3.224.0",
+            "@aws-sdk/util-endpoints": "3.224.0",
+            "@aws-sdk/util-user-agent-browser": "3.224.0",
+            "@aws-sdk/util-user-agent-node": "3.224.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.1.2",
+            "tslib": "^2.3.1"
+          },
+          "dependencies": {
+            "fast-xml-parser": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+              "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+          "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
+          "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+          "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
+          "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/credential-provider-sso": "3.224.0",
+            "@aws-sdk/credential-provider-web-identity": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
+          "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/credential-provider-ini": "3.224.0",
+            "@aws-sdk/credential-provider-process": "3.224.0",
+            "@aws-sdk/credential-provider-sso": "3.224.0",
+            "@aws-sdk/credential-provider-web-identity": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
+          "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
+          "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/token-providers": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
+          "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+          "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+          "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+          "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/md5-js": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.224.0.tgz",
+          "integrity": "sha512-DT9hKzBYJUcPvGxTXwoug5Ac4zJ7q5pwOVF/PFCsN3TiXHHfDAIA0/GJjA6pZwPEi/qVy0iNhGKQK8/0i5JeWw==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+          "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+          "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+          "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+          "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+          "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/service-error-classification": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
+          "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+          "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
+          "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+          "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+          "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+          "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+          "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+          "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+          "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+          "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+          "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+          "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+          "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+          "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+          "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+          "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+          "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+          "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+          "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+          "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+          "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "fast-xml-parser": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
         }
       }
     },
@@ -16469,44 +17615,628 @@
         "@aws-sdk/util-waiter": "3.224.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+          "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
+          "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/fetch-http-handler": "3.224.0",
+            "@aws-sdk/hash-node": "3.224.0",
+            "@aws-sdk/invalid-dependency": "3.224.0",
+            "@aws-sdk/middleware-content-length": "3.224.0",
+            "@aws-sdk/middleware-endpoint": "3.224.0",
+            "@aws-sdk/middleware-host-header": "3.224.0",
+            "@aws-sdk/middleware-logger": "3.224.0",
+            "@aws-sdk/middleware-recursion-detection": "3.224.0",
+            "@aws-sdk/middleware-retry": "3.224.0",
+            "@aws-sdk/middleware-serde": "3.224.0",
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/middleware-user-agent": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/node-http-handler": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/smithy-client": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+            "@aws-sdk/util-defaults-mode-node": "3.224.0",
+            "@aws-sdk/util-endpoints": "3.224.0",
+            "@aws-sdk/util-user-agent-browser": "3.224.0",
+            "@aws-sdk/util-user-agent-node": "3.224.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
+          "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/credential-provider-node": "3.224.0",
+            "@aws-sdk/fetch-http-handler": "3.224.0",
+            "@aws-sdk/hash-node": "3.224.0",
+            "@aws-sdk/invalid-dependency": "3.224.0",
+            "@aws-sdk/middleware-content-length": "3.224.0",
+            "@aws-sdk/middleware-endpoint": "3.224.0",
+            "@aws-sdk/middleware-host-header": "3.224.0",
+            "@aws-sdk/middleware-logger": "3.224.0",
+            "@aws-sdk/middleware-recursion-detection": "3.224.0",
+            "@aws-sdk/middleware-retry": "3.224.0",
+            "@aws-sdk/middleware-sdk-sts": "3.224.0",
+            "@aws-sdk/middleware-serde": "3.224.0",
+            "@aws-sdk/middleware-signing": "3.224.0",
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/middleware-user-agent": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/node-http-handler": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/smithy-client": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.224.0",
+            "@aws-sdk/util-defaults-mode-node": "3.224.0",
+            "@aws-sdk/util-endpoints": "3.224.0",
+            "@aws-sdk/util-user-agent-browser": "3.224.0",
+            "@aws-sdk/util-user-agent-node": "3.224.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+          "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
+          "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+          "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
+          "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/credential-provider-sso": "3.224.0",
+            "@aws-sdk/credential-provider-web-identity": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
+          "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/credential-provider-ini": "3.224.0",
+            "@aws-sdk/credential-provider-process": "3.224.0",
+            "@aws-sdk/credential-provider-sso": "3.224.0",
+            "@aws-sdk/credential-provider-web-identity": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
+          "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
+          "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/token-providers": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
+          "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+          "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+          "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+          "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+          "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+          "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+          "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+          "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+          "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/service-error-classification": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
+          "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+          "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
+          "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+          "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+          "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+          "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+          "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+          "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+          "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+          "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+          "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+          "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+          "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+          "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+          "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+          "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+          "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+          "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+          "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+          "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+          "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.224.0.tgz",
+          "integrity": "sha512-+SNItYzUSPa8PV1iWwOi3637ztlczJNa2pZ/R1nWf2N8sAmk0BXzGJISv/GKvzPDyAz+uOpT549e8P6rRLZedA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.224.0.tgz",
-      "integrity": "sha512-ZfqjGGBhv+sKxYN9FHbepaL+ucFbAFndvNdalGj4mZsv5AqxgemkFoRofNJk4nu79JVf5cdrj7zL+BDW3KwEGg==",
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16547,313 +18277,674 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-sts": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.224.0.tgz",
-      "integrity": "sha512-ao3jyjwk2fozk1d4PtrNf0BNsucPWAbALv8CCsPTC3r9g2Lg/TOi3pxmsfd69ddw89XSyP6zZATEHaWO+tk0CQ==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/credential-provider-node": "3.224.0",
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/hash-node": "3.224.0",
-        "@aws-sdk/invalid-dependency": "3.224.0",
-        "@aws-sdk/middleware-content-length": "3.224.0",
-        "@aws-sdk/middleware-endpoint": "3.224.0",
-        "@aws-sdk/middleware-host-header": "3.224.0",
-        "@aws-sdk/middleware-logger": "3.224.0",
-        "@aws-sdk/middleware-recursion-detection": "3.224.0",
-        "@aws-sdk/middleware-retry": "3.224.0",
-        "@aws-sdk/middleware-sdk-sts": "3.224.0",
-        "@aws-sdk/middleware-serde": "3.224.0",
-        "@aws-sdk/middleware-signing": "3.224.0",
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/middleware-user-agent": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/smithy-client": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.224.0",
-        "@aws-sdk/util-defaults-mode-node": "3.224.0",
-        "@aws-sdk/util-endpoints": "3.224.0",
-        "@aws-sdk/util-user-agent-browser": "3.224.0",
-        "@aws-sdk/util-user-agent-node": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
       },
       "dependencies": {
-        "fast-xml-parser": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.224.0.tgz",
+          "integrity": "sha512-6DxaHnSDc2V5WiwtDaRwJJb2fkmDTyGr1svIM9H671aXIwe+q17mtpm5IooKL8bW5mLJoB1pT/5ntLkfxDQgSQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
+          "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
+          "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/url-parser": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
+          "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
+          "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
+          "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
+          "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
+          "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
+          "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
+          "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
+          "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/service-error-classification": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+          "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
+          "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
+          "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
+          "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/shared-ini-file-loader": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
+          "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.224.0",
+            "@aws-sdk/protocol-http": "3.224.0",
+            "@aws-sdk/querystring-builder": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+          "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+          "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
+          "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+          "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
+          "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+          "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+          "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
+          "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+          "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
+          "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
+          "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.224.0",
+            "@aws-sdk/credential-provider-imds": "3.224.0",
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/property-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+          "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
+          "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
+          "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
         }
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.224.0.tgz",
-      "integrity": "sha512-jS53QvF2jdv7d6cpPUH6N85i1WNHik1eGvxqSndsNbLf0keEGXYyN4pBLNB0xK1nk0ZG+8slRsXgWvWTCcFYKA==",
+    "@aws-sdk/client-sts": {
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.105.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-recursion-detection": "3.105.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.224.0.tgz",
-      "integrity": "sha512-WUicVivCne9Ela2Nuufohy8+UV/W6GwanlpK9trJqrqHt2/zqdNYHqZbWL0zDNO8dvFN3+MC2a8boYPyR+cFRg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.224.0.tgz",
-      "integrity": "sha512-n7uVR5Z9EUfVbg0gSNrJvu1g0cM/HqhRt+kaRJBGNf4q1tEbnCukKj+qUZbT1qdbDTyu9NTRphMvuIyN3RBDtQ==",
+      "version": "3.81.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/url-parser": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.224.0.tgz",
-      "integrity": "sha512-YaAHoHJVspqy5f8C6EXBifMfodKXl88IHuL6eBComigTPR3s1Ed1+3AJdjA1X7SjAHfrYna/WvZEH3e8NCSzFA==",
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/credential-provider-sso": "3.224.0",
-        "@aws-sdk/credential-provider-web-identity": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.105.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.224.0.tgz",
-      "integrity": "sha512-n/gijJAA3uVFl1b3+hp2E3lPaiajsPLHqH+mMxNxPkGo39HV1v9RAyOVW4Y3AH1QcT7sURevjGoF2Eemcro88g==",
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/credential-provider-ini": "3.224.0",
-        "@aws-sdk/credential-provider-process": "3.224.0",
-        "@aws-sdk/credential-provider-sso": "3.224.0",
-        "@aws-sdk/credential-provider-web-identity": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.105.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.105.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.224.0.tgz",
-      "integrity": "sha512-0nc8vGmv6vDfFlVyKREwAa4namfuGqKg3TTM0nW2vE10fpDXZM/DGVAs5HInX+27QQNLVVh3/OHHgti9wMkYkw==",
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.224.0.tgz",
-      "integrity": "sha512-Qx5w8MCGAwT5cqimA3ZgtY1jSrC7QGPzZfNflY75PWQIaYgjUNNqdAW0jipr4M/dgVjvo1j/Ek+atNf/niTOsQ==",
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/token-providers": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/client-sso": "3.105.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.224.0.tgz",
-      "integrity": "sha512-Z/xRFTm9pBVyuIAkYohisb3KPJowPVng7ZuZiblU0PaESoJBTkhAFOblpPv/ZWwb6fT85ANUKrvl4858zLpk/Q==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.224.0.tgz",
-      "integrity": "sha512-p8DePCwvgrrlYK7r3euI5aX/VVxrCl+DClHy0TV6/Eq8WCgWqYfZ5TSl5kbrxIc4U7pDlNIBkTiQMIl/ilEiQg==",
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.224.0.tgz",
-      "integrity": "sha512-QeyGmKipZsbVkezI5OKe0Xad7u1JPkZWNm1m7uqjd9vTK3A+/fw7eNxOWYVdSKs/kHyAWr9PG+fASBtr3gesPA==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.224.0.tgz",
-      "integrity": "sha512-zl8YUa+JZV9Dj304pc2HovMuUsz3qzo8HHj+FjIHxVsNfFL4U/NX/eDhkiWNUwVMlQIWvjksoJZ75kIzDyWGKQ==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.224.0.tgz",
-      "integrity": "sha512-o0PXQwyyqeBk+kkn9wIPVIdzwp28EmRt2UqEH/UO6XzpmZTghuY4ZWkQTx9n+vMZ0e/EbqIlh2BPAhELwYzMug==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.224.0.tgz",
-      "integrity": "sha512-sI9WKnaKfpVamLCESHDOg8SkMtkjjYX3awny5PJC3/Jx9zOFN9AnvGtnIJrOGFxs5kBmQNj7c4sKCAPiTCcITw==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/eventstream-codec": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.224.0.tgz",
-      "integrity": "sha512-IO1Je6ZM0fwT5YYPwQwwXcD4LlsYmP52pwit8AAI4ppz6AkSfs0747uDK0DYnqls7sevBQzUSqBSt6XjcMKjYQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/querystring-builder": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.224.0.tgz",
-      "integrity": "sha512-nUBRZzxbq6mU8FIK6OizC5jIeRkVn5tB2ZYxPd7P2IDhh1OVod6gXkq9EKTf3kecNvYgWUVHcOezZF1qLMDLHg==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.188.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/chunked-blob-reader": "3.55.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.224.0.tgz",
-      "integrity": "sha512-y7TXMDOSy5E2VZPvmsvRfyXkcQWcjTLFTd85yc70AAeFZiffff1nvZifQSzD78bW6ELJsWHXA2O8yxdBURyoBg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.224.0.tgz",
-      "integrity": "sha512-5RDwzB2C4Zjn4M2kZYntkc2LJdqe8CH9xmudu3ZYESkZToN5Rd3JyqobW9KPbm//R43VR4ml2qUhYHFzK6jvgg==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.224.0.tgz",
-      "integrity": "sha512-6huV8LBYQYx84uMhQ2SS7nqEkhTkAufwhKceXnysrcrLDuUmyth09Y7fcFblFIDTr4wTgSI0mf6DKVF4nqYCwQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.224.0.tgz",
-      "integrity": "sha512-DT9hKzBYJUcPvGxTXwoug5Ac4zJ7q5pwOVF/PFCsN3TiXHHfDAIA0/GJjA6pZwPEi/qVy0iNhGKQK8/0i5JeWw==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.224.0.tgz",
-      "integrity": "sha512-cAmrSmVjBCENM9ojUBRhIsuQ2mPH4WxnqE5wxloHdP8BD7usNE/dMtGMhot3Dnf8WZEFpTMfhtrZrmSTCaANTQ==",
+      "version": "3.80.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.224.0.tgz",
-      "integrity": "sha512-L9b84b7X/BH+sFZaXg5hQQv0TRqZIGuOIiWJ8CkYeju7OQV03DzbCoNCAgZdI28SSevfrrVK/hwjEQrv+A6x1Q==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16870,99 +18961,198 @@
         "@aws-sdk/util-config-provider": "3.208.0",
         "@aws-sdk/util-middleware": "3.224.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
+          "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
+          "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
+          "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
+          "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.224.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.224.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
+          "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.224.0",
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
+          "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.224.0.tgz",
-      "integrity": "sha512-xgihNtu5dXzRqL0QrOuMLmSoji7BsKJ+rCXjW+X+Z1flYFV5UDY5PI0dgAlgWQDWZDyu17n4R5IIZUzb/aAI1g==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-header-default": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.224.0.tgz",
-      "integrity": "sha512-8umP3a1YNg5+sowQgzKNiq//vSVC53iTBzg8/oszstwIMYE9aNf4RKd/X/H9biBF/G05xdTjqNAQrAh54UbKrQ==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.224.0.tgz",
-      "integrity": "sha512-4eL8EVhgxTjvdVs+P3SSEkoMXBte7hSQ/+kOZVNR5ze8QPnUiDpJMS2BQrMoA2INxX9tSqp6zTrDNMc3LNvKbQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.224.0.tgz",
-      "integrity": "sha512-FpgKNGzImgmHTbz4Hjc41GEH4/dASxz6sTtn5T+kFDsT1j7o21tpWlS6psoazTz9Yi3ichBo2yzYUaY3QxOFew==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.224.0.tgz",
-      "integrity": "sha512-AmvuezI1vGgKZDsA2slHZJ6nQMqogUyzK27wM03458a2JgFqZvWCUPSY/P+OZ0FpnFEC34/kvvF4bI54T0C5jA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.224.0.tgz",
-      "integrity": "sha512-ySTGlMvNaH5J77jYVVgwOF1ozz3Kp6f/wjTvivOcBR1zlRv0FXa1y033QMnrAAtKSNkzClXtNOycBM463QImJw==",
+      "version": "3.105.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.224.0.tgz",
-      "integrity": "sha512-zwl8rZZb5OWLzOnEW58RRklbehDfcdtD98qtgm0NLM9ErBALEEb2Y4MM5zhRiMtVjzrDw71+Mhk5+4TAlwJyXA==",
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/service-error-classification": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.224.0.tgz",
-      "integrity": "sha512-SDyFandByU9UBQOxqFk8TCE0e9FPA/nr0FRjANxkIm24/zxk2yZbk3OUx/Zr7ibo28b5BqcQV69IClBOukPiEw==",
+      "version": "3.105.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16974,180 +19164,189 @@
         "@aws-sdk/types": "3.224.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.224.0.tgz",
-      "integrity": "sha512-rUoPPejj4N8S+P39ap9Iqbprl9L7LBlkuMHwMCqgeRJBhdI+1YeDfUekegJxceJv/BDXaoI2aSE0tCUS8rK0Ug==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.224.0.tgz",
-      "integrity": "sha512-4wHJ4DyhvyqQ853zfIw6sRw909VB+hFEqatmXYvO5OYap03Eed92wslsR2Gtfw1B2/zjDscPpwPyHoCIk30sHA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.224.0.tgz",
-      "integrity": "sha512-6T+dybVn5EYsxkNc4eVKAeoj6x6FfRXkZWMRxkepDoOJufMUNTfpoDEl6PcgJU6Wq4odbqV737x/3j53VZc6dA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-middleware": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.224.0.tgz",
-      "integrity": "sha512-S9a3fvF0Lv/NnXKbh0cbqhzfVcCOU1pPeGKuDB/p7AWCoql/KSG52MGBU6jKcevCtWVUKpSkgJfs+xkKmSiXIA==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.224.0.tgz",
-      "integrity": "sha512-8mBrc3nj4h6FnDWnxbjfFXUPr/7UIAaGAG15D27Z/KNFnMjOqNTtpkbcoh3QQHRLX3PjTuvzT5WCqXmgD2/oiw==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.224.0.tgz",
-      "integrity": "sha512-YXHC/n8k4qeIkqFVACPmF/QfJyKSOMD1HjM7iUZmJ9yGqDRFeGgn4o2Jktd0dor7sTv6pfUDkLqspxURAsokzA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.224.0.tgz",
-      "integrity": "sha512-ULv0Ao95vNEiwCreN9ZbZ5vntaGjdMLolCiyt3B2FDWbuOorZJR5QXFydPBpo4AQOh1y/S2MIUWLhz00DY364g==",
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/shared-ini-file-loader": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.224.0.tgz",
-      "integrity": "sha512-8h4jWsfVRUcJKkqZ9msSN4LhldBpXdNlMcA8ku8IVEBHf5waxqpIhupwR0uCMmV3FDINLqkf/8EwEYAODeRjrw==",
+      "version": "3.94.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.224.0",
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/querystring-builder": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
-      "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.224.0.tgz",
-      "integrity": "sha512-myp31UkADbktZtIZLc4cNfr5zSNVJjPReoH37NPpvgREKOGg7ZB6Lb3UyKbjzrmIv985brMOunlMgIBIJhuPIg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.224.0.tgz",
-      "integrity": "sha512-Fwzt42wWRhf04TetQPqDL03jX5W2cAkRFQewOkIRYVFV17b72z4BFhKID6bpLEtNb4YagyllCWosNg1xooDURQ==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.224.0.tgz",
-      "integrity": "sha512-UIJZ76ClFtALXRIQS3Za4R76JTsjCYReSBEQ7ag7RF1jwVZLAggdfED9w3XDrN7jbaK6i+aI3Y+eFeq0sB2fcA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.224.0.tgz",
-      "integrity": "sha512-0bnbYtCe+vqtaGItL+1UzQPt+yZLbU8G/aIXPQUL7555jdnjnbAtczCbIcLAJUqlE/OLwRhQVGLKbau8QAdxgQ=="
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
-      "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.224.0.tgz",
-      "integrity": "sha512-+oq1iylYQOvdXXO7r18SEhXIZpLd3GvJhmoReX+yjvVq8mGevDAmQiw6lwFZ6748sOmH4CREWD5H9Snrj+zLMg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.224.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.224.0.tgz",
-      "integrity": "sha512-xOW8rtEH2Rcadr+CFfiISZwcbf4jPdc4OvL6OiPsv+arndOhxk+4ZaRT2xic1FrVdYQypmSToRITYlZc9N7PjQ==",
+      "version": "3.88.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.224.0",
-        "@aws-sdk/signature-v4": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.224.0.tgz",
-      "integrity": "sha512-KXXzzrCBv8ewWdtm/aolZHr2f9NRZOcDutFaWXbfSptEsK50Zi9PNzB9ZVKUHyAXYjwJHb2Sl18WRrwIxH6H4g==",
+      "version": "3.99.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -17161,27 +19360,48 @@
         "@aws-sdk/shared-ini-file-loader": "3.224.0",
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.224.0.tgz",
+          "integrity": "sha512-1F1Hepndlmj6wykNv0ynlS9YTaT3LRF/mqXhCRGLbCWSmCiaW9BUH/ddMdBZJiSw7kcPePKid5ueW84fAO/nKg==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.224.0.tgz",
+          "integrity": "sha512-6a/XP3lRRcX5ic+bXzF2f644KERVqMx+s0JRrGsPAwTMaMiV0A7Ifl4HKggx6dnxh8j/MXUMsWMtuxt/kCu86A==",
+          "requires": {
+            "@aws-sdk/types": "3.224.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
-      "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+      "version": "3.78.0"
     },
     "@aws-sdk/url-parser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.224.0.tgz",
-      "integrity": "sha512-DGQoiOxRVq9eEbmcGF7oz/htcHxFtLlUTzKbaX1gFuh1kmhRQwJIzz6vkrMdxOgPjvUYMJuMEcYnsHolDNWbMg==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "version": "3.55.0",
       "dev": true,
       "peer": true,
       "requires": {
@@ -17195,62 +19415,98 @@
       "requires": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.58.0",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.224.0.tgz",
-      "integrity": "sha512-umk+A/pmlbuyvDCgdndgJUa0xitcTUF7XoUt/3qDTpNbzR5Dzgdbz74BgXUAEBJ8kPP5pCo2VE1ZD7fxqYU/dQ==",
+      "version": "3.99.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.224.0.tgz",
-      "integrity": "sha512-ZJQJ1McbQ5Rnf5foCFAKHT8Cbwg4IbM+bb6fCkHRJFH9AXEvwc+hPtSYf0KuI7TmoZFj9WG5JOE9Ns6g7lRHSA==",
+      "version": "3.99.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.224.0",
-        "@aws-sdk/credential-provider-imds": "3.224.0",
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/property-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -17261,12 +19517,19 @@
       "requires": {
         "@aws-sdk/types": "3.224.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.224.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.224.0.tgz",
+          "integrity": "sha512-7te9gRondKPjEebyiPYn59Kr5LZOL48HXC05TzFIN/JXwWPJbQpROBPeKd53V1aRdr3vSQhDY01a+vDOBBrEUQ=="
+        }
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.58.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -17278,116 +19541,86 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.224.0.tgz",
-      "integrity": "sha512-yA20k9sJdFgs7buVilWExUSJ/Ecr5UJRNQlmgzIpBo9kh5x/N8WyB4kN5MQw5UAA1UZ+j3jmA9+YLFT/mbX3IQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/service-error-classification": {
-          "version": "3.229.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
-        }
-      }
-    },
-    "@aws-sdk/util-stream-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.224.0.tgz",
-      "integrity": "sha512-JS+C8CyxVFMQ69P4QIDTrzkhseEFCVFy2YHZYlCx3M5P+L1/PQHebTETYFMmO9ThY8TRXmYZDJHv79guvV+saQ==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.224.0.tgz",
-      "integrity": "sha512-ztvZHJJg9/BwUrKnSz3jV6T8oOdxA1MRypK2zqTdjoPU9u/8CFQ2p0gszBApMjyxCnLWo1oM5oiMwzz1ufDrlA==",
+      "version": "3.78.0",
       "dev": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/node-http-handler": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.224.0.tgz",
-      "integrity": "sha512-Dm/30cLUIM1Oam4V//m9sPrXyGOKFslUXP7Mz2AlR1HelUYoreWAIe7Rx44HR6PaXyZmjW5K0ItmcJ7tCgyMpw==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.224.0.tgz",
-      "integrity": "sha512-BTj0vPorfT7AJzv6RxJHrnAKdIHwZmGjp5TFFaCYgFkHAPsyCPceSdZUjBRW+HbiwEwKfoHOXLGjnOBSqddZKg==",
+      "version": "3.80.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "version": "3.55.0",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "version": "3.55.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.224.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.224.0.tgz",
-      "integrity": "sha512-+SNItYzUSPa8PV1iWwOi3637ztlczJNa2pZ/R1nWf2N8sAmk0BXzGJISv/GKvzPDyAz+uOpT549e8P6rRLZedA==",
+      "version": "3.78.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.224.0",
-        "@aws-sdk/types": "3.224.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "version": "3.55.0",
       "dev": true,
       "peer": true,
       "requires": {
@@ -18268,7 +20501,6 @@
     },
     "@babel/runtime": {
       "version": "7.18.3",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -18356,296 +20588,229 @@
       }
     },
     "@hapi/accept": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
-      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
+      "version": "5.0.2",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/ammo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
-      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
+      "version": "5.0.1",
       "requires": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
-      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "version": "5.0.0",
       "requires": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "version": "9.1.4",
       "requires": {
-        "@hapi/hoek": "10.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
+      "version": "2.0.0",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bourne": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
+      "version": "2.1.0"
     },
     "@hapi/call": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
-      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
+      "version": "8.0.1",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
-      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
+      "version": "11.1.1",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
-      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
+      "version": "5.0.1",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "5.0.2",
       "requires": {
-        "@hapi/boom": "^10.0.0"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/cryptiles": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
-      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+      "version": "5.1.0",
       "requires": {
-        "@hapi/boom": "^10.0.0"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
+      "version": "2.0.0"
     },
     "@hapi/h2o2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
-      "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
+      "version": "9.1.0",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0",
-        "@hapi/wreck": "^18.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "@hapi/hapi": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
-      "integrity": "sha512-het7j9yLXZMVU1IvtN2JXkPkn/UcU1j8gsZxMS0Mu1q7791IQeyhT37tpRPUhqerOtL6L0E8Z8CvVVFOYxoN6w==",
+      "version": "20.2.2",
       "requires": {
-        "@hapi/accept": "^6.0.0",
-        "@hapi/ammo": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/call": "^9.0.0",
-        "@hapi/catbox": "^12.0.0",
-        "@hapi/catbox-memory": "^6.0.0",
-        "@hapi/heavy": "^8.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/mimos": "^7.0.0",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/shot": "^6.0.0",
-        "@hapi/somever": "^4.1.0",
-        "@hapi/statehood": "^8.0.0",
-        "@hapi/subtext": "^8.0.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/topo": "^6.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.4",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "^5.1.1",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
       }
     },
     "@hapi/heavy": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
-      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "version": "7.0.1",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/hoek": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
-      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+      "version": "9.3.0"
     },
     "@hapi/iron": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
-      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+      "version": "6.0.0",
       "requires": {
-        "@hapi/b64": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/mimos": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
-      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
+      "version": "6.0.0",
       "requires": {
-        "@hapi/hoek": "^10.0.0",
-        "mime-db": "^1.52.0"
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
-      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
+      "version": "4.0.2",
       "requires": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/vise": "^5.0.0"
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
-      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
+      "version": "5.0.3",
       "requires": {
-        "@hapi/b64": "^6.0.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/nigel": "^5.0.0"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
       }
     },
     "@hapi/podium": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
-      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "version": "4.1.3",
       "requires": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/shot": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
-      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
+      "version": "5.0.5",
       "requires": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/somever": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
-      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
+      "version": "3.0.1",
       "requires": {
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/hoek": "^9.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
-      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
+      "version": "7.0.4",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bounce": "^3.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/iron": "^7.0.0",
-        "@hapi/validate": "^2.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/subtext": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
-      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
+      "version": "7.0.3",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/file": "^3.0.0",
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/pez": "^6.0.0",
-        "@hapi/wreck": "^18.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "@hapi/teamwork": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
-      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A=="
+      "version": "5.1.1"
     },
     "@hapi/topo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
-      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "version": "5.1.0",
       "requires": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "@hapi/validate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
-      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "version": "1.1.3",
       "requires": {
-        "@hapi/hoek": "^10.0.0",
-        "@hapi/topo": "^6.0.0"
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
       }
     },
     "@hapi/vise": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
-      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
+      "version": "4.0.0",
       "requires": {
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
-      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
+      "version": "17.2.0",
       "requires": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/hoek": "^10.0.0"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@humanwhocodes/config-array": {
@@ -19208,7 +21373,7 @@
         "node-fetch": "^2.6.7",
         "open": "^7.4.2",
         "semver": "^7.3.7",
-        "simple-git": "3.16.0",
+        "simple-git": "3.15.0",
         "type": "^2.6.0",
         "uuid": "^8.3.2",
         "yamljs": "^0.3.0"
@@ -19230,9 +21395,9 @@
           }
         },
         "simple-git": {
-          "version": "3.16.0",
-          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
-          "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw=="
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
+          "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg=="
         }
       }
     },
@@ -19295,7 +21460,7 @@
         "event-emitter": "^0.3.5",
         "ext": "^1.7.0",
         "ext-name": "^5.0.0",
-        "file-type": "16.5.4",
+        "file-type": "17.1.3",
         "filenamify": "^4.3.0",
         "get-stream": "^6.0.1",
         "got": "^11.8.5",
@@ -19353,14 +21518,9 @@
           "version": "1.1.4"
         },
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-          "requires": {
-            "readable-web-to-node-stream": "^3.0.0",
-            "strtok3": "^6.2.4",
-            "token-types": "^4.1.1"
-          }
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         },
         "has-flag": {
           "version": "4.0.0"
@@ -19438,9 +21598,7 @@
       }
     },
     "@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "version": "0.3.0"
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -19582,9 +21740,7 @@
       }
     },
     "@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "version": "0.12.0"
     },
     "@types/sinon": {
       "version": "10.0.10",
@@ -19818,13 +21974,13 @@
     "archive-type": {
       "version": "4.0.0",
       "requires": {
-        "file-type": "16.5.4"
+        "file-type": "17.1.3"
       },
       "dependencies": {
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         }
       }
     },
@@ -19901,11 +22057,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "array-unflat-js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
-      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw=="
-    },
     "array-union": {
       "version": "2.1.0"
     },
@@ -19941,9 +22092,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1286.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1286.0.tgz",
-      "integrity": "sha512-CvkCD1+NSk2MPOutD2hEPhXDET/79w/gd9a359QWb9Ja0Fd4vVFXPkhlm1DTGzuwqFKGinpCMxDP4md7QPsVvw==",
+      "version": "2.1250.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1250.0.tgz",
+      "integrity": "sha512-/fZno2UC2elau/VUOepMvqwKGXmk+dXx1tmahdy1DaAJmELXShg/XWWrtCVg346iLD/XC8eJFR8kQb5ffat0Fw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -19958,14 +22109,10 @@
       },
       "dependencies": {
         "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+          "version": "0.2.0"
         },
         "uuid": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+          "version": "8.0.0"
         }
       }
     },
@@ -19982,6 +22129,15 @@
       "version": "0.24.0",
       "requires": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "axios-retry": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
+      "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "babel-jest": {
@@ -20148,77 +22304,72 @@
       "version": "2.11.0"
     },
     "boxen": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
-      "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
       "requires": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^7.0.0",
-        "chalk": "^5.0.1",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^5.1.2",
-        "type-fest": "^2.13.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.0.1"
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
         "ansi-styles": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
-        },
-        "camelcase": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-          "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw=="
-        },
-        "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
+            "color-convert": "^2.0.1"
           }
         },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
-            "ansi-regex": "^6.0.1"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        },
-        "wrap-ansi": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-          "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          }
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
     },
@@ -20258,8 +22409,6 @@
     },
     "buffer": {
       "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -20278,6 +22427,9 @@
     },
     "buffer-crc32": {
       "version": "0.2.13"
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1"
     },
     "buffer-fill": {
       "version": "1.0.0"
@@ -20424,18 +22576,18 @@
       "version": "1.0.3"
     },
     "ci-info": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-      "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
       "dev": true
     },
     "cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
     "cli-color": {
       "version": "2.0.2",
@@ -20624,13 +22776,11 @@
       "version": "3.5.0",
       "requires": {
         "is-nan": "^1.3.2",
-        "luxon": "1.28.1"
+        "luxon": "^1.26.0"
       },
       "dependencies": {
         "luxon": {
-          "version": "1.28.1",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
+          "version": "1.28.0"
         }
       }
     },
@@ -20659,6 +22809,9 @@
         }
       }
     },
+    "cuid": {
+      "version": "2.1.8"
+    },
     "d": {
       "version": "1.0.1",
       "requires": {
@@ -20671,11 +22824,6 @@
         }
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "data-urls": {
       "version": "2.0.0",
       "dev": true,
@@ -20686,9 +22834,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "debug": {
       "version": "4.3.4",
@@ -20740,7 +22888,7 @@
     "decompress-tar": {
       "version": "4.1.1",
       "requires": {
-        "file-type": "16.5.4",
+        "file-type": "17.1.3",
         "is-stream": "^1.1.0",
         "tar-stream": "^1.5.2"
       },
@@ -20753,9 +22901,9 @@
           }
         },
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -20796,16 +22944,16 @@
       "version": "4.1.1",
       "requires": {
         "decompress-tar": "^4.1.0",
-        "file-type": "16.5.4",
+        "file-type": "17.1.3",
         "is-stream": "^1.1.0",
         "seek-bzip": "^1.0.5",
         "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -20816,14 +22964,14 @@
       "version": "4.1.1",
       "requires": {
         "decompress-tar": "^4.1.1",
-        "file-type": "16.5.4",
+        "file-type": "17.1.3",
         "is-stream": "^1.1.0"
       },
       "dependencies": {
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         },
         "is-stream": {
           "version": "1.1.0"
@@ -20833,16 +22981,16 @@
     "decompress-unzip": {
       "version": "4.0.1",
       "requires": {
-        "file-type": "16.5.4",
+        "file-type": "17.1.3",
         "get-stream": "^2.2.0",
         "pify": "^2.3.0",
         "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
-          "version": "16.5.4",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="
+          "version": "17.1.3",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
         },
         "get-stream": {
           "version": "2.3.1",
@@ -20901,11 +23049,6 @@
     "delayed-stream": {
       "version": "1.0.0"
     },
-    "desm": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
-      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
-    },
     "detect-newline": {
       "version": "3.1.0",
       "dev": true
@@ -20961,10 +23104,11 @@
         "es5-ext": "~0.10.46"
       }
     },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.150"
@@ -20996,6 +23140,11 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "entities": {
+      "version": "2.2.0",
+      "dev": true,
+      "peer": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "dev": true,
@@ -21004,34 +23153,30 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.20.1",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
-        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.7",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
+        "object.assign": "^4.1.2",
         "regexp.prototype.flags": "^1.4.3",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
       }
     },
@@ -21451,14 +23596,14 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "eventemitter3": {
+      "version": "4.0.7"
+    },
     "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
+      "version": "1.1.1"
     },
     "execa": {
       "version": "5.1.1",
-      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -21540,12 +23685,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
-      "requires": {
-        "strnum": "^1.0.5"
-      }
+      "version": "3.19.0",
+      "dev": true,
+      "peer": true
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -21571,15 +23713,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -21595,6 +23728,16 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-type": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
+    },
     "filename-reserved-regex": {
       "version": "2.0.0"
     },
@@ -21607,9 +23750,9 @@
       }
     },
     "filesize": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.6.tgz",
-      "integrity": "sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.5.tgz",
+      "integrity": "sha512-qrzyt8gLh86nsyYiC3ibI5KyIYRCWg2yqIklYrWF4a0qNfekik4OQfn7AoPJG2hRrPMSlH6fET4VEITweZAzjA=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -21674,14 +23817,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
-    },
     "formidable": {
       "version": "1.2.6"
     },
@@ -21703,16 +23838,6 @@
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "requires": {
         "minipass": "^3.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -21767,9 +23892,7 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.1.2",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -21833,18 +23956,8 @@
         }
       }
     },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
-    },
     "got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "11.8.5",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -21939,8 +24052,7 @@
       }
     },
     "human-signals": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -22103,9 +24215,7 @@
       }
     },
     "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+      "version": "1.2.4"
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -22191,6 +24301,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "requires": {
@@ -22198,8 +24313,7 @@
       }
     },
     "is-stream": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "is-string": {
       "version": "1.0.7",
@@ -22214,14 +24328,14 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
+      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
     },
@@ -23351,14 +25465,7 @@
       }
     },
     "jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
-    "jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
+      "version": "0.16.0"
     },
     "js-string-escape": {
       "version": "1.0.1"
@@ -23455,9 +25562,7 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "version": "2.2.1",
       "dev": true
     },
     "jsonfile": {
@@ -23468,17 +25573,33 @@
       }
     },
     "jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
+      "version": "5.1.0"
     },
     "jsonschema": {
       "version": "1.4.1"
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1"
+        }
+      }
+    },
     "jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "version": "3.10.0",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -23511,6 +25632,21 @@
     "just-extend": {
       "version": "4.2.1",
       "dev": true
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "jwt-decode": {
       "version": "2.2.0"
@@ -23605,12 +25741,30 @@
       "version": "4.4.2",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0"
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3"
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4"
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3"
+    },
     "lodash.isplainobject": {
       "version": "4.0.6"
+    },
+    "lodash.isstring": {
+      "version": "4.0.1"
     },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1"
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -23728,9 +25882,7 @@
       }
     },
     "luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
+      "version": "2.4.0"
     },
     "make-dir": {
       "version": "3.1.0",
@@ -23747,6 +25899,12 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "memoizee": {
@@ -23807,9 +25965,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
-      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -23821,16 +25979,6 @@
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
       }
     },
     "mkdirp": {
@@ -23900,11 +26048,6 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
     "node-fetch": {
       "version": "2.6.7",
       "requires": {
@@ -23969,7 +26112,6 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       }
@@ -23993,13 +26135,11 @@
       "version": "1.1.1"
     },
     "object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.2",
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
       }
     },
@@ -24010,15 +26150,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
-      }
-    },
-    "object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
-      "requires": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
       }
     },
     "object.values": {
@@ -24130,6 +26261,9 @@
     "p-cancelable": {
       "version": "2.1.1"
     },
+    "p-defer": {
+      "version": "1.0.0"
+    },
     "p-event": {
       "version": "4.2.0",
       "requires": {
@@ -24154,33 +26288,51 @@
       }
     },
     "p-memoize": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
-      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
+      "version": "4.0.4",
       "requires": {
-        "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0",
+        "p-settle": "^4.1.1"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
-        },
-        "type-fest": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.0.tgz",
-          "integrity": "sha512-bI3zRmZC8K0tUz1HjbIOAGQwR2CoPQG68N5IF7gm0LBl8QSNXzkmaWnkWccCUL5uG9mCsp4sBwC8SBrNSISWew=="
+          "version": "3.1.0"
         }
       }
     },
-    "p-retry": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+    "p-queue": {
+      "version": "6.6.2",
       "requires": {
-        "@types/retry": "0.12.1",
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-reflect": {
+      "version": "2.1.0"
+    },
+    "p-retry": {
+      "version": "4.6.2",
+      "requires": {
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
+      }
+    },
+    "p-settle": {
+      "version": "4.1.1",
+      "requires": {
+        "p-limit": "^2.2.2",
+        "p-reflect": "^2.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0"
+        }
       }
     },
     "p-timeout": {
@@ -24258,9 +26410,7 @@
       "version": "0.1.0"
     },
     "peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+      "version": "4.1.0"
     },
     "pend": {
       "version": "1.2.0"
@@ -24440,8 +26590,6 @@
     },
     "readable-web-to-node-stream": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
       "requires": {
         "readable-stream": "^3.6.0"
       }
@@ -24470,8 +26618,7 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "dev": true
+      "version": "0.13.9"
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -24577,9 +26724,7 @@
       }
     },
     "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+      "version": "0.13.1"
     },
     "reusify": {
       "version": "1.0.4"
@@ -24609,9 +26754,9 @@
       }
     },
     "rxjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
-      "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -24619,23 +26764,11 @@
     "safe-buffer": {
       "version": "5.1.2"
     },
-    "safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2"
     },
     "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+      "version": "1.2.1"
     },
     "saxes": {
       "version": "5.0.1",
@@ -24673,36 +26806,36 @@
       }
     },
     "serverless": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.26.0.tgz",
-      "integrity": "sha512-drVr4akkQwm2Pj7ZN9boh5PoI2nKvlXmy+Cb8Hh1Zv8ybsf47ZUQE6t7dakGA4irYf4SQCbVc72nKqISfarMCQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.24.1.tgz",
+      "integrity": "sha512-v7WTprSqj0jFoKOY0BU4a7P7bOYHPsvhhxpZt8OJqYrnqyAQbnhM6GXbDimRMibsH3CNvMVWEKD+WWeimXzcHw==",
       "requires": {
         "@serverless/dashboard-plugin": "^6.2.2",
         "@serverless/platform-client": "^4.3.2",
         "@serverless/utils": "^6.8.2",
-        "ajv": "^8.11.2",
+        "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "archiver": "^5.3.1",
-        "aws-sdk": "^2.1280.0",
+        "aws-sdk": "^2.1247.0",
         "bluebird": "^3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.2",
         "child-process-ext": "^2.1.1",
-        "ci-info": "^3.7.0",
+        "ci-info": "^3.5.0",
         "cli-progress-footer": "^2.3.2",
         "d": "^1.0.1",
-        "dayjs": "^1.11.7",
+        "dayjs": "^1.11.6",
         "decompress": "^4.2.1",
         "dotenv": "^16.0.3",
         "dotenv-expand": "^9.0.0",
         "essentials": "^1.2.0",
         "ext": "^1.7.0",
         "fastest-levenshtein": "^1.0.16",
-        "filesize": "^10.0.6",
+        "filesize": "^10.0.5",
         "fs-extra": "^10.1.0",
         "get-stdin": "^8.0.0",
         "globby": "^11.1.0",
-        "got": "^11.8.6",
+        "got": "^11.8.5",
         "graceful-fs": "^4.2.10",
         "https-proxy-agent": "^5.0.1",
         "is-docker": "^2.2.1",
@@ -24724,7 +26857,7 @@
         "signal-exit": "^3.0.7",
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
-        "tar": "^6.1.13",
+        "tar": "^6.1.12",
         "timers-ext": "^0.1.7",
         "type": "^2.7.2",
         "untildify": "^4.0.0",
@@ -24733,9 +26866,7 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+          "version": "8.11.0",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -24796,9 +26927,7 @@
           }
         },
         "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+          "version": "1.0.0"
         },
         "open": {
           "version": "8.4.0",
@@ -24832,129 +26961,83 @@
       }
     },
     "serverless-offline": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
-      "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.8.1.tgz",
+      "integrity": "sha512-tpvAEGMf6qB9jGSDrpLQSYljqiIxOfjpsWq6q9ol3goqbcxXasvGR9nVX5cXq1MNBRXsJQE1PdHxtxivng2Lrw==",
       "requires": {
-        "@aws-sdk/client-lambda": "^3.241.0",
-        "@hapi/boom": "^10.0.0",
-        "@hapi/h2o2": "^10.0.0",
-        "@hapi/hapi": "^21.1.0",
-        "@serverless/utils": "^6.8.2",
-        "array-unflat-js": "^0.1.3",
-        "boxen": "^7.0.1",
-        "chalk": "^5.2.0",
-        "desm": "^1.3.0",
-        "execa": "^6.1.0",
-        "fs-extra": "^11.1.0",
-        "is-wsl": "^2.2.0",
+        "@hapi/boom": "^9.1.4",
+        "@hapi/h2o2": "^9.1.0",
+        "@hapi/hapi": "^20.2.2",
+        "aws-sdk": "^2.1136.0",
+        "boxen": "^5.1.2",
+        "chalk": "^4.1.2",
+        "cuid": "^2.1.8",
+        "execa": "^5.1.1",
+        "fs-extra": "^10.1.0",
         "java-invoke-local": "0.0.6",
-        "jose": "^4.11.2",
         "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^7.2.0",
-        "jsonschema": "^1.4.1",
-        "jszip": "^3.10.1",
-        "luxon": "1.28.1",
-        "node-fetch": "^3.3.0",
+        "jsonpath-plus": "^5.1.0",
+        "jsonschema": "^1.4.0",
+        "jsonwebtoken": "^8.5.1",
+        "jszip": "^3.9.1",
+        "luxon": "^2.4.0",
+        "node-fetch": "^2.6.7",
         "node-schedule": "^2.1.0",
-        "object.hasown": "^1.1.2",
-        "p-memoize": "^7.1.1",
-        "p-retry": "^5.1.2",
+        "p-memoize": "^4.0.4",
+        "p-queue": "^6.6.2",
+        "p-retry": "^4.6.2",
+        "semver": "^7.3.7",
         "velocityjs": "^2.0.6",
-        "ws": "^8.11.0"
+        "ws": "^7.5.7"
       },
       "dependencies": {
-        "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
-        },
-        "execa": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+        "ansi-styles": {
+          "version": "4.3.0",
           "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^3.0.1",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
+            "color-convert": "^2.0.1"
           }
         },
+        "chalk": {
+          "version": "4.1.2",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4"
+        },
         "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "version": "10.1.0",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
-        "human-signals": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
+        "has-flag": {
+          "version": "4.0.0"
         },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
-        },
-        "luxon": {
-          "version": "1.28.1",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
-        },
-        "node-fetch": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+        "semver": {
+          "version": "7.3.7",
           "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
+            "lru-cache": "^6.0.0"
           }
         },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+        "supports-color": {
+          "version": "7.2.0",
           "requires": {
-            "path-key": "^4.0.0"
+            "has-flag": "^4.0.0"
           }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
         },
         "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
+          "version": "7.5.8"
         }
       }
     },
@@ -25008,9 +27091,9 @@
       "version": "3.0.7"
     },
     "simple-git": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
-      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
+      "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -25079,9 +27162,9 @@
       }
     },
     "snyk": {
-      "version": "1.1068.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1068.0.tgz",
-      "integrity": "sha512-lVXp7yDTp9oznGDs9W4vMtY271smJ5wukB8g6gdLYRcNAozrN70kbvZGvBFELxdWdVak2qa+ut5AyIVHZ8XUew==",
+      "version": "1.1056.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1056.0.tgz",
+      "integrity": "sha512-Ny9dHfI6SgNHfh6HbRgtMN0MKUH0QhIcWYbw24t5GM0qejoMSEQSJv9kDzrIQLRd0OBBlZAba5EEPRiSafrxmQ==",
       "dev": true
     },
     "sort-keys": {
@@ -25167,23 +27250,19 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.5",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.5",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "es-abstract": "^1.19.5"
       }
     },
     "string_decoder": {
@@ -25214,8 +27293,7 @@
       }
     },
     "strip-final-newline": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -25234,8 +27312,6 @@
     },
     "strtok3": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -25357,13 +27433,13 @@
       "version": "2.2.1"
     },
     "tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.12.tgz",
+      "integrity": "sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^3.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -25389,6 +27465,8 @@
     },
     "terser": {
       "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -25467,18 +27545,14 @@
       }
     },
     "token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "4.2.0",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "dependencies": {
         "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+          "version": "1.2.1"
         }
       }
     },
@@ -25557,9 +27631,7 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+          "version": "1.0.1",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -25601,9 +27673,7 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.7.3",
       "optional": true,
       "peer": true
     },
@@ -25672,34 +27742,29 @@
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+          "version": "1.3.2"
         },
         "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+          "version": "0.2.0"
         }
       }
     },
     "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -25779,11 +27844,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -25872,54 +27932,24 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
+      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "is-typed-array": "^1.1.9"
       }
     },
     "widest-line": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
-        "string-width": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-          "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
+        "string-width": "^4.0.0"
       }
     },
     "word-wrap": {
@@ -25984,17 +28014,13 @@
     },
     "xml2js": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
+      "version": "9.0.7"
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/graph-db/package-lock.json
+++ b/graph-db/package-lock.json
@@ -14487,6 +14487,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@serverless/utils/node_modules/file-type": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
+      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "27.5.1",
       "dev": true,
@@ -15452,23 +15468,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "17.1.3",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/tslib": {
@@ -21520,7 +21519,12 @@
         "file-type": {
           "version": "17.1.3",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw=="
+          "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
+          "requires": {
+            "readable-web-to-node-stream": "^3.0.0",
+            "strtok3": "^6.2.4",
+            "token-types": "^4.1.1"
+          }
         },
         "has-flag": {
           "version": "4.0.0"
@@ -23726,16 +23730,6 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
-      }
-    },
-    "file-type": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.3.tgz",
-      "integrity": "sha512-MFVSozBIhvnx2dkxlf+010Xqn6+ojlMUT9LXQiPNoOijgRtXNMghWdGK0u2o1RoCqzHoVsw65IL8ZBcQ4MhIrw==",
-      "requires": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
       }
     },
     "filename-reserved-regex": {

--- a/graph-db/package.json
+++ b/graph-db/package.json
@@ -32,8 +32,8 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3.211.0",
-    "@aws-sdk/client-ssm": "^3.211.0",
+    "@aws-sdk/client-sqs": "^3.87.0",
+    "@aws-sdk/client-ssm": "^3.154.0",
     "array-foreach-async": "^1.0.1",
     "axios": "^0.24.0",
     "gremlin": "~3.4.10",

--- a/graph-db/package.json
+++ b/graph-db/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/client-ssm": "^3.211.0",
     "array-foreach-async": "^1.0.1",
     "axios": "^0.24.0",
+    "axios-retry": "^3.3.1",
     "gremlin": "~3.4.10",
     "lodash": "^4.17.21",
     "serverless": "^3.24.1",

--- a/graph-db/package.json
+++ b/graph-db/package.json
@@ -32,8 +32,8 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3.87.0",
-    "@aws-sdk/client-ssm": "^3.154.0",
+    "@aws-sdk/client-sqs": "^3.211.0",
+    "@aws-sdk/client-ssm": "^3.211.0",
     "array-foreach-async": "^1.0.1",
     "axios": "^0.24.0",
     "gremlin": "~3.4.10",

--- a/graph-db/serverless.yml
+++ b/graph-db/serverless.yml
@@ -13,15 +13,15 @@ provider:
    name: graphdb-driver-deployment-bucket-${self:provider.stage}
    skipPolicySetup: true
 
-  vpc:
-    securityGroupIds:
-      - ${cf:${self:provider.stage}.servicesSecurityGroupId}
-    subnetIds: !Split [',', '${cf:${self:provider.stage}.subnetIds}']
+  # vpc:
+  #   securityGroupIds:
+  #     - ${cf:${self:provider.stage}.servicesSecurityGroupId}
+  #   subnetIds: !Split [',', '${cf:${self:provider.stage}.subnetIds}']
 
   environment:
     CMR_ROOT: ${self:custom.variables.CMR_ROOT}
-    COLLECTION_INDEXING_QUEUE_URL:
-      Ref: CollectionIndexingQueue
+    # COLLECTION_INDEXING_QUEUE_URL:
+    #   Ref: CollectionIndexingQueue
     ENVIRONMENT: ${self:custom.variables.ENVIRONMENT}
     GREMLIN_URL: ${self:custom.variables.GREMLIN_URL}
     PAGE_SIZE: ${self:custom.variables.PAGE_SIZE}

--- a/graph-db/serverless.yml
+++ b/graph-db/serverless.yml
@@ -13,15 +13,15 @@ provider:
    name: graphdb-driver-deployment-bucket-${self:provider.stage}
    skipPolicySetup: true
 
-  # vpc:
-  #   securityGroupIds:
-  #     - ${cf:${self:provider.stage}.servicesSecurityGroupId}
-  #   subnetIds: !Split [',', '${cf:${self:provider.stage}.subnetIds}']
+  vpc:
+    securityGroupIds:
+      - ${cf:${self:provider.stage}.servicesSecurityGroupId}
+    subnetIds: !Split [',', '${cf:${self:provider.stage}.subnetIds}']
 
   environment:
     CMR_ROOT: ${self:custom.variables.CMR_ROOT}
-    # COLLECTION_INDEXING_QUEUE_URL:
-    #   Ref: CollectionIndexingQueue
+    COLLECTION_INDEXING_QUEUE_URL:
+      Ref: CollectionIndexingQueue
     ENVIRONMENT: ${self:custom.variables.ENVIRONMENT}
     GREMLIN_URL: ${self:custom.variables.GREMLIN_URL}
     PAGE_SIZE: ${self:custom.variables.PAGE_SIZE}

--- a/graph-db/serverless/src/bootstrapGremlinServer/handler.js
+++ b/graph-db/serverless/src/bootstrapGremlinServer/handler.js
@@ -20,6 +20,7 @@ const bootstrapGremlinServer = async (event) => {
 
   const { body } = bootstrapEvents[0]
 
+  // Parse the optional provider Id for bootstrap events limited to a single provider
   const { 'provider-id': providerId = null } = JSON.parse(body)
 
   // Fetch all CMR Collections and index each page

--- a/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
+++ b/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
@@ -120,7 +120,7 @@ describe('indexCmrCollection handler', () => {
     expect(statusCode).toBe(200)
   })
 
-  test('test collection that has an index on CMR but, it is on actually stored in db', async () => {
+  test('test collection that has an index on CMR but, it is Not stored in db', async () => {
     const conceptId = 'C123755555-TESTPROV'
     nock(/local-cmr/)
       .get(/collections/)

--- a/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
+++ b/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
@@ -120,27 +120,74 @@ describe('indexCmrCollection handler', () => {
     expect(statusCode).toBe(200)
   })
 
-  test('test indexing of a broken collection', async () => {
+  test('test collection that has an index but, is not in the oracle db', async () => {
     // Pass an error to the response of fetchCmrCollection
     // Emits an error event on the request object, not the reply
+    const conceptId = 'C123755555-TESTPROV'
     nock(/local-cmr/)
       .get(/collections/)
-      .replyWithError('Error Collection not found', { statusCode: 404 })
+      .replyWithError('Collection not found', { statusCode: 404 })
+      // commenting out for now TODO may use for exponential back-off strategy
+      // .get(/collections/)
+      // .replyWithError('Error Collection not found', { statusCode: 404 })
+      // .get(/collections/)
+      // .replyWithError('Error Collection not found', { statusCode: 404 })
 
-    const event = getEvent('C123755555-TESTPROV', 'concept-update')
+    const event = getEvent(conceptId, 'concept-update')
 
     const consoleMock = jest.spyOn(console, 'log')
 
     const indexed = await indexCmrCollection(event)
-
+    // It will try to reindex TODO won't reindex right now. I'm not sure yet why this is the value 2 since the error is only printed once
     expect(consoleMock).toBeCalledTimes(2)
-    expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Error Collection not found')
-    expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown: ', new Error('Cannot read properties of null (reading \'data\')'))
+    // expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Error Collection not found')
+    expect(consoleMock).toBeCalledWith(`Could not fetch collection ${conceptId} due to error: Error: Collection not found`)
+    // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error: Collection not found')
+    expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: ', new Error('Cannot read properties of null (reading \'data\')'))
+    // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error Collection not found')
+
+    // expect(consoleMock).toBeCalledWith('Exception raised, retrying to index collection # ', 0)
 
     const { body } = indexed
 
     expect(body).toBe('Successfully indexed 0 collection(s).')
   })
+  // TODO Need more logging information from AWS before using retry keep commented out for now
+  // test.only('testing the retry policy for failed attempts', async () => {
+  //   // Pass errors until the third attempt does not return an error
+  //   // Emits an error event on the request object, not the reply
+  //   nock(/local-cmr/)
+  //     .get(/collections/)
+  //     .replyWithError('ConcurrentModificationException', { statusCode: 500, code: 'ConcurrentModificationException' })
+  //     .get(/collections/)
+  //     .replyWithError('ConcurrentModificationException', { statusCode: 500, code: 'ConcurrentModificationException' })
+  //     .get(/collections/)
+  //     .reply(200, {
+  //       hits: 0,
+  //       took: 6,
+  //       items: []
+  //     })
+
+  //   const event = getEvent('C123755555-TESTPROV', 'concept-update')
+
+  //   const consoleMock = jest.spyOn(console, 'log')
+
+  //   const indexed = await indexCmrCollection(event)
+
+  //   // Error code called twice, retrying called twice, skip called once
+  //   expect(consoleMock).toBeCalledTimes(5)
+
+  //   // expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: ConcurrentModificationException')
+  //   expect(consoleMock).toBeCalledWith('Exception raised, retrying to index collection # ', 0)
+  //   expect(consoleMock).toBeCalledWith('Exception raised, retrying to index collection # ', 1)
+
+  //   // Will stop trying after the maximum depth has been passed
+  //   expect(consoleMock).toBeCalledWith('Skip indexing of collection [C123755555-TESTPROV] as it is not found in CMR')
+
+  //   const { body } = indexed
+
+  //   expect(body).toBe('Successfully indexed 0 collection(s).')
+  // })
 
   test('test unsupported event type', async () => {
     const event = getEvent('C1237293909-TESTPROV', 'concept-create')

--- a/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
+++ b/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
@@ -161,6 +161,22 @@ describe('indexCmrCollection handler', () => {
     expect(statusCode).toBe(200)
   })
 
+  test('test unsupported event type', async () => {
+    const event = getEvent('C1237293909-TESTPROV', 'concept-create')
+
+    const consoleMock = jest.spyOn(console, 'log')
+
+    const indexed = await indexCmrCollection(event)
+
+    expect(consoleMock).toBeCalledTimes(1)
+    expect(consoleMock).toBeCalledWith('Action [concept-create] was unsupported for concept [C1237293909-TESTPROV]')
+
+    const { body, statusCode } = indexed
+
+    expect(body).toBe('Successfully indexed 0 collection(s).')
+    expect(statusCode).toBe(200)
+  })
+
   test('test deletion of single collection', async () => {
     const collectionTitle = 'Latent reserves within the Swiss NFI'
     const project1 = 'Project One'
@@ -362,60 +378,4 @@ describe('indexCmrCollection handler', () => {
     await verifyRelatedUrlExistInGraphDb(anothercollectionTitle, keptDocUrl)
     await verifyRelatedUrlExistInGraphDb(anothercollectionTitle, newDocUrl)
   })
-})
-
-test('test indexing a collection where the event types is invalid', async () => {
-  nock(/local-cmr/)
-    .get(/collections/)
-    .reply(200, {
-      hits: 0,
-      took: 6,
-      items: []
-    })
-
-  const fetchGroupsMock = jest.spyOn(fetchCollectionPermittedGroups, 'fetchCollectionPermittedGroups').mockReturnValueOnce([])
-
-  const event = getEvent('C123755555-TESTPROV', 'undefined')
-
-  const consoleMock = jest.spyOn(console, 'log')
-
-  const indexed = await indexCmrCollection(event)
-
-  expect(fetchGroupsMock).toBeCalledTimes(0)
-
-  expect(consoleMock).toBeCalledTimes(1)
-  expect(consoleMock).toBeCalledWith('Action [undefined] was unsupported for concept [C123755555-TESTPROV]')
-
-  const { body, statusCode } = indexed
-
-  expect(body).toBe('Successfully indexed 0 collection(s).')
-  expect(statusCode).toBe(200)
-})
-
-test('test indexing a collection where the event types is invalid', async () => {
-  nock(/local-cmr/)
-    .get(/collections/)
-    .reply(200, {
-      hits: 0,
-      took: 6,
-      items: []
-    })
-
-  const fetchGroupsMock = jest.spyOn(fetchCollectionPermittedGroups, 'fetchCollectionPermittedGroups').mockReturnValueOnce([])
-
-  const event = getEvent('C123755555-TESTPROV', 'undefined')
-
-  const consoleMock = jest.spyOn(console, 'log')
-
-  const indexed = await indexCmrCollection(event)
-
-  expect(fetchGroupsMock).toBeCalledTimes(0)
-
-  expect(consoleMock).toBeCalledTimes(1)
-  expect(consoleMock).toBeCalledWith('Action [undefined] was unsupported for concept [C123755555-TESTPROV]')
-
-  const { body, statusCode } = indexed
-
-  expect(body).toBe('Successfully indexed 0 collection(s).')
-  expect(statusCode).toBe(200)
 })

--- a/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
+++ b/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
@@ -120,38 +120,39 @@ describe('indexCmrCollection handler', () => {
     expect(statusCode).toBe(200)
   })
 
-  test('test collection that has an index but, is not in the oracle db', async () => {
-    // Pass an error to the response of fetchCmrCollection
-    // Emits an error event on the request object, not the reply
-    const conceptId = 'C123755555-TESTPROV'
-    nock(/local-cmr/)
-      .get(/collections/)
-      .replyWithError('Collection not found', { statusCode: 404 })
-      // commenting out for now TODO may use for exponential back-off strategy
-      // .get(/collections/)
-      // .replyWithError('Error Collection not found', { statusCode: 404 })
-      // .get(/collections/)
-      // .replyWithError('Error Collection not found', { statusCode: 404 })
+  // test('test collection that has an index but, is not in the oracle db', async () => {
+  //   // Pass an error to the response of fetchCmrCollection
+  //   // Emits an error event on the request object, not the reply
+  //   const conceptId = 'C123755555-TESTPROV'
+  //   nock(/local-cmr/)
+  //     .get(/collections/)
+  //     .replyWithError('Collection not found', { statusCode: 404 })
+  //     // commenting out for now TODO may use for exponential back-off strategy
+  //     // .get(/collections/)
+  //     // .replyWithError('Error Collection not found', { statusCode: 404 })
+  //     // .get(/collections/)
+  //     // .replyWithError('Error Collection not found', { statusCode: 404 })
 
-    const event = getEvent(conceptId, 'concept-update')
+  //   const event = getEvent(conceptId, 'concept-update')
 
-    const consoleMock = jest.spyOn(console, 'log')
+  //   const consoleMock = jest.spyOn(console, 'log')
 
-    const indexed = await indexCmrCollection(event)
-    // It will try to reindex TODO won't reindex right now. I'm not sure yet why this is the value 2 since the error is only printed once
-    expect(consoleMock).toBeCalledTimes(2)
-    // expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Error Collection not found')
-    // expect(consoleMock).toBeCalledWith(`Could not fetch collection ${conceptId} due to error: Error: Collection not found`)
-    // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error: Collection not found')
-    expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: ', new Error('Cannot read properties of null (reading \'data\')'))
-    // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error Collection not found')
+  //   const indexed = await indexCmrCollection(event)
+  //   // It will try to reindex TODO won't reindex right now. I'm not sure yet why this is the value 2 since the error is only printed once
+  //   expect(consoleMock).toBeCalledTimes(2)
+  //   // expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Error Collection not found')
+  //   // expect(consoleMock).toBeCalledWith(`Could not fetch collection ${conceptId} due to error: Error: Collection not found`)
+  //   // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error: Collection not found')
+  //   // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in index collection handler: ', new Error('Cannot read properties of null (reading \'data\')'))
+  //   expect(consoleMock).toBeCalledWith('Could not fetch collection C123755555-TESTPROV due to error:')
+  //   // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error Collection not found')
 
-    // expect(consoleMock).toBeCalledWith('Exception raised, retrying to index collection # ', 0)
+  //   // expect(consoleMock).toBeCalledWith('Exception raised, retrying to index collection # ', 0)
 
-    const { body } = indexed
+  //   const { body } = indexed
 
-    expect(body).toBe('Successfully indexed 0 collection(s).')
-  })
+  //   expect(body).toBe('Successfully indexed 0 collection(s).')
+  // })
   // TODO Need more logging information from AWS before using retry keep commented out for now
   // test.only('testing the retry policy for failed attempts', async () => {
   //   // Pass errors until the third attempt does not return an error

--- a/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
+++ b/graph-db/serverless/src/indexCmrCollection/__test__/handler.test.js
@@ -141,7 +141,7 @@ describe('indexCmrCollection handler', () => {
     // It will try to reindex TODO won't reindex right now. I'm not sure yet why this is the value 2 since the error is only printed once
     expect(consoleMock).toBeCalledTimes(2)
     // expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Error Collection not found')
-    expect(consoleMock).toBeCalledWith(`Could not fetch collection ${conceptId} due to error: Error: Collection not found`)
+    // expect(consoleMock).toBeCalledWith(`Could not fetch collection ${conceptId} due to error: Error: Collection not found`)
     // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error: Collection not found')
     expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: ', new Error('Cannot read properties of null (reading \'data\')'))
     // expect(consoleMock).toBeCalledWith('Error indexing collection, Exception was thrown in lambda: Error Collection not found')

--- a/graph-db/serverless/src/indexCmrCollection/handler.js
+++ b/graph-db/serverless/src/indexCmrCollection/handler.js
@@ -14,8 +14,6 @@ let token
 const updateActionType = 'concept-update'
 const deleteActionType = 'concept-delete'
 
-// Maximum number of retries for the function
-
 const indexCmrCollections = async (event) => {
   // Prevent creating more tokens than necessary
   if (token === undefined) {
@@ -76,7 +74,7 @@ const indexCmrCollections = async (event) => {
           recordCount += 1
         }
       } catch (error) {
-        console.log('Error indexing collection, Exception was thrown in lambda: ', error)
+        console.log(`Error indexing collection [${conceptId}], Exception was thrown in index collection handler ${error}`)
       }
     }
     if (getConceptType(conceptId) === 'collection' && action === deleteActionType) {

--- a/graph-db/serverless/src/indexCmrCollection/handler.js
+++ b/graph-db/serverless/src/indexCmrCollection/handler.js
@@ -63,6 +63,9 @@ const indexCmrCollections = async (event) => {
         } else {
           const [firstCollection] = items
 
+          // TODO: slow down how frequently we are sending responses to the access-control application
+          // since this effects all collection calls that get indexed it may help with the collection problems
+          // await new Promise((rate) => setTimeout(rate, 500))
           // Fetch the permitted groups for this collection from access-control
           const groupList = await fetchCollectionPermittedGroups(conceptId, token)
 

--- a/graph-db/serverless/src/indexCmrCollection/handler.js
+++ b/graph-db/serverless/src/indexCmrCollection/handler.js
@@ -74,7 +74,7 @@ const indexCmrCollections = async (event) => {
           recordCount += 1
         }
       } catch (error) {
-        console.log(`Error indexing collection [${conceptId}], Exception was thrown in index collection handler ${error}`)
+        console.log(`Error indexing collection [${conceptId}], Exception was thrown in index-collection handler ${error}`)
       }
     }
     if (getConceptType(conceptId) === 'collection' && action === deleteActionType) {

--- a/graph-db/serverless/src/testUtil/indexCollection.js
+++ b/graph-db/serverless/src/testUtil/indexCollection.js
@@ -3,17 +3,17 @@ import nock from 'nock'
 
 import indexCmrCollection from '../indexCmrCollection/handler'
 
-// Helper to create a Project object simular to the one returned by CMR
+// Helper to create a Project object similar to the one returned by CMR
 const projectObj = (shortName) => ({
   ShortName: shortName
 })
 
-// Helper to create a Instrument object simular to the one returned by CMR
+// Helper to create a Instrument object similar to the one returned by CMR
 const instrumentObj = (shortName) => ({
   ShortName: shortName
 })
 
-// Helper to create a Platforms object simular to the one returned by CMR
+// Helper to create a Platforms object similar to the one returned by CMR
 // {platform: platformName, instruments: [instrumentName ...]}
 const platformInstrumentsObj = (attributes) => {
   const { platform, instruments } = attributes
@@ -29,7 +29,7 @@ const platformInstrumentsObj = (attributes) => {
   return returnObj
 }
 
-// Helper to create a RelatedUrl object simular to the one returned by CMR
+// Helper to create a RelatedUrl object similar to the one returned by CMR
 const relatedUrlObj = (relatedUrl) => ({
   URLContentType: 'PublicationURL',
   Type: 'VIEW RELATED INFORMATION',

--- a/graph-db/serverless/src/utils/cmr/__test__/fetchCmrCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/fetchCmrCollection.test.js
@@ -51,5 +51,6 @@ describe('fetchCmrCollection', () => {
     expect(result).toBe(null)
 
     expect(consoleMock).toHaveBeenCalledTimes(1)
+    expect(consoleMock).toBeCalledWith('Could not fetch collection C1216257563-LPDAAC_TS1 due to error: Error: Request failed with status code 500')
   })
 })

--- a/graph-db/serverless/src/utils/cmr/__test__/fetchCollectionPermittedGroups.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/fetchCollectionPermittedGroups.test.js
@@ -178,7 +178,7 @@ describe('fetchCollectionPermittedGroups', () => {
 
     const result = await fetchCollectionPermittedGroups('C1708620364-NSIDC_ECS', 'mock_token')
 
-    // The result should be equal to a list of groups ['a', 'b', 'c']
+    // The result should be equal to a list of groups ['group-a', 'group-b', 'group-c']
     const permittedGroups = []
     expect(result).toEqual(permittedGroups)
   })

--- a/graph-db/serverless/src/utils/cmr/__test__/fetchCollectionPermittedGroups.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/fetchCollectionPermittedGroups.test.js
@@ -75,26 +75,28 @@ describe('fetchCollectionPermittedGroups', () => {
   test('If the concept_id does not exist CMR returns a 400 error', async () => {
     const consoleMock = jest.spyOn(console, 'log')
     const mockedBody = []
+    const conceptId = 'Not_a_real_Collection'
 
     nock(/local-cmr/)
       .get(/acls/)
       .reply(400, mockedBody)
 
-    const result = await fetchCollectionPermittedGroups('Not_a_real_Collection', 'mock_token')
+    const result = await fetchCollectionPermittedGroups(conceptId, 'mock_token')
 
-    expect(consoleMock).toHaveBeenCalledWith('Could not complete request to acl due to error: Error: Request failed with status code 400')
+    expect(consoleMock).toHaveBeenCalledWith(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: Error: Request failed with status code 400`)
     expect(result).toEqual(mockedBody)
   })
 
   test('If the no token was supplied', async () => {
     const consoleMock = jest.spyOn(console, 'log')
     const mockedBody = []
+    const conceptId = 'Not_a_real_Collection'
 
     nock(/local-cmr/)
       .get(/acls/)
       .reply(400, mockedBody)
-    const result = await fetchCollectionPermittedGroups('Not_a_real_Collection')
-    expect(consoleMock).toHaveBeenCalledWith('Could not complete request to acl due to error: Error: Request failed with status code 400')
+    const result = await fetchCollectionPermittedGroups(conceptId)
+    expect(consoleMock).toHaveBeenCalledWith(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: Error: Request failed with status code 400`)
     expect(result).toEqual(mockedBody)
   })
 

--- a/graph-db/serverless/src/utils/cmr/__test__/fetchPageFromCmr.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/fetchPageFromCmr.test.js
@@ -251,7 +251,7 @@ describe('fetchPageFromCMR', () => {
       providerId: null
     })
 
-    expect(consoleMock).toBeCalledWith('Could not complete request due to error: Error: Oh no! I sure hope this exception is handled')
+    expect(consoleMock).toBeCalledWith('Could not complete request due to an error requesting a page from CMR: Error: Oh no! I sure hope this exception is handled')
     expect(errorResponse).toBeCalledTimes(1)
   })
 })

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -67,18 +67,18 @@ describe('utils#indexCmrCollection', () => {
       // expect(result).toBeFalsy()
       await expect(
         indexCmrCollection(collectionObj, [], null)
-      ).rejects.toThrow('throwing error in indexCmrCollection')
+      ).rejects.toThrow('throwing error in indexCmrCollection maximum attempts reached')
       // expect(result.toThrow(Error))
       // await expect(indexCmrCollection(collectionObj, [], null)).rejects.toThrow('some error')
       // expect(() => { indexCmrCollection(collectionObj, [], null) }).toThrow(TypeError)
       // Retry policy in place. Called 5 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
-      expect(consoleMock).toBeCalledTimes(2)
+      expect(consoleMock).toBeCalledTimes(11)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)
 
       // Error message logged because addV failed because of null gremlinConnection
-      expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
+      expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV'), retrying attempt #[1]`)
       // Function is being called recursively
       // expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
       // expect(result.toThrow(Error))

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -75,7 +75,7 @@ describe('utils#indexCmrCollection', () => {
       // Error message logged because addV failed because of null gremlinConnection
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
       // Function is being called recursively
-      expect(consoleMock.mock.calls[2][0]).toEqual('retrying the lambda function to index the graph database depth = ')
+      expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
     })
   })
   // Keep retry retry policy out for now

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
 
 describe('utils#indexCmrCollection', () => {
   describe('when an exception is thrown', () => {
-    test.only('it is caught and logged', async () => {
+    test('it is caught and logged', async () => {
       const consoleMock = jest.spyOn(console, 'log')
 
       const conceptId = 'C1000000-CMR'
@@ -62,10 +62,15 @@ describe('utils#indexCmrCollection', () => {
         .reply(200, mockAclResponse)
 
       // Provide `null` for the gremlin connection to throw an error
-      const result = await indexCmrCollection(collectionObj, [], null)
+      // const result = await indexCmrCollection(collectionObj, [], null)
 
-      expect(result).toBeFalsy()
-
+      // expect(result).toBeFalsy()
+      await expect(
+        indexCmrCollection(collectionObj, [], null)
+      ).rejects.toThrow('throwing error in indexCmrCollection')
+      // expect(result.toThrow(Error))
+      // await expect(indexCmrCollection(collectionObj, [], null)).rejects.toThrow('some error')
+      // expect(() => { indexCmrCollection(collectionObj, [], null) }).toThrow(TypeError)
       // Retry policy in place. Called 5 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
       expect(consoleMock).toBeCalledTimes(2)
 
@@ -76,6 +81,7 @@ describe('utils#indexCmrCollection', () => {
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
       // Function is being called recursively
       // expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
+      // expect(result.toThrow(Error))
     })
   })
   // Keep retry retry policy out for now

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -61,13 +61,10 @@ describe('utils#indexCmrCollection', () => {
         .reply(200, mockAclResponse)
 
       // Provide `null` for the gremlin connection to throw an error
-      // await expect(indexCmrCollection(collectionObj, [], null))
-
       const result = await indexCmrCollection(collectionObj, [], null)
 
       expect(result).toBeFalsy()
 
-      // Retry policy in place. Called 5 times (maxDepth) uses two different logs for this error the project and the collection itself. One additional log for max attempts being reached
       expect(consoleMock).toBeCalledTimes(2)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
@@ -75,9 +72,6 @@ describe('utils#indexCmrCollection', () => {
 
       // Error message logged because addV failed, first attempt being printed to console
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
-
-      // // Error message that max attempts have been reached according to the retry policy
-      // expect(consoleMock.mock.calls[10][0]).toEqual(`Maximum attempts to index the graph database for [${conceptId}] error: TypeError: Cannot read properties of null (reading 'addV')`)
     })
   })
 })

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -1,7 +1,6 @@
 import nock from 'nock'
 
 import { indexCmrCollection } from '../indexCmrCollection'
-// import { initializeGremlinConnection } from '../../gremlin/initializeGremlinConnection'
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -62,49 +61,21 @@ describe('utils#indexCmrCollection', () => {
         .reply(200, mockAclResponse)
 
       // Provide `null` for the gremlin connection to throw an error
-      // const result = await indexCmrCollection(collectionObj, [], null)
-
-      // expect(result).toBeFalsy()
       await expect(
         indexCmrCollection(collectionObj, [], null)
       ).rejects.toThrow('throwing error in indexCmrCollection maximum attempts reached')
-      // expect(result.toThrow(Error))
-      // await expect(indexCmrCollection(collectionObj, [], null)).rejects.toThrow('some error')
-      // expect(() => { indexCmrCollection(collectionObj, [], null) }).toThrow(TypeError)
-      // Retry policy in place. Called 5 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
+
+      // Retry policy in place. Called 5 times (maxDepth) uses two different logs for this error the project and the collection itself. One additional log for max attempts being reached
       expect(consoleMock).toBeCalledTimes(11)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)
 
-      // Error message logged because addV failed because of null gremlinConnection
+      // Error message logged because addV failed, first attempt being printed to console
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV'), retrying attempt #[1]`)
-      // Function is being called recursively
-      // expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
-      // expect(result.toThrow(Error))
+
+      // Error message that max attempts have been reached according to the retry policy
+      expect(consoleMock.mock.calls[10][0]).toEqual(`Maximum attempts to index the graph database for [${conceptId}] error: TypeError: Cannot read properties of null (reading 'addV')`)
     })
   })
-  // Keep retry retry policy out for now
-  // describe('When an exception is thrown and retrying begins', () => {
-  //   test('test retry to index a collection if there is a failure such as a Concurrent Modification Error', async () => {
-  //     const gremlinConnection = initializeGremlinConnection()
-  //     const collectionObj = {
-  //       meta: {
-  //         'concept-id': 'C1000000-CMR'
-  //       },
-  //       umm: {
-  //         EntryTitle: 'entryTitle',
-  //         DOI: {
-  //           DOI: 'doiDescription'
-  //         },
-  //         Projects: 'projects',
-  //         Platforms: 'platforms',
-  //         RelatedUrls: 'relatedUrls',
-  //         ShortName: 'shortName'
-  //       }
-  //     }
-  //     // depth defaults to 0
-  //     const result = await indexCmrCollection(collectionObj, ['guest'], gremlinConnection)
-  //   })
-  // })
 })

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -66,8 +66,8 @@ describe('utils#indexCmrCollection', () => {
 
       expect(result).toBeFalsy()
 
-      // Retry policy in place. Called 4 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
-      expect(consoleMock).toBeCalledTimes(12)
+      // Retry policy in place. Called 5 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
+      expect(consoleMock).toBeCalledTimes(18)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -61,21 +61,23 @@ describe('utils#indexCmrCollection', () => {
         .reply(200, mockAclResponse)
 
       // Provide `null` for the gremlin connection to throw an error
-      await expect(
-        indexCmrCollection(collectionObj, [], null)
-      ).rejects.toThrow('throwing error in indexCmrCollection maximum attempts reached')
+      // await expect(indexCmrCollection(collectionObj, [], null))
+
+      const result = await indexCmrCollection(collectionObj, [], null)
+
+      expect(result).toBeFalsy()
 
       // Retry policy in place. Called 5 times (maxDepth) uses two different logs for this error the project and the collection itself. One additional log for max attempts being reached
-      expect(consoleMock).toBeCalledTimes(11)
+      expect(consoleMock).toBeCalledTimes(2)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)
 
       // Error message logged because addV failed, first attempt being printed to console
-      expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV'), retrying attempt #[1]`)
+      expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
 
-      // Error message that max attempts have been reached according to the retry policy
-      expect(consoleMock.mock.calls[10][0]).toEqual(`Maximum attempts to index the graph database for [${conceptId}] error: TypeError: Cannot read properties of null (reading 'addV')`)
+      // // Error message that max attempts have been reached according to the retry policy
+      // expect(consoleMock.mock.calls[10][0]).toEqual(`Maximum attempts to index the graph database for [${conceptId}] error: TypeError: Cannot read properties of null (reading 'addV')`)
     })
   })
 })

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -67,7 +67,7 @@ describe('utils#indexCmrCollection', () => {
       expect(result).toBeFalsy()
 
       // Retry policy in place. Called 5 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
-      expect(consoleMock).toBeCalledTimes(18)
+      expect(consoleMock).toBeCalledTimes(2)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)
@@ -75,7 +75,7 @@ describe('utils#indexCmrCollection', () => {
       // Error message logged because addV failed because of null gremlinConnection
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
       // Function is being called recursively
-      expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
+      // expect(consoleMock.mock.calls[2][0]).toEqual(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #1`)
     })
   })
   // Keep retry retry policy out for now

--- a/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexCollection.test.js
@@ -66,14 +66,16 @@ describe('utils#indexCmrCollection', () => {
 
       expect(result).toBeFalsy()
 
-      // Retry policy in place. Called 3 times using two different logs, so 6 total calls TODO use this after test, for now leave it off for 2
-      expect(consoleMock).toBeCalledTimes(2)
+      // Retry policy in place. Called 4 times using three different logs, so 12 total calls TODO use this after test, for now leave it off for 2
+      expect(consoleMock).toBeCalledTimes(12)
 
       // Error message logged because deleteCmrCollection failed because of null gremlinConnection
       expect(consoleMock.mock.calls[0][0]).toEqual(`Error deleting project vertices only linked to collection [${conceptId}]: Cannot read properties of null (reading 'V')`)
 
       // Error message logged because addV failed because of null gremlinConnection
       expect(consoleMock.mock.calls[1][0]).toEqual(`Error indexing collection into graph database [${conceptId}]: Cannot read properties of null (reading 'addV')`)
+      // Function is being called recursively
+      expect(consoleMock.mock.calls[2][0]).toEqual('retrying the lambda function to index the graph database depth = ')
     })
   })
   // Keep retry retry policy out for now

--- a/graph-db/serverless/src/utils/cmr/__test__/indexRelatedUrl.test.js
+++ b/graph-db/serverless/src/utils/cmr/__test__/indexRelatedUrl.test.js
@@ -48,6 +48,25 @@ describe('indexRelatedUrl', () => {
     })
   })
 
+  describe('when the provided relatedUrl is missing both SubType and Description', () => {
+    test('it indexes the relatedUrl', async () => {
+      const relatedUrl = {
+        Type: 'VIEW RELATED INFORMATION',
+        URL: 'https://example.com/test.json'
+      }
+
+      await updateCollection(
+        'C100000-CMR',
+        'Vulputate Mollis Commodo',
+        {
+          relatedUrls: [relatedUrl.URL]
+        }
+      )
+
+      await verifyRelatedUrlExistInGraphDb('Vulputate Mollis Commodo', 'https://example.com/test.json')
+    })
+  })
+
   describe('when an exception is thrown', () => {
     test('it is caught and a new one is thrown', async () => {
       const consoleMock = jest.spyOn(console, 'log')

--- a/graph-db/serverless/src/utils/cmr/fetchCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCmrCollection.js
@@ -22,7 +22,7 @@ export const fetchCmrCollection = async (conceptId, token) => {
       json: true
     })
   } catch (error) {
-    console.log(`Could not complete request due to error: ${error}`)
+    console.log(`Could not fetch collection ${conceptId} due to error: ${error}`)
 
     return null
   }

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -8,11 +8,11 @@ import axiosRetry from 'axios-retry'
  */
 
 // axiosRetry(axios, { retries: 3 })
-// Compensate for any misses to the endpoint max retries is going to be 3 using
+// Compensate for any misses to the endpoint max retries is going to be 8 using
 // exponential timing between the calls
 axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
 
-export const fetchCollectionPermittedGroups = async (conceptId, token, depth = 1) => {
+export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}
   const groups = []
   // const maxTries = 3

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -9,7 +9,7 @@ import axiosRetry from 'axios-retry'
 
 // Compensate for any misses to the endpoint max retries is going to be 4 using
 // exponential timing between the calls
-axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
+axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 3 })
 
 export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}
@@ -60,6 +60,5 @@ export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   } catch (error) {
     console.log(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: ${error}`)
   }
-
   return groups
 }

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -12,7 +12,7 @@ import axiosRetry from 'axios-retry'
 // axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
 // More aggressive wait between call request attempts than from the exponential delay
 axiosRetry(axios, {
-  retryDelay: (retryCount) => retryCount * 500,
+  retryDelay: (retryCount) => retryCount * 600,
   retries: 3
 })
 // exponential delay

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -7,21 +7,11 @@ import axiosRetry from 'axios-retry'
  * @returns [] An array containing the permitted groups of a collection
  */
 
-// Compensate for any misses to the endpoint max retries is going to be 4 using
-// exponential timing between the calls
-// axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
-// More aggressive wait between call request attempts than from the exponential delay
+// Compensate for any misses to the endpoint
 axiosRetry(axios, {
   retryDelay: (retryCount) => retryCount * 600,
   retries: 3
 })
-// exponential delay
-// export function exponentialDelay(retryNumber = 0) {
-//   const delay = Math.pow(2, retryNumber) * 100
-//   const randomSum = delay * 0.2 * Math.random() // 0-20% of the delay
-//   return delay + randomSum
-// }
-// 4th try would take approximately 800ms
 
 export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}
@@ -33,9 +23,6 @@ export const fetchCollectionPermittedGroups = async (conceptId, token) => {
 
   let response
   try {
-    // TODO: We can put a wait function here to ensure that this thing is waiting a long time between calls so that we can
-    // ensure that we do not overwhelm the access-control app
-
     response = await axios({
       url: `${process.env.CMR_ROOT}/access-control/acls?permitted_concept_id=${conceptId}&include_full_acl=true`,
       method: 'GET',

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -1,15 +1,21 @@
 import axios from 'axios'
-
+import axiosRetry from 'axios-retry'
 /**
  * Fetch a the permitted groups of a collection from CMR access control
  * @param {String} conceptId Collection concept id from CMR
  * @param {String} token An optional Authorization Token
  * @returns [] An array containing the permitted groups of a collection
  */
+
+// axiosRetry(axios, { retries: 3 })
+// Compensate for any misses to the endpoint max retries is going to be 3 using
+// exponential timing between the calls
+axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
+
 export const fetchCollectionPermittedGroups = async (conceptId, token, depth = 1) => {
   const requestHeaders = {}
   const groups = []
-  const maxTries = 3
+  // const maxTries = 3
 
   if (token) {
     requestHeaders.Authorization = token
@@ -55,6 +61,7 @@ export const fetchCollectionPermittedGroups = async (conceptId, token, depth = 1
     })
   } catch (error) {
     console.log(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: ${error}`)
+
     // if (depth < maxTries) {
     //   await fetchCollectionPermittedGroups(conceptId, token, depth + 1)
     // }

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -6,9 +6,10 @@ import axios from 'axios'
  * @param {String} token An optional Authorization Token
  * @returns [] An array containing the permitted groups of a collection
  */
-export const fetchCollectionPermittedGroups = async (conceptId, token) => {
+export const fetchCollectionPermittedGroups = async (conceptId, token, depth = 1) => {
   const requestHeaders = {}
   const groups = []
+  const maxTries = 3
 
   if (token) {
     requestHeaders.Authorization = token
@@ -53,7 +54,10 @@ export const fetchCollectionPermittedGroups = async (conceptId, token) => {
       })
     })
   } catch (error) {
-    console.log(`Could not complete request to acl due to error: ${error}`)
+    console.log(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: ${error}`)
+    // if (depth < maxTries) {
+    //   await fetchCollectionPermittedGroups(conceptId, token, depth + 1)
+    // }
   }
 
   return groups

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -7,15 +7,13 @@ import axiosRetry from 'axios-retry'
  * @returns [] An array containing the permitted groups of a collection
  */
 
-// axiosRetry(axios, { retries: 3 })
-// Compensate for any misses to the endpoint max retries is going to be 8 using
+// Compensate for any misses to the endpoint max retries is going to be 4 using
 // exponential timing between the calls
 axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
 
 export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}
   const groups = []
-  // const maxTries = 3
 
   if (token) {
     requestHeaders.Authorization = token
@@ -61,10 +59,6 @@ export const fetchCollectionPermittedGroups = async (conceptId, token) => {
     })
   } catch (error) {
     console.log(`Could not complete request to Access Control App to retrieve group information for ${conceptId} due to error: ${error}`)
-
-    // if (depth < maxTries) {
-    //   await fetchCollectionPermittedGroups(conceptId, token, depth + 1)
-    // }
   }
 
   return groups

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -9,7 +9,7 @@ import axiosRetry from 'axios-retry'
 
 // Compensate for any misses to the endpoint max retries is going to be 4 using
 // exponential timing between the calls
-axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 3 })
+axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
 
 export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}

--- a/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
+++ b/graph-db/serverless/src/utils/cmr/fetchCollectionPermittedGroups.js
@@ -9,7 +9,19 @@ import axiosRetry from 'axios-retry'
 
 // Compensate for any misses to the endpoint max retries is going to be 4 using
 // exponential timing between the calls
-axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
+// axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay, retries: 4 })
+// More aggressive wait between call request attempts than from the exponential delay
+axiosRetry(axios, {
+  retryDelay: (retryCount) => retryCount * 500,
+  retries: 3
+})
+// exponential delay
+// export function exponentialDelay(retryNumber = 0) {
+//   const delay = Math.pow(2, retryNumber) * 100
+//   const randomSum = delay * 0.2 * Math.random() // 0-20% of the delay
+//   return delay + randomSum
+// }
+// 4th try would take approximately 800ms
 
 export const fetchCollectionPermittedGroups = async (conceptId, token) => {
   const requestHeaders = {}
@@ -21,6 +33,9 @@ export const fetchCollectionPermittedGroups = async (conceptId, token) => {
 
   let response
   try {
+    // TODO: We can put a wait function here to ensure that this thing is waiting a long time between calls so that we can
+    // ensure that we do not overwhelm the access-control app
+
     response = await axios({
       url: `${process.env.CMR_ROOT}/access-control/acls?permitted_concept_id=${conceptId}&include_full_acl=true`,
       method: 'GET',

--- a/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
+++ b/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
@@ -56,7 +56,7 @@ export const fetchPageFromCMR = async ({
       method: 'GET',
       headers: requestHeaders
     })
-
+    // Iterate over CMR-pages
     const { data, headers } = cmrCollections
     const { 'cmr-search-after': cmrsearchAfter } = headers
 

--- a/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
+++ b/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
@@ -48,7 +48,7 @@ export const fetchPageFromCMR = async ({
     if (sqs == null) {
       sqs = new SQSClient()
     }
-
+    // Send request to CMR
     const cmrCollections = await axios({
       url: fetchUrl,
       method: 'GET',
@@ -61,6 +61,7 @@ export const fetchPageFromCMR = async ({
     const { feed = {} } = data
     const { entry = [] } = feed
 
+    // Split page array into array with sub-arrays of size 10
     const chunkedItems = chunkArray(entry, 10)
 
     if (chunkedItems.length > 0) {
@@ -79,7 +80,7 @@ export const fetchPageFromCMR = async ({
               })
             }
           })
-
+          // Locally we will call indexCmrCollections directly, otherwise send the job to SQS queue
           await indexCmrCollections({ Records: queueBody })
         } else {
           const sqsEntries = []
@@ -116,7 +117,7 @@ export const fetchPageFromCMR = async ({
         searchAfterNum: (searchAfterNum + 1)
       })
     }
-  } catch (e) {
-    console.log(`Could not complete request due to error: ${e}`)
+  } catch (error) {
+    console.log(`Could not complete request due to an error requesting a page from CMR: ${error}`)
   }
 }

--- a/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
+++ b/graph-db/serverless/src/utils/cmr/fetchPageFromCMR.js
@@ -89,6 +89,9 @@ export const fetchPageFromCMR = async ({
           chunk.forEach((collection) => {
             const { id: conceptId } = collection
 
+            // TODO: Since we already made a call to CMR we may want to pass that information into the event
+            // TODO: it is possible that by passing cmr data in the event the data could be stale by the time
+            // the indexCollection handler picks it up to index it into the graphDb
             sqsEntries.push({
               Id: conceptId,
               MessageBody: JSON.stringify({
@@ -111,7 +114,10 @@ export const fetchPageFromCMR = async ({
     }
 
     // If we have an active searchAfter so we aren't on the last page and there are more results
+    // Second argument is to parse integers in base 10
     if (cmrsearchAfter && entry.length === parseInt(process.env.PAGE_SIZE, 10)) {
+      // TODO: Investigate putting in a wait function between calls for each page to allow it to get picked
+      // up by the other lambda and indexed into the graph database
       await fetchPageFromCMR({
         searchAfter: cmrsearchAfter,
         token,

--- a/graph-db/serverless/src/utils/cmr/getEchoToken.js
+++ b/graph-db/serverless/src/utils/cmr/getEchoToken.js
@@ -12,7 +12,7 @@ export const getEchoToken = async () => {
   // Destructure env variables
   const {
     CMR_TOKEN_KEY: cmrTokenKey,
-    ENVIRONMENT: envrionment,
+    ENVIRONMENT: environment,
     IS_LOCAL: isLocal,
     TOKEN: localToken
   } = env
@@ -26,7 +26,7 @@ export const getEchoToken = async () => {
   if (cmrTokenKey) {
     try {
       token = await getSecureParam(
-        `/${envrionment}/graph-db/${cmrTokenKey}`
+        `/${environment}/graph-db/${cmrTokenKey}`
       )
     } catch (error) {
       console.log(`Could not get token: ${error}`)

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -17,8 +17,9 @@ const gremlinStatistics = gremlin.process.statics
  * @returns
  */
 
+// eslint-disable-next-line max-len
 export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection, depth = 1) => {
-  // const maxDepth = 5
+  const maxDepth = 4
   const wait = (ms) => new Promise((res) => setTimeout(res, ms))
   const {
     meta: {
@@ -39,7 +40,6 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
 
   // Delete the collection first so that we can clean up its related, relatedUrl vertices
   await deleteCmrCollection(conceptId, gremlinConnection)
-  // TODO Introduce some kind of timeout here so that this can finnish executing on gremlin?
   let collection = null
   try {
     const addVCommand = gremlinConnection.addV('collection')
@@ -73,16 +73,13 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
   } catch (error) {
     console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}, retrying attempt #[${depth}]`)
 
-    if (depth > 4) {
+    if (depth > maxDepth) {
       console.log(`Maximum attempts to index the graph database for [${conceptId}] error: ${error}`)
       throw Error('throwing error in indexCmrCollection maximum attempts reached for', conceptId)
     }
     await wait(2 ** depth * 10)
     // Exponential retry on the function
     return indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
-    // console.log(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #${depth}`)
-
-    // await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
   }
 
   const { value = {} } = collection

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -17,7 +17,7 @@ const gremlinStatistics = gremlin.process.statics
  * @returns
  */
 
-export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection, depth = 1) => {
+export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection) => {
   // const maxDepth = 5
   const {
     meta: {
@@ -72,16 +72,16 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
   } catch (error) {
     console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}`)
 
-    if (depth > 5) {
-      console.log(`Maximum attempts to index the graph database for [${conceptId}] attempt #${depth}`)
-      return false
-    }
+    // if (depth > 5) {
+    //   console.log(`Maximum attempts to index the graph database for [${conceptId}] attempt #${depth}`)
+    //   return false
+    // }
 
-    console.log(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #${depth}`)
+    // console.log(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #${depth}`)
 
-    await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
-
-    return false
+    // await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
+    // Throw this error to have this be picked up by AWS dead letter queue to observe effects
+    throw Error
   }
 
   const { value = {} } = collection

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -11,7 +11,9 @@ const gremlinStatistics = gremlin.process.statics
 /**
  * Given a collection from the CMR, index it into Gremlin
  * @param {JSON} collectionObj collection object from `items` array in cmr response
+ * @param {JSON} collectionObj List of groups that the collection can be read by from access-control
  * @param {Gremlin Traversal Object} gremlinConnection connection to gremlin server
+ * @param {number} [depth=1] the recursion depth the function is currently on
  * @returns
  */
 
@@ -69,15 +71,16 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
       .next()
   } catch (error) {
     console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}`)
-    if (depth > 3) {
-      console.log('Max depth exceeded with depth at value', depth)
+
+    if (depth > 5) {
+      console.log(`Maximum attempts to index the graph database for [${conceptId}] attempt #${depth}`)
       return false
     }
-    // setTimeout(5000)
-    console.log('retrying the lambda function to index the graph database depth = ', depth)
-    // Exponential back-off and retry policy
+
+    console.log(`Retrying the lambda function to index the graph database for [${conceptId}] attempt #${depth}`)
 
     await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
+
     return false
   }
 

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -14,8 +14,9 @@ const gremlinStatistics = gremlin.process.statics
  * @param {Gremlin Traversal Object} gremlinConnection connection to gremlin server
  * @returns
  */
-export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection) => {
-  // const maxDepth = 3
+
+export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection, depth = 1) => {
+  // const maxDepth = 5
   const {
     meta: {
       'concept-id': conceptId,
@@ -68,11 +69,15 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
       .next()
   } catch (error) {
     console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}`)
-    // This might not work because the delete is also being done in this block
-    // if (depth < maxDepth) {
-    //   console.log(`Retrying to index collection ${conceptId}  into graph database attempt #', ${depth}`)
-    //   await indexCmrCollection(collectionObj, groupList, gremlinConn, depth + 1)
-    // }
+    if (depth > 3) {
+      console.log('Max depth exceeded with depth at value', depth)
+      return false
+    }
+    // setTimeout(5000)
+    console.log('retrying the lambda function to index the graph database depth = ', depth)
+    // Exponential back-off and retry policy
+
+    await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
     return false
   }
 

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -81,7 +81,7 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
 
     // await indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
     // Throw this error to have this be picked up by AWS dead letter queue to observe effects
-    throw Error
+    throw Error('throwing error in indexCmrCollection')
   }
 
   const { value = {} } = collection

--- a/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
+++ b/graph-db/serverless/src/utils/cmr/indexCmrCollection.js
@@ -13,14 +13,11 @@ const gremlinStatistics = gremlin.process.statics
  * @param {JSON} collectionObj collection object from `items` array in cmr response
  * @param {JSON} collectionObj List of groups that the collection can be read by from access-control
  * @param {Gremlin Traversal Object} gremlinConnection connection to gremlin server
- * @param {number} [depth=1] the recursion depth the function is currently on
  * @returns
  */
 
 // eslint-disable-next-line max-len
-export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection, depth = 1) => {
-  const maxDepth = 4
-  const wait = (ms) => new Promise((res) => setTimeout(res, ms))
+export const indexCmrCollection = async (collectionObj, groupList, gremlinConnection) => {
   const {
     meta: {
       'concept-id': conceptId,
@@ -71,15 +68,8 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
       )
       .next()
   } catch (error) {
-    console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}, retrying attempt #[${depth}]`)
-
-    if (depth > maxDepth) {
-      console.log(`Maximum attempts to index the graph database for [${conceptId}] error: ${error}`)
-      throw Error('throwing error in indexCmrCollection maximum attempts reached for', conceptId)
-    }
-    await wait(2 ** depth * 10)
-    // Exponential retry on the function
-    return indexCmrCollection(collectionObj, groupList, gremlinConnection, depth + 1)
+    console.log(`Error indexing collection into graph database [${conceptId}]: ${error.message}`)
+    return false
   }
 
   const { value = {} } = collection
@@ -103,7 +93,7 @@ export const indexCmrCollection = async (collectionObj, groupList, gremlinConnec
     })
   }
 
-  console.log(`Collection vertex [${collectionId}] indexed for collection [${conceptId}]`)
+  console.log(`Collection vertex [${collectionId}] successfully indexed for collection [${conceptId}]`)
 
   return true
 }

--- a/graph-db/serverless/src/utils/cmr/indexPlatform.js
+++ b/graph-db/serverless/src/utils/cmr/indexPlatform.js
@@ -25,7 +25,7 @@ export const indexPlatform = async (platform, gremlinConnection, collection, con
         await indexInstrument(instrument, gremlinConnection, platformName, collection)
       })
     } else {
-      // Use `fold` and `coalesce` to check existance of vertex, and create one if none exists.
+      // Use `fold` and `coalesce` to check existence of vertex, and create one if none exists.
       const piVertex = await gremlinConnection
         .V()
         .has('platformInstrument', 'platform', platformName)

--- a/graph-db/serverless/src/utils/cmr/indexProject.js
+++ b/graph-db/serverless/src/utils/cmr/indexProject.js
@@ -16,7 +16,7 @@ export const indexProject = async (project, gremlinConnection, collection, conce
   } = project
 
   try {
-    // Use `fold` and `coalesce` to check existance of vertex, and create one if none exists.
+    // Use `fold` and `coalesce` to check existence of vertex, and create one if none exists.
     const projectVertex = await gremlinConnection
       .V()
       .has('project', 'name', shortName)
@@ -45,7 +45,7 @@ export const indexProject = async (project, gremlinConnection, collection, conce
     const { value: edgeValue = {} } = projectEdge
     const { id: edgeId } = edgeValue
 
-    console.log(`project edge [${edgeId}] indexed to point to collection [${collection}]`)
+    console.log(`Project edge [${edgeId}] indexed to point to collection [${collection}]`)
   } catch (error) {
     // Log useful information pertaining to the error
     console.log(`Failed to index Project for concept [${conceptId}] ${JSON.stringify(project)}`)

--- a/graph-db/serverless/src/utils/cmr/indexRelatedUrl.js
+++ b/graph-db/serverless/src/utils/cmr/indexRelatedUrl.js
@@ -35,7 +35,7 @@ export const indexRelatedUrl = async (
       addVCommand.property('subtype', subtype)
     }
 
-    // Use `fold` and `coalesce` to check existance of vertex, and create one if none exists.
+    // Use `fold` and `coalesce` to check existence of vertex, and create one if none exists.
     const relatedUrlVertex = await gremlinConnection
       .V()
       .has('relatedUrl', 'url', url)

--- a/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
@@ -119,7 +119,6 @@
 
       (index/wait-until-indexed)
       (variables/assert-variable-search-order [variable] (variables/search {:provider "PROV1"}))))
-
   (testing "variable associations with high concept-id searches return as expected"
     (let [coll (d/ingest-umm-spec-collection "PROV3"
                                              (data-umm-c/collection

--- a/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
@@ -119,6 +119,7 @@
 
       (index/wait-until-indexed)
       (variables/assert-variable-search-order [variable] (variables/search {:provider "PROV1"}))))
+  
   (testing "variable associations with high concept-id searches return as expected"
     (let [coll (d/ingest-umm-spec-collection "PROV3"
                                              (data-umm-c/collection

--- a/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
@@ -119,6 +119,7 @@
 
       (index/wait-until-indexed)
       (variables/assert-variable-search-order [variable] (variables/search {:provider "PROV1"}))))
+
   (testing "variable associations with high concept-id searches return as expected"
     (let [coll (d/ingest-umm-spec-collection "PROV3"
                                              (data-umm-c/collection

--- a/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/high_concept_number_test.clj
@@ -119,7 +119,6 @@
 
       (index/wait-until-indexed)
       (variables/assert-variable-search-order [variable] (variables/search {:provider "PROV1"}))))
-  
   (testing "variable associations with high concept-id searches return as expected"
     (let [coll (d/ingest-umm-spec-collection "PROV3"
                                              (data-umm-c/collection


### PR DESCRIPTION
* Adds a retry policy for indexCmrCollections that reduces instances of concurrent modification errors
* Adds a retry policy using axios-retry for requests to the access-control app
* This does not seem to completely fix the concurrency issues however, there are now scripts to index missing collections into graphDb to compensate
* Update to package.json
* Minor updates to unrelated tests and SC
* Improves logs so that cloudwatch interpretation is easier