### PR TITLE
CMR-9049 - Making change to restore legacy-services format

### DIFF
--- a/ingest-app/src/cmr/ingest/api/provider.clj
+++ b/ingest-app/src/cmr/ingest/api/provider.clj
@@ -54,13 +54,9 @@
                      (json/parse-string)
                      (get "metadata")
                      (json/generate-string))]
-    ;; This behavior is because get-provider-by-id in metadata-db does not throw
-    ;; an exception by default for this interface
-    (if (= "null" body)
-      (srvc-errors/throw-service-error :not-found "Provider not found")
-      {:status status
-       :headers {"Content-Type" (mt/with-utf-8 mt/json)}
-       :body (if (= status 200) metadata body)})))
+    {:status status
+     :headers {"Content-Type" (mt/with-utf-8 mt/json)}
+     :body (if (= status 200) metadata body)}))
 
 (defn read-body
   [headers body-input]

--- a/ingest-app/src/cmr/ingest/api/provider.clj
+++ b/ingest-app/src/cmr/ingest/api/provider.clj
@@ -54,9 +54,13 @@
                      (json/parse-string)
                      (get "metadata")
                      (json/generate-string))]
-    {:status status
-     :headers {"Content-Type" (mt/with-utf-8 mt/json)}
-     :body (if (= status 200) metadata body)}))
+    ;; This behavior is because get-provider-by-id in metadata-db does not throw
+    ;; an exception by default for this interface
+    (if (= "null" body)
+      (srvc-errors/throw-service-error :not-found "Provider not found")
+      {:status status
+       :headers {"Content-Type" (mt/with-utf-8 mt/json)}
+       :body (if (= status 200) metadata body)})))
 
 (defn read-body
   [headers body-input]

--- a/metadata-db-app/src/cmr/metadata_db/api/provider.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/provider.clj
@@ -35,7 +35,7 @@
 (defn- get-provider
   "Read a provider"
   [context params provider-id]
-  (let [provider (provider-service/get-provider-by-id context provider-id)]
+  (let [provider (provider-service/get-provider-by-id context provider-id true)]
     {:status 200
      :body (json/generate-string provider)
      :headers rh/json-header}))

--- a/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/ingest_util.clj
@@ -59,11 +59,20 @@
    (url/create-provider-url)))
 
 (defn create-ingest-provider
-  "Create the provider with the given provider id through ingest app"
+  "Create the provider with the given provider id through ingest app using a template
+   metadata document for the provider metadata."
   [provider]
   (create-provider-through-url
    (prov-util/minimum-provider->metadata-only provider)
    (url/ingest-create-provider-url)))
+
+(defn create-ingest-legacy-services-provider
+  "Create the provider with the given provider id through ingest app, but do not
+   try to expand the provider out into a fully flushed out metadata document.
+   Assume the caller knows what data to send in and just pass it to ingest as is.
+   To post metadata, use (create-ingest-provider) instead."
+  [provider]
+  (create-provider-through-url provider (url/ingest-create-provider-url)))
 
 (defn get-providers-through-url
   [provider-url]

--- a/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider_ingest_test.clj
@@ -50,6 +50,24 @@
          "PROV7" "S7" nil nil
          "PROV8" nil nil nil))
 
+  (testing "create a legacy-service style provider through the ingest app"
+    ;; ingest/create-ingest-legacy-services-provider does not assume a metadata
+    ;; document and will post the provider as-is!
+    (are [provider-id short-name cmr-only small]
+         (let [provider {:provider-id provider-id
+                         :short-name short-name
+                         :cmr-only cmr-only
+                         :small small}
+               {:keys [status]} (ingest/create-ingest-legacy-services-provider provider)]
+           (and (= 201 status))
+           (= (ingest/get-providers) (ingest/get-ingest-providers)))
+      "PROV9" "S9" false false
+      "PROVA" "SA" true false
+      "PROVB" "SB" false true
+      "PROVC" "SC" true true
+      "PROVD" "SD" nil nil
+      "PROVE" nil nil nil))
+
   (testing "create provider invalid value"
     (u/are3
       [provider error]


### PR DESCRIPTION
Restoring the legacy-services format for providers which does not have any metadata.