### PR TITLE
CMR-8834: Fixed the code and added tests to make sure native-id is only unique within the same provider and concept type.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -76,6 +76,11 @@
   [_ {:keys [provider-id]} base-clause]
   (add-provider-clause provider-id base-clause))
 
+(doseq [doseq-concept-type (common-concepts/get-generic-concept-types-array)]
+  (defmethod by-provider doseq-concept-type
+    [_ {:keys [provider-id]} base-clause]
+    (add-provider-clause provider-id base-clause)))
+
 (defmethod by-provider :default
   [_ {:keys [provider-id small]} base-clause]
   (if small
@@ -231,7 +236,12 @@
                                                                      (from table)
                                                                      (where `(= :concept-id ~concept-id))))))]
     (when (and (and concept_id native_id)
-               (or (not= concept_id concept-id) (not= native_id native-id)))
+               (or (and (not= concept_id concept-id)
+                        ;; In case of generic documents, we need to make sure
+                        ;; the concept types are the same.
+                        (= (common-concepts/concept-id->type concept_id)
+                           (common-concepts/concept-id->type concept-id)))
+                   (not= native_id native-id)))
       {:error :concept-id-concept-conflict
        :error-message (format (str "Concept id [%s] and native id [%s] to save do not match "
                                    "existing concepts with concept id [%s] and native id [%s].")
@@ -305,12 +315,21 @@
 
 (defn get-concept-id
   [db concept-type provider native-id]
-  (let [table (tables/get-table-name provider concept-type)]
-    (:concept_id
-     (su/find-one db (select [:concept-id]
-                             (from table)
-                             (where (by-provider concept-type
-                                     provider `(= :native-id ~native-id))))))))
+  (let [table (tables/get-table-name provider concept-type)
+        concept-id (:concept_id
+                    (su/find-one db (select [:concept-id]
+                                            (from table)
+                                            (where (by-provider concept-type
+                                                    provider `(= :native-id ~native-id))))))]
+    ;; In generic document case, they all share the same CMR_GENERIC_DOCUMENTS table,
+    ;; which doesn't contain the concept-type that can be used
+    ;; in the sql constraint. Therefore, we need to make sure the concept-id
+    ;; returned belongs to the same concept-type, so that concepts from different concept types
+    ;; won't be updated on top of each other just because they share the same native-id.
+    (when (and concept-id
+               (= concept-type (common-concepts/concept-id->type concept-id)))
+      concept-id)))
+
 
 (defn get-granule-concept-ids
   [db provider native-id]


### PR DESCRIPTION
Note: The fix covered both CMR-8834 and CMR-8832.