### PR TITLE
CMR-8961: change Launchpad token authentication call from legacy services to URS

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -1022,6 +1022,32 @@
           false))
       false)))
 
+;; Note: Similar code exists at gov.nasa.echo.kernel.service.authentication
+(def URS_TOKEN_MAX_LENGTH 100)
+(def BEARER "Bearer ")
+
+;; TODO - remove legacy token check after legacy token retirement
+(defn is-legacy-token?
+  "There are two uses cases captured by this test, the Legacy token and the
+   new style legacy token made to behave like a legacy token but are prefixed
+   with EDL- to aid in indentification. This function will not match very short
+   JWT tokens.
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
+  [token]
+  (or (<= (count token) URS_TOKEN_MAX_LENGTH)
+      (string/starts-with? token "EDL-")
+      (string/starts-with? token (str BEARER "EDL-"))))
+
+(defn is-launchpad-token?
+  "Returns true if the given token is a launchpad token.
+   If the token is not a Legacy (ECHO), Heritage (EDL+), or JWT (newest) token,
+   then it must be a Launchpad token.
+   Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
+  [token]
+  ;; note: ordered from least expensive to most
+  (not (or (is-legacy-token? token)
+           (is-jwt-token? token))))
+
 (defn human-join
   "Given a vector of strings, return a string joining the elements of the collection with 'separator', except for
   the last two which are joined with \"'separator' 'final-separator' \".

--- a/common-lib/test/cmr/common/test/launchpad_token_validation_tests.clj
+++ b/common-lib/test/cmr/common/test/launchpad_token_validation_tests.clj
@@ -1,10 +1,9 @@
-(ns cmr.common-app.test.api.launchpad-token-validation-tests
+(ns cmr.common.test.launchpad-token-validation-tests
   "Unit tests for health checks"
   (:require
    [clojure.data.codec.base64 :as base64]
    [clojure.test :refer :all]
-   [cmr.common.util :as util]
-   [cmr.common-app.api.launchpad-token-validation :as token]))
+   [cmr.common.util :as util]))
 
 (defn- test-matrix
   "The input-list, message-list, and expected-list are all seq of the same size.
@@ -70,16 +69,17 @@
                    true true true true
                    true true
                    false false false
-                   false] #'token/is-legacy-token?))
+                   false] #'util/is-legacy-token?))
     (testing "Is token a LaunchPad token?"
       (test-group [false
                    false false false false
                    false false
                    false false false
-                   true] #'token/is-launchpad-token?))
-    (testing "get-token-type"
+                   true] #'util/is-launchpad-token?))
+    ;; TODO - add me back in after we remove echo tokens and can move this function from common-app to common-lib like the others
+    #_(testing "get-token-type"
       (test-group ["Echo-Token"
                    "Legacy-EDL" "Legacy-EDL" "Legacy-EDL" "Legacy-EDL"
                    "Legacy-EDL" "Legacy-EDL"
                    "JWT" "JWT" "JWT"
-                   "Launchpad"] token/get-token-type))))
+                   "Launchpad"] util/get-token-type))))

--- a/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/tokens.clj
@@ -4,7 +4,6 @@
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as string]
-   [cmr.common-app.api.launchpad-token-validation :as lt-validation]
    [cmr.common.log :refer (debug info warn error)]
    [cmr.common.util :as common-util]
    [cmr.common.services.errors :as svc-errors]
@@ -59,7 +58,7 @@
   "Returns the mock token info for the token with the given token id"
   [context token-id]
   ;; for launchpad token, remove the padding before searching
-  (let [token-id (if lt-validation/is-launchpad-token?
+  (let [token-id (if common-util/is-launchpad-token?
                    (string/replace token-id echo-util/LAUNCHPAD_TOKEN_PADDING "")
                    token-id)
         {:keys [username client_id expires id]} (get-token-or-error context token-id)]

--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -46,6 +46,15 @@
        :headers {"content-type" mt/xml}})
     {:status 404 :body "Not found.\n"}))
 
+(defn get-launchpad-user
+  "Processes a request to get a user using their launchpad token."
+  [context token] 
+  (when token
+    (case token
+      "ABC-1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+      {:status 200 :body {:uid "user1" :first-name "User" :last-name "Name" :email-address "somebody@nasa.gov"}} 
+      {:status 400 :body {:error "Launchpad SSO authentication failed"}})))
+
 (defn get-user-info
   "Returns mock URS info for a user"
   [user-id]
@@ -249,6 +258,12 @@
           (GET "/" {:keys [request-context params] :as request}
             (assert-bearer-token request)
             (get-groups-for-user request-context user-id))))
+      
+      (context "/api/nams" []
+        (POST "/edl_user" {:keys [request-context params] :as request}
+          (println "REQ PARAM:" (:token params))
+          (assert-bearer-token request)
+          (get-launchpad-user request-context (:token params))))
 
       (context "/users" []
         ;; Create a bunch of users all at once

--- a/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
+++ b/mock-echo-app/src/cmr/mock_echo/client/echo_util.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as string]
-   [cmr.common-app.api.launchpad-token-validation :as lt-validation]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.util :as util]
    [cmr.mock-echo.client.mock-echo-client :as echo-client]
@@ -78,7 +77,7 @@
 (def LAUNCHPAD_TOKEN_PADDING
   "Padding to make a regular token into launchpad token
    (i.e. make it longer than max length of URS token)."
-  (string/join (repeat lt-validation/URS_TOKEN_MAX_LENGTH "Z")))
+  (string/join (repeat util/URS_TOKEN_MAX_LENGTH "Z")))
 
 (defn login-with-launchpad-token
   "Logs in as the specified user and returns the launchpad token.

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -147,7 +147,7 @@
                           hrs/humanizer-report-generator-job])}]
     (transmit-config/system-with-connections
      sys
-     [:indexer :echo-rest :metadata-db :kms :access-control])))
+     [:indexer :echo-rest :metadata-db :kms :access-control :urs])))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -70,7 +70,14 @@
           {:keys [concept-id revision-id]} (ingest/ingest-concept concept)]
       (index/wait-until-indexed)
       (is (= 5 revision-id))
-      (is (mdb/concept-exists-in-mdb? concept-id 5)))))
+      (is (mdb/concept-exists-in-mdb? concept-id 5))))
+  (testing "ingest of a new concept using a launchpad token"
+    (let [concept (data-umm-c/collection-concept {})
+          launchpad-token (echo-util/login-with-launchpad-token (system/context) "user1")
+          {:keys [concept-id revision-id]} (ingest/ingest-concept concept {:token launchpad-token})]
+      (index/wait-until-indexed)
+      (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+      (is (= 1 revision-id)))))
 
 ;; Verify a concept can be ingested twice to get two revisions and ignore_conflict can impact the reindex status.
 (deftest collection-ingest-test

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -10,7 +10,6 @@
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.6"]
                  [inflections "0.13.0"]
-                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-redis-utils-lib "0.1.0-SNAPSHOT"]
                  [org.apache.httpcomponents/httpcore "4.4.10"]

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -10,6 +10,7 @@
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.6"]
                  [inflections "0.13.0"]
+                 [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-redis-utils-lib "0.1.0-SNAPSHOT"]
                  [org.apache.httpcomponents/httpcore "4.4.10"]

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -12,7 +12,6 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as common-util]
-   [cmr.common-app.api.launchpad-token-validation :as lt-validation]
    [cmr.transmit.config :as transmit-config]
    [cmr.transmit.echo.rest :as r]
    [cmr.transmit.urs :as urs]))
@@ -113,7 +112,7 @@
     (if (and (common-util/is-jwt-token? token)
              (transmit-config/local-edl-verification))
       (verify-edl-token-locally token)
-      (if (lt-validation/is-launchpad-token? token)
+      (if (common-util/is-launchpad-token? token)
         (urs/get-launchpad-user context token)
         (let [[status parsed body] (r/rest-post context "/tokens/get_token_info"
                                                 {:headers {"Accept" mt/json


### PR DESCRIPTION
Before, the control flow in transmit-lib's `tokens.clj` was: 
if this is a JWT token and local EDL verification is turned on, then verify the token locally; 
else send the token to legacy services. 
This meant that legacy services was being used for BOTH echo tokens and Launchpad tokens.

Because we are still supporting echo tokens today, the legacy services call is still there. One more `if` has been added to check if the token is a Launchpad token, if so send it to URS. 

Adding that `if` check, means that the token checking code had to be moved from common-app-lib to common-lib in order to avoid a circular dependency, because transmit-lib needs to be loaded before common-app-lib. (As common-app-lib requires transmit-lib)