### PR TITLE
CMR-9504 Moving Granule ACL Collection Cache to Redis

### DIFF
--- a/common-lib/src/cmr/common/cache.clj
+++ b/common-lib/src/cmr/common/cache.clj
@@ -12,7 +12,7 @@
   "Defines a protocol used for caching data."
   (get-keys
     [cache]
-    "Returns the list of keys for the given cache. The keys are conveted to non-keyword strings.")
+    "Returns the list of keys for the given cache. The keys are converted to non-keyword strings.")
 
   (get-value
     [cache key]
@@ -29,7 +29,7 @@
   (set-value
     [cache key value]
     "Associates the value in the cache with the given key.")
-  
+
   (cache-size
    [cache]
    "Returns the size of the cache in bytes."))

--- a/common-lib/src/cmr/common/cache/in_memory_cache.clj
+++ b/common-lib/src/cmr/common/cache/in_memory_cache.clj
@@ -102,7 +102,7 @@
   (set-value
     [this key value]
     (swap! cache-atom assoc key value))
-  
+
   (cache-size
    [_]
    (reduce + 0 (map size-in-bytes (vals @cache-atom)))))

--- a/common-lib/src/cmr/common/cache/in_memory_cache.clj
+++ b/common-lib/src/cmr/common/cache/in_memory_cache.clj
@@ -102,7 +102,6 @@
   (set-value
     [this key value]
     (swap! cache-atom assoc key value))
-
   (cache-size
    [_]
    (reduce + 0 (map size-in-bytes (vals @cache-atom)))))

--- a/common-lib/src/cmr/common/cache/in_memory_cache.clj
+++ b/common-lib/src/cmr/common/cache/in_memory_cache.clj
@@ -102,6 +102,7 @@
   (set-value
     [this key value]
     (swap! cache-atom assoc key value))
+
   (cache-size
    [_]
    (reduce + 0 (map size-in-bytes (vals @cache-atom)))))

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -737,13 +737,13 @@
       (sequential? v) (mapcat #(get-in-all %1 ks) v)
       :else (get-in-all v ks))))
 
-(defn- key->delay-name
+(defn key->delay-name
   "Returns the key that the delay is stored in for a lazy value"
   [k]
   {:pre [(keyword? k)]}
   (keyword (str "cmr.common.util/" (name k) "-delay")))
 
-(defn- delay-name->key
+(defn delay-name->key
   "Reverse key name"
   [key]
   {:pre [(keyword? key)]}

--- a/common-lib/test/cmr/common/test/generics.clj
+++ b/common-lib/test/cmr/common/test/generics.clj
@@ -14,8 +14,9 @@
     (cmr.common.util/are3
      [body]
      (let [one (do (cutil/time-execution body))
-           two (do (cutil/time-execution body))]
-       (is (<= (first two) (first one))))
+           two (do (cutil/time-execution body))
+           diff (- (first two) (first one))]
+       (is (<= diff 2) (format "durration was %d > %d" diff 2)))
 
      "approved"
      (gconfig/approved-generic? :grid "0.0.1")

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -553,6 +553,14 @@
     (testing "original key is not used"
       (is (= 3 (get my-map :a))))))
 
+(deftest delay-name-key-test
+  (testing "Check that a round trip on delay name keys can be made"
+    (doseq [expected (gen/sample gen/keyword)]
+      (let [actual (-> expected
+                     util/key->delay-name
+                     util/delay-name->key)]
+      (is (= expected actual) (str "round trip test failed with " expected))))))
+
 (deftest delazy-tests
   (let [test (-> {:unrelated "value to not touch"}
                   (util/lazy-assoc :base 10)

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -553,6 +553,21 @@
     (testing "original key is not used"
       (is (= 3 (get my-map :a))))))
 
+(deftest delazy-tests
+  (let [test (-> {:unrelated "value to not touch"}
+                  (util/lazy-assoc :base 10)
+                  (util/lazy-assoc :everything 42))]
+    (testing "check that a single values can be removed"
+      (let [actual (util/delazy-value test :base)]
+        (is (nil? (:everything actual)) "everything value was changed")
+        (is (= 10 (:base actual)) "base was not changed")
+        (is (= "value to not touch" (:unrelated actual)) "unrelated was touched")))
+
+    (testing "check that multiple lazy values can be removed"
+      (is (= {:unrelated "value to not touch" :base 10, :everything 42}
+             (util/delazy-all test))
+          "checking that only lazy values are converted"))))
+
 (deftest extract-between-strings-test
   (let [test-str "abcdefghjklmnopqrstuvwxyz"]
     (are [expected start end include-start-and-end?]

--- a/common-lib/test/cmr/common/test/util.clj
+++ b/common-lib/test/cmr/common/test/util.clj
@@ -557,7 +557,7 @@
   (let [test (-> {:unrelated "value to not touch"}
                   (util/lazy-assoc :base 10)
                   (util/lazy-assoc :everything 42))]
-    (testing "check that a single values can be removed"
+    (testing "check that a single value can be removed"
       (let [actual (util/delazy-value test :base)]
         (is (nil? (:everything actual)) "everything value was changed")
         (is (= 10 (:base actual)) "base was not changed")

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -62,18 +62,6 @@
    (doseq [the-key keys-to-track]
      (wcar* (carmine/del (serialize the-key)))))
 
-  ;(comment reset
-  ;  [this]
-  ;  ;; 💣 - as a test, check keys for nill
-  ;  (if (some? keys-to-track)
-  ;    ;;(assert (= clojure.lang.PersistentVector (type keys-to-track)))
-  ;    (doseq [the-key keys-to-track]
-  ;      (try
-  ;        (wcar* (carmine/del (serialize the-key)))
-  ;        (catch Exception e
-  ;          (error "Exception in reset of redis cache on behalf of"
-  ;                 the-key ": " (.getMessage e)))))))
-
   (set-value
     [this key value]
     ;; Store value in map to aid deserialization of numbers.

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -7,7 +7,7 @@
   (:require
    [clojure.edn :as edn]
    [cmr.common.cache :as cache]
-   [cmr.common.log :as log :refer [debug info warn error]] 
+   [cmr.common.log :as log :refer [debug info warn error]]
    [cmr.redis-utils.redis :as redis :refer [wcar*]]
    [taoensso.carmine :as carmine]))
 
@@ -59,12 +59,16 @@
 
   (reset
    [this]
-   (doseq [the-key keys-to-track]
-     (try
-       (wcar* (carmine/del (serialize the-key)))
-       (catch Exception e
-         (error "Exception in reset of redis cache on behalf of"
-                  the-key ": " (.getMessage e))))))
+   ;; 💣 - as a test, check keys for nill
+   ;;(println "🚀 - " keys-to-track "is of type" (type keys-to-track))
+   (if (some? keys-to-track)
+     (assert (= clojure.lang.PersistentVector (type keys-to-track)))
+     (doseq [the-key keys-to-track]
+       (try
+         (wcar* (carmine/del (serialize the-key)))
+         (catch Exception e
+           (error "Exception in reset of redis cache on behalf of"
+                  the-key ": " (.getMessage e)))))))
 
   (set-value
     [this key value]

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -58,9 +58,9 @@
           value))))
 
   (reset
-   [this]
-   (doseq [the-key keys-to-track]
-     (wcar* (carmine/del (serialize the-key)))))
+    [this]
+    (doseq [the-key keys-to-track]
+      (wcar* (carmine/del (serialize the-key)))))
 
   (set-value
     [this key value]
@@ -68,10 +68,11 @@
     (let [s-key (serialize key)]
       (wcar* (carmine/set s-key {:value value})
              (when ttl (carmine/expire s-key ttl)))))
+
   (cache-size
-   [_]
-   ;; not relevant for redis
-   -1))
+    [_]
+    ;; not relevant for redis
+    -1))
 
 (defn create-redis-cache
   "Creates an instance of the redis cache.

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -59,16 +59,20 @@
 
   (reset
    [this]
-   ;; 💣 - as a test, check keys for nill
-   ;;(println "🚀 - " keys-to-track "is of type" (type keys-to-track))
-   (if (some? keys-to-track)
-     (assert (= clojure.lang.PersistentVector (type keys-to-track)))
-     (doseq [the-key keys-to-track]
-       (try
-         (wcar* (carmine/del (serialize the-key)))
-         (catch Exception e
-           (error "Exception in reset of redis cache on behalf of"
-                  the-key ": " (.getMessage e)))))))
+   (doseq [the-key keys-to-track]
+     (wcar* (carmine/del (serialize the-key)))))
+
+  ;(comment reset
+  ;  [this]
+  ;  ;; 💣 - as a test, check keys for nill
+  ;  (if (some? keys-to-track)
+  ;    ;;(assert (= clojure.lang.PersistentVector (type keys-to-track)))
+  ;    (doseq [the-key keys-to-track]
+  ;      (try
+  ;        (wcar* (carmine/del (serialize the-key)))
+  ;        (catch Exception e
+  ;          (error "Exception in reset of redis cache on behalf of"
+  ;                 the-key ": " (.getMessage e)))))))
 
   (set-value
     [this key value]

--- a/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
@@ -44,8 +44,7 @@
           start-date1 :start-date
           end-date1 :end-date} :_source} elastic-result
         start-date (parse-elastic-datetime start-date1)
-        end-date (parse-elastic-datetime end-date1)
-        ]
+        end-date (parse-elastic-datetime end-date1)]
     (-> {:concept-type concept-type
          :provider-id provider-id
          :EntryTitle entry-title}

--- a/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
@@ -41,20 +41,26 @@
   (let [{{entry-title :entry-title
           provider-id :provider-id
           access-value :access-value
-          start-date :start-date
-          end-date :end-date} :_source} elastic-result
-        start-date (parse-elastic-datetime start-date)
-        end-date (parse-elastic-datetime end-date)]
-
+          start-date1 :start-date
+          end-date1 :end-date} :_source} elastic-result
+        start-date (parse-elastic-datetime start-date1)
+        end-date (parse-elastic-datetime end-date1)
+        ]
+    (println "raw dates in parse elastic item" start-date1 end-date1)
     (-> {:concept-type concept-type
          :provider-id provider-id
          :EntryTitle entry-title}
-        (u/lazy-assoc :AccessConstraints {:Value access-value})
-        (u/lazy-assoc :TemporalExtents
-                      (let [start-date (parse-elastic-datetime start-date)
-                            end-date (parse-elastic-datetime end-date)]
-                        [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date
-                                                             :EndingDateTime end-date}])}])))))
+        (assoc :AccessConstraints {:Value access-value})
+        ;;(u/lazy-assoc :AccessConstraints {:Value access-value})
+        (assoc :TemporalExtents [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date1
+                                                                     :EndingDateTime end-date1}])}])
+        ;(u/lazy-assoc :TemporalExtents
+        ;              (let [start-date (parse-elastic-datetime start-date)
+        ;                    end-date (parse-elastic-datetime end-date)]
+        ;                [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date
+        ;                                                     :EndingDateTime end-date}])}]))
+
+        )))
 
 (defmethod parse-elastic-item :granule
   [concept-type elastic-result]

--- a/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
@@ -41,19 +41,19 @@
   (let [{{entry-title :entry-title
           provider-id :provider-id
           access-value :access-value
-          start-date1 :start-date
-          end-date1 :end-date} :_source} elastic-result
-        start-date (parse-elastic-datetime start-date1)
-        end-date (parse-elastic-datetime end-date1)]
+          start-date :start-date
+          end-date :end-date} :_source} elastic-result
+        elastic-start-date (parse-elastic-datetime start-date)
+        elastic-end-date (parse-elastic-datetime end-date)]
     (-> {:concept-type concept-type
          :provider-id provider-id
          :EntryTitle entry-title}
         (u/lazy-assoc :AccessConstraints {:Value access-value})
         (u/lazy-assoc :TemporalExtents
-                      (let [start-date (parse-elastic-datetime start-date)
-                            end-date (parse-elastic-datetime end-date)]
-                        [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date
-                                                             :EndingDateTime end-date}])}])))))
+                      (let [elastic-start-date (parse-elastic-datetime elastic-start-date)
+                            elastic-end-date (parse-elastic-datetime elastic-end-date)]
+                        [{:RangeDateTimes (when elastic-start-date [{:BeginningDateTime elastic-start-date
+                                                             :EndingDateTime elastic-end-date}])}])))))
 
 (defmethod parse-elastic-item :granule
   [concept-type elastic-result]

--- a/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
@@ -46,7 +46,6 @@
         start-date (parse-elastic-datetime start-date1)
         end-date (parse-elastic-datetime end-date1)
         ]
-    (println "raw dates in parse elastic item" start-date1 end-date1)
     (-> {:concept-type concept-type
          :provider-id provider-id
          :EntryTitle entry-title}

--- a/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
+++ b/search-app/src/cmr/search/services/acls/acl_results_handler_helper.clj
@@ -50,17 +50,12 @@
     (-> {:concept-type concept-type
          :provider-id provider-id
          :EntryTitle entry-title}
-        (assoc :AccessConstraints {:Value access-value})
-        ;;(u/lazy-assoc :AccessConstraints {:Value access-value})
-        (assoc :TemporalExtents [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date1
-                                                                     :EndingDateTime end-date1}])}])
-        ;(u/lazy-assoc :TemporalExtents
-        ;              (let [start-date (parse-elastic-datetime start-date)
-        ;                    end-date (parse-elastic-datetime end-date)]
-        ;                [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date
-        ;                                                     :EndingDateTime end-date}])}]))
-
-        )))
+        (u/lazy-assoc :AccessConstraints {:Value access-value})
+        (u/lazy-assoc :TemporalExtents
+                      (let [start-date (parse-elastic-datetime start-date)
+                            end-date (parse-elastic-datetime end-date)]
+                        [{:RangeDateTimes (when start-date [{:BeginningDateTime start-date
+                                                             :EndingDateTime end-date}])}])))))
 
 (defmethod parse-elastic-item :granule
   [concept-type elastic-result]

--- a/search-app/src/cmr/search/services/acls/collections_cache.clj
+++ b/search-app/src/cmr/search/services/acls/collections_cache.clj
@@ -21,10 +21,24 @@
   "The initial cache state."
   nil)
 
+(def job-refresh-rate
+  "This is the frequency that the cron job will run. It should be less then
+   coll-for-gran-acl-ttl"
+  ;; 15 minutes
+  (* 15 60))
+
+(def coll-for-gran-acl-ttl
+  "This is when Redis should expire the data, this value should never be hit if
+   the cron job is working correctly, however in some modes (such as local dev
+   with no database) it may come into play."
+  ;; 30 minutes
+  (* 30 60))
+
 (defn create-cache
   "Creates a new empty collections cache."
   []
-  (redis-cache/create-redis-cache {:keys-to-track [:collections-for-gran-acls] :ttl (* 15 60)}))
+  (redis-cache/create-redis-cache {:keys-to-track [:collections-for-gran-acls]
+                                   :ttl coll-for-gran-acl-ttl}))
 
 (defn clj-times->time-strs
   "Take a map and convert any date objects into strings so the map can be cached.
@@ -120,5 +134,4 @@
 
 (def refresh-collections-cache-for-granule-acls-job
   {:job-type RefreshCollectionsCacheForGranuleAclsJob
-   ;; 15 minutes
-   :interval (* 15 60)})
+   :interval job-refresh-rate})

--- a/search-app/src/cmr/search/services/acls/collections_cache.clj
+++ b/search-app/src/cmr/search/services/acls/collections_cache.clj
@@ -4,13 +4,11 @@
             [cmr.common.jobs :refer [defjob]]
             [cmr.common.log :as log :refer (debug info warn error)]
             [cmr.common.cache :as cache]
-            [cmr.common.cache.in-memory-cache :as mem-cache]
             [cmr.common-app.services.search.query-model :as q]
             [cmr.common-app.services.search.query-execution :as qe]
             [cmr.redis-utils.redis-cache :as redis-cache]
             [cmr.search.services.acls.acl-results-handler-helper :as acl-rhh]
             [cmr.common.util :as u]
-            [clojure.pprint :as pp]
             [clojure.walk :as walk]
             [cmr.common.util :as util]))
 
@@ -29,6 +27,8 @@
   (redis-cache/create-redis-cache {:keys-to-track [:collections-for-gran-acls] :ttl (* 15 60)}))
 
 (defn- clj-times->time-strs
+  "Take a map and convert any date objects into strings so the map can be cached.
+   This can be reversed with time-strs->clj-times."
   [data]
   (walk/postwalk
    #(if (true? (instance? org.joda.time.DateTime %))
@@ -37,6 +37,8 @@
    data))
 
 (defn- time-strs->clj-times
+  "Take a map which has string dates and convert them to DateTime objects. This
+   can be reversed with clj-times->time-strs."
   [data]
   (walk/postwalk
    #(if (and (instance? String %) (cmr.common.date-time-parser/try-parse-datetime %))

--- a/search-app/src/cmr/search/services/acls/collections_cache.clj
+++ b/search-app/src/cmr/search/services/acls/collections_cache.clj
@@ -25,8 +25,7 @@
   "Creates a new empty collections cache."
   []
   ;;(mem-cache/create-in-memory-cache)
-  (println "loading redis cache for collections")
-  (redis-cache/create-redis-cache {:keys-to-track :collections-for-gran-acls :ttl (* 15 60)}))
+  (redis-cache/create-redis-cache {:keys-to-track [:collections-for-gran-acls] :ttl (* 15 60)}))
 
 (defn- fetch-collections
   "Executes a query that will fetch all of the collection information needed for caching."

--- a/search-app/test/cmr/search/test/unit/services/acls/collections_cache.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/collections_cache.clj
@@ -1,0 +1,23 @@
+(ns cmr.search.test.unit.services.acls.collections-cache
+  (:require
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [cmr.search.services.acls.collections-cache :as coll-cache]))
+
+(defn- random-text
+  "Create a random string by combining all the values from gen/string-alphanumeric"
+  []
+  (apply str (vec (gen/sample gen/string-alphanumeric))))
+
+(deftest make-dates-safe-for-serialize-test
+  "Confirm that an object can be serialized to text and then back"
+  (testing "round trip"
+    (let [some-text (random-text)
+          some-date "2024-12-31T4:3:2"
+          supplied-data {:point-of-time some-date :a-field some-text}
+          expected-date "2024-12-31T04:03:02.000Z"
+          actual (-> supplied-data
+                     coll-cache/time-strs->clj-times
+                     coll-cache/clj-times->time-strs)]
+      (is (= some-text (:a-field actual)) "field should not change")
+      (is (= expected-date (str (:point-of-time actual))) "Date should exist"))))

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -3,7 +3,12 @@
             [cmr.common.cache :as cache]
             [cmr.search.services.acls.granule-acls :as g]
             [cmr.search.services.acls.collections-cache :as coll-cache]
-            [cmr.common.cache.in-memory-cache :as mem-cache]))
+            [cmr.common.cache.in-memory-cache :as mem-cache]
+            [cmr.redis-utils.test.test-util :as test-util]
+            [cmr.common.util :as util :refer [are3]]
+            [cmr.search.services.acl-service :as acl-service]))
+
+(use-fixtures :once test-util/embedded-redis-server-fixture)
 
 (defn access-value
   "Creates an access value filter"
@@ -72,8 +77,8 @@
 
 (deftest acl-match-granule-concept-test
   (testing "provider ids"
-    (is (not (g/acl-match-concept? {} (make-acl "P1") (concept "P2" "C2-P2"))))
-    (is (g/acl-match-concept? {} (make-acl "P1") (concept "P1" "C2-P1"))))
+    (is (not (g/acl-match-concept? {} (make-acl "P1") (concept "P2" "C2-P2"))) "not same provider failed")
+    (is (g/acl-match-concept? {} (make-acl "P1") (concept "P1" "C2-P1")) "is same provider failed"))
 
   (let [collections [["C1-P1" "coll1" nil]
                      ["C2-P1" "coll2" 1]
@@ -82,99 +87,128 @@
                      ["C5-P2" "coll2" 1]]
         context (context-with-cached-collections
                   (for [coll-args collections]
-                    (apply collection coll-args)))]
+                    (apply collection coll-args)))
+        ;; setup the redis cache (rcache) from the memory cache
+        rcache (cmr.search.services.acls.collections-cache/create-cache)
+        old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
+        context (assoc-in context [:system :caches :collections-for-gran-acls] rcache)
+        data (.get-value old-mem-cache :collections)]
+    (.set-value rcache :collections-for-gran-acls data)
+
     (testing "collection identifier"
-      (are [entry-titles access-value-args collection-concept-id should-match?]
-           (let [access-value-filter (when access-value-args (apply access-value access-value-args))
-                 coll-identifier (coll-id entry-titles access-value-filter)
-                 acl (make-acl "P1" coll-identifier)
-                 granule (concept "P1" collection-concept-id)
-                 matches? (not (not (g/acl-match-concept? context acl granule)))]
-             (when-not (= should-match? matches?)
-               (println "context" (pr-str context))
-               (println "acl" (pr-str acl))
-               (println "granule" (pr-str granule)))
-             (= should-match? matches?))
+      (are3 [entry-titles access-value-args collection-concept-id should-match?]
+            (let [access-value-filter (when access-value-args (apply access-value access-value-args))
+                  coll-identifier (coll-id entry-titles access-value-filter)
+                  acl (make-acl "P1" coll-identifier)
+                  granule (concept "P1" collection-concept-id)
+                  matches? (not (not (g/acl-match-concept? context acl granule)))]
+              (is (= should-match? matches?) "match failed"))
 
-           ["coll1"] nil "C1-P1" true
+            "all good"
+            ["coll1"] nil "C1-P1" true
 
-           ;; collection doesn't exist
-           ["foo"] nil "C1-P1" false
-           ["foo" "coll2"] nil "C1-P1" false
-           ["foo" "coll1"] nil "C1-P1" true
+            ;; collection doesn't exist
+            "foo"
+            ["foo"] nil "C1-P1" false
+            "coll2"
+            ["foo" "coll2"] nil "C1-P1" false
+            "found with coll1"
+            ["foo" "coll1"] nil "C1-P1" true
 
-           ;;access value filter
-           ;; this is checked more completely in collection matcher tests
-           nil [1 2] "C2-P1" true
-           nil [1 2] "C1-P1" false
+            ;;access value filter
+            ;; this is checked more completely in collection matcher tests
+            "c2 check"
+            nil [1 2] "C2-P1" true
+            "c1 check"
+            nil [1 2] "C1-P1" false
 
-           ["foo" "coll2" "coll1"] [1 2] "C1-P1" false
-           ["foo" "coll2" "coll1"] [1 2] "C2-P1" true))
+            "c1 check"
+            ["foo" "coll2" "coll1"] [1 2] "C1-P1" false
+            "c2 check"
+            ["foo" "coll2" "coll1"] [1 2] "C2-P1" true))
 
     (testing "collection identifier and granule access-value"
-      (are [entry-titles access-value-args collection-concept-id gran-access-value should-match?]
-           (let [granule-identifier (gran-id (apply access-value access-value-args))
-                 coll-identifier (coll-id entry-titles nil)
-                 acl (make-acl "P1" coll-identifier granule-identifier)
-                 granule (concept "P1" collection-concept-id gran-access-value)
-                 matches? (not (not (g/acl-match-concept? context acl granule)))]
-             (when-not (= should-match? matches?)
-               (println "context" (pr-str context))
-               (println "acl" (pr-str acl))
-               (println "granule" (pr-str granule)))
-             (= should-match? matches?))
+      (are3
+       [entry-titles access-value-args collection-concept-id gran-access-value should-match?]
+       (let [granule-identifier (gran-id (apply access-value access-value-args))
+             coll-identifier (coll-id entry-titles nil)
+             acl (make-acl "P1" coll-identifier granule-identifier)
+             granule (concept "P1" collection-concept-id gran-access-value)
+             matches? (not (not (g/acl-match-concept? context acl granule)))]
+         (is (= should-match? matches?) "match failed"))
 
-           ["coll1"] [1 2] "C1-P1" 1 true
+       "- access value is good"
+       ["coll1"] [1 2] "C1-P1" 1 true
 
-           ;; access value outside range
-           ["coll1"] [1 2] "C1-P1" 3 false
+       "- access value outside range"
+       ["coll1"] [1 2] "C1-P1" 3 false
 
-           ;; different collection
-           ["coll1"] [1 2] "C2-P1" 1 false
+       "- different collection"
+       ["coll1"] [1 2] "C2-P1" 1 false
 
-           ;; collection doesn't exist
-           ["foo"] [1 2] "C1-P1" 1 false)))
-
+       "- collection does not exist"
+       ["foo"] [1 2] "C1-P1" 1 false)))
 
   (testing "granule access value"
-    (are [access-value-args gran-value should-match?]
-         (let [acl (make-acl "P1" nil (gran-id (apply access-value access-value-args)))
-               granule (concept "P1" "C1-P1" gran-value)
-               ;; not not makes truthy values true or false
-               matches? (not (not (g/acl-match-concept? {} acl granule)))]
-           (when-not (= should-match? matches?)
-             (println "acl" (pr-str acl))
-             (println "granule" (pr-str granule)))
-           (= should-match? matches?))
+    (are3
+     [access-value-args gran-value should-match?]
+     (let [acl (make-acl "P1" nil (gran-id (apply access-value access-value-args)))
+           granule (concept "P1" "C1-P1" gran-value)
+           ;; not not makes truthy values true or false
+           matches? (not (not (g/acl-match-concept? {} acl granule)))]
+       (is (= should-match? matches?)) "match failed")
 
-         ;; include undefined
-         [1 2 true] nil true
-         [nil nil true] 3 false
-         [1 2 true] 3 false
-         [1 2 true] 2 true
+     "include undefined"
+     [1 2 true] nil true
 
-         ;; just min
-         [7 nil] 7.0 true
-         [7 nil] 7 true
-         [7 nil] 7.1 true
-         [7 nil] 8 true
-         [7 nil] 6.999 false
-         [7 nil] -7.999 false
+     "no value"
+     [nil nil true] 3 false
+     "outside"
+     [1 2 true] 3 false
+     "on edge"
+     [1 2 true] 2 true
 
-         ;; just max
-         [nil 8] 8.0 true
-         [nil 8] 8 true
-         [nil 8] 8.1 false
-         [nil 8] 7 true
-         [nil 8] 7.999 true
-         [nil 8] -8.1 true
+     "just min - 7.0"
+     [7 nil] 7.0 true
+     "min - 7"
+     [7 nil] 7 true
+     "min - just inside"
+     [7 nil] 7.1 true
+     "min - well over"
+     [7 nil] 8 true
+     "min - just under"
+     [7 nil] 6.999 false
+     "min - way under"
+     [7 nil] -7.999 false
 
-         ;; min and max
-         [5 7] 5 true
-         [5 7] 5.0 true
-         [5 7] 7.0 true
-         [5 7] 6 true
-         [5 7] 5.5 true
-         [5 7] 7.2 false
-         [5 7] 4.2 false
-         [5 7] -7.2 false)))
+     ;;just max
+     "Right on max"
+     [nil 8] 8.0 true
+     "on max"
+     [nil 8] 8 true
+     "just over max"
+     [nil 8] 8.1 false
+     "under max"
+     [nil 8] 7 true
+     "just under max"
+     [nil 8] 7.999 true
+     "way under max"
+     [nil 8] -8.1 true
+
+     ;; min and max
+     "on min"
+     [5 7] 5 true
+     "exact on min"
+     [5 7] 5.0 true
+     "on max"
+     [5 7] 7.0 true
+     "between"
+     [5 7] 6 true
+     "just between, min side"
+     [5 7] 5.5 true
+     "just over max"
+     [5 7] 7.2 false
+     "just under min"
+     [5 7] 4.2 false
+     "way under min"
+     [5 7] -7.2 false)))

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -1,10 +1,10 @@
 (ns cmr.search.test.unit.services.acls.granule-acls
   (:require [clojure.test :refer :all]
-            [cmr.search.services.acls.granule-acls :as g]
-            [cmr.search.services.acls.collections-cache :as coll-cache]
             [cmr.common.cache.in-memory-cache :as mem-cache]
+            [cmr.common.util :as util :refer [are3]]
             [cmr.redis-utils.test.test-util :as test-util]
-            [cmr.common.util :as util :refer [are3]]))
+            [cmr.search.services.acls.collections-cache :as coll-cache]
+            [cmr.search.services.acls.granule-acls :as g]))
 
 (use-fixtures :once test-util/embedded-redis-server-fixture)
 

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -1,12 +1,10 @@
 (ns cmr.search.test.unit.services.acls.granule-acls
   (:require [clojure.test :refer :all]
-            [cmr.common.cache :as cache]
             [cmr.search.services.acls.granule-acls :as g]
             [cmr.search.services.acls.collections-cache :as coll-cache]
             [cmr.common.cache.in-memory-cache :as mem-cache]
             [cmr.redis-utils.test.test-util :as test-util]
-            [cmr.common.util :as util :refer [are3]]
-            [cmr.search.services.acl-service :as acl-service]))
+            [cmr.common.util :as util :refer [are3]]))
 
 (use-fixtures :once test-util/embedded-redis-server-fixture)
 

--- a/system-int-test/src/cmr/system_int_test/utils/dev_system_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/dev_system_util.clj
@@ -26,7 +26,6 @@
     (client/post (url/dev-system-reset-url) (admin-connect-options))
     (index/refresh-elastic-index)
     (catch Exception e
-      (println "Failed to send reset to dev-system")
       (error "Failed to send reset to dev-system\n" e)
       (throw e))))
 

--- a/system-int-test/src/cmr/system_int_test/utils/dev_system_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/dev_system_util.clj
@@ -5,6 +5,7 @@
    [clj-http.client :as client]
    [clojure.string :as str]
    [clojure.test :refer [is]]
+   [cmr.common.log :as log :refer [debug info warn error]]
    [cmr.common.util :as util]
    [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
    [cmr.system-int-test.system :as s]
@@ -21,8 +22,13 @@
   "Resets the database, queues, and the elastic indexes"
   []
   (qb-side-api/wait-for-terminal-states)
-  (client/post (url/dev-system-reset-url) (admin-connect-options))
-  (index/refresh-elastic-index))
+  (try
+    (client/post (url/dev-system-reset-url) (admin-connect-options))
+    (index/refresh-elastic-index)
+    (catch Exception e
+      (println "Failed to send reset to dev-system")
+      (error "Failed to send reset to dev-system\n" e)
+      (throw e))))
 
 (defn eval-in-dev-sys*
   "Evaluates the code given in dev system"

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -15,8 +15,6 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.url-helper :as url]))
 
-;; 💣 - try to add redis and see if this fixes test
-
 (use-fixtures
   :each (ingest/reset-fixture
          {"prov1guid" "PROV1" "prov2guid" "PROV2" "prov3guid" "PROV3"}))

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -6,6 +6,7 @@
    [clojure.test :refer :all]
    [cmr.common.config :as common-config]
    [cmr.mock-echo.client.echo-util :as e]
+   [cmr.redis-utils.test.test-util :as test-util]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.system :as s]
@@ -13,8 +14,10 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.url-helper :as url]))
 
-(use-fixtures :each (ingest/reset-fixture
-                     {"prov1guid" "PROV1" "prov2guid" "PROV2" "prov3guid" "PROV3"}))
+(use-fixtures
+  :each (ingest/reset-fixture
+         {"prov1guid" "PROV1" "prov2guid" "PROV2" "prov3guid" "PROV3"})
+  :once test-util/embedded-redis-server-fixture)
 
 (deftest cache-apis
   ;; login as a member of group 1

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
@@ -148,16 +148,16 @@
         (are3 [token grans colls]
           (let [concept-ids all-gran-concept-ids
                 gran-atom (da/granules->expected-atom
-                            grans colls
-                            (str "granules.atom?"
+                           grans colls
+                           (str "granules.atom?"
                                 (when token (str "token=" token "&"))
                                 "page_size=100&concept_id="
                                 (str/join "&concept_id=" concept-ids)))]
             (is (= gran-atom (:results (search/find-concepts-atom
                                         :granule (util/remove-nil-keys
                                                   {:token token
-                                                    :page-size 100
-                                                    :concept-id concept-ids}))))))
+                                                   :page-size 100
+                                                   :concept-id concept-ids}))))))
           "Guests find nothing" nil [] []
           "group1" user1 group1-granules group1-colls
           "group2" user2 group2-granules group2-colls

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
@@ -126,73 +126,73 @@
 
       (testing "Collection temporal as applied to granule searches"
         (are2 [token items]
-              (d/refs-match? items (search/find-refs :granule (when token {:token token})))
-              "Guests find nothing"
-              nil []
-              "group1" user1 group1-granules
-              "group2" user2 group2-granules
-              "group3" user3 group3-granules
-              "group4" user4 group4-granules))
+          (d/refs-match? items (search/find-refs :granule (when token {:token token})))
+          "Guests find nothing"
+          nil []
+          "group1" user1 group1-granules
+          "group2" user2 group2-granules
+          "group3" user3 group3-granules
+          "group4" user4 group4-granules))
 
       (testing "Parameter searching ACL enforcement"
         (are2 [token items]
-              (d/refs-match? items (search/find-refs :collection (when token {:token token})))
-              "Guests find nothing"
-              nil []
-              "group1" user1 group1-colls
-              "group2" user2 group2-colls
-              "group3" user3 group3-colls
-              "group4" user4 group4-colls))
+          (d/refs-match? items (search/find-refs :collection (when token {:token token})))
+          "Guests find nothing"
+          nil []
+          "group1" user1 group1-colls
+          "group2" user2 group2-colls
+          "group3" user3 group3-colls
+          "group4" user4 group4-colls))
 
       (testing "Granule ACL Enforcement by concept id"
         (are3 [token grans colls]
-              (let [concept-ids all-gran-concept-ids
-                    gran-atom (da/granules->expected-atom
-                               grans colls
-                               (str "granules.atom?"
-                                    (when token (str "token=" token "&"))
-                                    "page_size=100&concept_id="
-                                    (str/join "&concept_id=" concept-ids)))]
-                (is (= gran-atom (:results (search/find-concepts-atom
-                                            :granule (util/remove-nil-keys
-                                                      {:token token
-                                                       :page-size 100
-                                                       :concept-id concept-ids}))))))
-              "Guests find nothing" nil [] []
-              "group1" user1 group1-granules group1-colls
-              "group2" user2 group2-granules group2-colls
-              "group3" user3 group3-granules group3-colls
-              "group4" user4 group4-granules group4-colls))
+          (let [concept-ids all-gran-concept-ids
+                gran-atom (da/granules->expected-atom
+                            grans colls
+                            (str "granules.atom?"
+                                (when token (str "token=" token "&"))
+                                "page_size=100&concept_id="
+                                (str/join "&concept_id=" concept-ids)))]
+            (is (= gran-atom (:results (search/find-concepts-atom
+                                        :granule (util/remove-nil-keys
+                                                  {:token token
+                                                    :page-size 100
+                                                    :concept-id concept-ids}))))))
+          "Guests find nothing" nil [] []
+          "group1" user1 group1-granules group1-colls
+          "group2" user2 group2-granules group2-colls
+          "group3" user3 group3-granules group3-colls
+          "group4" user4 group4-granules group4-colls))
 
       (testing "Collection ATOM ACL Enforcement by concept id"
         (are2 [token colls]
-              (= (set (map :entry-title colls))
-                 (atom-results->title-set
-                  (search/find-concepts-atom
-                   :collection (util/remove-nil-keys
-                                {:token token
-                                 :page-size 100
-                                 :concept-id all-coll-concept-ids}))))
-              "Guests find nothing" nil []
-              "group1" user1 group1-colls
-              "group2" user2 group2-colls
-              "group3" user3 group3-colls
-              "group4" user4 group4-colls))
+          (= (set (map :entry-title colls))
+              (atom-results->title-set
+              (search/find-concepts-atom
+                :collection (util/remove-nil-keys
+                            {:token token
+                              :page-size 100
+                              :concept-id all-coll-concept-ids}))))
+          "Guests find nothing" nil []
+          "group1" user1 group1-colls
+          "group2" user2 group2-colls
+          "group3" user3 group3-colls
+          "group4" user4 group4-colls))
 
       (testing "Collection JSON ACL Enforcement by concept id"
         (are2 [token colls]
-              (= (set (map :entry-title colls))
-                 (atom-results->title-set
-                  (search/find-concepts-json
-                   :collection (util/remove-nil-keys
-                                {:token token
-                                 :page-size 100
-                                 :concept-id all-coll-concept-ids}))))
-              "Guests find nothing" nil []
-              "group1" user1 group1-colls
-              "group2" user2 group2-colls
-              "group3" user3 group3-colls
-              "group4" user4 group4-colls))
+          (= (set (map :entry-title colls))
+              (atom-results->title-set
+              (search/find-concepts-json
+                :collection (util/remove-nil-keys
+                            {:token token
+                              :page-size 100
+                              :concept-id all-coll-concept-ids}))))
+          "Guests find nothing" nil []
+          "group1" user1 group1-colls
+          "group2" user2 group2-colls
+          "group3" user3 group3-colls
+          "group4" user4 group4-colls))
 
       (testing "Collection OpenData ACL Enforcement by concept id"
         (let [open-data-results (search/find-concepts-opendata :collection {:token user1
@@ -277,52 +277,52 @@
 
       (testing "ATOM ACL Enforcement by concept id"
         (are2 [token items]
-              (let [concept-ids (map :concept-id all-grans)
-                    expected-urs (set (map :granule-ur items))]
-                (is (= expected-urs
-                       (atom-results->title-set (search/find-concepts-atom
-                                                 :granule (util/remove-nil-keys
-                                                           {:token token
-                                                            :page-size 100
-                                                            :concept-id concept-ids}))))))
-              "Guests find nothing" nil []
-              "group1" user1 group1-granules
-              "group2" user2 group2-granules
-              "group3" user3 group3-granules
-              "group4" user4 group4-granules))
+          (let [concept-ids (map :concept-id all-grans)
+                expected-urs (set (map :granule-ur items))]
+            (is (= expected-urs
+                    (atom-results->title-set (search/find-concepts-atom
+                                              :granule (util/remove-nil-keys
+                                                        {:token token
+                                                        :page-size 100
+                                                        :concept-id concept-ids}))))))
+          "Guests find nothing" nil []
+          "group1" user1 group1-granules
+          "group2" user2 group2-granules
+          "group3" user3 group3-granules
+          "group4" user4 group4-granules))
 
       (testing "JSON ACL Enforcement by concept id"
         (are2 [token items]
-              (let [concept-ids (map :concept-id all-grans)
-                    expected-urs (set (map :granule-ur items))]
-                (is (= expected-urs
-                       (atom-results->title-set (search/find-concepts-json
-                                                 :granule (util/remove-nil-keys
-                                                           {:token token
-                                                            :page-size 100
-                                                            :concept-id concept-ids}))))))
-              "Guests find nothing" nil []
-              "group1" user1 group1-granules
-              "group2" user2 group2-granules
-              "group3" user3 group3-granules
-              "group4" user4 group4-granules))
+          (let [concept-ids (map :concept-id all-grans)
+                expected-urs (set (map :granule-ur items))]
+            (is (= expected-urs
+                    (atom-results->title-set (search/find-concepts-json
+                                              :granule (util/remove-nil-keys
+                                                        {:token token
+                                                        :page-size 100
+                                                        :concept-id concept-ids}))))))
+          "Guests find nothing" nil []
+          "group1" user1 group1-granules
+          "group2" user2 group2-granules
+          "group3" user3 group3-granules
+          "group4" user4 group4-granules))
 
       (testing "CSV ACL Enforcement by concept id"
         (are2 [token items]
-              (let [concept-ids (map :concept-id all-grans)]
-                (= (set (map :granule-ur items))
-                   (set (search/csv-response->granule-urs
-                         (search/find-concepts-csv
-                          :granule
-                          (util/remove-nil-keys
-                           {:token token
-                            :page-size 100
-                            :concept-id concept-ids}))))))
-              "Guests find nothing" nil []
-              "group1" user1 group1-granules
-              "group2" user2 group2-granules
-              "group3" user3 group3-granules
-              "group4" user4 group4-granules))
+          (let [concept-ids (map :concept-id all-grans)]
+            (= (set (map :granule-ur items))
+                (set (search/csv-response->granule-urs
+                      (search/find-concepts-csv
+                      :granule
+                      (util/remove-nil-keys
+                        {:token token
+                        :page-size 100
+                        :concept-id concept-ids}))))))
+          "Guests find nothing" nil []
+          "group1" user1 group1-granules
+          "group2" user2 group2-granules
+          "group3" user3 group3-granules
+          "group4" user4 group4-granules))
 
       (testing "Direct transformer retrieval acl enforcement"
         (d/assert-metadata-results-match

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
@@ -167,12 +167,12 @@
       (testing "Collection ATOM ACL Enforcement by concept id"
         (are2 [token colls]
           (= (set (map :entry-title colls))
-              (atom-results->title-set
+             (atom-results->title-set
               (search/find-concepts-atom
-                :collection (util/remove-nil-keys
+               :collection (util/remove-nil-keys
                             {:token token
-                              :page-size 100
-                              :concept-id all-coll-concept-ids}))))
+                             :page-size 100
+                             :concept-id all-coll-concept-ids}))))
           "Guests find nothing" nil []
           "group1" user1 group1-colls
           "group2" user2 group2-colls
@@ -182,12 +182,12 @@
       (testing "Collection JSON ACL Enforcement by concept id"
         (are2 [token colls]
           (= (set (map :entry-title colls))
-              (atom-results->title-set
+             (atom-results->title-set
               (search/find-concepts-json
-                :collection (util/remove-nil-keys
+               :collection (util/remove-nil-keys
                             {:token token
-                              :page-size 100
-                              :concept-id all-coll-concept-ids}))))
+                             :page-size 100
+                             :concept-id all-coll-concept-ids}))))
           "Guests find nothing" nil []
           "group1" user1 group1-colls
           "group2" user2 group2-colls
@@ -313,11 +313,11 @@
             (= (set (map :granule-ur items))
                 (set (search/csv-response->granule-urs
                       (search/find-concepts-csv
-                      :granule
-                      (util/remove-nil-keys
+                       :granule
+                       (util/remove-nil-keys
                         {:token token
-                        :page-size 100
-                        :concept-id concept-ids}))))))
+                         :page-size 100
+                         :concept-id concept-ids}))))))
           "Guests find nothing" nil []
           "group1" user1 group1-granules
           "group2" user2 group2-granules

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
@@ -8,6 +8,7 @@
    [cmr.common.test.time-util :as tu]
    [cmr.common.util :refer [are2 are3] :as util]
    [cmr.mock-echo.client.echo-util :as e]
+   [cmr.redis-utils.test.test-util :as test-util]
    [cmr.system-int-test.data2.atom :as da]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
@@ -22,9 +23,11 @@
    [cmr.transmit.config :as tc]))
 
 (use-fixtures :each (join-fixtures
-                      [(ingest/reset-fixture {"provguid1" "PROV1"}
-                                             {:grant-all-search? false})
-                       (dev-sys-util/freeze-resume-time-fixture)]))
+                     [(ingest/reset-fixture {"provguid1" "PROV1"}
+                                            {:grant-all-search? false})
+                      (dev-sys-util/freeze-resume-time-fixture)]))
+
+(use-fixtures :once test-util/embedded-redis-server-fixture)
 
 (def now-n
   "The N value for the current time. Uses N values for date times as describd in
@@ -47,7 +50,7 @@
                                          :granule_applicable true)
 
                                   (e/gran-catalog-item-id
-                                    "PROV1" nil (e/gran-id nil temporal-filter)))]
+                                   "PROV1" nil (e/gran-id nil temporal-filter)))]
     (e/grant-group (s/context) group-id catalog-item-identifier)))
 
 (defn atom-results->title-set
@@ -123,73 +126,73 @@
 
       (testing "Collection temporal as applied to granule searches"
         (are2 [token items]
-          (d/refs-match? items (search/find-refs :granule (when token {:token token})))
-          "Guests find nothing"
-          nil []
-          "group1" user1 group1-granules
-          "group2" user2 group2-granules
-          "group3" user3 group3-granules
-          "group4" user4 group4-granules))
+              (d/refs-match? items (search/find-refs :granule (when token {:token token})))
+              "Guests find nothing"
+              nil []
+              "group1" user1 group1-granules
+              "group2" user2 group2-granules
+              "group3" user3 group3-granules
+              "group4" user4 group4-granules))
 
       (testing "Parameter searching ACL enforcement"
         (are2 [token items]
-          (d/refs-match? items (search/find-refs :collection (when token {:token token})))
-          "Guests find nothing"
-          nil []
-          "group1" user1 group1-colls
-          "group2" user2 group2-colls
-          "group3" user3 group3-colls
-          "group4" user4 group4-colls))
+              (d/refs-match? items (search/find-refs :collection (when token {:token token})))
+              "Guests find nothing"
+              nil []
+              "group1" user1 group1-colls
+              "group2" user2 group2-colls
+              "group3" user3 group3-colls
+              "group4" user4 group4-colls))
 
       (testing "Granule ACL Enforcement by concept id"
         (are3 [token grans colls]
-          (let [concept-ids all-gran-concept-ids
-                gran-atom (da/granules->expected-atom
-                           grans colls
-                           (str "granules.atom?"
-                                (when token (str "token=" token "&"))
-                                "page_size=100&concept_id="
-                                (str/join "&concept_id=" concept-ids)))]
-            (is (= gran-atom (:results (search/find-concepts-atom
-                                        :granule (util/remove-nil-keys
-                                                  {:token token
-                                                   :page-size 100
-                                                   :concept-id concept-ids}))))))
-          "Guests find nothing" nil [] []
-          "group1" user1 group1-granules group1-colls
-          "group2" user2 group2-granules group2-colls
-          "group3" user3 group3-granules group3-colls
-          "group4" user4 group4-granules group4-colls))
+              (let [concept-ids all-gran-concept-ids
+                    gran-atom (da/granules->expected-atom
+                               grans colls
+                               (str "granules.atom?"
+                                    (when token (str "token=" token "&"))
+                                    "page_size=100&concept_id="
+                                    (str/join "&concept_id=" concept-ids)))]
+                (is (= gran-atom (:results (search/find-concepts-atom
+                                            :granule (util/remove-nil-keys
+                                                      {:token token
+                                                       :page-size 100
+                                                       :concept-id concept-ids}))))))
+              "Guests find nothing" nil [] []
+              "group1" user1 group1-granules group1-colls
+              "group2" user2 group2-granules group2-colls
+              "group3" user3 group3-granules group3-colls
+              "group4" user4 group4-granules group4-colls))
 
       (testing "Collection ATOM ACL Enforcement by concept id"
         (are2 [token colls]
-          (= (set (map :entry-title colls))
-             (atom-results->title-set
-              (search/find-concepts-atom
-               :collection (util/remove-nil-keys
-                            {:token token
-                             :page-size 100
-                             :concept-id all-coll-concept-ids}))))
-          "Guests find nothing" nil []
-          "group1" user1 group1-colls
-          "group2" user2 group2-colls
-          "group3" user3 group3-colls
-          "group4" user4 group4-colls))
+              (= (set (map :entry-title colls))
+                 (atom-results->title-set
+                  (search/find-concepts-atom
+                   :collection (util/remove-nil-keys
+                                {:token token
+                                 :page-size 100
+                                 :concept-id all-coll-concept-ids}))))
+              "Guests find nothing" nil []
+              "group1" user1 group1-colls
+              "group2" user2 group2-colls
+              "group3" user3 group3-colls
+              "group4" user4 group4-colls))
 
       (testing "Collection JSON ACL Enforcement by concept id"
         (are2 [token colls]
-          (= (set (map :entry-title colls))
-             (atom-results->title-set
-              (search/find-concepts-json
-               :collection (util/remove-nil-keys
-                            {:token token
-                             :page-size 100
-                             :concept-id all-coll-concept-ids}))))
-          "Guests find nothing" nil []
-          "group1" user1 group1-colls
-          "group2" user2 group2-colls
-          "group3" user3 group3-colls
-          "group4" user4 group4-colls))
+              (= (set (map :entry-title colls))
+                 (atom-results->title-set
+                  (search/find-concepts-json
+                   :collection (util/remove-nil-keys
+                                {:token token
+                                 :page-size 100
+                                 :concept-id all-coll-concept-ids}))))
+              "Guests find nothing" nil []
+              "group1" user1 group1-colls
+              "group2" user2 group2-colls
+              "group3" user3 group3-colls
+              "group4" user4 group4-colls))
 
       (testing "Collection OpenData ACL Enforcement by concept id"
         (let [open-data-results (search/find-concepts-opendata :collection {:token user1
@@ -215,19 +218,19 @@
         gran-num (atom 0)
         single-date-gran (fn [n metadata-format]
                            (d/ingest
-                             "PROV1"
-                             (dg/granule collection
-                                         {:granule-ur (str "gran" (swap! gran-num inc))
-                                          :single-date-time (tu/n->date-time-string n)})
-                             {:format metadata-format}))
-        range-date-gran (fn [begin end metadata-format]
-                          (d/ingest
                             "PROV1"
                             (dg/granule collection
                                         {:granule-ur (str "gran" (swap! gran-num inc))
-                                         :beginning-date-time (tu/n->date-time-string begin)
-                                         :ending-date-time (tu/n->date-time-string end)})
-                            {:format metadata-format}))]
+                                         :single-date-time (tu/n->date-time-string n)})
+                            {:format metadata-format}))
+        range-date-gran (fn [begin end metadata-format]
+                          (d/ingest
+                           "PROV1"
+                           (dg/granule collection
+                                       {:granule-ur (str "gran" (swap! gran-num inc))
+                                        :beginning-date-time (tu/n->date-time-string begin)
+                                        :ending-date-time (tu/n->date-time-string end)})
+                           {:format metadata-format}))]
     ;; Set current time
     (dev-sys-util/freeze-time! (tu/n->date-time-string now-n))
 
@@ -278,10 +281,10 @@
                     expected-urs (set (map :granule-ur items))]
                 (is (= expected-urs
                        (atom-results->title-set (search/find-concepts-atom
-                                                  :granule (util/remove-nil-keys
-                                                             {:token token
-                                                              :page-size 100
-                                                              :concept-id concept-ids}))))))
+                                                 :granule (util/remove-nil-keys
+                                                           {:token token
+                                                            :page-size 100
+                                                            :concept-id concept-ids}))))))
               "Guests find nothing" nil []
               "group1" user1 group1-granules
               "group2" user2 group2-granules
@@ -294,10 +297,10 @@
                     expected-urs (set (map :granule-ur items))]
                 (is (= expected-urs
                        (atom-results->title-set (search/find-concepts-json
-                                                  :granule (util/remove-nil-keys
-                                                             {:token token
-                                                              :page-size 100
-                                                              :concept-id concept-ids}))))))
+                                                 :granule (util/remove-nil-keys
+                                                           {:token token
+                                                            :page-size 100
+                                                            :concept-id concept-ids}))))))
               "Guests find nothing" nil []
               "group1" user1 group1-granules
               "group2" user2 group2-granules
@@ -309,12 +312,12 @@
               (let [concept-ids (map :concept-id all-grans)]
                 (= (set (map :granule-ur items))
                    (set (search/csv-response->granule-urs
-                          (search/find-concepts-csv
-                            :granule
-                            (util/remove-nil-keys
-                              {:token token
-                               :page-size 100
-                               :concept-id concept-ids}))))))
+                         (search/find-concepts-csv
+                          :granule
+                          (util/remove-nil-keys
+                           {:token token
+                            :page-size 100
+                            :concept-id concept-ids}))))))
               "Guests find nothing" nil []
               "group1" user1 group1-granules
               "group2" user2 group2-granules
@@ -323,10 +326,10 @@
 
       (testing "Direct transformer retrieval acl enforcement"
         (d/assert-metadata-results-match
-          :echo10 group1-granules
-          (search/find-metadata :granule :echo10 {:token user1
-                                                  :page-size 100
-                                                  :concept-id (map :concept-id all-grans)})))
+         :echo10 group1-granules
+         (search/find-metadata :granule :echo10 {:token user1
+                                                 :page-size 100
+                                                 :concept-id (map :concept-id all-grans)})))
 
       (testing "granule counts acl enforcement"
         (let [refs-result (search/find-refs :collection {:token user1

--- a/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
@@ -5,20 +5,15 @@
    [clj-time.format :as f]
    [clojure.set :as set]
    [clojure.string :as str]
-   [cmr.acl.core :as acl-core]
    [cmr.common.cache :as cache]
-   [cmr.common.cache.cache-spec :as cache-spec]
-   [cmr.common.cache.in-memory-cache :as mem-cache]
    [cmr.common.log :refer [info debug warn error]]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as u :refer [update-in-each]]
-   [cmr.redis-utils.redis-cache :as redis-cache]
    [cmr.umm-spec.legacy :as legacy]
    [cmr.umm-spec.time :as umm-time]
    [cmr.umm-spec.umm-spec-core :as umm-spec-core]
-   [cmr.umm.acl-matchers :as umm-lib-acl-matchers]
-   [cmr.common.util :as util]))
+   [cmr.umm.acl-matchers :as umm-lib-acl-matchers]))
 
 (def ^:private supported-collection-identifier-keys
   #{:entry-titles :access-value :temporal :concept-ids})
@@ -131,7 +126,6 @@
              (matches-temporal-filter? :collection (u/get-real-or-lazy coll :TemporalExtents) temporal)))))
 
 (comment
-
   ;; these are what the maps look like
   (let [coll {:concept-type :collection
               :provider-id "TCHERRY"
@@ -142,17 +136,13 @@
                 [{:BeginningDateTime "2000-01-01T00:00:00.000Z"
                   :EndingDateTime nil}]}]
               :concept-id "C1200000219-TCHERRY"}
-        coll (cmr.common.util/lazy-assoc coll :AccessConstraints {:Value 5})
+        coll (u/lazy-assoc coll :AccessConstraints {:Value 5})
         coll-id {:entry-titles ["LarcDatasetId-sampleGranule0002"]
                  :access-value {:min-value 0 :max-value 6}
                  :concept-ids ["C1200000219-TCHERRY"]}]
     (println (coll-matches-collection-identifier? coll coll-id)))
 
-
-  {cmr.common.util/lazy-assoc {} :AccessConstraints {:Value 5}}
-
-  )
-
+  {u/lazy-assoc {} :AccessConstraints {:Value 5}})
 
 (defn- validate-collection-identiier
   "Verifies the collection identifier isn't using any unsupported ACL features."

--- a/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
@@ -17,7 +17,8 @@
    [cmr.umm-spec.legacy :as legacy]
    [cmr.umm-spec.time :as umm-time]
    [cmr.umm-spec.umm-spec-core :as umm-spec-core]
-   [cmr.umm.acl-matchers :as umm-lib-acl-matchers]))
+   [cmr.umm.acl-matchers :as umm-lib-acl-matchers]
+   [cmr.common.util :as util]))
 
 (def ^:private supported-collection-identifier-keys
   #{:entry-titles :access-value :temporal :concept-ids})
@@ -110,7 +111,9 @@
       (get-acl-enforcement-collection-fields-fn concept))))
 
 (defn coll-matches-collection-identifier?
-  "Returns true if the collection matches the collection identifier"
+  "Returns true if the collection matches the collection identifier.
+   coll is a cached collection
+   coll-id is the catalog_item_identity"
   [coll coll-id]
   (let [coll-entry-title (:EntryTitle coll)
         concept-id (or (:concept-id coll)
@@ -126,6 +129,29 @@
          ;; want to pull out this specific value
          (or (nil? temporal)
              (matches-temporal-filter? :collection (u/get-real-or-lazy coll :TemporalExtents) temporal)))))
+
+(comment
+
+  (let [coll {:concept-type :collection
+              :provider-id "TCHERRY"
+              :EntryTitle "LarcDatasetId-sampleGranule0002"
+              :AccessConstraints {:Value 5}
+              :TemporalExtents
+              [{:RangeDateTimes
+                [{:BeginningDateTime "2000-01-01T00:00:00.000Z"
+                  :EndingDateTime nil}]}]
+              :concept-id "C1200000219-TCHERRY"}
+        coll (cmr.common.util/lazy-assoc coll :AccessConstraints {:Value 5})
+        coll-id {:entry-titles ["LarcDatasetId-sampleGranule0002"]
+                 :access-value {:min-value 0 :max-value 6}
+                 :concept-ids ["C1200000219-TCHERRY"]}]
+    (println (coll-matches-collection-identifier? coll coll-id)))
+
+
+  {cmr.common.util/lazy-assoc {} :AccessConstraints {:Value 5}}
+
+  )
+
 
 (defn- validate-collection-identiier
   "Verifies the collection identifier isn't using any unsupported ACL features."

--- a/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/acl_matchers.clj
@@ -132,6 +132,7 @@
 
 (comment
 
+  ;; these are what the maps look like
   (let [coll {:concept-type :collection
               :provider-id "TCHERRY"
               :EntryTitle "LarcDatasetId-sampleGranule0002"


### PR DESCRIPTION
This change moves the Granule ACL Collection cache from a local in-memory cache to a shared Redis service.