### PR TITLE
CMR-9188: Refactoring MDB calls for Access Control Permissions endpoint

### DIFF
--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -260,12 +260,18 @@
 (defn- add-acl-enforcement-fields
   "Adds all fields necessary for comparing concept map against ACLs."
   [context concept]
-  (let [concept (acl-matchers/add-acl-enforcement-fields-to-concept concept)]
-    (if-let [parent-id (:collection-concept-id concept)]
+  (let [concept (acl-matchers/add-acl-enforcement-fields-to-concept context concept)]
+    (if-let [parent-collection (:parent-collection concept)]
       (assoc concept :parent-collection
                      (acl-matchers/add-acl-enforcement-fields-to-concept
-                       (mdb/get-latest-concept context parent-id)))
+                       context parent-collection))
       concept)))
+
+(defn add-parent-collection-to-concept
+  [concept parent-concepts]
+  (let [parent-id (get-in concept [:extra-fields :parent-collection-id])
+        parent (first (filter #(= parent-id (:concept-id %)) parent-concepts))]
+    (assoc concept :parent-collection parent)))
 
 (defn get-catalog-item-permissions
   "Returns a map of concept ids to seqs of permissions granted on that concept for the given username."
@@ -275,9 +281,13 @@
                (acl-util/get-acl-concepts-by-identity-type-and-target
                 context index/provider-identity-type-name schema/ingest-management-acl-target)
                (acl-util/get-acl-concepts-by-identity-type-and-target
-                context index/catalog-item-identity-type-name nil))]
+                context index/catalog-item-identity-type-name nil))
+        concepts (mdb1/get-latest-concepts context concept-ids)
+        parent-concepts (mdb1/get-latest-concepts context (remove nil? (map #(get-in % [:extra-fields :parent-collection-id]) concepts)))
+        concepts-with-parents (map #(add-parent-collection-to-concept % parent-concepts) concepts)]
+
     (into {}
-          (for [concept (mdb1/get-latest-concepts context concept-ids)
+          (for [concept concepts-with-parents
                 :let [concept-with-acl-fields (add-acl-enforcement-fields context concept)]]
             [(:concept-id concept)
              (concept-permissions-granted-by-acls concept-with-acl-fields sids acls)]))))

--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -283,7 +283,7 @@
                (acl-util/get-acl-concepts-by-identity-type-and-target
                 context index/catalog-item-identity-type-name nil))
         concepts (mdb1/get-latest-concepts context concept-ids)
-        parent-concepts (mdb1/get-latest-concepts context (remove nil? (map #(get-in % [:extra-fields :parent-collection-id]) concepts)))
+        parent-concepts (distinct (mdb1/get-latest-concepts context (remove nil? (map #(get-in % [:extra-fields :parent-collection-id]) concepts))))
         concepts-with-parents (map #(add-parent-collection-to-concept % parent-concepts) concepts)]
 
     (into {}

--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -24,7 +24,7 @@
    [cmr.common.concepts :as concepts]
    [cmr.common.log :refer [info debug]]
    [cmr.common.services.errors :as errors]
-   [cmr.common.util :as util]
+   [cmr.common.util :as util :refer [defn-timed]]
    [cmr.transmit.echo.tokens :as tokens]
    [cmr.transmit.metadata-db :as mdb1]
    [cmr.transmit.metadata-db2 :as mdb]
@@ -273,7 +273,7 @@
         parent (first (filter #(= parent-id (:concept-id %)) parent-concepts))]
     (assoc concept :parent-collection parent)))
 
-(defn get-catalog-item-permissions
+(defn-timed get-catalog-item-permissions
   "Returns a map of concept ids to seqs of permissions granted on that concept for the given username."
   [context username-or-type concept-ids]
   (let [sids (auth-util/get-sids context username-or-type)

--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -282,8 +282,8 @@
                 context index/provider-identity-type-name schema/ingest-management-acl-target)
                (acl-util/get-acl-concepts-by-identity-type-and-target
                 context index/catalog-item-identity-type-name nil))
-        concepts (mdb1/get-latest-concepts context concept-ids)
-        parent-concepts (distinct (mdb1/get-latest-concepts context (remove nil? (map #(get-in % [:extra-fields :parent-collection-id]) concepts))))
+        concepts (mdb1/get-latest-concepts context (distinct concept-ids))
+        parent-concepts (mdb1/get-latest-concepts context (distinct (remove nil? (map #(get-in % [:extra-fields :parent-collection-id]) concepts))))
         concepts-with-parents (map #(add-parent-collection-to-concept % parent-concepts) concepts)]
 
     (into {}

--- a/access-control-app/src/cmr/access_control/services/event_handler.clj
+++ b/access-control-app/src/cmr/access_control/services/event_handler.clj
@@ -80,7 +80,7 @@
 (defmethod handle-indexing-event [:concept-delete :collection]
   [context {:keys [concept-id revision-id]}]
   (let [concept-map (mdb/get-concept context concept-id revision-id)
-        collection-concept (acl-matchers/add-acl-enforcement-fields-to-concept concept-map)]
+        collection-concept (acl-matchers/add-acl-enforcement-fields-to-concept context concept-map)]
     (doseq [acl-concept (acl-service/get-all-acl-concepts context)
             :let [parsed-acl (acl-service/get-parsed-acl acl-concept)
                   catalog-item-id (:catalog-item-identity parsed-acl)

--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -10,6 +10,7 @@
    [cmr.access-control.test.bootstrap :as bootstrap]
    [cmr.access-control.routes :as routes]
    [cmr.acl.acl-fetcher :as af]
+   [cmr.acl.core :as acl]
    [cmr.common.cache.in-memory-cache :as mem-cache]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.health :as common-health]
@@ -97,6 +98,7 @@
                                         [:system-object :provider-object :single-instance-object])
                       :providers (mem-cache/create-in-memory-cache :ttl {} {:ttl (hours->ms 12)})
                       gf/group-cache-key (gf/create-cache)
+                      acl/collection-field-constraints-cache-key (acl/create-access-constraints-cache)
                       common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
                       common-health/health-cache-key (common-health/create-health-cache)
                       launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -5,7 +5,6 @@
                [potemkin]]
   :dependencies [[commons-io "2.6"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
-                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [potemkin "0.4.5"]]
   :plugins [[lein-shell "0.5.0"]

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -5,6 +5,7 @@
                [potemkin]]
   :dependencies [[commons-io "2.6"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [potemkin "0.4.5"]]
   :plugins [[lein-shell "0.5.0"]

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -170,8 +170,10 @@
 
 (defn get-acl-enforcement-collection-fields-fn
   [concept]
-  {:AccessConstraints (umm-spec-core/parse-concept-access-value concept)
-   :TemporalExtents (umm-spec-core/parse-concept-temporal concept)})
+  {:AccessConstraints (when-not (= "" (:metadata concept))
+                        (umm-spec-core/parse-concept-access-value concept))
+   :TemporalExtents (when-not (= "" (:metadata concept))
+                        (umm-spec-core/parse-concept-temporal concept))})
 
 (defn get-acl-enforcement-collection-fields
   [context concept]

--- a/acl-lib/src/cmr/acl/core.clj
+++ b/acl-lib/src/cmr/acl/core.clj
@@ -13,20 +13,19 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
    [cmr.transmit.access-control :as access-control]
-   [cmr.transmit.config :as transmit-config]
-   [cmr.umm-spec.umm-spec-core :as umm-spec-core]))
+   [cmr.transmit.config :as transmit-config]))
 
 (def BROWSER_CLIENT_ID "browser")
 (def CURL_CLIENT_ID "curl")
 (def UNKNOWN_CLIENT_ID "unknown")
 
-(def collection-field-constraints-cache-key
-  "The cache key for a urs cache."
-  :collection-field-constraints)
-
 (defconfig allow-echo-token
   "Flag that indicates if we accept the 'Echo-Token' header."
   {:default true :type Boolean})
+
+(def collection-field-constraints-cache-key
+  "The cache key for a urs cache."
+  :collection-field-constraints)
 
 (defn non-empty-string
   [s]
@@ -145,18 +144,13 @@
   "The cache key for the token to subscription management permission cache."
   :token-smp)
 
-(def TOKEN_IMP_CACHE_TIME
-  "The number of milliseconds token information will be cached."
-  (* 5 60 1000))
-
 (def CONCEPT_MAP_CACHE_TIME
   "The number of milliseconds token information will be cached."
   (* 5 60 1000))
 
-(defn create-access-constraints-cache
-  "Creates a cache for access constraint mapping."
-  []
-  (mem-cache/create-in-memory-cache :ttl {} {:ttl CONCEPT_MAP_CACHE_TIME}))
+(def TOKEN_IMP_CACHE_TIME
+  "The number of milliseconds token information will be cached."
+  (* 5 60 1000))
 
 (defn create-token-imp-cache
   "Creates a cache for which tokens have ingest management permission."
@@ -168,19 +162,10 @@
   []
   (mem-cache/create-in-memory-cache :ttl {} {:ttl TOKEN_IMP_CACHE_TIME}))
 
-(defn get-acl-enforcement-collection-fields-fn
-  [concept]
-  {:AccessConstraints (when-not (= "" (:metadata concept))
-                        (umm-spec-core/parse-concept-access-value concept))
-   :TemporalExtents (when-not (= "" (:metadata concept))
-                        (umm-spec-core/parse-concept-temporal concept))})
-
-(defn get-acl-enforcement-collection-fields
-  [context concept]
-  (let [concept-id-key (keyword (:concept-id concept))]
-    (if-let [cache (cache/context->cache context collection-field-constraints-cache-key)]
-      (cache/get-value cache concept-id-key (fn [] (get-acl-enforcement-collection-fields-fn concept)))
-      (get-acl-enforcement-collection-fields-fn concept))))
+(defn create-access-constraints-cache
+  "Creates a cache for access constraint mapping."
+  []
+  (mem-cache/create-in-memory-cache :ttl {} {:ttl CONCEPT_MAP_CACHE_TIME}))
 
 (defn get-permitting-acls
   "Gets ACLs for the current user of the given object identity type and target that grant the given

--- a/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
+++ b/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
@@ -376,7 +376,7 @@
          concepts)
 
        ;; Convert concepts to results with acl enforcment
-       (let [[t3 concepts] (u/time-execution (acl-match/add-acl-enforcement-fields concepts))
+       (let [[t3 concepts] (u/time-execution (acl-match/add-acl-enforcement-fields context concepts))
              [t4 concepts] (u/time-execution (acl-service/filter-concepts context concepts))
              [t5 concepts] (u/time-execution
                             (metadata-transformer/transform-concepts

--- a/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
+++ b/search-app/src/cmr/search/data/metadata_retrieval/metadata_cache.clj
@@ -404,7 +404,7 @@
                  "The revision [%d] of concept [%s] represents a deleted concept and does not contain metadata."
                  revision-id
                  concept-id)]))
-        [t2 concept] (u/time-execution (acl-match/add-acl-enforcement-fields-to-concept concept))
+        [t2 concept] (u/time-execution (acl-match/add-acl-enforcement-fields-to-concept context concept))
         [t3 [concept]] (u/time-execution (acl-service/filter-concepts context [concept]))
         ;; format concept
         [t4 [concept]] (u/time-execution

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -60,7 +60,8 @@
                                               "providers"
                                               "launchpad-user"
                                               "urs"
-                                              "write-enabled"]
+                                              "write-enabled"
+                                              "collection-field-constraints"]
         (url/search-read-caches-url) ["acls"
                                       "collections-for-gran-acls"
                                       "has-granules-map"

--- a/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
@@ -7,6 +7,7 @@
    [clojure.string :as str]
    [cmr.acl.core :as acl-core]
    [cmr.common.cache :as cache]
+   [cmr.common.cache.in-memory-cache :as mem-cache]
    [cmr.common.cache.cache-spec :as cache-spec]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
@@ -19,6 +20,10 @@
 
 (def ^:private supported-collection-identifier-keys
   #{:entry-titles :access-value :temporal :concept-ids})
+
+(def collection-field-constraints-cache-key
+  "The cache key for a urs cache."
+  :collection-field-constraints)
 
 (defmulti matches-access-value-filter?
  "Returns true if the umm item matches the access-value filter"
@@ -89,6 +94,20 @@
  [concept-type umm-temporal temporal-filter]
  (umm-lib-acl-matchers/matches-temporal-filter? concept-type umm-temporal temporal-filter))
 
+(defn get-acl-enforcement-collection-fields-fn
+  [concept]
+  {:AccessConstraints (when-not (= "" (:metadata concept))
+                        (umm-spec-core/parse-concept-access-value concept))
+   :TemporalExtents (when-not (= "" (:metadata concept))
+                        (umm-spec-core/parse-concept-temporal concept))})
+
+(defn get-acl-enforcement-collection-fields
+  [context concept]
+  (let [concept-id-key (keyword (:concept-id concept))]
+    (if-let [cache (cache/context->cache context collection-field-constraints-cache-key)]
+      (cache/get-value cache concept-id-key (fn [] (get-acl-enforcement-collection-fields-fn concept)))
+      (get-acl-enforcement-collection-fields-fn concept))))
+
 (defn coll-matches-collection-identifier?
   "Returns true if the collection matches the collection identifier"
   [coll coll-id]
@@ -155,7 +174,7 @@
 
 (defmethod add-acl-enforcement-fields-to-concept :collection
   [context concept]
-  (let [concept-map (acl-core/get-acl-enforcement-collection-fields context concept)]
+  (let [concept-map (get-acl-enforcement-collection-fields context concept)]
     (-> concept
         (merge concept-map)
         (assoc :EntryTitle (get-in concept [:extra-fields :entry-title])))))

--- a/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
@@ -170,4 +170,4 @@
 (defn add-acl-enforcement-fields
   "Adds the fields necessary to enforce ACLs to the concepts."
   [context concepts]
-  (mapv add-acl-enforcement-fields-to-concept concepts))
+  (mapv add-acl-enforcement-fields-to-concept context concepts))


### PR DESCRIPTION
Access Control Permissions was not very efficient in how it processes large lists of records it gets from Metadata DB. Requests to the permissions endpoint was making redundant calls to metadata-db, resulting in slow response times for requests with a large number of granules.