### PR TITLE
CMR-9108 encodes token as hash value, fixes default ttl

### DIFF
--- a/mock-echo-app/src/cmr/mock_echo/api/urs.clj
+++ b/mock-echo-app/src/cmr/mock_echo/api/urs.clj
@@ -51,7 +51,7 @@
   [context token]
   (case token
       "ABC-1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
-      {:status 200 :body {:uid "user1" :lp-token-expires-in 1600}}
+      {:status 200 :body {:uid "user1" :lp_token_expires_in 1600}}
       {:status 400 :body {:error "Launchpad SSO authentication failed"}}))
 
 (defn get-user-info

--- a/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
+++ b/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
@@ -6,7 +6,10 @@
    [clj-time.format :as t-format]
    [cmr.common.cache :as cache]
    [cmr.common.cache.in-memory-cache :as mem-cache]
+   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
+   [cmr.common.util :as common-util]
    [cmr.transmit.urs :as urs]))
 
 (def launchpad-user-cache-key
@@ -15,7 +18,7 @@
 
 (def LAUNCHPAD_USER_CACHE_TIME
   "The number of milliseconds launchpad token information will be cached."
-  3600000)
+  (* 60 60 1000))
 
 (defn create-launchpad-user-cache
   "Creates a cache for which launchpad token users are stored in memory."
@@ -23,19 +26,24 @@
   (mem-cache/create-in-memory-cache :ttl {} {:ttl LAUNCHPAD_USER_CACHE_TIME}))
 
 (defn get-launchpad-user
-
   "Get the launchpad user from the cache, uses token as key on miss.
   Expiration time is calculated via the response from EDL and saved in the cache."
   [context token]
   (let [get-launchpad-user-fn (fn []
                                 (when-let [resp (urs/get-launchpad-user context token)]
-                                  (assoc resp :expiration-time (-> (or (:lp-token-expires-in resp)
-                                                                       LAUNCHPAD_USER_CACHE_TIME)
+                                  (assoc resp :expiration-time (-> (or (:lp_token_expires_in resp)
+                                                                       (/ LAUNCHPAD_USER_CACHE_TIME 1000))
                                                                    (t/seconds)
                                                                    (t/from-now)))))]
     (if-let [cache (cache/context->cache context launchpad-user-cache-key)]
-      (let [token-info (cache/get-value cache (keyword token) get-launchpad-user-fn)]
+      (let [token-info (cache/get-value cache (keyword (str (hash token))) get-launchpad-user-fn)]
         (if (t/before? (:expiration-time token-info) (time-keeper/now))
-          (get-launchpad-user-fn)
+          (do
+            (error (format "Launchpad token (partially redacted) [%s] has expired."
+                           (common-util/scrub-token token)))
+            (errors/throw-service-error
+             :unauthorized
+             (format "Launchpad token (partially redacted) [%s] has expired."
+                     (common-util/scrub-token token))))
           token-info))
       (get-launchpad-user-fn))))

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -78,7 +78,7 @@
        :unauthorized
        (format "Cannot get info for Launchpad token (partially redacted) [%s] in URS. Failed with status code [%d]."
                (common-util/scrub-token token) status)))
-    (select-keys body [:lp-token-expires-in :uid])))
+    (select-keys body [:lp_token_expires_in :uid])))
 
 (defn user-exists?
   "Returns true if the given user exists in URS"


### PR DESCRIPTION
Fixes issue where we were using kebab instead of snake to retrieve expiration time of the token.