### PR TITLE
CMR-9342 - removing calls to the echo health check

### DIFF
--- a/access-control-app/src/cmr/access_control/services/group_service.clj
+++ b/access-control-app/src/cmr/access_control/services/group_service.clj
@@ -22,7 +22,6 @@
     [cmr.common.util :as u]
     [cmr.common.validations.core :as v]
     [cmr.transmit.config :as transmit-config]
-    [cmr.transmit.echo.rest :as rest]
     [cmr.transmit.echo.tokens :as tokens]
     [cmr.transmit.metadata-db2 :as mdb]
     [cmr.transmit.urs :as urs])
@@ -425,9 +424,7 @@
 (defn health
   "Returns the health state of the app."
   [context]
-  (let [echo-rest-health (rest/health context)
-        metadata-db-health (mdb/get-metadata-db-health context)
-        ok? (every? :ok? [echo-rest-health metadata-db-health])]
+  (let [metadata-db-health (mdb/get-metadata-db-health context)
+        ok? (every? :ok? [metadata-db-health])]
     {:ok? ok?
-     :dependencies {:echo echo-rest-health
-                    :metadata-db metadata-db-health}}))
+     :dependencies {:metadata-db metadata-db-health}}))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -24,7 +24,6 @@
    [cmr.indexer.data.metrics-fetcher :as metrics-fetcher]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
    [cmr.message-queue.services.queue :as queue]
-   [cmr.transmit.echo.rest :as rest]
    [cmr.transmit.metadata-db :as meta-db]
    [cmr.transmit.metadata-db2 :as meta-db2]
    [cmr.transmit.search :as search]
@@ -429,7 +428,7 @@
 
 (defn create-association-map-keys
   "Creates the association map keys that lists out all of the different association types.
-  For example, this function changes the named concept type from variable-association to a 
+  For example, this function changes the named concept type from variable-association to a
   key of :variable-associations."
   [key-str]
   {key-str (keyword (inf/plural key-str))})
@@ -584,7 +583,7 @@
 (defmethod index-concept :service-association
   [context concept parsed-concept options]
   (index-associated-collection context concept options)
-  (index-associated-concept context 
+  (index-associated-concept context
                             (get-in concept [:extra-fields :service-concept-id])
                             options))
 
@@ -824,7 +823,6 @@
 (def health-check-fns
   "A map of keywords to functions to be called for health checks"
   {:elastic_search #(es-util/health % :db)
-   :echo rest/health
    :metadata-db meta-db2/get-metadata-db-health
    :message-queue (fn [context]
                     (when-let [qb (get-in context [:system :queue-broker])]

--- a/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
@@ -12,8 +12,6 @@
    [cmr.ingest.data.provider-acl-hash :as pah]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
    [cmr.oracle.connection :as conn]
-   [cmr.redis-utils.redis :as redis]
-   [cmr.transmit.echo.rest :as rest]
    [cmr.transmit.indexer :as indexer]
    [cmr.transmit.metadata-db :as mdb]
    [cmr.transmit.metadata-db2 :as mdb2]))
@@ -39,7 +37,6 @@
 (def health-check-fns
   "A map of keywords to functions to be called for health checks"
   {:oracle #(conn/health (pah/context->db %))
-   :echo rest/health
    :metadata-db mdb2/get-metadata-db-health
    :indexer indexer/get-indexer-health
    :message-queue #(queue-protocol/health (get-in % [:system :queue-broker]))})

--- a/search-app/src/cmr/search/services/health_service.clj
+++ b/search-app/src/cmr/search/services/health_service.clj
@@ -2,19 +2,16 @@
   "Contains fuctions to provider health status of the search app."
   (:require
    [cmr.metadata-db.services.health-service :as meta-db]
-   [cmr.transmit.echo.rest :as rest]
    [cmr.transmit.indexer :as indexer]))
 
 (defn health
   "Returns the health state of the app."
   [context]
-  (let [echo-rest-health (rest/health context)
-        indexer-health (indexer/get-indexer-health context)
+  (let [indexer-health (indexer/get-indexer-health context)
         metadata-db-context (assoc context :system
                                    (get-in context [:system :embedded-systems :metadata-db]))
         metadata-db-health (meta-db/health metadata-db-context)
-        ok? (every? :ok? [echo-rest-health metadata-db-health indexer-health])]
+        ok? (every? :ok? [metadata-db-health indexer-health])]
     {:ok? ok?
-     :dependencies {:echo echo-rest-health
-                    :internal-metadata-db metadata-db-health
+     :dependencies {:internal-metadata-db metadata-db-health
                     :indexer indexer-health}}))

--- a/system-int-test/test/cmr/system_int_test/misc/health_test.clj
+++ b/system-int-test/test/cmr/system_int_test/misc/health_test.clj
@@ -68,7 +68,6 @@
 (deftest ^:oracle indexer-health-test
   (s/only-with-real-database
     (is (= [200 {:elastic_search {:ok? true}
-                 :echo {:ok? true}
                  :message-queue {:ok? true}
                  :metadata-db good-metadata-db-health}]
            (get-app-health (url/indexer-health-url))))))
@@ -76,7 +75,6 @@
 (deftest ^:oracle ingest-health-test
   (s/only-with-real-database
     (is (= [200 {:oracle {:ok? true}
-                 :echo {:ok? true}
                  :metadata-db good-metadata-db-health
                  :message-queue {:ok? true}
                  :indexer good-indexer-health}]
@@ -84,8 +82,7 @@
 
 (deftest ^:oracle search-health-test
   (s/only-with-real-database
-    (is (= [200 {:echo {:ok? true}
-                 :internal-metadata-db good-metadata-db-health
+    (is (= [200 {:internal-metadata-db good-metadata-db-health
                  :indexer good-indexer-health}]
            (get-app-health (url/search-health-url))))))
 
@@ -105,6 +102,5 @@
 
 (deftest ^:oracle access-control-health-test
   (s/only-with-real-database
-    (is (= [200 {:echo {:ok? true}
-                 :metadata-db good-metadata-db-health}]
+    (is (= [200 {:metadata-db good-metadata-db-health}]
            (get-app-health (url/access-control-health-url))))))

--- a/system-int-test/test/cmr/system_int_test/misc/health_test.clj
+++ b/system-int-test/test/cmr/system_int_test/misc/health_test.clj
@@ -6,8 +6,6 @@
    [clojure.test :refer :all]
    [clojure.string :as str]
    [cmr.common-app.test.side-api :as side]
-   [cmr.common.time-keeper :as tk]
-   [cmr.elastic-utils.connect :as es-util]
    [cmr.search.routes :as routes]
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.url-helper :as url]))
@@ -30,14 +28,12 @@
 (def good-indexer-health
   {:ok? true
    :dependencies {:elastic_search {:ok? true}
-                  :echo {:ok? true}
                   :message-queue {:ok? true}
                   :metadata-db good-metadata-db-health}})
 
 (def good-ingest-health
   {:ok? true
    :dependencies {:oracle {:ok? true}
-                  :echo {:ok? true}
                   :metadata-db good-metadata-db-health
                   :message-queue {:ok? true}
                   :indexer good-indexer-health}})

--- a/transmit-lib/src/cmr/transmit/echo/rest.clj
+++ b/transmit-lib/src/cmr/transmit/echo/rest.clj
@@ -106,7 +106,7 @@
       {:ok? false
        :problem (format "Received %d from availability check. %s" status-code (:body response))})))
 
-(defn health
+(defn- health
   "Returns the echo-rest health with timeout handling."
   [context]
   (hh/get-health #(health-fn context)))

--- a/transmit-lib/src/cmr/transmit/echo/rest.clj
+++ b/transmit-lib/src/cmr/transmit/echo/rest.clj
@@ -97,6 +97,7 @@
 (defn health-fn
   "Returns the availability status of echo-rest by calling its availability endpoint"
   [context]
+  (warn "Code is still calling the echo health check")
   (let [conn (config/context->app-connection context :echo-rest)
         url (format "%s%s" (conn/root-url conn) "/availability")
         response (get-rest-health url)


### PR DESCRIPTION
removed the echo health check from 4 applications: access control, indexer, ingest, and search