### PR TITLE
CMR-9591: Write a memory dump on exist if requested 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ browse-scaler/src/node_modules
 *.clj-kondo
 *.ruby-version
 .cljfmt.edn
+dev-system/local.edn
 
 ###############################
 ### Test Files

--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -89,7 +89,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   []
-  (let [sys {:log (log/create-logger-with-log-level (log-level))
+  (let [sys {:instance-name (common-sys/instance-name "access-control")
+             :log (log/create-logger-with-log-level (log-level))
              :search-index (search-index/create-elastic-search-index)
              :web (web-server/create-web-server (transmit-config/access-control-port) routes/handlers)
              :nrepl (nrepl/create-nrepl-if-configured (access-control-nrepl-port))

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -66,7 +66,8 @@
                     ;; Specify an Elasticsearch http retry handler
                     (assoc-in [:db :config :retry-handler] bi/elastic-retry-handler))
         queue-broker (queue-broker/create-queue-broker (bootstrap-config/queue-config))
-        sys {:log (log/create-logger-with-log-level (log-level))
+        sys {:instance-name (common-sys/instance-name "bootstrap")
+             :log (log/create-logger-with-log-level (log-level))
              :embedded-systems {:metadata-db metadata-db
                                 :indexer indexer}
              :search-index (search-index/create-elastic-search-index)

--- a/common-app-lib/src/cmr/common_app/app_events.clj
+++ b/common-app-lib/src/cmr/common_app/app_events.clj
@@ -1,0 +1,74 @@
+(ns cmr.common-app.app-events
+  "Common events which applications can use when starting and stopping."
+  (:require
+   [clojure.java.io :as io]
+   [cmr.common-app.config :as config]
+   [cmr.common.log :refer [debugf infof warnf errorf]]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import 'com.sun.management.HotSpotDiagnosticMXBean)
+(import 'java.lang.management.ManagementFactory)
+
+;;
+;; The internet suggests the following as how one would write the dump file in java:
+;;
+;;public static void dumpHeap (String filePath, boolean live) throws IOException {
+;;  MBeanServer server = ManagementFactory.getPlatformMBeanServer ();
+;;  HotSpotDiagnosticMXBean mxBean = ManagementFactory.newPlatformMXBeanProxy (server,
+;;      "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
+;;   mxBean.dumpHeap (filePath, live);
+;;}
+
+(defn- dump-heap
+  "Write a diagnostics file to the file system for analysis in Visual VM"
+  [^String app-name ^String file-path ^java.lang.Boolean live]
+  (let [bean (-> (ManagementFactory/getPlatformMBeanServer)
+                 (ManagementFactory/newPlatformMXBeanProxy "com.sun.management:type=HotSpotDiagnostic"
+                                                           HotSpotDiagnosticMXBean))]
+    (try
+      (when (.exists (io/file file-path))
+        (warnf (format "dump-heap: %s deleting diagnostic file %s." app-name file-path))
+        (io/delete-file file-path))
+      (.dumpHeap bean file-path live)
+      (infof "dump-heap: %s finished creating diagnostic file %s." app-name file-path)
+      (catch Exception err
+        (errorf "dump-heap: %s because %s" app-name (.getMessage err))))))
+
+(defn- writeDump
+  "A call back function which writes a diagnostics file if the application config
+   dump-diagnostics-on-exist-to has been set to a file path. To test this out,
+   run the following commands:
+   >CMR_DUMP_DIAGNOSTICS_ON_EXIT_TO='/tmp/dump-test.hprof'
+       java -cp cmr-search-app-0.1.0-SNAPSHOT-standalone.jar clojure.main
+       -m cmr.search.runner
+   >kill -15 $(jps | grep main | cut -f 1 -d ' ')"
+  [app-name]
+  (let [path-to-file (config/dump-diagnostics-on-exit-to)]
+    (infof "dump-heap: %s is writing a diagnostic file to %s..." app-name path-to-file)
+    (dump-heap app-name path-to-file false)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn stop-on-exit-hook
+  "Add a shutdown hook to call the CMR app stop command found in most if not all
+   CMR microservices. Caller must supply a function that calls the application's
+   stop function such as: #(cmr.search.system/stop system)"
+  [app-name stop-thread]
+  (.addShutdownHook (Runtime/getRuntime) (new Thread stop-thread)))
+
+(defn dump-on-exit-hook
+  "Add a shutdown hook to the current run time which will write a memory dump file
+   if the app has been configured to do so. Set the config dump-diagnostics-on-exist-to
+   a path to the file the log should be saved to."
+  [app-name]
+  (let [path-to-file (config/dump-diagnostics-on-exit-to)]
+    (when-not (empty? path-to-file)
+      (debugf "dump-heap: %s Will write a diagnostic file to %s on exit." app-name path-to-file)
+      (.addShutdownHook (Runtime/getRuntime) (new Thread #(writeDump app-name))))))
+
+(comment
+  ;; use these to create a memory file locally for use in Visual VM
+  (config/set-dump-diagnostics-on-exit-to! "/tmp/dump-auto.txt")
+  (dump-heap "/tmp/dump.txt" true)
+  (dump-heap "/tmp/dump.hprof" false))

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -59,3 +59,8 @@
    them in the custome request log controlled by custom-request-log"
   {:default true
    :type Boolean})
+
+(defconfig dump-diagnostics-on-exit-to
+  "Write a HotSpotDiagnostic file to the path provided. If no path is provided,
+   or the value of 'none' is given, then no file will be written."
+  {:default ""})

--- a/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_fetcher.clj
@@ -91,7 +91,13 @@
 ;; Job for refreshing the KMS keywords cache. Only one node needs to refresh the cache.
 (def-stateful-job RefreshKmsCacheJob
   [_ system]
-  (refresh-kms-cache {:system system}))
+  (try
+    ;; Locally KMS may not be configured or ready to go, in this case a bad URL
+    ;; May exist. Trap the error and print out a shorter message to shorten the
+    ;; logs
+    (refresh-kms-cache {:system system})
+    (catch java.net.MalformedURLException mue
+      (error "Malformed URL"  (.getMessage  mue)))))
 
 (defn refresh-kms-cache-job
   "The singleton job that refreshes the KMS cache. The keywords are infrequently updated by the

--- a/common-lib/src/cmr/common/log.clj
+++ b/common-lib/src/cmr/common/log.clj
@@ -94,6 +94,41 @@
   [& body]
   `(t/report ~@body))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Log macros like the above but using a format like all the cool kids do
+
+(defmacro tracef
+  "Logs a message at the trace level."
+  [& body]
+  `(t/tracef ~@body))
+
+(defmacro debugf
+  "Logs a message at the debug level using a format."
+  [& body]
+  `(t/debugf ~@body))
+
+(defmacro infof
+  "Logs a message at the info level."
+  [& body]
+  `(t/infof ~@body))
+
+(defmacro warnf
+  "Logs a message at the warn level."
+  [& body]
+  `(t/warnf ~@body))
+
+(defmacro errorf
+  "Logs a message at the error level."
+  [& body]
+  `(t/errorf ~@body))
+
+(defmacro reportf
+  "Log a report level message. Report level logs differ from Error in that they
+   always display but are not considered an Error or Fatal event and are already
+   supported by the base library."
+  [& body]
+  `(t/reportf ~@body))
+
 (defrecord Logger
   [level ; The level to log out
    file  ; The path to the file to log to

--- a/common-lib/src/cmr/common/system.clj
+++ b/common-lib/src/cmr/common/system.clj
@@ -2,7 +2,7 @@
   "Contains helper functions for application systems."
   (:require
    [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :as log :refer (debug info warn error)]))
+   [cmr.common.log :as log :refer (debug info warn error reportf)]))
 
 (defn stop
   "Stops the system using the given component order."
@@ -46,19 +46,19 @@
   starting and started"
   [system-name component-order]
   (fn [s]
-    (info (str system-name " System starting"))
+    (reportf "%s System starting" system-name)
     (try
       (start s component-order)
       (finally
-        (info (str system-name " System started"))))))
+        (reportf "%s System started" system-name)))))
 
 (defn stop-fn
   "Creates a generic system stop function that logs when the system is stopping
   and stopped"
   [system-name component-order]
   (fn [s]
-    (info (str system-name " System stopping"))
+    (reportf "%s System stopping" system-name)
     (try
       (stop s component-order)
       (finally
-        (info (str system-name " System stopped"))))))
+        (reportf "%s System stopped" system-name)))))

--- a/dev-system/dev/refresh_persistent_settings.clj
+++ b/dev-system/dev/refresh_persistent_settings.clj
@@ -1,14 +1,39 @@
 (ns refresh-persistent-settings
   "A namespace that can contain development time settings that will not be lost during a refresh."
-  (:require [clojure.tools.namespace.repl :as r]))
+  (:require [clojure.tools.namespace.repl :as r]
+            [clojure.java.io :as io]))
 
 ;; Disable reloading of this namespace.
 (r/disable-reload!)
 (r/disable-unload!)
 
+(defn local-overrides
+  "To prevent the need to ignore this file in git status, reading settings from
+   an optional file which is not expected to be in git. Currently this file is
+   defined as: dev-system/local.edn.
+   and the content could contain two keys like this:
+
+   {:logging-level :warn
+    :run-modes {:db :external}}
+
+   The first is the log level to use, the second is simply merged in with the
+   default.
+   This file is only read at initial launch of CMR, (user/reset) will not pickup
+   changes.
+   "
+  [which default]
+  (let [home (System/getProperty "user.dir")
+        file-path (format "%s/local.edn" home)
+        exists (.exists (io/file file-path))
+        local-settings (if exists (read-string (slurp file-path)) {})
+        settings (get local-settings which default)]
+    ;; Aggresivly display that settings are being set from this process
+    (println (format "🚀 - Using settings %s = %s." which settings))
+    settings))
+
 (def logging-level
   "The logging level to use locally"
-  (atom :error))
+  (atom (local-overrides :logging-level :error)))
 
 (def legacy?
   "Whether to run the dev-system with legacy services enabled and configured"
@@ -35,8 +60,9 @@
 (def run-modes
   "The data structure that maintains the run modes for each individual
   component"
-  (atom {:elastic default-run-mode
+  (atom (merge {:elastic default-run-mode
          :echo default-run-mode
          :db default-run-mode
          :messaging default-run-mode
-         :redis default-run-mode}))
+         :redis default-run-mode}
+         (local-overrides :run-modes {}))))

--- a/dev-system/dev/refresh_persistent_settings.clj
+++ b/dev-system/dev/refresh_persistent_settings.clj
@@ -27,7 +27,7 @@
         exists (.exists (io/file file-path))
         local-settings (if exists (read-string (slurp file-path)) {})
         settings (get local-settings which default)]
-    ;; Aggresivly display that settings are being set from this process
+    ;; Aggressively display that settings are being set from this process
     (println (format "🚀 - Using settings %s = %s." which settings))
     settings))
 

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -7,6 +7,7 @@
    [cmr.common.jobs :as jobs]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.system :as common-sys]
    [cmr.common.util :as u]
    [cmr.dev-system.config :as dev-config]
    [cmr.dev-system.control :as control]
@@ -272,7 +273,8 @@
         elastic-server (create-elastic elastic)
         redis-server (create-redis redis)
         control-server (control/create-server)]
-    {:apps (u/remove-nil-keys
+    {:instance-name (common-sys/instance-name "dev-system")
+     :apps (u/remove-nil-keys
              {:mock-echo echo-component
               :access-control (create-access-control-app queue-broker)
               :metadata-db (create-metadata-db-app db-component queue-broker)

--- a/indexer-app/src/cmr/indexer/system.clj
+++ b/indexer-app/src/cmr/indexer/system.clj
@@ -54,7 +54,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   []
-  (let [sys {:log (log/create-logger-with-log-level (log-level))
+  (let [sys {:instance-name (common-sys/instance-name "indexer")
+             :log (log/create-logger-with-log-level (log-level))
              :db (es/create-elasticsearch-store (es-config/elastic-config))
              :web (web/create-web-server (transmit-config/indexer-port) routes/make-api)
              :nrepl (nrepl/create-nrepl-if-configured (config/indexer-nrepl-port))

--- a/ingest-app/src/cmr/ingest/runner.clj
+++ b/ingest-app/src/cmr/ingest/runner.clj
@@ -1,10 +1,7 @@
 (ns cmr.ingest.runner
   "Entry point for the application. Defines a main method that accepts arguments."
   (:require [cmr.ingest.system :as system]
-            [clojure.string :as string]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.common.api.web-server :as web]
-            [cmr.ingest.api.routes :as routes]
+            [cmr.common-app.app-events :as events]
             [cmr.common.config :as cfg])
   (:gen-class))
 
@@ -12,5 +9,6 @@
   "Starts the App."
   [& args]
   (let [system (system/start (system/create-system))]
-    (info "Running...")
-    (cfg/check-env-vars)))
+    (cfg/check-env-vars)
+    (events/stop-on-exit-hook (:instance-name system) #(system/stop system))
+    (events/dump-on-exit-hook (:instance-name system))))

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -90,7 +90,8 @@
   ([]
    (create-system "ingest"))
   ([connection-pool-name]
-   (let [sys {:log (log/create-logger-with-log-level (log-level))
+   (let [sys {:instance-name (format "%s-%d" connection-pool-name (int (rand 1024)))
+              :log (log/create-logger-with-log-level (log-level))
               :web (web/create-web-server (transmit-config/ingest-port) routes/handlers)
               :nrepl (nrepl/create-nrepl-if-configured (config/ingest-nrepl-port))
               :db (mdb-util/create-db (config/db-spec connection-pool-name))
@@ -139,4 +140,5 @@
 (def stop
   "Performs side effects to shut down the system and release its
   resources. Returns an updated instance of the system."
-  (common-sys/stop-fn "ingest" component-order))
+  (let [stopped-system (common-sys/stop-fn "ingest" component-order)]
+    stopped-system))

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -90,7 +90,7 @@
   ([]
    (create-system "ingest"))
   ([connection-pool-name]
-   (let [sys {:instance-name (format "%s-%d" connection-pool-name (int (rand 1024)))
+   (let [sys {:instance-name (common-sys/instance-name connection-pool-name)
               :log (log/create-logger-with-log-level (log-level))
               :web (web/create-web-server (transmit-config/ingest-port) routes/handlers)
               :nrepl (nrepl/create-nrepl-if-configured (config/ingest-nrepl-port))

--- a/metadata-db-app/src/cmr/metadata_db/system.clj
+++ b/metadata-db-app/src/cmr/metadata_db/system.clj
@@ -43,7 +43,8 @@
   ([]
    (create-system "metadata-db"))
   ([connection-pool-name]
-   (let [sys {:db (assoc (mdb-util/create-db (config/db-spec connection-pool-name))
+   (let [sys {:instance-name (common-sys/instance-name "metadata-db")
+              :db (assoc (mdb-util/create-db (config/db-spec connection-pool-name))
                          :result-set-fetch-size
                          (config/result-set-fetch-size))
               :log (log/create-logger-with-log-level (log-level))

--- a/mock-echo-app/src/cmr/mock_echo/system.clj
+++ b/mock-echo-app/src/cmr/mock_echo/system.clj
@@ -22,7 +22,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   []
-  (let [system {:log (log/create-logger)
+  (let [system {:instance-name (common-sys/instance-name "mock-echo")
+                :log (log/create-logger)
                 :token-db (token-db/create-db)
                 :provider-db (provider-db/create-db)
                 :acl-db (acl-db/create-db)

--- a/search-app/src/cmr/search/runner.clj
+++ b/search-app/src/cmr/search/runner.clj
@@ -1,12 +1,13 @@
 (ns cmr.search.runner
-  (:require [cmr.search.system :as system]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.config :as cfg])
-  (:gen-class))
+  "Entry point for the application. Defines a main method that accepts arguments."
+  (:require [cmr.common-app.app-events :as events]
+            [cmr.common.config :as cfg]
+            [cmr.search.system :as system]))
 
 (defn -main
   "Starts the App."
   [& args]
   (let [system (system/start (system/create-system))]
-    (info "Running...")
-    (cfg/check-env-vars)))
+    (cfg/check-env-vars)
+    (events/stop-on-exit-hook (:instance-name system) #(system/stop system))
+    (events/dump-on-exit-hook (:instance-name system))))

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -104,7 +104,8 @@
   []
   (let [metadata-db (-> (mdb-system/create-system "metadata-db-in-search-app-pool")
                         (dissoc :log :web :scheduler :unclustered-scheduler))
-        sys {:log (log/create-logger-with-log-level (log-level))
+        sys {:instance-name (format "%s-%d" "search" (int (rand 1024)))
+             :log (log/create-logger-with-log-level (log-level))
              ;; An embedded version of the metadata db app to allow quick retrieval of data
              ;; from oracle.
              :embedded-systems {:metadata-db metadata-db}
@@ -164,20 +165,16 @@
   "Performs side effects to initialize the system, acquire resources,
   and start it running. Returns an updated instance of the system."
   [this]
-  (info "search System starting")
   (let [started-system (-> this
                            (update-in [:embedded-systems :metadata-db] mdb-system/start)
                            (common-sys/start component-order))]
-    (info "search System started")
     started-system))
 
 (defn stop
   "Performs side effects to shut down the system and release its
   resources. Returns an updated instance of the system."
   [this]
-  (info "search System shutting down")
   (let [stopped-system (-> this
                            (common-sys/stop component-order)
                            (update-in [:embedded-systems :metadata-db] mdb-system/stop))]
-    (info "search System stopped")
     stopped-system))

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -104,7 +104,7 @@
   []
   (let [metadata-db (-> (mdb-system/create-system "metadata-db-in-search-app-pool")
                         (dissoc :log :web :scheduler :unclustered-scheduler))
-        sys {:instance-name (format "%s-%d" "search" (int (rand 1024)))
+        sys {:instance-name (common-sys/instance-name "search")
              :log (log/create-logger-with-log-level (log-level))
              ;; An embedded version of the metadata db app to allow quick retrieval of data
              ;; from oracle.

--- a/system-int-test/src/cmr/system_int_test/system.clj
+++ b/system-int-test/src/cmr/system_int_test/system.clj
@@ -8,6 +8,7 @@
    [cmr.bootstrap.config :as bootstrap-config]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.system :as common-sys]
    [cmr.metadata-db.services.util :as mdb-util]
    [cmr.oracle.connection :as oracle]
    [cmr.system-int-test.utils.url-helper :as url]
@@ -32,7 +33,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   [component-type-map]
-  (let [sys {:log (log/create-logger {:level @logging-level-atom})
+  (let [sys {:instance-name (common-sys/instance-name "system-int-test")
+             :log (log/create-logger {:level @logging-level-atom})
              :bootstrap-db (when (= :external (:db component-type-map))
                              (mdb-util/create-db (bootstrap-config/db-spec "bootstrap-test-pool")))
              ;; the HTTP connection manager to use. This allows system integration tests to use persistent

--- a/virtual-product-app/src/cmr/virtual_product/system.clj
+++ b/virtual-product-app/src/cmr/virtual_product/system.clj
@@ -39,7 +39,8 @@
 (defn create-system
   "Returns a new instance of the whole application."
   []
-  (let [sys {:log (log/create-logger-with-log-level (log-level))
+  (let [sys {:instance-name (common-sys/instance-name "virtual-product")
+             :log (log/create-logger-with-log-level (log-level))
              :web (web/create-web-server (transmit-config/virtual-product-port) routes/make-api)
              :nrepl (nrepl/create-nrepl-if-configured (virtual-product-nrepl-port))
              :relative-root-url (transmit-config/virtual-product-relative-root-url)


### PR DESCRIPTION
1. Write a memory dump to the file system if sent a `kill -15 <pid>`. This memory dump can then be loaded into visual vm for analyses.
2. RefreshKmsCacheJob now uses a try/catch and writes a short error message if an exception is thrown to shorten the logs. This normally happens locally when starting CMR
3. Adding a new way to make local configurations through refresh_persistent_settings.clj which will not trigger a file change in git status