### PR TITLE
CMR-9043: fix URS launchpad validation url to send token in body instead of URL

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -49,11 +49,10 @@
 (defn get-launchpad-user
   "Processes a request to get a user using their launchpad token."
   [context token] 
-  (when token
-    (case token
+  (case token
       "ABC-1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
       {:status 200 :body {:uid "user1"}} 
-      {:status 400 :body {:error "Launchpad SSO authentication failed"}})))
+      {:status 400 :body {:error "Launchpad SSO authentication failed"}}))
 
 (defn get-user-info
   "Returns mock URS info for a user"


### PR DESCRIPTION
This fixes the breaking change introduced by URSFOUR-1973