### PR TITLE
CMR-9130: add handling 401 from invalid LP token to transmit lib

### DIFF
--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -49,6 +49,7 @@
   [{:keys [status body] :as resp}]
   (cond
     (<= 200 status 299) body
+    (= status 401) (errors/throw-service-errors :unauthorized (:errors body))
     (= status 404) nil
     :else (errors/internal-error!
             (format "Received unexpected status code %s with response %s"


### PR DESCRIPTION
This quick fix will hopefully stop the recent spikes of 500 errors in search app. 