### PR TITLE
CMR-8925 Stepping down snapshot version

### DIFF
--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -39,7 +39,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [org.eclipse.emf/org.eclipse.emf.ecore "2.23.0"]
                  [org.eclipse.emf/org.eclipse.emf.common "2.21.0"]
-                 [org.geotools/gt-shapefile "29-SNAPSHOT"]
+                 [org.geotools/gt-shapefile "28-SNAPSHOT"]
                  [org.geotools/gt-geojsondatastore "24.6"]
                  [org.geotools.xsd/gt-xsd-kml "27.1"]
                  [org.mozilla/rhino "1.7.12"]


### PR DESCRIPTION
The CMR Search app has a dependency on `org.geotools/gt-shapefile` which was pulling version 29 snapshot which is no longer on the Maven Repository with a Java 8 version. Snapshot version reverted to 28.