### PR TITLE
CMR-9545: As a CMR Search User, I Want the Collection_Concept_Id to be Returned in the Granule UMM_JSON Response Format

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -857,8 +857,8 @@
       m)
     (dissoc m k)))
 
-(defn dissoc-in-mult
-  "Dissociates an vector of keys from a nested associative structure returning a new
+(defn dissoc-multiple
+  "Dissociates a vector of keys from a nested associative structure returning a new
   nested structure. ks is a vector of keys."
   [m ks]
   (w/postwalk #(if (map? %) (apply dissoc % ks) %) m))

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -847,7 +847,7 @@
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. keys is a sequence of keys. Any empty maps that result
   will not be present in the new structure."
-  [m [k & ks :as keys]]
+  [m [k & ks]]
   (if ks
     (if-let [nextmap (get m k)]
       (let [newmap (dissoc-in nextmap ks)]
@@ -856,6 +856,14 @@
           (dissoc m k)))
       m)
     (dissoc m k)))
+
+(defn dissoc-in-mult
+  [m ks]
+  (w/postwalk #(if (map? %) (apply dissoc % ks) %) m))
+
+(defn test-func
+  [m ks]
+  (update-in m [ks] (fn [nested] (apply dissoc nested [ks]))))
 
 (defn seqv
   "Returns (vec coll) when (seq coll) is not nil."

--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -858,12 +858,10 @@
     (dissoc m k)))
 
 (defn dissoc-in-mult
+  "Dissociates an vector of keys from a nested associative structure returning a new
+  nested structure. ks is a vector of keys."
   [m ks]
   (w/postwalk #(if (map? %) (apply dissoc % ks) %) m))
-
-(defn test-func
-  [m ks]
-  (update-in m [ks] (fn [nested] (apply dissoc nested [ks]))))
 
 (defn seqv
   "Returns (vec coll) when (seq coll) is not nil."

--- a/search-app/src/cmr/search/results_handlers/granules_umm_json_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/granules_umm_json_results_handler.clj
@@ -18,7 +18,8 @@
    "native-id"
    "provider-id"
    "metadata-format"
-   "revision-date"])
+   "revision-date"
+   "collection-concept-id"])
 
 (defn granule-elastic-result->meta
   "Takes an elasticsearch result and returns a map of the meta fields in granule UMM JSON response."
@@ -28,6 +29,7 @@
          native-id :native-id
          provider-id :provider-id
          metadata-format :metadata-format
+         collection-concept-id :collection-concept-id
          revision-date :revision-date} (:_source elastic-result)
         revision-date (when revision-date (string/replace (str revision-date) #"\+0000" "Z"))]
     (util/remove-nil-keys
@@ -35,6 +37,7 @@
       :concept-id concept-id
       :revision-id revision-id
       :native-id native-id
+      :collection-concept-id collection-concept-id
       :provider-id provider-id
       :format (mt/format->mime-type (keyword metadata-format))
       :revision-date revision-date})))

--- a/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
@@ -168,7 +168,7 @@
                             (:body search-result) version)))
           "UMM search result JSON was invalid")
       (is (= (set (map #(granule->umm-json version %) granules))
-             (set (map #(util/dissoc-in-mult % [:collection-concept-id :revision-date])
+             (set (map #(util/dissoc-multiple % [:collection-concept-id :revision-date])
                        (get-in search-result [:results :items]))))))))
 
 (defn- variable->umm-json-meta

--- a/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
@@ -138,11 +138,10 @@
 (defn- granule->umm-json-meta
   "Returns the meta section of granule UMM JSON search result."
   [granule]
-  (let [{:keys [concept-id revision-id provider-id native-id format collection-concept-id]} granule]
+  (let [{:keys [concept-id revision-id provider-id native-id format]} granule]
     (util/remove-nil-keys
      {:concept-type "granule"
       :concept-id concept-id
-      :collection-concept-id collection-concept-id
       :revision-id revision-id
       :native-id native-id
       :provider-id provider-id

--- a/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_json.clj
@@ -3,7 +3,6 @@
   (:require
    [cheshire.core :as json]
    [clojure.test :refer :all]
-   [clojure.walk :as walk]
    [cmr.common.mime-types :as mt]
    [cmr.common.util :as util]
    [cmr.search.results-handlers.results-handler-util :as rs-util]
@@ -149,29 +148,18 @@
       :provider-id provider-id
       :format (mt/format->mime-type format)})))
 
-(defn remove-granule-keys
-  [m ks]
-  (walk/postwalk #(if (map? %) (apply dissoc % ks) %) m))
-
-
 (defn- granule->umm-json
   "Returns the UMM JSON search result of the given granule."
   [version granule]
   ;; Currently there is no version migration
   ;; We need to handle version migration later when it is supported for UMM-G
-  (def myGran granule)
   (let [{:keys [metadata]} granule]
     {:meta (granule->umm-json-meta granule)
      :umm (json/decode metadata true)}))
-;; todo are version migrations available now on this?
-;; todo this is the test failing fixture
-;; todo mt/umm-json-results this isn't resolving anywhere....
+
 (defn assert-granule-umm-jsons-match
   "Returns true if the UMM JSON response returned from the search matches the given granules."
   [version granules search-result]
-  (def myGranules granules)
-  (def mySearchResult search-result)
-  (def myVersion version)
   (if (and (some? (:status search-result)) (not= 200 (:status search-result)))
     (is (= 200 (:status search-result)) (pr-str search-result))
     (do
@@ -180,8 +168,6 @@
       (is (nil? (util/seqv (umm-json-schema/validate-granule-umm-json-search-result
                             (:body search-result) version)))
           "UMM search result JSON was invalid")
-      (def myExpected (set (map #(granule->umm-json version %) granules)))
-      (println (set (map #(granule->umm-json version %) granules)))
       (is (= (set (map #(granule->umm-json version %) granules))
              (set (map #(util/dissoc-in-mult % [:collection-concept-id :revision-date])
                        (get-in search-result [:results :items]))))))))

--- a/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_search_test.clj
@@ -1,10 +1,8 @@
 (ns cmr.system-int-test.search.granule-search-test
   "Integration test for CMR granule search"
   (:require
-   [clojure.string :as s]
    [clojure.test :refer :all]
    [cmr.common-app.services.search.messages :as cmsg]
-   [cmr.common-app.services.search.messages :as vmsg]
    [cmr.common.services.messages :as msg]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
@@ -329,7 +327,7 @@
       (let [min-value 30.0
             max-value 0.0]
         (is (= {:status 400
-                :errors [(vmsg/min-value-greater-than-max min-value max-value)]}
+                :errors [(cmsg/min-value-greater-than-max min-value max-value)]}
                (search/find-refs :granule {"cloud_cover" (format "%s,%s" min-value max-value)})))))
     (testing "search by cloud-cover with non numeric str 'c9c,'"
       (let [num-range "c9c,"]

--- a/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
@@ -51,6 +51,9 @@
         echo10-gran (ingest-granule-concept collection coll1-entry-title "echo10-gran" :echo10)
         smap-gran (ingest-granule-concept collection coll1-entry-title "iso-smap-gran" :iso-smap)
         umm-g-gran (ingest-granule-concept collection coll1-entry-title "umm-g-gran" :umm-json)]
+    (def mygran echo10-gran)
+    (def mysmapgran smap-gran)
+    (def ummgGran umm-g-gran)
     ;; delete a granule and verify that the deleted granule is not found
     (ingest/delete-concept (d/item->concept gran-to-be-deleted :echo10))
     (index/wait-until-indexed)

--- a/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule_umm_json_search_test.clj
@@ -51,9 +51,6 @@
         echo10-gran (ingest-granule-concept collection coll1-entry-title "echo10-gran" :echo10)
         smap-gran (ingest-granule-concept collection coll1-entry-title "iso-smap-gran" :iso-smap)
         umm-g-gran (ingest-granule-concept collection coll1-entry-title "umm-g-gran" :umm-json)]
-    (def mygran echo10-gran)
-    (def mysmapgran smap-gran)
-    (def ummgGran umm-g-gran)
     ;; delete a granule and verify that the deleted granule is not found
     (ingest/delete-concept (d/item->concept gran-to-be-deleted :echo10))
     (index/wait-until-indexed)

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.4/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.4/umm-g-search-results-json-schema.json
@@ -39,6 +39,10 @@
         "concept-id": {
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
+        }, 
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
         },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.5/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.5/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.1/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.1/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.2/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.2/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.3/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.3/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.4/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.4/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.5/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.5/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/resources/json-schemas/granule/umm/v1.6/umm-g-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/granule/umm/v1.6/umm-g-search-results-json-schema.json
@@ -40,6 +40,10 @@
           "description": "The concept id of the item found.",
           "$ref": "#/definitions/ConceptIdType"
         },
+        "collection-concept-id": {
+          "description": "The concept id of the parent collection to this granule found.",
+          "$ref": "#/definitions/ConceptIdType"
+        },
         "revision-id": {
           "description": "A number >= 1 that indicates which revision of the item.",
           "type": "number"
@@ -55,7 +59,7 @@
           "minLength": 1
         }
       },
-      "required": ["provider-id", "concept-type", "native-id", "concept-id", "revision-id", "revision-date", "format"]
+      "required": ["provider-id", "concept-type", "native-id", "concept-id", "collection-concept-id", "revision-id", "revision-date", "format"]
     },
     "ConceptIdType": {
       "description": "The concept id of a concept.",

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -7,7 +7,6 @@
    [clojure.string :as str]
    [cmr.common.date-time-parser :as dtp]
    [cmr.common.log :as log]
-   [cmr.common.util :as util]
    [cmr.common.validations.json-schema :as js-validations]
    [cmr.umm-spec.models.umm-common-models :as umm-cmn]
    [cmr.umm-spec.versioning :as ver]))
@@ -275,6 +274,7 @@
 (defn- validate-umm-json-search-result
   "Validates the UMM JSON search result and returns a list of errors if invalid."
   [json-str concept-type schema-name umm-version]
+  (print json-str)
   (if-let [java-schema-obj (js-validations/parse-json-schema-from-path
                             (umm-schema-path concept-type schema-name umm-version))]
     (js-validations/validate-json java-schema-obj json-str)

--- a/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/json_schema.clj
@@ -274,7 +274,6 @@
 (defn- validate-umm-json-search-result
   "Validates the UMM JSON search result and returns a list of errors if invalid."
   [json-str concept-type schema-name umm-version]
-  (print json-str)
   (if-let [java-schema-obj (js-validations/parse-json-schema-from-path
                             (umm-schema-path concept-type schema-name umm-version))]
     (js-validations/validate-json java-schema-obj json-str)


### PR DESCRIPTION
Feature request:

This ticket is to include the collection_concept_id in the UMM_JSON:meta body for granule response data.
We include this in the .atom/.json response type, but not in the umm_json. The value is one of client convenience and response consistency. Currently, the clients need to reference the CollectionReference value to identify the parent collection.