### PR TITLE
CMR-8872: Fixed a in memory db issue for variable collection association

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -439,11 +439,6 @@
    so that it aligns with what index-concept :default expects."
   [context concept]
   (let [combined-assocs (meta-db/find-associations context concept)
-        ;; in-memory db returns variable-collection association in an additional [].
-        combined-assocs (map #(if (and (sequential? %) (= 1 (count %)))
-                                (first %)
-                                %)
-                             combined-assocs)
         grouped-assocs (group-by :concept-type combined-assocs)
         new-key-map (into {} (map #(create-association-map-keys %) (keys grouped-assocs)))]
     (cset/rename-keys grouped-assocs new-key-map)))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -439,6 +439,11 @@
    so that it aligns with what index-concept :default expects."
   [context concept]
   (let [combined-assocs (meta-db/find-associations context concept)
+        ;; in-memory db returns variable-collection association in an additional [].
+        combined-assocs (map #(if (and (sequential? %) (= 1 (count %)))
+                                (first %)
+                                %)
+                             combined-assocs)
         grouped-assocs (group-by :concept-type combined-assocs)
         new-key-map (into {} (map #(create-association-map-keys %) (keys grouped-assocs)))]
     (cset/rename-keys grouped-assocs new-key-map)))

--- a/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/memory_db.clj
@@ -302,7 +302,7 @@
   involve the passed in concept id."
   [concepts concept-id]
   (util/remove-nils-empty-maps-seqs
-   (merge
+   (concat
     (concepts/search-with-params concepts {:associated-concept-id concept-id})
     (concepts/search-with-params concepts {:tool-concept-id concept-id})
     (concepts/search-with-params concepts {:service-concept-id concept-id})


### PR DESCRIPTION
The related tests already exist. It's just that they are run with real db, instead of in-memory db in bamboo and have always run successfully.  With this fix,  I could run the tests successfully locally using in-memory db.