### PR TITLE
CMR-9577 - moving httparty and other libs needed to get the app to run and pass snyk checks

### DIFF
--- a/system-validation-test/Gemfile.lock
+++ b/system-validation-test/Gemfile.lock
@@ -28,20 +28,23 @@ GEM
     cucumber-tag-expressions (4.1.0)
     diff-lcs (1.5.0)
     ffi (1.15.5)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     jsonpath (1.1.2)
       multi_json
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.1003)
+    mini_mime (1.1.5)
     multi_json (1.15.0)
     multi_test (1.1.0)
     multi_xml (0.6.0)
-    nokogiri (1.13.10)
+    nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
-    racc (1.6.1)
+    nokogiri (1.15.5-x86_64-darwin)
+      racc (~> 1.4)
+    racc (1.7.3)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -60,6 +63,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   cucumber

--- a/system-validation-test/README.md
+++ b/system-validation-test/README.md
@@ -5,6 +5,7 @@ This is the repository for the Common Metadata Repository Client Validation Gem.
 ## Prerequisites
 
 * Ruby
+	* as of 2023-12-04 - Ruby 3.2.2 under rbenv worked	
 
 ## Installation
 


### PR DESCRIPTION
Please let me know if nokogiri is wrong for referencing a platform. Otherwise, this should be just a basic `bundle update httparty`. The other changes are a result of getting the package to work with ruby 3.2.2