### PR TITLE
Feature CMR-9539 - Update the coll-cache from standard redis to new Hash Map Redis 

### DIFF
--- a/search-app/src/cmr/search/services/acls/collections_cache.clj
+++ b/search-app/src/cmr/search/services/acls/collections_cache.clj
@@ -3,18 +3,20 @@
   (:require
    [clojure.walk :as walk]
    [cmr.common-app.services.search.query-execution :as qe]
-   [cmr.common-app.services.search.query-model :as q]
-   [cmr.common.cache :as cache]
+   [cmr.common-app.services.search.query-model :as q-mod]
    [cmr.common.date-time-parser :as time-parser]
+   [cmr.common.hash-cache :as hash-cache]
    [cmr.common.jobs :refer [defjob]]
    [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
-   [cmr.redis-utils.redis-cache :as redis-cache]
-   [cmr.search.services.acls.acl-results-handler-helper :as acl-rhh]))
+   [cmr.redis-utils.redis-hash-cache :as red-hash-cache]
+   [cmr.search.services.acls.acl-results-handler-helper :as acl-rhh]
+   [cmr.search.services.messages.collections-cache-messages :as coll-msg]))
 
-;; No other file reads this cache
 (def cache-key
+  "This is the key name that will show up in redis.
+   Note: No other file reads this cache, so it is functionally private."
   :collections-for-gran-acls)
 
 (def initial-cache-state
@@ -25,20 +27,20 @@
   "This is the frequency that the cron job will run. It should be less then
    coll-for-gran-acl-ttl"
   ;; 15 minutes
-  (* 15 60))
+  (* 60 15))
 
 (def coll-for-gran-acl-ttl
   "This is when Redis should expire the data, this value should never be hit if
    the cron job is working correctly, however in some modes (such as local dev
    with no database) it may come into play."
   ;; 30 minutes
-  (* 30 60))
+  (* 60 30))
 
 (defn create-cache
   "Creates a new empty collections cache."
   []
-  (redis-cache/create-redis-cache {:keys-to-track [:collections-for-gran-acls]
-                                   :ttl coll-for-gran-acl-ttl}))
+  (red-hash-cache/create-redis-hash-cache {:keys-to-track [:collections-for-gran-acls]
+                                           :ttl coll-for-gran-acl-ttl}))
 
 (defn clj-times->time-strs
   "Take a map and convert any date objects into strings so the map can be cached.
@@ -69,13 +71,13 @@
                                                     :collection
                                                     elastic-item))
                                   :concept-id (:_id elastic-item)))
-        query (q/query {:concept-type :collection
-                        :condition q/match-all
-                        :skip-acls? true
-                        :page-size :unlimited
-                        :result-format :query-specified
-                        :result-fields (cons :concept-id acl-rhh/collection-elastic-fields)
-                        :result-features {:query-specified {:result-processor result-processor}}})]
+        query (q-mod/query {:concept-type :collection
+                            :condition q-mod/match-all
+                            :skip-acls? true
+                            :page-size :unlimited
+                            :result-format :query-specified
+                            :result-fields (cons :concept-id acl-rhh/collection-elastic-fields)
+                            :result-features {:query-specified {:result-processor result-processor}}})]
     (:items (qe/execute-query context query))))
 
 (defn- fetch-collections-map
@@ -88,6 +90,7 @@
                                          (for [{:keys [provider-id EntryTitle] :as coll}
                                                collections]
                                            [[provider-id EntryTitle] coll]))]
+    (debug "fetch-collections-map count" (count collections))
     ;; We could reduce the amount of memory here if needed by only fetching the collections that
     ;; have granules.
     {:by-concept-id by-concept-id
@@ -98,34 +101,35 @@
   to keep the cache fresh. This will throw an exception if there is a problem fetching collections. The
   caller is responsible for catching and logging the exception."
   [context]
-  (let [cache (cache/context->cache context cache-key)
+  (let [cache (hash-cache/context->cache context cache-key)
         collections-map (fetch-collections-map context)]
-    (cache/set-value cache cache-key (clj-times->time-strs collections-map))))
+    (doseq [[coll-key coll-value] collections-map]
+      (debug (format "refresh-cache %s" coll-key))
+      (hash-cache/set-value cache cache-key coll-key (clj-times->time-strs coll-value)))))
 
 (defn- get-collections-map
   "Gets the cached value."
-  [context]
-  (let [coll-cache (cache/context->cache context cache-key)
-        collection-map (cache/get-value
+  [context key-type]
+  (let [coll-cache (hash-cache/context->cache context cache-key)
+        collection-map (hash-cache/get-value
                         coll-cache
                         cache-key
-                        (fn [] (clj-times->time-strs (fetch-collections-map context))))]
+                        key-type)]
     (if (empty? collection-map)
-      (errors/internal-error! "Collections were not in cache.")
+      (errors/internal-error! (coll-msg/collections-not-in-cache key-type))
       (time-strs->clj-times collection-map))))
 
 (defn get-collection
   "Gets a single collection from the cache by concept id. Handles refreshing the cache if it is not found in it.
   Also allows provider-id and entry-title to be used."
   ([context concept-id]
-   (let [by-concept-id (:by-concept-id (get-collections-map context))]
+   (let [by-concept-id (get-collections-map context :by-concept-id)]
      (when-not (by-concept-id concept-id)
-       (info (format "Collection with id %s not found in cache. Manually triggering cache refresh"
-                     concept-id))
+       (info (coll-msg/collection-not-found concept-id))
        (refresh-cache context))
-     (get (:by-concept-id (get-collections-map context)) concept-id)))
+     (get (get-collections-map context :by-concept-id ) concept-id)))
   ([context provider-id entry-title]
-   (let [by-provider-id-entry-title (:by-provider-id-entry-title (get-collections-map context))]
+   (let [by-provider-id-entry-title (get-collections-map context :by-provider-id-entry-title )]
      (get by-provider-id-entry-title [provider-id entry-title]))))
 
 (defjob RefreshCollectionsCacheForGranuleAclsJob

--- a/search-app/src/cmr/search/services/acls/collections_cache.clj
+++ b/search-app/src/cmr/search/services/acls/collections_cache.clj
@@ -90,7 +90,6 @@
                                          (for [{:keys [provider-id EntryTitle] :as coll}
                                                collections]
                                            [[provider-id EntryTitle] coll]))]
-    (debug "fetch-collections-map count" (count collections))
     ;; We could reduce the amount of memory here if needed by only fetching the collections that
     ;; have granules.
     {:by-concept-id by-concept-id
@@ -104,7 +103,6 @@
   (let [cache (hash-cache/context->cache context cache-key)
         collections-map (fetch-collections-map context)]
     (doseq [[coll-key coll-value] collections-map]
-      (debug (format "collections-cache refresh-cache working on %s" coll-key))
       (hash-cache/set-value cache cache-key coll-key (clj-times->time-strs coll-value)))))
 
 (defn- get-collections-map

--- a/search-app/src/cmr/search/services/messages/collections_cache_messages.clj
+++ b/search-app/src/cmr/search/services/messages/collections_cache_messages.clj
@@ -1,0 +1,11 @@
+(ns cmr.search.services.messages.collections-cache-messages
+  "Contains messages for reporting responses to the user")
+
+(defn collection-not-found
+  [concept-id]
+  (format "Collection with id %s not found in cache. Manually triggering cache refresh"
+          concept-id))
+
+(defn collections-not-in-cache
+  [cache-type]
+  (format "Collections were not in hash cache by %s." cache-type))

--- a/search-app/src/cmr/search/services/messages/collections_cache_messages.clj
+++ b/search-app/src/cmr/search/services/messages/collections_cache_messages.clj
@@ -1,5 +1,5 @@
 (ns cmr.search.services.messages.collections-cache-messages
-  "Contains messages for reporting responses to the user")
+  "Contains messages for reporting responses from the collections-cache to the user")
 
 (defn collection-not-found
   [concept-id]

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -91,7 +91,7 @@
         old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
         context (assoc-in context [:system :caches :collections-for-gran-acls] rcache)
         data (.get-value old-mem-cache :collections)]
-    (.set-value rcache :collections-for-gran-acls data)
+    (.set-values rcache :collections-for-gran-acls data)
 
     (testing "collection identifier"
       (are3 [entry-titles access-value-args collection-concept-id should-match?]

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -1,7 +1,7 @@
 (ns cmr.search.test.unit.services.acls.granule-acls
   (:require [clojure.test :refer :all]
             [cmr.common.cache.in-memory-cache :as mem-cache]
-            ;;[cmr.common.hash-cache :as hash-cache]
+            [cmr.common.hash-cache :as hash-cache]
             [cmr.common.util :as util :refer [are3]]
             [cmr.redis-utils.test.test-util :as test-util]
             [cmr.search.services.acls.collections-cache :as coll-cache]

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -87,17 +87,13 @@
         context (context-with-cached-collections
                  (for [coll-args collections]
                    (apply collection coll-args)))
-
-        ;;🚀 - clean this section up before merging! Do a test first
-
         ;; setup the redis cache (rcache) from the memory cache
         rcache (cmr.search.services.acls.collections-cache/create-cache)
-        ;;old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
+        old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
         context (assoc-in context [:system :caches :collections-for-gran-acls] rcache)
-        ;;data (.get-value old-mem-cache :collections)
-        ]
+        data (.get-value old-mem-cache :collections)]
     ;;(.set-values rcache :collections-for-gran-acls data)
-    ;;(hash-cache/set-values rcache :collections-for-gran-acls data)
+    (hash-cache/set-values rcache :collections-for-gran-acls data)
 
     (testing "collection identifier"
       (are3 [entry-titles access-value-args collection-concept-id should-match?]

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -1,6 +1,7 @@
 (ns cmr.search.test.unit.services.acls.granule-acls
   (:require [clojure.test :refer :all]
             [cmr.common.cache.in-memory-cache :as mem-cache]
+            ;;[cmr.common.hash-cache :as hash-cache]
             [cmr.common.util :as util :refer [are3]]
             [cmr.redis-utils.test.test-util :as test-util]
             [cmr.search.services.acls.collections-cache :as coll-cache]
@@ -84,14 +85,19 @@
                      ["C4-P2" "coll1" nil]
                      ["C5-P2" "coll2" 1]]
         context (context-with-cached-collections
-                  (for [coll-args collections]
-                    (apply collection coll-args)))
+                 (for [coll-args collections]
+                   (apply collection coll-args)))
+
+        ;;🚀 - clean this section up before merging! Do a test first
+
         ;; setup the redis cache (rcache) from the memory cache
         rcache (cmr.search.services.acls.collections-cache/create-cache)
-        old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
+        ;;old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
         context (assoc-in context [:system :caches :collections-for-gran-acls] rcache)
-        data (.get-value old-mem-cache :collections)]
-    (.set-values rcache :collections-for-gran-acls data)
+        ;;data (.get-value old-mem-cache :collections)
+        ]
+    ;;(.set-values rcache :collections-for-gran-acls data)
+    ;;(hash-cache/set-values rcache :collections-for-gran-acls data)
 
     (testing "collection identifier"
       (are3 [entry-titles access-value-args collection-concept-id should-match?]

--- a/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
+++ b/search-app/test/cmr/search/test/unit/services/acls/granule_acls.clj
@@ -87,12 +87,12 @@
         context (context-with-cached-collections
                  (for [coll-args collections]
                    (apply collection coll-args)))
-        ;; setup the redis cache (rcache) from the memory cache
+        ;; Setup the redis cache (rcache) from the memory cache
+        ;; Without doing this, tests will pass locally but not in CI/CD
         rcache (cmr.search.services.acls.collections-cache/create-cache)
         old-mem-cache (get-in context [:system :caches :collections-for-gran-acls])
         context (assoc-in context [:system :caches :collections-for-gran-acls] rcache)
         data (.get-value old-mem-cache :collections)]
-    ;;(.set-values rcache :collections-for-gran-acls data)
     (hash-cache/set-values rcache :collections-for-gran-acls data)
 
     (testing "collection identifier"

--- a/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/acls/temporal_collection_granule_test.clj
@@ -27,8 +27,6 @@
                                             {:grant-all-search? false})
                       (dev-sys-util/freeze-resume-time-fixture)]))
 
-(use-fixtures :once test-util/embedded-redis-server-fixture)
-
 (def now-n
   "The N value for the current time. Uses N values for date times as describd in
   cmr.common.test.time-util."


### PR DESCRIPTION
Moving the code over to the new hash map redis cache and breaking up the data into two different hashes within that cache to limit the request data being transmitted over the "wire".