### PR TITLE
CMR-8038: Fix CMR search app 500 error when searching with empty JSON

### DIFF
--- a/search-app/src/cmr/search/services/json_parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/json_parameters/conversion.clj
@@ -113,7 +113,7 @@
   [concept-type json-query]
   (concept-type-validation concept-type)
   (when-not json-query
-    (errors/throw-service-errors :invalid-data ["json query cannot be empty"]))
+    (errors/throw-service-errors :invalid-data ["JSON query cannot be empty"]))
   (when-let [errors (seq (js/validate-json (concept-type->json-query-schema concept-type) json-query))]
     (errors/throw-service-errors :bad-request errors)))
 

--- a/search-app/src/cmr/search/services/json_parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/json_parameters/conversion.clj
@@ -112,6 +112,8 @@
   "Perform all validations against the provided JSON query."
   [concept-type json-query]
   (concept-type-validation concept-type)
+  (when-not json-query
+    (errors/throw-service-errors :invalid-data ["json query cannot be empty"]))
   (when-let [errors (seq (js/validate-json (concept-type->json-query-schema concept-type) json-query))]
     (errors/throw-service-errors :bad-request errors)))
 

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -1222,20 +1222,30 @@
              (:errors response)
              (:errors ext-response))))))
 
-;; CMR-8038
 (deftest search-with-empty-json
-  (let [coll1 (d/ingest "PROV1" (dc/collection {:entry-title "Dataset1"
-                                                 :beginning-date-time "2000-01-01T12:00:00Z"
-                                                 :spatial-coverage (dc/spatial {:gsr :geodetic})}))
-        coll-concept-id (:concept-id coll1)
-        (index/wait-until-indexed)]
-
-      (testing "testing collection search with empty json body"
-        (let [response (client/post)
-                   (url/search-url :collection)
-                   {:accept "application/json; profile=stac-catalogue"
-                    :content-type "application/json"
-                    :body (json/generate-string {})
-                    :throw-exceptions false
-                    :connection-manager (s/conn-mgr)}]
-            (is (= 422 (:status response)))))))
+  (let [coll1 (d/ingest "PROV1" (dc/collection))
+        coll-concept-id (:concept-id coll1)]
+    (index/wait-until-indexed)
+    (testing "testing collection search with empty json body"
+      (let [response1 (client/get
+                       (url/search-url :collection)
+                       {:accept "application/json"
+                        :content-type "application/json"
+                        :body nil
+                        :throw-exceptions false
+                        :connection-manager (s/conn-mgr)})
+            response2 (client/get
+                             (url/search-url :collection)
+                             {:accept "application/json"
+                              :content-type "application/json"
+                              :body ""
+                              :throw-exceptions false
+                              :connection-manager (s/conn-mgr)})]
+         (is (=
+               422
+               (:status response1)
+               (:status response2)))
+         (is (=
+               "json query cannot be empty"
+               (first (:errors (json/decode (:body response1) true)))
+               (first (:errors (json/decode (:body response2) true)))))))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -1224,28 +1224,26 @@
 
 (deftest search-with-empty-json
   (let [coll1 (d/ingest "PROV1" (dc/collection))
-        coll-concept-id (:concept-id coll1)]
-    (index/wait-until-indexed)
+        coll-concept-id (:concept-id coll1)
+        _ (index/wait-until-indexed)
+        response1 (client/get
+                    (url/search-url :collection)
+                    {:accept "application/json"
+                     :content-type "application/json"
+                     :body nil
+                     :throw-exceptions false
+                     :connection-manager (s/conn-mgr)})
+        response2 (client/get
+                    (url/search-url :collection)
+                    {:accept "application/json"
+                     :content-type "application/json"
+                     :body ""
+                     :throw-exceptions false
+                     :connection-manager (s/conn-mgr)})]
     (testing "testing collection search with empty json body"
-      (let [response1 (client/get
-                       (url/search-url :collection)
-                       {:accept "application/json"
-                        :content-type "application/json"
-                        :body nil
-                        :throw-exceptions false
-                        :connection-manager (s/conn-mgr)})
-            response2 (client/get
-                             (url/search-url :collection)
-                             {:accept "application/json"
-                              :content-type "application/json"
-                              :body ""
-                              :throw-exceptions false
-                              :connection-manager (s/conn-mgr)})]
-         (is (=
-               422
-               (:status response1)
-               (:status response2)))
-         (is (=
-               "JSON query cannot be empty"
-               (first (:errors (json/decode (:body response1) true)))
-               (first (:errors (json/decode (:body response2) true)))))))))
+      (is (= 422
+             (:status response1)
+             (:status response2)))
+      (is (= "JSON query cannot be empty"
+             (first (:errors (json/decode (:body response1) true)))
+             (first (:errors (json/decode (:body response2) true))))))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -1246,6 +1246,6 @@
                (:status response1)
                (:status response2)))
          (is (=
-               "json query cannot be empty"
+               "JSON query cannot be empty"
                (first (:errors (json/decode (:body response1) true)))
                (first (:errors (json/decode (:body response2) true)))))))))

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -1227,19 +1227,19 @@
         coll-concept-id (:concept-id coll1)
         _ (index/wait-until-indexed)
         response1 (client/get
-                    (url/search-url :collection)
-                    {:accept "application/json"
-                     :content-type "application/json"
-                     :body nil
-                     :throw-exceptions false
-                     :connection-manager (s/conn-mgr)})
+                   (url/search-url :collection)
+                   {:accept "application/json"
+                    :content-type "application/json"
+                    :body nil
+                    :throw-exceptions false
+                    :connection-manager (s/conn-mgr)})
         response2 (client/get
-                    (url/search-url :collection)
-                    {:accept "application/json"
-                     :content-type "application/json"
-                     :body ""
-                     :throw-exceptions false
-                     :connection-manager (s/conn-mgr)})]
+                   (url/search-url :collection)
+                   {:accept "application/json"
+                    :content-type "application/json"
+                    :body ""
+                    :throw-exceptions false
+                    :connection-manager (s/conn-mgr)})]
     (testing "testing collection search with empty json body"
       (is (= 422
              (:status response1)


### PR DESCRIPTION
Requests to CMR Search App with an empty JSON should return a 422 `invalid-data` response rather than crashing with a 500 error.