### PR TITLE
CMR-9532 Pass a "has_combine" field in the JSON response for collections 

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -106,6 +106,16 @@
   [service]
   (has-subset-type? service :VariableSubset))
 
+(defn- has-combine?
+  "Returns true if the given service has ConcatenateDefault = true, false otherwise."
+  [service]
+  (-> service
+      :ServiceOptions
+      :Aggregation
+      :Concatenate
+      :ConcatenateDefault
+      boolean))
+
 (defn- has-transforms?
   "Returns true if the given service has a defined SubsetTypes or InterpolationTypes,
   or multiple supported projections values."
@@ -125,6 +135,7 @@
   [services]
   {:has-formats (boolean (some has-formats? services))
    :has-transforms (boolean (some has-transforms? services))
+   :has-combine (boolean (some has-combine? services))
    :has-variables (boolean (some has-variables? services))
    :has-spatial-subsetting (boolean (some has-spatial-subsetting? services))
    :has-temporal-subsetting (boolean (some has-temporal-subsetting? services))})
@@ -144,7 +155,7 @@
         harmony-services (filter #(= "Harmony" (:Type %)) services)]
     (util/remove-map-keys
       empty?
-      {:opendap (get-trimmed-has-features opendap-services )
+      {:opendap (get-trimmed-has-features opendap-services)
        :esi (get-trimmed-has-features esi-services)
        :harmony (get-trimmed-has-features harmony-services)})))
 

--- a/indexer-app/src/cmr/indexer/data/concepts/service.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/service.clj
@@ -114,7 +114,7 @@
       :Aggregation
       :Concatenate
       :ConcatenateDefault
-      boolean))
+      some?))
 
 (defn- has-transforms?
   "Returns true if the given service has a defined SubsetTypes or InterpolationTypes,

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -394,6 +394,7 @@
           :has-variables m/bool-field-mapping
           :has-formats m/bool-field-mapping
           :has-transforms m/bool-field-mapping
+          :has-combine m/bool-field-mapping
           :has-spatial-subsetting m/bool-field-mapping
           :has-temporal-subsetting m/bool-field-mapping
           :has-opendap-url m/bool-field-mapping

--- a/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_json_results_handler.clj
@@ -51,7 +51,7 @@
                 processing-level-id original-format data-center archive-center start-date end-date
                 atom-links associated-difs online-access-flag browse-flag coordinate-system shapes
                 orbit-parameters highlighted-summary-snippets tags organizations
-                has-variables has-formats has-transforms has-spatial-subsetting has-temporal-subsetting
+                has-variables has-formats has-transforms has-combine has-spatial-subsetting has-temporal-subsetting
                 cloud-hosted platforms consortiums service-features associations eula-identifiers]} reference
         shape-result (atom-spatial/shapes->json shapes)
         granule-count (get granule-counts-map id 0)
@@ -82,6 +82,7 @@
                        :has_variables has-variables
                        :has_formats has-formats
                        :has_transforms has-transforms
+                       :has_combine has-combine
                        :has_spatial_subsetting has-spatial-subsetting
                        :has_temporal_subsetting has-temporal-subsetting
                        :cloud_hosted cloud-hosted

--- a/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/atom_results_handler.clj
@@ -64,6 +64,7 @@
                      "has-variables"
                      "has-formats"
                      "has-transforms"
+                     "has-combine"
                      "has-spatial-subsetting"
                      "has-temporal-subsetting"
                      "cloud-hosted"
@@ -114,6 +115,7 @@
   {:has-formats false
    :has-variables false
    :has-transforms false
+   :has-combine false
    :has-spatial-subsetting false
    :has-temporal-subsetting false})
 
@@ -164,6 +166,7 @@
           has-variables :has-variables
           has-formats :has-formats
           has-transforms :has-transforms
+          has-combine :has-combine
           has-spatial-subsetting :has-spatial-subsetting
           has-temporal-subsetting :has-temporal-subsetting
           cloud-hosted :cloud-hosted
@@ -220,6 +223,7 @@
             :has-variables has-variables
             :has-formats has-formats
             :has-transforms has-transforms
+            :has-combine has-combine
             :has-spatial-subsetting has-spatial-subsetting
             :has-temporal-subsetting has-temporal-subsetting
             :cloud-hosted cloud-hosted
@@ -467,7 +471,7 @@
         {:keys [id score title short-name version-id summary updated dataset-id collection-data-type
                 processing-level-id original-format data-center archive-center start-date end-date
                 atom-links associated-difs online-access-flag browse-flag coordinate-system shapes
-                orbit-parameters organizations tags has-variables has-formats has-transforms
+                orbit-parameters organizations tags has-variables has-formats has-transforms has-combine
                 has-spatial-subsetting has-temporal-subsetting cloud-hosted consortiums]} reference
         granule-count (get granule-counts-map id 0)]
     (x/element :entry {}
@@ -502,6 +506,7 @@
                (x/element :echo:hasVariables {} has-variables)
                (x/element :echo:hasFormats {} has-formats)
                (x/element :echo:hasTransforms {} has-transforms)
+               (x/element :echo:hasCombine {} has-combine)
                (x/element :echo:hasSpatialSubsetting {} has-spatial-subsetting)
                (x/element :echo:hasTemporalSubsetting {} has-temporal-subsetting)
                (x/element :echo:cloudHosted {} cloud-hosted)

--- a/search-app/src/cmr/search/results_handlers/umm_json_results_helper.clj
+++ b/search-app/src/cmr/search/results_handlers/umm_json_results_helper.clj
@@ -24,6 +24,7 @@
    "has-variables"
    "has-formats"
    "has-transforms"
+   "has-combine"
    "has-spatial-subsetting"
    "has-temporal-subsetting"
    "associations-gzip-b64"
@@ -33,7 +34,7 @@
   "Takes an elasticsearch result and returns a map of the meta fields for the response."
   [concept-type elastic-result]
   (let [{:keys [concept-id revision-id native-id user-id provider-id metadata-format
-                creation-date revision-date deleted has-variables has-formats has-transforms
+                creation-date revision-date deleted has-variables has-formats has-transforms has-combine
                 has-spatial-subsetting has-temporal-subsetting
                 associations-gzip-b64 s3-bucket-and-object-prefix-names]} (:_source elastic-result)
         creation-date (when creation-date (string/replace (str creation-date) #"\+0000" "Z"))
@@ -55,6 +56,7 @@
       :has-variables has-variables
       :has-formats has-formats
       :has-transforms has-transforms
+      :has-combine has-combine
       :has-spatial-subsetting has-spatial-subsetting
       :has-temporal-subsetting has-temporal-subsetting
       :s3-links s3-bucket-and-object-prefix-names

--- a/system-int-test/src/cmr/system_int_test/data2/atom.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom.clj
@@ -169,6 +169,7 @@
      :has-variables (cx/bool-at-path entry-elem [:hasVariables])
      :has-formats (cx/bool-at-path entry-elem [:hasFormats])
      :has-transforms (cx/bool-at-path entry-elem [:hasTransforms])
+     :has-combine (cx/bool-at-path entry-elem [:hasCombine])
      :has-spatial-subsetting (cx/bool-at-path entry-elem [:hasSpatialSubsetting])
      :has-temporal-subsetting (cx/bool-at-path entry-elem [:hasTemporalSubsetting])
      :cloud-hosted (cx/bool-at-path entry-elem [:cloudHosted])
@@ -280,7 +281,7 @@
   that will do a conversion to echo10"
   [collection]
   (let [{{:keys [short-name version-id processing-level-id collection-data-type]} :product
-         :keys [concept-id format-key has-variables has-formats has-transforms
+         :keys [concept-id format-key has-variables has-formats has-transforms has-combine
                 has-spatial-subsetting has-temporal-subsetting cloud-hosted
                 services variables tools]} collection
         collection (data-core/mimic-ingest-retrieve-metadata-conversion collection)
@@ -341,6 +342,7 @@
       :has-variables (boolean has-variables)
       :has-formats (boolean has-formats)
       :has-transforms (boolean has-transforms)
+      :has-combine (boolean has-combine)
       :has-spatial-subsetting (boolean has-spatial-subsetting)
       :has-temporal-subsetting (boolean has-temporal-subsetting)
       :cloud-hosted (boolean cloud-hosted)

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -106,7 +106,7 @@
                 processing-level-id original-format data-center archive-center time-start time-end
                 links dif-ids online-access-flag browse-flag coordinate-system score platforms
                 shapes points boxes polygons lines granule-count has-granules has-granules-or-cwic
-                has-variables has-formats has-transforms has-spatial-subsetting
+                has-variables has-formats has-transforms has-combine has-spatial-subsetting
                 has-temporal-subsetting cloud-hosted orbit-parameters highlighted-summary-snippets
                 organizations service-features associations consortiums eula-identifiers]} json-entry]
     (util/remove-nil-keys
@@ -138,6 +138,7 @@
        :has-variables has-variables
        :has-formats has-formats
        :has-transforms has-transforms
+       :has-combine has-combine
        :has-spatial-subsetting has-spatial-subsetting
        :has-temporal-subsetting has-temporal-subsetting
        :cloud-hosted cloud-hosted

--- a/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
@@ -21,7 +21,7 @@
   "Returns the meta section of umm-json format."
   [collection]
   (let [{:keys [user-id format-key revision-id concept-id provider-id deleted
-                has-variables has-formats has-transforms has-spatial-subsetting
+                has-variables has-formats has-transforms has-combine has-spatial-subsetting
                 has-temporal-subsetting variables services tools s3-bucket-and-object-prefix-names]} collection
         associations (when (or (seq services) (seq variables) (seq tools))
                        (util/remove-map-keys empty? {:variables (set variables)
@@ -39,6 +39,7 @@
       :has-variables (when-not deleted (boolean has-variables))
       :has-formats (when-not deleted (boolean has-formats))
       :has-transforms (when-not deleted (boolean has-transforms))
+      :has-combine (when-not deleted (boolean has-combine))
       :has-spatial-subsetting (when-not deleted (boolean has-spatial-subsetting))
       :has-temporal-subsetting (when-not deleted (boolean has-temporal-subsetting))
       :s3-links s3-bucket-and-object-prefix-names

--- a/system-int-test/src/cmr/system_int_test/utils/service_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/service_util.clj
@@ -280,7 +280,7 @@
         "JSON Result failed")))
 
 (defn- assert-collection-atom-json-result
-  "Verify collection in ATOM and JSON response has-formats, has-variables, has-transforms,
+  "Verify collection in ATOM and JSON response has-formats, has-variables, has-transforms, has-combine
   has-spatial-subsetting, has-temporal-subsetting and associations fields"
   [coll expected-fields serv-concept-ids var-concept-ids]
   (let [service-features {:opendap (merge handler/base-has-features
@@ -299,7 +299,7 @@
     (assert-collection-json-result coll expected-fields serv-concept-ids var-concept-ids)))
 
 (defn- assert-collection-umm-json-result
-  "Verify collection in UMM JSON response has-formats, has-variables, has-transforms,
+  "Verify collection in UMM JSON response has-formats, has-variables, has-transforms, has-combine,
   has-spatial-subsetting, has-temporal-subsetting and associations fields"
   [coll expected-fields serv-concept-ids var-concept-ids]
   (let [expected-fields (merge handler/base-has-features
@@ -317,7 +317,7 @@
 
 (defn assert-collection-search-result
   "Verify collection in ATOM, JSON and UMM JSON response has-formats, has-variables,
-  has-transforms, has-spatial-subsetting, has-temporal-subsetting and associations fields"
+  has-transforms, has-combine, has-spatial-subsetting, has-temporal-subsetting and associations fields"
   ([coll expected-fields serv-concept-ids]
    (assert-collection-search-result coll expected-fields serv-concept-ids nil))
   ([coll expected-fields serv-concept-ids var-concept-ids]

--- a/system-int-test/src/cmr/system_int_test/utils/tool_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/tool_util.clj
@@ -162,7 +162,7 @@
 
 
 (defn- assert-collection-atom-result
-  "Verify the collection ATOM response has-formats, has-variables, has transforms fields
+  "Verify the collection ATOM response has-formats, has-variables, has-transforms, has-combine fields
   have the correct values"
   [coll expected-fields]
   (let [coll-with-extra-fields (merge coll expected-fields)
@@ -194,7 +194,7 @@
            [status results]))))
 
 (defn- assert-collection-atom-json-result
-  "Verify collection in ATOM and JSON response has-formats, has-variables, has-transforms,
+  "Verify collection in ATOM and JSON response has-formats, has-variables, has-transforms, has-combine,
   has-spatial-subsetting, has-temporal-subsetting and associations fields"
   [coll expected-fields tool-concept-ids var-concept-ids]
   (let [service-features {:opendap (merge handler/base-has-features
@@ -213,7 +213,7 @@
     (assert-collection-json-result coll expected-fields tool-concept-ids var-concept-ids)))
 
 (defn- assert-collection-umm-json-result
-  "Verify collection in UMM JSON response has-formats, has-variables, has-transforms,
+  "Verify collection in UMM JSON response has-formats, has-variables, has-transforms, has-combine,
   has-spatial-subsetting, has-temporal-subsetting and associations fields"
   [coll expected-fields tool-concept-ids var-concept-ids]
   (let [expected-fields (merge handler/base-has-features
@@ -231,7 +231,7 @@
 
 (defn assert-collection-search-result
   "Verify collection in ATOM, JSON and UMM JSON response has-formats, has-variables,
-  has-transforms, has-spatial-subsetting, has-temporal-subsetting and associations fields"
+  has-transforms, has-combine, has-spatial-subsetting, has-temporal-subsetting and associations fields"
   ([coll expected-fields tool-concept-ids]
    (assert-collection-search-result coll expected-fields tool-concept-ids nil))
   ([coll expected-fields tool-concept-ids var-concept-ids]

--- a/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
@@ -499,3 +499,47 @@
 
         "multiple search search"
         [coll1 coll2 coll3 coll4] ["Harmony" "OPeNDAP"]))))
+
+(deftest collection-services-search-has-combine-test
+  (let [token (e/login (s/context) "user1")
+        coll1 (d/ingest "PROV1" (dc/collection {:entry-title "ET1"
+                                                :short-name "S1"
+                                                :version-id "V1"}))
+        coll2 (d/ingest "PROV1" (dc/collection {:entry-title "ET2"
+                                                :short-name "S2"
+                                                :version-id "V2"}))
+        coll3 (d/ingest "PROV1" (dc/collection {:entry-title "ET3"
+                                                :short-name "S3"
+                                                :version-id "V3"}))
+        ;; create services
+        {serv1-concept-id :concept-id}
+        (service-util/ingest-service-with-attrs
+         {:native-id "serv1"
+          :Type "Harmony"
+          :Name "service1"})
+
+        {serv2-concept-id :concept-id}
+        (service-util/ingest-service-with-attrs
+          {:native-id "serv2"
+           :Name "service2"
+           :Type "Harmony"
+           :ServiceOptions {:Aggregation {:Concatenate {:ConcatenateDefault true}}}})
+
+        {serv3-concept-id :concept-id}
+        (service-util/ingest-service-with-attrs
+         {:native-id "serv3"
+          :Name "service3"
+          :Type "Harmony"
+          :ServiceOptions {:Aggregation {:Concatenate {:ConcatenateDefault false}}}})]
+
+    (index/wait-until-indexed)
+    (au/associate-by-concept-ids token serv1-concept-id [{:concept-id (:concept-id coll1)}])
+    (au/associate-by-concept-ids token serv2-concept-id [{:concept-id (:concept-id coll2)}])
+    (au/associate-by-concept-ids token serv3-concept-id [{:concept-id (:concept-id coll3)}])
+    (index/wait-until-indexed)
+    (testing "when Aggregation is not present"
+      (service-util/assert-collection-search-result coll1 {:has-combine false :service-features {:harmony {:has-combine false}}} [serv1-concept-id]))
+    (testing "when concatenateDefault is true"
+      (service-util/assert-collection-search-result coll2 {:has-combine true :service-features {:harmony {:has-combine true}}} [serv2-concept-id]))
+    (testing "when concatenateDefault is false"
+      (service-util/assert-collection-search-result coll3 {:has-combine false :service-features {:harmony {:has-combine false}}} [serv3-concept-id]))))

--- a/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/service/collection_service_search_test.clj
@@ -542,4 +542,4 @@
     (testing "when concatenateDefault is true"
       (service-util/assert-collection-search-result coll2 {:has-combine true :service-features {:harmony {:has-combine true}}} [serv2-concept-id]))
     (testing "when concatenateDefault is false"
-      (service-util/assert-collection-search-result coll3 {:has-combine false :service-features {:harmony {:has-combine false}}} [serv3-concept-id]))))
+      (service-util/assert-collection-search-result coll3 {:has-combine true :service-features {:harmony {:has-combine true}}} [serv3-concept-id]))))

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.0/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.0/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.1/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.1/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.10/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.11/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.11/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.12/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.12/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.13/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.13/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.14/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.14/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.1/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.1/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.2/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.2/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.3/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.4/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.4/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.5/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15.5/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.15/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.15/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.1/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.1/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.2/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.2/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.3/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.3/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.4/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.4/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.5/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.5/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.6/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.6/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.7/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16.7/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.16/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.16/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.0/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.0/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.1/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.1/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.2/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.2/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.3/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.17.3/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.2/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.2/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.3/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.3/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.4/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.4/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.5/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.5/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.6/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.6/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.7/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.7/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.8/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.8/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"

--- a/umm-spec-lib/resources/json-schemas/collection/umm/v1.9/umm-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/collection/umm/v1.9/umm-search-results-json-schema.json
@@ -79,6 +79,10 @@
           "description": "Indicates if there are transformations (subset, interpolation or projection) in any services associated with the collection",
           "type": "boolean"
         },
+        "has-combine": {
+          "description": "Indicates if there is concatenation available in any services associated with the collection",
+          "type": "boolean"
+        },
         "has-spatial-subsetting": {
           "description": "Indicates if any associated services support spatial subsetting",
           "type": "boolean"


### PR DESCRIPTION
Adds has_combine to umm_json, json, and atom coll search results to facilitate order option presentation on earthadata search.