### PR TITLE
CMR-9154 - remove tokens from /access-control/current-sids logs

### DIFF
--- a/access-control-app/README.md
+++ b/access-control-app/README.md
@@ -36,6 +36,15 @@ Update elasticsearch mappings to the latest version:
 
     curl -v -XPOST -H "Echo-Token: XXXX" http://localhost:3011/db-migrate
 
+## Searching for sids
+
+Searching for a user's sids:
+
+    curl -XPOST \
+        -H "Content-Type: application/json" \
+        -d '{"user-token": "XXXX"}' \
+        http://localhost:3011/current-sids
+
 ***
 
 ## License

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -247,141 +247,153 @@
 
       ;; Reindex all groups
       (POST "/reindex-groups"
-            {ctx :request-context params :params}
-            (acl/verify-ingest-management-permission ctx :update)
-            (pv/validate-standard-params params)
-            (reindex-groups ctx))
+        {ctx :request-context params :params}
+        (acl/verify-ingest-management-permission ctx :update)
+        (pv/validate-standard-params params)
+        (reindex-groups ctx))
 
       ;; Reindex all acls
       (POST "/reindex-acls"
-            {ctx :request-context params :params}
-            (acl/verify-ingest-management-permission ctx :update)
-            (pv/validate-standard-params params)
-            (reindex-acls ctx))
+        {ctx :request-context params :params}
+        (acl/verify-ingest-management-permission ctx :update)
+        (pv/validate-standard-params params)
+        (reindex-acls ctx))
 
       (if (access-control-config/enable-cmr-groups)
         (context "/groups" []
           (OPTIONS "/"
-                   {params :params}
-                   (pv/validate-standard-params params)
-                   (common-routes/options-response))
+            {params :params}
+            (pv/validate-standard-params params)
+            (common-routes/options-response))
 
           ;; Search for groups
           (GET "/"
-               {ctx :request-context params :params headers :headers}
-               (search-for-groups ctx headers params))
+            {ctx :request-context params :params headers :headers}
+            (search-for-groups ctx headers params))
 
           ;; Create a group
           (POST "/"
-                {ctx :request-context params :params headers :headers body :body}
-                (lt-validation/validate-launchpad-token ctx)
-                (pv/validate-create-group-route-params params)
-                (create-group ctx
-                              headers
-                              (slurp body)
-                              (or (:managing-group-id params)
-                                  (:managing_group_id params))))
+            {ctx :request-context params :params headers :headers body :body}
+            (lt-validation/validate-launchpad-token ctx)
+            (pv/validate-create-group-route-params params)
+            (create-group ctx
+                          headers
+                          (slurp body)
+                          (or (:managing-group-id params)
+                              (:managing_group_id params))))
 
           (context "/:group-id" [group-id]
             (OPTIONS "/" req (common-routes/options-response))
             ;; Get a group
             (GET "/"
-                 {ctx :request-context params :params}
-                 (pv/validate-group-route-params params)
-                 (get-group ctx group-id))
+              {ctx :request-context params :params}
+              (pv/validate-group-route-params params)
+              (get-group ctx group-id))
 
             ;; Delete a group
             (DELETE "/"
-                    {ctx :request-context params :params}
-                    (lt-validation/validate-launchpad-token ctx)
-                    (pv/validate-group-route-params params)
-                    (delete-group ctx group-id))
+              {ctx :request-context params :params}
+              (lt-validation/validate-launchpad-token ctx)
+              (pv/validate-group-route-params params)
+              (delete-group ctx group-id))
 
             ;; Update a group
             (PUT "/"
-                 {ctx :request-context params :params headers :headers body :body}
-                 (lt-validation/validate-launchpad-token ctx)
-                 (pv/validate-group-route-params params)
-                 (update-group ctx headers (slurp body) group-id))
+              {ctx :request-context params :params headers :headers body :body}
+              (lt-validation/validate-launchpad-token ctx)
+              (pv/validate-group-route-params params)
+              (update-group ctx headers (slurp body) group-id))
 
             (context "/members" []
               (OPTIONS "/" req (common-routes/options-response))
               (GET "/"
-                   {ctx :request-context params :params}
-                   (pv/validate-group-route-params params)
-                   (get-members ctx group-id))
+                {ctx :request-context params :params}
+                (pv/validate-group-route-params params)
+                (get-members ctx group-id))
 
               (POST "/"
-                    {ctx :request-context params :params headers :headers body :body}
-                    (lt-validation/validate-launchpad-token ctx)
-                    (pv/validate-group-route-params params)
-                    (add-members ctx headers (slurp body) group-id))
+                {ctx :request-context params :params headers :headers body :body}
+                (lt-validation/validate-launchpad-token ctx)
+                (pv/validate-group-route-params params)
+                (add-members ctx headers (slurp body) group-id))
 
               (DELETE "/"
-                      {ctx :request-context params :params headers :headers body :body}
-                      (lt-validation/validate-launchpad-token ctx)
-                      (pv/validate-group-route-params params)
-                      (remove-members ctx headers (slurp body) group-id)))))
+                {ctx :request-context params :params headers :headers body :body}
+                (lt-validation/validate-launchpad-token ctx)
+                (pv/validate-group-route-params params)
+                (remove-members ctx headers (slurp body) group-id)))))
         (context "/groups" []))
 
       (context "/acls" []
         (OPTIONS "/"
-                 {params :params}
-                 (pv/validate-standard-params params)
-                 (common-routes/options-response))
+          {params :params}
+          (pv/validate-standard-params params)
+          (common-routes/options-response))
 
         ;; Search for ACLs with either GET or POST
         (GET "/"
-             {ctx :request-context params :params headers :headers}
-             (search-for-acls ctx headers params))
+          {ctx :request-context params :params headers :headers}
+          (search-for-acls ctx headers params))
         ;; POST search is at a different route to avoid a collision with the ACL creation route
         (POST "/search"
-              {ctx :request-context params :params headers :headers}
-              (search-for-acls ctx headers params))
+          {ctx :request-context params :params headers :headers}
+          (search-for-acls ctx headers params))
 
         ;; Create an ACL
         (POST "/"
-              {ctx :request-context params :params headers :headers body :body}
-              (lt-validation/validate-launchpad-token ctx)
-              (pv/validate-standard-params params)
-              (create-acl ctx headers (slurp body)))
+          {ctx :request-context params :params headers :headers body :body}
+          (lt-validation/validate-launchpad-token ctx)
+          (pv/validate-standard-params params)
+          (create-acl ctx headers (slurp body)))
 
         (context "/:concept-id" [concept-id]
           (OPTIONS "/" req (common-routes/options-response))
 
           ;; Update an ACL
           (PUT "/"
-               {ctx :request-context headers :headers body :body}
-               (lt-validation/validate-launchpad-token ctx)
-               (update-acl ctx concept-id headers (slurp body)))
+            {ctx :request-context headers :headers body :body}
+            (lt-validation/validate-launchpad-token ctx)
+            (update-acl ctx concept-id headers (slurp body)))
 
           ;; Delete an ACL
           (DELETE "/"
-                  {ctx :request-context headers :headers}
-                  (lt-validation/validate-launchpad-token ctx)
-                  (delete-acl ctx concept-id headers))
+            {ctx :request-context headers :headers}
+            (lt-validation/validate-launchpad-token ctx)
+            (delete-acl ctx concept-id headers))
 
           ;; Retrieve an ACL
           (GET "/"
-               {ctx :request-context params :params headers :headers}
-               (get-acl ctx headers concept-id params))))
+            {ctx :request-context params :params headers :headers}
+            (get-acl ctx headers concept-id params))))
 
       (context "/permissions" []
         (OPTIONS "/" [] (common-routes/options-response))
 
         (GET "/"
-             {ctx :request-context params :params}
-             (get-permissions ctx params))
+          {ctx :request-context params :params}
+          (get-permissions ctx params))
 
         (POST "/"
-              {ctx :request-context headers :headers params :params}
-              (get-permissions ctx params)))
+          {ctx :request-context headers :headers params :params}
+          (get-permissions ctx params)))
 
       (context "/current-sids" []
         (OPTIONS "/" [] (common-routes/options-response))
 
-        (GET "/" {:keys [request-context params]}
-             (get-current-sids request-context params)))
+        (GET "/"
+          {:keys [request-context headers params]}
+
+          (when (access-control-config/enable-sids-get)
+            (do
+              (println "responding to /GET current-sids")
+              (error (format "client [%s] Using GET instead of POST when requesting current sids"
+                            (:client-id request-context)))
+              (get-current-sids request-context params))))
+
+        (POST "/" {:keys [request-context params]}
+          (do
+            (println "responding to /POST current-sids")
+            (cmr.common.util/tee (get-current-sids request-context params)))))
 
       (context "/s3-buckets" []
         (OPTIONS "/" [] (common-routes/options-response))

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -381,19 +381,18 @@
         (OPTIONS "/" [] (common-routes/options-response))
 
         (GET "/"
-          {:keys [request-context headers params]}
+          {:keys [request-context params]}
 
           (when (access-control-config/enable-sids-get)
             (do
-              (println "responding to /GET current-sids")
               (error (format "client [%s] Using GET instead of POST when requesting current sids"
                             (:client-id request-context)))
               (get-current-sids request-context params))))
 
-        (POST "/" {:keys [request-context params]}
-          (do
-            (println "responding to /POST current-sids")
-            (cmr.common.util/tee (get-current-sids request-context params)))))
+        (POST "/" {:keys [request-context body]}
+            (get-current-sids request-context (-> (slurp body)
+                                                  (json/parse-string true)
+                                                  (clojure.walk/keywordize-keys)))))
 
       (context "/s3-buckets" []
         (OPTIONS "/" [] (common-routes/options-response))

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -312,10 +312,10 @@
                    (get-members ctx group-id))
 
               (POST "/"
-                   {ctx :request-context params :params headers :headers body :body}
-                   (lt-validation/validate-launchpad-token ctx)
-                   (pv/validate-group-route-params params)
-                   (add-members ctx headers (slurp body) group-id))
+                    {ctx :request-context params :params headers :headers body :body}
+                    (lt-validation/validate-launchpad-token ctx)
+                    (pv/validate-group-route-params params)
+                    (add-members ctx headers (slurp body) group-id))
 
               (DELETE "/"
                       {ctx :request-context params :params headers :headers body :body}
@@ -326,9 +326,9 @@
 
       (context "/acls" []
         (OPTIONS "/"
-                {params :params}
-                (pv/validate-standard-params params)
-                (common-routes/options-response))
+                 {params :params}
+                 (pv/validate-standard-params params)
+                 (common-routes/options-response))
 
         ;; Search for ACLs with either GET or POST
         (GET "/"
@@ -374,8 +374,8 @@
              (get-permissions ctx params))
 
         (POST "/"
-             {ctx :request-context headers :headers params :params}
-             (get-permissions ctx params)))
+              {ctx :request-context headers :headers params :params}
+              (get-permissions ctx params)))
 
       (context "/current-sids" []
         (OPTIONS "/" [] (common-routes/options-response))

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -380,13 +380,14 @@
       (context "/current-sids" []
         (OPTIONS "/" [] (common-routes/options-response))
 
-        (when (access-control-config/enable-sids-get)
+        (if (access-control-config/enable-sids-get)
           (GET "/"
                {:keys [request-context params]}
                (do
                  (error (format "client [%s] Using GET instead of POST when requesting current sids"
                                 (:client-id request-context)))
-                 (get-current-sids request-context params))))
+                 (get-current-sids request-context params)))
+          {:status 404})
 
         (POST "/"
               {:keys [request-context body]}

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -247,152 +247,152 @@
 
       ;; Reindex all groups
       (POST "/reindex-groups"
-        {ctx :request-context params :params}
-        (acl/verify-ingest-management-permission ctx :update)
-        (pv/validate-standard-params params)
-        (reindex-groups ctx))
+            {ctx :request-context params :params}
+            (acl/verify-ingest-management-permission ctx :update)
+            (pv/validate-standard-params params)
+            (reindex-groups ctx))
 
       ;; Reindex all acls
       (POST "/reindex-acls"
-        {ctx :request-context params :params}
-        (acl/verify-ingest-management-permission ctx :update)
-        (pv/validate-standard-params params)
-        (reindex-acls ctx))
+            {ctx :request-context params :params}
+            (acl/verify-ingest-management-permission ctx :update)
+            (pv/validate-standard-params params)
+            (reindex-acls ctx))
 
       (if (access-control-config/enable-cmr-groups)
         (context "/groups" []
           (OPTIONS "/"
-            {params :params}
-            (pv/validate-standard-params params)
-            (common-routes/options-response))
+                   {params :params}
+                   (pv/validate-standard-params params)
+                   (common-routes/options-response))
 
           ;; Search for groups
           (GET "/"
-            {ctx :request-context params :params headers :headers}
-            (search-for-groups ctx headers params))
+               {ctx :request-context params :params headers :headers}
+               (search-for-groups ctx headers params))
 
           ;; Create a group
           (POST "/"
-            {ctx :request-context params :params headers :headers body :body}
-            (lt-validation/validate-launchpad-token ctx)
-            (pv/validate-create-group-route-params params)
-            (create-group ctx
-                          headers
-                          (slurp body)
-                          (or (:managing-group-id params)
-                              (:managing_group_id params))))
+                {ctx :request-context params :params headers :headers body :body}
+                (lt-validation/validate-launchpad-token ctx)
+                (pv/validate-create-group-route-params params)
+                (create-group ctx
+                              headers
+                              (slurp body)
+                              (or (:managing-group-id params)
+                                  (:managing_group_id params))))
 
           (context "/:group-id" [group-id]
             (OPTIONS "/" req (common-routes/options-response))
             ;; Get a group
             (GET "/"
-              {ctx :request-context params :params}
-              (pv/validate-group-route-params params)
-              (get-group ctx group-id))
+                 {ctx :request-context params :params}
+                 (pv/validate-group-route-params params)
+                 (get-group ctx group-id))
 
             ;; Delete a group
             (DELETE "/"
-              {ctx :request-context params :params}
-              (lt-validation/validate-launchpad-token ctx)
-              (pv/validate-group-route-params params)
-              (delete-group ctx group-id))
+                    {ctx :request-context params :params}
+                    (lt-validation/validate-launchpad-token ctx)
+                    (pv/validate-group-route-params params)
+                    (delete-group ctx group-id))
 
             ;; Update a group
             (PUT "/"
-              {ctx :request-context params :params headers :headers body :body}
-              (lt-validation/validate-launchpad-token ctx)
-              (pv/validate-group-route-params params)
-              (update-group ctx headers (slurp body) group-id))
+                 {ctx :request-context params :params headers :headers body :body}
+                 (lt-validation/validate-launchpad-token ctx)
+                 (pv/validate-group-route-params params)
+                 (update-group ctx headers (slurp body) group-id))
 
             (context "/members" []
               (OPTIONS "/" req (common-routes/options-response))
               (GET "/"
-                {ctx :request-context params :params}
-                (pv/validate-group-route-params params)
-                (get-members ctx group-id))
+                   {ctx :request-context params :params}
+                   (pv/validate-group-route-params params)
+                   (get-members ctx group-id))
 
               (POST "/"
-                {ctx :request-context params :params headers :headers body :body}
-                (lt-validation/validate-launchpad-token ctx)
-                (pv/validate-group-route-params params)
-                (add-members ctx headers (slurp body) group-id))
+                   {ctx :request-context params :params headers :headers body :body}
+                   (lt-validation/validate-launchpad-token ctx)
+                   (pv/validate-group-route-params params)
+                   (add-members ctx headers (slurp body) group-id))
 
               (DELETE "/"
-                {ctx :request-context params :params headers :headers body :body}
-                (lt-validation/validate-launchpad-token ctx)
-                (pv/validate-group-route-params params)
-                (remove-members ctx headers (slurp body) group-id)))))
+                      {ctx :request-context params :params headers :headers body :body}
+                      (lt-validation/validate-launchpad-token ctx)
+                      (pv/validate-group-route-params params)
+                      (remove-members ctx headers (slurp body) group-id)))))
         (context "/groups" []))
 
       (context "/acls" []
         (OPTIONS "/"
-          {params :params}
-          (pv/validate-standard-params params)
-          (common-routes/options-response))
+                {params :params}
+                (pv/validate-standard-params params)
+                (common-routes/options-response))
 
         ;; Search for ACLs with either GET or POST
         (GET "/"
-          {ctx :request-context params :params headers :headers}
-          (search-for-acls ctx headers params))
+             {ctx :request-context params :params headers :headers}
+             (search-for-acls ctx headers params))
         ;; POST search is at a different route to avoid a collision with the ACL creation route
         (POST "/search"
-          {ctx :request-context params :params headers :headers}
-          (search-for-acls ctx headers params))
+              {ctx :request-context params :params headers :headers}
+              (search-for-acls ctx headers params))
 
         ;; Create an ACL
         (POST "/"
-          {ctx :request-context params :params headers :headers body :body}
-          (lt-validation/validate-launchpad-token ctx)
-          (pv/validate-standard-params params)
-          (create-acl ctx headers (slurp body)))
+              {ctx :request-context params :params headers :headers body :body}
+              (lt-validation/validate-launchpad-token ctx)
+              (pv/validate-standard-params params)
+              (create-acl ctx headers (slurp body)))
 
         (context "/:concept-id" [concept-id]
           (OPTIONS "/" req (common-routes/options-response))
 
           ;; Update an ACL
           (PUT "/"
-            {ctx :request-context headers :headers body :body}
-            (lt-validation/validate-launchpad-token ctx)
-            (update-acl ctx concept-id headers (slurp body)))
+               {ctx :request-context headers :headers body :body}
+               (lt-validation/validate-launchpad-token ctx)
+               (update-acl ctx concept-id headers (slurp body)))
 
           ;; Delete an ACL
           (DELETE "/"
-            {ctx :request-context headers :headers}
-            (lt-validation/validate-launchpad-token ctx)
-            (delete-acl ctx concept-id headers))
+                  {ctx :request-context headers :headers}
+                  (lt-validation/validate-launchpad-token ctx)
+                  (delete-acl ctx concept-id headers))
 
           ;; Retrieve an ACL
           (GET "/"
-            {ctx :request-context params :params headers :headers}
-            (get-acl ctx headers concept-id params))))
+               {ctx :request-context params :params headers :headers}
+               (get-acl ctx headers concept-id params))))
 
       (context "/permissions" []
         (OPTIONS "/" [] (common-routes/options-response))
 
         (GET "/"
-          {ctx :request-context params :params}
-          (get-permissions ctx params))
+             {ctx :request-context params :params}
+             (get-permissions ctx params))
 
         (POST "/"
-          {ctx :request-context headers :headers params :params}
-          (get-permissions ctx params)))
+             {ctx :request-context headers :headers params :params}
+             (get-permissions ctx params)))
 
       (context "/current-sids" []
         (OPTIONS "/" [] (common-routes/options-response))
 
-        (GET "/"
-          {:keys [request-context params]}
+        (when (access-control-config/enable-sids-get)
+          (GET "/"
+               {:keys [request-context params]}
+               (do
+                 (error (format "client [%s] Using GET instead of POST when requesting current sids"
+                                (:client-id request-context)))
+                 (get-current-sids request-context params))))
 
-          (when (access-control-config/enable-sids-get)
-            (do
-              (error (format "client [%s] Using GET instead of POST when requesting current sids"
-                            (:client-id request-context)))
-              (get-current-sids request-context params))))
-
-        (POST "/" {:keys [request-context body]}
-            (get-current-sids request-context (-> (slurp body)
-                                                  (json/parse-string true)
-                                                  (clojure.walk/keywordize-keys)))))
+        (POST "/"
+              {:keys [request-context body]}
+              (get-current-sids request-context (-> (slurp body)
+                                                    (json/parse-string true)
+                                                    (clojure.walk/keywordize-keys)))))
 
       (context "/s3-buckets" []
         (OPTIONS "/" [] (common-routes/options-response))

--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -173,6 +173,9 @@
 (defn- get-current-sids
   "Returns a Ring response with the current user's sids"
   [request-context params]
+  (print "p params:" params "\n")
+  (error "e params:" params "\n")
+  (def mypramas params)
   (pv/validate-current-sids-params params)
   (let [result (acl-service/get-current-sids request-context params)]
     {:status 200
@@ -391,9 +394,7 @@
 
         (POST "/"
               {:keys [request-context body]}
-              (get-current-sids request-context (-> (slurp body)
-                                                    (json/parse-string true)
-                                                    (clojure.walk/keywordize-keys)))))
+              (get-current-sids request-context (json/parse-string (slurp body) true))))
 
       (context "/s3-buckets" []
         (OPTIONS "/" [] (common-routes/options-response))

--- a/access-control-app/src/cmr/access_control/config.clj
+++ b/access-control-app/src/cmr/access_control/config.clj
@@ -46,6 +46,10 @@
   "Flag that indicates we allow crud on cmr groups."
   {:default true :type Boolean})
 
+(defconfig enable-sids-get
+  "Feature toggle to enable the GET verb for /current-sids - remove after all clients have been migrated"
+  {:default true :type Boolean})
+
 (defn queue-config
   "Returns the queue configuration for the application."
   []

--- a/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
+++ b/system-int-test/test/cmr/system_int_test/access_control/edl_group_test.clj
@@ -54,7 +54,7 @@
              {:user_type (name user)}
              {:user_id user})))))
 
-(defn get-current-sids
+(defn- get-current-sids
   "For given token, returns list of sids."
   [token]
   (json/parse-string
@@ -63,7 +63,7 @@
     token)))
 
 (deftest toggle-cmr-group-sids
-  (mock-urs-client/create-users (u/conn-context) [{:username "edl-group-user1" 
+  (mock-urs-client/create-users (u/conn-context) [{:username "edl-group-user1"
                                                    :password "edl-group-user1-pass"}])
   (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
   (let [cmr-group (:concept_id
@@ -77,19 +77,20 @@
     (testing "Both EDL and CMR group sids are turned on"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-cmr-group-sids! true))
-      (is (= (set (get-current-sids token)) (set ["registered" cmr-group "group-id-1" "group-id-2"]))))
+      (is (= (set ["registered" cmr-group "group-id-1" "group-id-2"])
+             (set (get-current-sids token)))))
     (testing "Both EDL and CMR group sids are turned off"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! false))
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-cmr-group-sids! false))
-      (is (= (get-current-sids token) ["registered"])))
+      (is (= ["registered"] (get-current-sids token))))
     (testing "EDL sids are on and CMR group sids are off"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! true))
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-cmr-group-sids! false))
-      (is (= (set (get-current-sids token)) (set ["registered" "group-id-1" "group-id-2"]))))
+      (is (= (set ["registered" "group-id-1" "group-id-2"]) (set (get-current-sids token)))))
     (testing "EDL sids are off and CMR group sids are on"
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-edl-groups! false))
       (dev-sys-util/eval-in-dev-sys `(access-control-config/set-enable-cmr-group-sids! true))
-      (is (= (set (get-current-sids token)) (set ["registered" cmr-group]))))))
+      (is (= (set ["registered" cmr-group]) (set (get-current-sids token)))))))
 
 (deftest collection-simple-catalog-item-identity-permission-check-test
   (let [save-prov1-collection #(u/save-collection {:provider-id "PROV1"

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -134,7 +134,7 @@
   (let [token (:token context)
         headers (-> token
                     (when {config/token-header token})
-                    (as-> item (merge {:client-id "cmr-access-control"} item)))
+                    (as-> item (merge {:client-id "cmr-internal"} item)))
         body (json/generate-string {:user-token user-token})]
     (h/request context :access-control
                {:url-fn current-sids-url

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -133,12 +133,14 @@
   [context user-token]
   (let [token (:token context)
         headers (when token {config/token-header token})]
-    (h/request context :access-control
+    (println "get-current-sids here with token" user-token)
+    (cmr.common.log/error "get-current-sids")
+    (cmr.common.util/tee (h/request context :access-control
                {:url-fn current-sids-url
-                :method :get
-                :http-options {:query-params {:user-token user-token}
+                :method :post
+                :http-options {:body (format "user-token=%s" user-token)
                                :headers headers
-                               :accept :json}})))
+                               :accept :json}}))))
 
 ;;; ACL Functions
 

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -132,15 +132,14 @@
   "Gets a list of the SIDs for the specified token (used for assigning permissions via ACLs)."
   [context user-token]
   (let [token (:token context)
-        headers (when token {config/token-header token})]
-    (println "get-current-sids here with token" user-token)
-    (cmr.common.log/error "get-current-sids")
-    (cmr.common.util/tee (h/request context :access-control
+        headers (-> token
+                    (when {config/token-header token})
+                    (as-> item (merge {:client-id "cmr-access-control"} item)))
+        body (json/generate-string {:user-token user-token})]
+    (h/request context :access-control
                {:url-fn current-sids-url
                 :method :post
-                :http-options {:body (format "user-token=%s" user-token)
-                               :headers headers
-                               :accept :json}}))))
+                :http-options {:body body :headers headers :accept :json}})))
 
 ;;; ACL Functions
 

--- a/transmit-lib/src/cmr/transmit/access_control.clj
+++ b/transmit-lib/src/cmr/transmit/access_control.clj
@@ -134,7 +134,8 @@
   (let [token (:token context)
         headers (-> token
                     (when {config/token-header token})
-                    (as-> item (merge {:client-id "cmr-internal"} item)))
+                    (as-> item (merge {:client-id "cmr-internal"
+                                       :content-type "application/json"} item)))
         body (json/generate-string {:user-token user-token})]
     (h/request context :access-control
                {:url-fn current-sids-url


### PR DESCRIPTION
Remove the token from the URL because it is showing up in /access-control/current-sids, by moving the API call from GET to POST and sending the token as data. Also added a configuration to disable the GET interface.