### PR TITLE
CMR-9308 Adding in changes to UMM-G version 1.6.5 that doesn't requir…

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule_ingest_test.clj
@@ -483,9 +483,7 @@
       (let [{:keys [status errors]} (ingest/ingest-concept
                                       (ingest/concept :granule "PROV1" "foo" :iso-smap invalid-gran-metadata))]
          (is (= 422 status))
-         (is (= [{:errors ["[Geometries] cannot be set when the parent collection's GranuleSpatialRepresentation is ORBIT"],
-                  :path ["SpatialCoverage" "Geometries"]}
-                 {:errors ["[Orbit] must be provided when the parent collection's GranuleSpatialRepresentation is ORBIT"],
+         (is (= [{:errors ["[Orbit] must be provided when the parent collection's GranuleSpatialRepresentation is ORBIT"],
                   :path ["SpatialCoverage" "Orbit"]}]
                 errors))))))
 

--- a/umm-lib/src/cmr/umm/echo10/granule.clj
+++ b/umm-lib/src/cmr/umm/echo10/granule.clj
@@ -145,9 +145,9 @@
     (let [{:keys [geometries orbit]} spatial-coverage]
       (x/element :Spatial {}
                  (x/element :HorizontalSpatialDomain {}
-                            (if geometries
-                              (s/generate-geometry-xml geometries)
-                              (s/generate-orbit-xml orbit)))))))
+                            (if orbit
+                              (s/generate-orbit-xml orbit)
+                              (s/generate-geometry-xml geometries)))))))
 
 (defn xml-elem->DataProviderTimestamps
   "Returns a UMM DataProviderTimestamps from a parsed Collection Content XML structure"

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.5/umm-g-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.5/umm-g-json-schema.json
@@ -516,7 +516,7 @@
           "$ref": "#/definitions/TrackType"
         }
       },
-      "oneOf": [{
+      "anyOf": [{
         "required": ["Geometry"]
       }, {
         "required": ["Orbit"]
@@ -713,7 +713,7 @@
           "minItems": 1
         }
       },
-      "required": ["Cycle", "Passes"]
+      "required": ["Cycle"]
     },
     "TrackPassTileType": {
       "type": "object",

--- a/umm-spec-lib/src/cmr/umm_spec/validation/granule.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/validation/granule.clj
@@ -64,8 +64,7 @@
                               (is-not-allowed :geometries)]
                  (:geodetic :cartesian) [(is-required :geometries)
                                          (is-not-allowed :orbit)]
-                 :orbit [(is-not-allowed :geometries)
-                         (is-required :orbit)])]
+                 :orbit [ (is-required :orbit)])]
     (apply merge (remove nil? errors))))
 
 (defn set-geometries-spatial-representation

--- a/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_granule_validation_tests.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/validation/umm_spec_granule_validation_tests.clj
@@ -140,9 +140,7 @@
           :errors ["[Geometries] must be provided when the parent collection's GranuleSpatialRepresentation is CARTESIAN"]}]
 
         collection-with-orbit granule-with-geometry
-        [{:path [:spatial-coverage :geometries]
-          :errors ["[Geometries] cannot be set when the parent collection's GranuleSpatialRepresentation is ORBIT"]}
-         {:path [:spatial-coverage :orbit]
+        [{:path [:spatial-coverage :orbit]
           :errors ["[Orbit] must be provided when the parent collection's GranuleSpatialRepresentation is ORBIT"]}]
 
         collection-with-no-spatial granule-with-geometry


### PR DESCRIPTION
…e a version change. Contraints have changed to allow more metadata for PODAAC without affecting the CMR's data or other granule records.