### PR TITLE
CMR-9625 

### DIFF
--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -274,6 +274,15 @@
         search-result (mdb/get-latest-concept context concept-id)
         draft-native-id (:native-id search-result)
         metadata (:metadata search-result)
+        ;; need to convert metadata to map and remove the mmt private data
+        ;; then convert it back to json. Currently it only applies to variable-draft
+        ;; publishing.
+        metadata (if (= :variable concept-type)
+                   (-> metadata
+                       (json/parse-string)
+                       (dissoc "_private")
+                       (json/generate-string))
+                   metadata)
         format (:format search-result)
         _ (when-not (and metadata format)
             (errors/throw-service-error

--- a/schemas/resources/schemas/variable-draft/v1.0.0/metadata_with_private_data.json
+++ b/schemas/resources/schemas/variable-draft/v1.0.0/metadata_with_private_data.json
@@ -1,0 +1,42 @@
+{
+  "_private" : {"CollectionId" : "C12345-PROV"},
+  "AdditionalIdentifiers" : [ {
+    "Identifier" : "air_temp"
+  }, {
+    "Description" : "AIRS_name",
+    "Identifier" : "TAirSup"
+  } ],
+  "VariableType" : "SCIENCE_VARIABLE",
+  "DataType" : "float32",
+  "StandardName" : "air_temperature",
+  "FillValues" : [ {
+    "Type" : "SCIENCE_FILLVALUE",
+    "Value" : 9.969209968E36
+  } ],
+  "Dimensions" : [ {
+    "Name" : "atrack",
+    "Size" : 45,
+    "Type" : "ALONG_TRACK_DIMENSION"
+  }, {
+    "Name" : "xtrack",
+    "Size" : 30,
+    "Type" : "CROSS_TRACK_DIMENSION"
+  }, {
+    "Name" : "air_pres",
+    "Size" : "Varies",
+    "Type" : "PRESSURE_DIMENSION"
+  } ],
+  "Definition" : "Air temperature profile from SNDRSNIML2CCPRET_2",
+  "Name" : "/air_temp",
+  "ValidRanges" : [ {
+    "Max" : 400,
+    "Min" : 100
+  } ],
+  "MetadataSpecification" : {
+    "Name" : "UMM-Var",
+    "URL" : "https://cdn.earthdata.nasa.gov/umm/variable/v1.8.2",
+    "Version" : "1.8.2"
+  },
+  "Units" : "Kelvin",
+  "LongName" : "Air temperature profile"
+}

--- a/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/generic_util.clj
@@ -37,7 +37,7 @@
                             (slurp)
                             (json/parse-string true)))
 
-(def variable-draft (-> "schemas/variable-draft/v1.0.0/metadata.json"
+(def variable-draft (-> "schemas/variable-draft/v1.0.0/metadata_with_private_data.json"
                         (jio/resource)
                         (slurp)
                         (json/parse-string true)))


### PR DESCRIPTION
Added functionality to allow MMT to add private data in the metadata for variable draft. It's removed at publishing.
No new tests are necessary.  If it's not removed correctly, the existing tests should fail during schema validation at publishing.