### PR TITLE
DRAFT - Feature/CMR-9465 - Use memoize to improve Generic common functions

### DIFF
--- a/common-lib/src/cmr/common/generics.clj
+++ b/common-lib/src/cmr/common/generics.clj
@@ -18,6 +18,7 @@
    Returns: true if schema and version are supported, nil otherwise"
   [schema version]
   (when (and schema version)
+    (info (format "Making a request for Generic [%s] at version [%s]" schema version))
     (some #(= version %) (schema (cfg/approved-pipeline-documents)))))
 
 (def approved-generic?
@@ -33,6 +34,7 @@
    string for each one.
    Return {:doc-type \"1.2.3\"}"
   []
+  (info "Making a request for All Generic documents")
   (reduce (fn [data item]
             (assoc data (first item) (last (second item))))
           {}
@@ -72,6 +74,10 @@
    * generic-version: 0.0.1
    Returns: string"
   [file-name generic-keyword generic-version]
+  (info (format "Making a request for Generic file [%s] [%s] at version [%s]"
+                file-name
+                generic-keyword
+                generic-version))
   (try
     (-> "schemas/%s/v%s/%s.json"
         (format (name generic-keyword) generic-version (name file-name))

--- a/common-lib/test/cmr/common/test/generics.clj
+++ b/common-lib/test/cmr/common/test/generics.clj
@@ -1,0 +1,30 @@
+(ns cmr.common.test.generics
+  (:require
+   [clojure.string :as string]
+   [clojure.test :refer :all]
+   [cmr.common.generics :as gconfig]
+   [cmr.common.util :as cutil]))
+
+
+(deftest fast-generic-test
+  "Make sure that highly used generic functions are memoized and are faster (or
+   at least not worse) with a second call"
+  (testing "don't take to long - "
+
+    (cmr.common.util/are3
+     [body]
+     (let [one (do (cutil/time-execution body))
+           two (do (cutil/time-execution body))]
+       (is (<= (first two) (first one))))
+
+     "approved"
+     (gconfig/approved-generic? :grid "0.0.1")
+
+     "latest docs"
+     (gconfig/latest-approved-documents)
+
+     "read schema"
+     (gconfig/read-schema-file "metadata" :grid, "0.0.1")
+
+     "approved prefixes"
+     (gconfig/approved-generic-concept-prefixes))))


### PR DESCRIPTION
While Generics are dynamic, the actual generic values will not change for the duration of a deployment of CMR. Use memoize to speed up the lookup functions for internal details of a generic and do so for the most commonly used functions.