### PR TITLE
CMR-9108 adds launchpad user caching

### DIFF
--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -23,7 +23,8 @@
    [cmr.common.nrepl :as nrepl]
    [cmr.common.system :as common-sys]
    [cmr.message-queue.queue.queue-broker :as queue-broker]
-   [cmr.transmit.config :as transmit-config]))
+   [cmr.transmit.config :as transmit-config]
+   [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]))
 
 (defconfig access-control-nrepl-port
   "Port to listen for nREPL connections"
@@ -96,7 +97,8 @@
                       :providers (mem-cache/create-in-memory-cache :ttl {} {:ttl (hours->ms 12)})
                       gf/group-cache-key (gf/create-cache)
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
-                      common-health/health-cache-key (common-health/create-health-cache)}
+                      common-health/health-cache-key (common-health/create-health-cache)
+                      launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)}
 
              :public-conf (public-conf)
              :relative-root-url (transmit-config/access-control-relative-root-url)

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -1029,7 +1029,7 @@
 ;; TODO - remove legacy token check after legacy token retirement
 (defn is-legacy-token?
   "There are two uses cases captured by this test, the Legacy token and the
-   new style legacy token made to behave like a legacy token. This function 
+   new style legacy token made to behave like a legacy token. This function
    will not match very short JWT tokens.
    Note: Similar code exists at gov.nasa.echo.kernel.service.authentication."
   [token]

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -28,7 +28,8 @@
    [cmr.ingest.services.providers-cache :as pc]
    [cmr.message-queue.queue.queue-broker :as queue-broker]
    [cmr.oracle.connection :as oracle]
-   [cmr.transmit.config :as transmit-config]))
+   [cmr.transmit.config :as transmit-config]
+   [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]))
 
 (def ^:private component-order
   "Defines the order to start the components."
@@ -110,7 +111,8 @@
                        kf/kms-cache-key (kf/create-kms-cache)
                        common-health/health-cache-key (common-health/create-health-cache)
                        common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
-                       humanizer-alias-cache/humanizer-alias-cache-key (humanizer-alias-cache/create-cache)}
+                       humanizer-alias-cache/humanizer-alias-cache-key (humanizer-alias-cache/create-cache)
+                       launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)}
               :public-conf (public-conf)
               :queue-broker (queue-broker/create-queue-broker (config/queue-config))}]
      (transmit-config/system-with-connections

--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -48,10 +48,10 @@
 
 (defn get-launchpad-user
   "Processes a request to get a user using their launchpad token."
-  [context token] 
+  [context token]
   (case token
       "ABC-1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
-      {:status 200 :body {:uid "user1"}} 
+      {:status 200 :body {:uid "user1" :lp-token-expires-in 1600}}
       {:status 400 :body {:error "Launchpad SSO authentication failed"}}))
 
 (defn get-user-info
@@ -257,7 +257,7 @@
           (GET "/" {:keys [request-context params] :as request}
             (assert-bearer-token request)
             (get-groups-for-user request-context user-id))))
-      
+
       (context "/api/nams" []
         (POST "/edl_user_uid" {:keys [request-context params] :as request}
           (assert-bearer-token request)

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -28,7 +28,8 @@
    [cmr.search.services.humanizers.humanizer-range-facet-service :as hrfs]
    [cmr.search.services.query-execution.has-granules-results-feature :as hgrf]
    [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as hgocrf]
-   [cmr.transmit.config :as transmit-config]))
+   [cmr.transmit.config :as transmit-config]
+   [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]))
 
 ;; Design based on http://stuartsierra.com/2013/09/15/lifecycle-composition and related posts
 
@@ -121,6 +122,7 @@
                       ;; Note that search does not have a job to refresh the KMS cache. The indexer
                       ;; already refreshes the cache. Since we use a consistent cache, the search
                       ;; application will also pick up the updated KMS keywords.
+                      launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)
                       kf/kms-cache-key (kf/create-kms-cache)
                       search/scroll-id-cache-key (search/create-scroll-id-cache)
                       search/scroll-first-page-cache-key (search/create-scroll-first-page-cache)

--- a/system-int-test/src/cmr/system_int_test/utils/cache_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/cache_util.clj
@@ -1,0 +1,52 @@
+(ns cmr.system-int-test.utils.cache-util
+  "Verifies the cache api is working."
+  (:require
+   [cheshire.core :as json]
+   [clj-http.client :as client]
+   [cmr.system-int-test.system :as s]))
+
+(defn list-caches-for-app
+  "Gets a list of the caches for the given url."
+  [url token]
+  (let [response (client/request {:url url
+                                  :method :get
+                                  :query-params {:token token}
+                                  :connection-manager (s/conn-mgr)
+                                  :throw-exceptions false})
+        status (:status response)]
+
+    ;; Make sure the status returned is success
+    (when (not= status 200)
+      (throw (Exception. (str "Unexpected status " status " response:" (:body response)))))
+    (json/decode (:body response) true)))
+
+(defn list-cache-keys
+  "Gets a list of the cache keys for the given cache at the given url."
+  [url cache-name token]
+  (let [full-url (str url "/" cache-name)
+        response (client/request {:url full-url
+                                  :method :get
+                                  :query-params {:token token}
+                                  :connection-manager (s/conn-mgr)
+                                  :throw-exceptions false})
+        status (:status response)]
+    ;; Make sure the status returned is success
+    (when (not= status 200)
+      (throw (Exception. (str "Unexpected status " status " response:" (:body response)))))
+    (json/decode (:body response) true)))
+
+(defn get-cache-value
+  "Gets the value for a given key from the given cache. Checks that the returned status code
+  matches the expected status code."
+  [url cache-name cache-key token expected-status]
+  (let [full-url (str url "/" cache-name "/" cache-key)
+        response (client/request {:url full-url
+                                  :method :get
+                                  :query-params {:token token}
+                                  :connection-manager (s/conn-mgr)
+                                  :throw-exceptions false})
+        status (:status response)]
+    ;; Make sure the returned status matches the expected-status
+    (when (not= status expected-status)
+      (throw (Exception. (str "Unexpected status " status " response:" (:body response)))))
+    (json/decode (:body response) true)))

--- a/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection_ingest_test.clj
@@ -58,7 +58,7 @@
             (:errors coll4-wrong-collection-data-type)))))
 
 ;; Verify a new concept is ingested successfully.
-(deftest collection-ingest-test
+(deftest basic-collection-ingest-test
   (testing "ingest of a new concept"
     (let [concept (data-umm-c/collection-concept {})
           {:keys [concept-id revision-id]} (ingest/ingest-concept concept)]
@@ -77,7 +77,7 @@
           {:keys [concept-id revision-id]} (ingest/ingest-concept concept {:token launchpad-token})]
       (index/wait-until-indexed)
       (is (mdb/concept-exists-in-mdb? concept-id revision-id))
-      (is (= 1 revision-id)))))
+      (is (= 6 revision-id)))))
 
 ;; Verify a concept can be ingested twice to get two revisions and ignore_conflict can impact the reindex status.
 (deftest collection-ingest-test

--- a/system-int-test/test/cmr/system_int_test/misc/launchpad_user_cache.clj
+++ b/system-int-test/test/cmr/system_int_test/misc/launchpad_user_cache.clj
@@ -1,0 +1,60 @@
+(ns cmr.system-int-test.misc.launchpad-user-cache
+  (:require
+   [clj-time.core :as t]
+   [clojure.test :refer :all]
+   [cmr.mock-echo.client.echo-util :as echo-util]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.url-helper :as url]
+   [cmr.transmit.config :as transmit-config]))
+
+(use-fixtures :each (join-fixtures
+                      [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"})
+                       (dev-sys-util/freeze-resume-time-fixture)]))
+
+(deftest launchpad-user-cache-test
+  (testing "launchpad cache initial value"
+    (let [launchpad-token (echo-util/login-with-launchpad-token (system/context) "user1")]
+      (is (empty? (cache-util/list-cache-keys (url/ingest-read-caches-url) "launchpad-user" transmit-config/mock-echo-system-token)))
+      (let [concept (data-umm-c/collection-concept {})
+            {:keys [concept-id revision-id]} (ingest/ingest-concept concept {:token launchpad-token})]
+        (index/wait-until-indexed)
+
+        (is (mdb/concept-exists-in-mdb? concept-id revision-id))
+        (is (= 1 revision-id))
+        (is (some #{"launchpad-user"} (cache-util/list-caches-for-app (url/ingest-read-caches-url) transmit-config/mock-echo-system-token)))
+        (is (= (:uid (cache-util/get-cache-value
+                      (url/ingest-read-caches-url)
+                      "launchpad-user"
+                      launchpad-token
+                      transmit-config/mock-echo-system-token
+                      200))
+               "user1"))
+
+        (testing "Launchpad token cache value mantains expiration date"
+          (dev-sys-util/advance-time! 20)
+          (let [expiration-time (:expiration-time (cache-util/get-cache-value
+                                                   (url/ingest-read-caches-url)
+                                                   "launchpad-user"
+                                                   launchpad-token
+                                                   transmit-config/mock-echo-system-token
+                                                   200))]
+            (ingest/ingest-concept concept {:token launchpad-token})
+            (index/wait-until-indexed)
+
+            (is (= expiration-time (:expiration-time (cache-util/get-cache-value
+                                                      (url/ingest-read-caches-url)
+                                                      "launchpad-user"
+                                                      launchpad-token
+                                                      transmit-config/mock-echo-system-token
+                                                      200))))
+            (testing "token cache value expires"
+              (dev-sys-util/advance-time! 2000)
+              (ingest/ingest-concept concept {:token launchpad-token})
+              (index/wait-until-indexed)
+              (is (not= expiration-time (cache-util/list-cache-keys (url/ingest-read-caches-url) "launchpad-user" transmit-config/mock-echo-system-token))))))))))

--- a/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/scrolling_search_test.clj
@@ -10,7 +10,7 @@
    [cmr.common.util :as util :refer [are3]]
    [cmr.elastic-utils.config :as es-config]
    [cmr.mock-echo.client.echo-util :as e]
-   [cmr.system-int-test.admin.cache-api-test :as cache-test]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
    [cmr.system-int-test.data2.core :as data2-core]
    [cmr.system-int-test.data2.granule :as data2-granule]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
@@ -168,46 +168,44 @@
 
         (testing "Subsequent searches gets original page-size results"
           (let [result (search/find-refs :granule
-            {:scroll "defer" :page-size 10}
-            {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
+                        {:scroll "defer" :page-size 10}
+                        {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
             (is (= (count all-grans) hits))
             (is (data2-core/refs-match? [gran1 gran2] result))))
-            
         (testing "Cache is cleared after first page is read",
           (let [
                 url (url/search-read-caches-url)
-                result (cache-test/get-cache-value 
-                        url 
+                result (cache-util/get-cache-value
+                        url
                         (name cs/scroll-first-page-cache-key)
                         (str "first-page-" scroll-id)
                         admin-read-token
                         404)]
             (is (= #{[:error (str "missing key [:first-page-"
                                   scroll-id
-                                  "] for cache [first-page-cache]")]} 
+                                  "] for cache [first-page-cache]")]}
                    (set result)))))
-          
         (testing "Using scroll 'true' also works after defer if scroll-id is passed in"
           (let [result (search/find-refs :granule
-            {:scroll true}
-            {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
+                        {:scroll true}
+                        {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
             (is (= (count all-grans) hits))
             (is (data2-core/refs-match? [gran3 gran4] result))))
-                
+
         (testing "Remaining results returned on last search"
           (let [result (search/find-refs :granule
-            {:scroll true}
-            {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
+                        {:scroll true}
+                        {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
             (is (= (count all-grans) hits))
             (is (data2-core/refs-match? [gran5] result))))
-                    
+
         (testing "Searches beyond total hits return empty list"
           (let [result (search/find-refs :granule
-            {:scroll true}
-            {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
+                        {:scroll true}
+                        {:headers {routes/SCROLL_ID_HEADER scroll-id}})]
             (is (= (count all-grans) hits))
             (is (data2-core/refs-match? [] result))))))
-                        
+
     (testing "Scrolling with different search params from the original"
       (let [result (search/find-concepts-in-format
                     mime-types/xml

--- a/transmit-lib/src/cmr/transmit/echo/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/echo/tokens.clj
@@ -14,6 +14,7 @@
    [cmr.common.util :as common-util]
    [cmr.transmit.config :as transmit-config]
    [cmr.transmit.echo.rest :as r]
+   [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]
    [cmr.transmit.urs :as urs]))
 
 (defn login
@@ -83,7 +84,7 @@
     401 (errors/throw-service-errors
          :unauthorized
          (let [errs (:errors (json/decode body true))]
-           (if (string/includes? (first errs) "Caught exception") 
+           (if (string/includes? (first errs) "Caught exception")
              [(format "Token %s is invalid" (common-util/scrub-token token))]
              errs)))
 
@@ -113,7 +114,7 @@
              (transmit-config/local-edl-verification))
       (verify-edl-token-locally token)
       (if (common-util/is-launchpad-token? token)
-        (urs/get-launchpad-user context token)
+        (:uid (launchpad-user-cache/get-launchpad-user context token))
         (let [[status parsed body] (r/rest-post context "/tokens/get_token_info"
                                                 {:headers {"Accept" mt/json
                                                            "Authorization" (transmit-config/echo-system-token)}

--- a/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
+++ b/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
@@ -1,0 +1,41 @@
+(ns cmr.transmit.launchpad-user-cache
+  "Contains code for managing the launchpad user cache.  We want to cache the launchpad token expiration date and username for
+  launchpad tokens to avoid needing to call out to EDL for authentication every time.  Launchpad tokens have a lifetime currently of 60 minutes."
+  (:require
+   [clj-time.core :as t]
+   [clj-time.format :as t-format]
+   [cmr.common.cache :as cache]
+   [cmr.common.cache.in-memory-cache :as mem-cache]
+   [cmr.common.time-keeper :as time-keeper]
+   [cmr.transmit.urs :as urs]))
+
+(def launchpad-user-cache-key
+  "The cache key for a launchpad token cache."
+  :launchpad-user)
+
+(def LAUNCHPAD_USER_CACHE_TIME
+  "The number of milliseconds launchpad token information will be cached."
+  3600000)
+
+(defn create-launchpad-user-cache
+  "Creates a cache for which launchpad token users are stored in memory."
+  []
+  (mem-cache/create-in-memory-cache :ttl {} {:ttl LAUNCHPAD_USER_CACHE_TIME}))
+
+(defn get-launchpad-user
+
+  "Get the launchpad user from the cache, uses token as key on miss.
+  Expiration time is calculated via the response from EDL and saved in the cache."
+  [context token]
+  (let [get-launchpad-user-fn (fn []
+                                (when-let [resp (urs/get-launchpad-user context token)]
+                                  (assoc resp :expiration-time (-> (or (:lp-token-expires-in resp)
+                                                                       LAUNCHPAD_USER_CACHE_TIME)
+                                                                   (t/seconds)
+                                                                   (t/from-now)))))]
+    (if-let [cache (cache/context->cache context launchpad-user-cache-key)]
+      (let [token-info (cache/get-value cache (keyword token) get-launchpad-user-fn)]
+        (if (t/before? (:expiration-time token-info) (time-keeper/now))
+          (get-launchpad-user-fn)
+          token-info))
+      (get-launchpad-user-fn))))

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -69,7 +69,7 @@
   "Returns URS user info associated with a launchpad token"
   [context token]
   (let [{:keys [status body]} (request-with-auth context {:url-fn #(launchpad-validation-url %)
-                                                          :method :post :raw? true 
+                                                          :method :post :raw? true
                                                           :http-options {:form-params {:token token}}})]
     (when-not (= 200 status)
       (error (format "Cannot get info for Launchpad token (partially redacted) [%s] in URS. Failed with status code [%d].
@@ -78,7 +78,7 @@
        :unauthorized
        (format "Cannot get info for Launchpad token (partially redacted) [%s] in URS. Failed with status code [%d]."
                (common-util/scrub-token token) status)))
-    (:uid body)))
+    (select-keys body [:lp-token-expires-in :uid])))
 
 (defn user-exists?
   "Returns true if the given user exists in URS"
@@ -159,7 +159,7 @@
  (login context "notexist" "foopass")
  (login context "notexist" "")
  (login context "notexist" nil)
- 
+
  ;; when REPL launched with non-local connection configs
  (def context
    {:system (config/system-with-connections {} [:urs])})


### PR DESCRIPTION
This pull request implements a caching solution to prevent calls out to EDL to verify launchpad tokens every time CMR receives one.