### PR TITLE
CMR-9134: As a CMR developer I want the system-validation-tests to have up-to-date tests

### DIFF
--- a/system-validation-test/features/healthchecks.feature
+++ b/system-validation-test/features/healthchecks.feature
@@ -12,4 +12,3 @@ Feature: Service Health Checks
       | "/search/health"                     | "application/json" |
       | "/access-control/health"             | "application/json" |
       | "/ingest/health"                     | "application/json" |
-      | "/legacy-services/rest/availability" | "application/xml"  |

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -7,6 +7,17 @@ Feature: Basic Ingest API calls
 
     And set body to the following XML "<Collection><ShortName>TestCollection001</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId0001</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
+    @ingest
+    Scenario: Using an invalid Bearer token value
+      Given I am ingesting a "Collection"
+      And I clear headers
+      And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+      And I add header "Content-type=application/echo10+xml"
+      And I add header "Authorization=Bearer INVALID_TOKEN"
+      When I submit a "PUT" request
+      Then the response status code is 401
+      And the response body contains "is not a valid Launchpad or URS token"
+
   @ingest
   Scenario: Ingest of a Collection
     Given I am ingesting a "Collection"

--- a/system-validation-test/features/ingest_basic.feature
+++ b/system-validation-test/features/ingest_basic.feature
@@ -5,13 +5,13 @@ Feature: Basic Ingest API calls
     Given I use the authorization token from environment variable "CMR_TOKEN"
     And the provider from environment variable "CMR_TEST_PROV" exists
 
-    And set body to the following XML "<Collection><ShortName>TestCollection001</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><LongName>CMR8021COLLECTION</LongName><DataSetId>LarcDatasetId0001</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
+    And set body to the following XML "<Collection><ShortName>TestCollection001</ShortName><VersionId>Version01</VersionId><InsertTime>1999-12-31T19:00:00-05:00</InsertTime><LastUpdate>1999-12-31T19:00:00-05:00</LastUpdate><DeleteTime>2025-05-23T22:30:59</DeleteTime><LongName>TestCollection001LongName</LongName><DataSetId>TestCollection001Id</DataSetId><Description>A minimal valid collection</Description><Orderable>true</Orderable><Visible>true</Visible></Collection>"
 
     @ingest
     Scenario: Using an invalid Bearer token value
       Given I am ingesting a "Collection"
       And I clear headers
-      And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+      And I add url path "providers/CMR_ONLY/collections/TestCollection001"
       And I add header "Content-type=application/echo10+xml"
       And I add header "Authorization=Bearer INVALID_TOKEN"
       When I submit a "PUT" request
@@ -21,7 +21,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Ingest of a Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+    And I add url path "providers/CMR_ONLY/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     Then the response status code is in "200,201"
@@ -29,7 +29,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Searching for ingested Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+    And I add url path "providers/CMR_ONLY/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
@@ -48,7 +48,7 @@ Feature: Basic Ingest API calls
   @ingest
   Scenario: Deleting ingested Collection
     Given I am ingesting a "Collection"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+    And I add url path "providers/CMR_ONLY/collections/TestCollection001"
     And I add header "Content-type=application/echo10+xml"
     When I submit a "PUT" request
     And I wait "2.25" seconds for ingest to complete
@@ -58,7 +58,7 @@ Feature: Basic Ingest API calls
     And I clear headers
     And I clear the body
     And I use the authorization token from environment variable "CMR_TOKEN"
-    And I add url path "providers/DEMO_PROV/collections/TestCollection001"
+    And I add url path "providers/CMR_ONLY/collections/TestCollection001"
     When I submit a "DELETE" request
     Then the response status code is 200
     And I wait "2.25" seconds for deletion to complete

--- a/system-validation-test/features/legacy_services.feature
+++ b/system-validation-test/features/legacy_services.feature
@@ -1,7 +1,0 @@
-Feature: Legacy Services comprises a set of SOAP and RESTful endpoints
-
-  @quick
-  Scenario: Legacy Services
-    When I send a "GET" request to "/legacy-services/apis.html"
-    Then the response status code is 200
-    And the response Content-Type is "text/html"

--- a/system-validation-test/features/search_with_authorizations.feature
+++ b/system-validation-test/features/search_with_authorizations.feature
@@ -1,11 +1,12 @@
 Feature: CMR limits access to certain concepts and data to users with proper credentials
 
   @search
-  Scenario: Using invalid Echo-Token header
+  Scenario: Using an invalid Bearer token value
     Given I am searching for "collections"
-    And I set header "Echo-Token=invalid"
+    And I set header "Authorization=Bearer INVALID_TOKEN"
     When I submit a "GET" request
     Then the response status code is 401
+    And the response body contains "is not a valid Launchpad or URS token"
 
   @search
   Scenario: Using Authorization header


### PR DESCRIPTION
Legacy services is being retired, and echo-tokens are no more. Remove those tests from the suite and update with any relevant token tests.