### PR TITLE
CMR-9372 CMR Internal server error when disassociating tags

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -1009,7 +1009,9 @@
     (if (some? (re-find #"[A-Za-z0-9=_-]+\.[A-Za-z0-9=_-]+\.[:A-Za-z0-9=_-]+" token))
       (let [token-parts (string/split token #"\.")
             token-header (first token-parts)
-            header-raw (String. (.decode (java.util.Base64/getDecoder) token-header))]
+            header-raw (try
+                         (String. (.decode (java.util.Base64/getDecoder) token-header))
+                         (catch java.lang.IllegalArgumentException e false))]
         ;; don't parse the data unless it is really needed to prevent unnecessary
         ;; processing. Check first to see if the data looks like JSON
         (if (and (string/starts-with? header-raw "{")


### PR DESCRIPTION
After legacy services shutdown, invalid tokens can get routed to a 301 returning endpoint for verification.  If we receive a 301 we will now assume the token does not exist as it has failed jwt and launchpad verification.  This is done to preserve the mock-echo testing functionality for now.  I ticket will be written to decouple CMR tests from mock echo.