### PR TITLE
CMR-9419: Browse Scaler Builds are Failing

### DIFF
--- a/browse-scaler/README.md
+++ b/browse-scaler/README.md
@@ -6,7 +6,7 @@ Nodejs application to return thumbnails for NASA's Earthdata Search
 
 **NOTE**: because Sharp uses C++ extensions, it must be built in a Docker container to run on AWS (unless your machine is also linux). If you are using macOs you may need to un-install sharp using: `npm uninstall sharp` and then re-install it using: `npm install --platform=linux --arch=x64 sharp` in order to be able to run against the docker container locally.
 
-You can do this by running `docker-compose up --build` from the `browse-scaler/src` directory.
+You can do this by running `docker compose up --build` from the `browse-scaler/src` directory.
 
 You are able to package the code for deployment easily with the `zip-browse-scaler.sh` script. This script builds the node_modules
 automatically so you do not have to worry about manual builds.

--- a/browse-scaler/test-cicd.sh
+++ b/browse-scaler/test-cicd.sh
@@ -2,12 +2,12 @@
 # Runs tests in docker and saves output as junit.xml
 
 echo "Running tests..."
-(cd src && docker compose -f docker compose.test.yml run --rm browse-scaler-cicd)
+(cd src && docker compose -f docker-compose.test.yml run --rm browse-scaler-cicd)
 
 # Cleanup image
 echo "Cleaning up image..."
 
-(cd src && docker compose -f docker compose.test.yml stop)
+(cd src && docker compose -f docker-compose.test.yml stop)
 
 docker rmi -f \
   $(docker inspect browse-scaler:test-cicd \

--- a/browse-scaler/test-cicd.sh
+++ b/browse-scaler/test-cicd.sh
@@ -2,12 +2,12 @@
 # Runs tests in docker and saves output as junit.xml
 
 echo "Running tests..."
-(cd src && docker-compose -f docker-compose.test.yml run --rm browse-scaler-cicd)
+(cd src && docker compose -f docker compose.test.yml run --rm browse-scaler-cicd)
 
 # Cleanup image
 echo "Cleaning up image..."
 
-(cd src && docker-compose -f docker-compose.test.yml stop)
+(cd src && docker compose -f docker compose.test.yml stop)
 
 docker rmi -f \
   $(docker inspect browse-scaler:test-cicd \

--- a/browse-scaler/zip-browse-scaler.sh
+++ b/browse-scaler/zip-browse-scaler.sh
@@ -3,6 +3,6 @@
 # for the browse-scaler to be read by the browse_scaler.tf file.
 # see the `source_code_hash` field
 
-(cd src && CURRENT_UID=$(id -u):$(id -u) docker-compose up --build)
+(cd src && CURRENT_UID=$(id -u):$(id -u) docker compose up --build)
 
 (cd src && zip -r scaler.zip index.js cache.js cmr.js resize.js util.js config.js in-memory-cache.js package.json package-lock.json image-unavailable.svg node_modules)


### PR DESCRIPTION
When the RHEL8 update occured on bamboo we could no longer use `docker-compose` this command was changed to `docker compose`. Please see `https://docs.docker.com/engine/reference/commandline/compose/`

Build result branch: https://ci.earthdata.nasa.gov/browse/CN2-BN2584-3