### PR TITLE
CMR-9154 - left in debug statments which caused manual tests to fail

### DIFF
--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -173,9 +173,6 @@
 (defn- get-current-sids
   "Returns a Ring response with the current user's sids"
   [request-context params]
-  (print "p params:" params "\n")
-  (error "e params:" params "\n")
-  (def mypramas params)
   (pv/validate-current-sids-params params)
   (let [result (acl-service/get-current-sids request-context params)]
     {:status 200


### PR DESCRIPTION
Some developer left in debug statements which negated the workings of the ticket.