### PR TITLE
CMR-9526 CVE-2023-36478

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -47,7 +47,7 @@
                            [org.clojure/clojure "1.10.0"]
                            [org.clojure/tools.reader "1.3.2"]
                            [ring/ring-codec "1.1.3"]
-                           [ring/ring-core "1.9.6"]
+                           [ring/ring-core "1.10.0"]
                            [ring/ring-json "0.5.1"]]
                          project-dependencies)
   :plugins [[lein-modules "0.3.11"]

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -34,7 +34,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [potemkin "0.4.5"]
                  [ring/ring-codec "1.1.3"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
             [lein-exec "0.3.7"]

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -17,7 +17,7 @@
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [com.vladsch.flexmark/flexmark-all "0.64.0"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]
                  [selmer "1.12.5"]]
   :plugins [[lein-shell "0.5.0"]]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -42,17 +42,17 @@
                  [org.clojure/tools.reader "1.3.2"]
                  ;; These dependencies should be updated in tandem with the ring dependencies below.
                  ;; To find the corresponding versions, see: https://clojars.org/ring/ring-core/versions/1.9.6
-                 [org.eclipse.jetty/jetty-http "9.4.48.v20220622"]
-                 [org.eclipse.jetty/jetty-io "9.4.48.v20220622"]
-                 [org.eclipse.jetty/jetty-servlets "9.4.48.v20220622"]
-                 [org.eclipse.jetty/jetty-util "9.4.48.v20220622"]
+                 [org.eclipse.jetty/jetty-http "9.4.53.v20231009"]
+                 [org.eclipse.jetty/jetty-io "9.4.53.v20231009"]
+                 [org.eclipse.jetty/jetty-servlets "9.4.53.v20231009"]
+                 [org.eclipse.jetty/jetty-util "9.4.53.v20231009"]
                  ;; load jts core lib first to make sure it is available for shapefile integration,
                  ;; otherwise ES referenced 1.15.0 version will be mistakenly picked for shapefile
                  [org.locationtech.jts/jts-core "1.18.2"]
                  [org.ow2.asm/asm "7.0"]
                  [potemkin "0.4.5"]
-                 [ring/ring-core "1.9.6"]
-                 [ring/ring-jetty-adapter "1.9.6"]
+                 [ring/ring-core "1.10.0"]
+                 [ring/ring-jetty-adapter "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :repositories [["jitpack.io" "https://jitpack.io"]]
   :plugins [[lein-exec "0.3.7"]

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -15,7 +15,7 @@
                  [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.nrepl "0.2.13"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[lein-shell "0.5.0"]]
   :repl-options {:init-ns user}

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -40,7 +40,7 @@
                  [org.yaml/snakeyaml "1.31"]
                  [potemkin "0.4.5"]
                  [ring/ring-codec "1.1.3"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
             [lein-exec "0.3.7"]]

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -29,7 +29,7 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [org.quartz-scheduler/quartz "2.3.2"]
                  [org.slf4j/slf4j-api "1.7.30"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
             [lein-exec "0.3.7"]

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -11,7 +11,7 @@
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.reader "1.3.2"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[lein-exec "0.3.7"]
             [lein-shell "0.5.0"]]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -44,7 +44,7 @@
                  [org.geotools.xsd/gt-xsd-kml "29.1"]
                  [org.mozilla/rhino "1.7.12"]
                  [ring/ring-codec "1.1.3"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]
                  [selmer "1.12.5"]
                  ;; Temporary inclusion of libraries needed for swagger UI until the dev portal is

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -51,7 +51,7 @@
                  [potemkin "0.4.5"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-codec "1.1.3"]
-                 [ring/ring-core "1.9.6"]]
+                 [ring/ring-core "1.10.0"]]
   :plugins [[lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"

--- a/system-int-test/test/cmr/system_int_test/search/granule_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_shapefile_search_test.clj
@@ -66,7 +66,7 @@
         "missing_shapefile_shp.zip" {:name "provider" :content "PROV1"} #"Incomplete shapefile: missing .shp file"
 
         "Shapefile is too big"
-        "too_big.zip" {:name "provider" :content "PROV1"} #"Shapefile size exceeds the 50000 byte limit"
+        "too_big.zip" {:name "provider" :content "PROV1"} #"Uploaded content exceeded limits."
 
         "Shapefile has too many features"
         "too_many_features.zip" {:name "provider" :content "PROV1"} #"Shapefile feature count \[3\] exceeds the 2 feature limit"

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -12,7 +12,7 @@
                  [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.nrepl "0.2.13"]
-                 [ring/ring-core "1.9.6"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-json "0.5.1"]]
   :plugins [[lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"


### PR DESCRIPTION
Update Jetty to 9.4.53.v20231009 (as indicated by the CVE resolution path)
Update Ring to 1.10.0, as a result of the Jetty update.
