### PR TITLE
CMR-9555: Incorporate integration test coverage results into code coverage step

### DIFF
--- a/system-int-test/tests.edn
+++ b/system-int-test/tests.edn
@@ -9,6 +9,7 @@
 
  :plugins [:kaocha.plugin.alpha/info
            :kaocha.plugin/capture-output
+           :kaocha.plugin/cloverage
            :kaocha.plugin/randomize
            :junit-xml
            :print-invocations]
@@ -19,6 +20,9 @@
  :fail-fast? false
 
  :reporter kaocha.report/documentation
+
+ :cloverage/opts {:codecov? #profile {:default false :ci true}
+                  :html? #profile {:default true :ci false}}
 
  :kaocha.plugin.randomize/randomize? false
  :kaocha.plugin.junit-xml/target-file "target/junit.xml"}


### PR DESCRIPTION
Adding to test configuration so a codecov file is generated by the integration tests