### PR TITLE
CMR-8995 allows entry_id for granule searches

### DIFF
--- a/search-app/src/cmr/search/validators/all_granule_validation.clj
+++ b/search-app/src/cmr/search/validators/all_granule_validation.clj
@@ -15,7 +15,7 @@
    :default 10000})
 
 (def granule-limiting-search-fields
-  #{:concept-id :provider :provider-id :short-name :entry-title :version :collection-concept-id})
+  #{:concept-id :provider :provider-id :short-name :entry-title :version :entry-id :collection-concept-id})
 
 (defn- granule-limiting-condition?
   "Returns true if the condition limits the query to granules within a set of collections."


### PR DESCRIPTION
Allows granules to be queried by entry_id without additional narrowing parameters.