### PR TITLE
CMR-9518 Modified code to get the correct extensions for the output f…

### DIFF
--- a/other/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
+++ b/other/cmr-exchange/ous-plugin/src/cmr/ous/common.clj
@@ -131,10 +131,15 @@
                           #(granule-link->opendap-url % tag-data))
                     granule-links)
           format (or (:format params) const/default-format)
-          dap-format (if (and (is-dap-version-4? dap-version)
-                              (= "nc" format))
+          dap-format (if (or (and (is-dap-version-4? dap-version)
+                                  (= "nc" format))
+                             (and (is-dap-version-4? dap-version)
+                                  (= "nc4" format)))
                        "dap.nc4"
-                       format)]
+                       (if (and (is-dap-version-4? dap-version)
+                                (= "ascii" format))
+                         "dap.csv"
+                         format))]
       (if (errors/any-erred? urls)
         (do
           (log/error "Some problematic urls:" (vec urls))


### PR DESCRIPTION
A user of EDSC reported that when they selected granules for download, chose opendap and then specified the NETCDF-4 format the generated URLs had the .nc4 extension and not the expected .dap.nc4 extension. These URLs were invalid and generated a 400 error.