### PR TITLE
CMR-9684: Humanizer report cache to bootstrap

### DIFF
--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -25,6 +25,7 @@
                  [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-metadata-db-app "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"]
                  [org.apache.httpcomponents/httpclient "4.5.13"]

--- a/bootstrap-app/src/cmr/bootstrap/data/metadata_retrieval/collection_metadata_cache.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/metadata_retrieval/collection_metadata_cache.clj
@@ -58,7 +58,7 @@
     (reduce #(assoc %1 (:concept-id %2) %2) {} rfms)))
 
 (defn update-cache
-  "Updates the collection metadata cache by querying elastic search for updates since the 
+  "Updates the collection metadata cache by querying elastic search for updates since the
   last time the cache was updated."
   [context]
   (info "Updating collection metadata cache")
@@ -68,12 +68,12 @@
                                 {}
                                 (partition-all 1000 concepts-tuples))
         cache (hash-cache/context->cache context cmn-coll-metadata-cache/cache-key)]
-    (hash-cache/set-value cache 
-                          cmn-coll-metadata-cache/cache-key 
-                          cmn-coll-metadata-cache/incremental-since-refresh-date-key 
+    (hash-cache/set-value cache
+                          cmn-coll-metadata-cache/cache-key
+                          cmn-coll-metadata-cache/incremental-since-refresh-date-key
                           incremental-since-refresh-date)
-    (hash-cache/set-values cache 
-                           cmn-coll-metadata-cache/cache-key 
+    (hash-cache/set-values cache
+                           cmn-coll-metadata-cache/cache-key
                            new-cache-value)
     (info "Metadata cache update complete. Cache Size:" (hash-cache/cache-size cache cmn-coll-metadata-cache/cache-key))))
 
@@ -87,13 +87,13 @@
                                 {}
                                 (partition-all 1000 concepts-tuples))
         cache (hash-cache/context->cache context cmn-coll-metadata-cache/cache-key)]
-    (hash-cache/set-value cache 
-                          cmn-coll-metadata-cache/cache-key 
-                          cmn-coll-metadata-cache/incremental-since-refresh-date-key 
+    (hash-cache/set-value cache
+                          cmn-coll-metadata-cache/cache-key
+                          cmn-coll-metadata-cache/incremental-since-refresh-date-key
                           incremental-since-refresh-date)
     (hash-cache/set-values cache cmn-coll-metadata-cache/cache-key new-cache-value)
-    
-    (info "Metadata cache refresh complete. Cache Size:" 
+
+    (info "Metadata cache refresh complete. Cache Size:"
           (hash-cache/cache-size cache cmn-coll-metadata-cache/cache-key))))
 
 (defjob RefreshCollectionsMetadataCache

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -95,7 +95,8 @@
                       cmn-coll-metadata-cache/cache-key (cmn-coll-metadata-cache/create-cache)
                       coll-gran-acls-caches/coll-by-concept-id-cache-key (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
                       elastic-search-index-names-cache/index-names-cache-key (elastic-search-index-names-cache/create-index-cache)
-                      humanizer-alias-cache/humanizer-alias-cache-key (humanizer-alias-cache/create-cache-client)}
+                      humanizer-alias-cache/humanizer-alias-cache-key (humanizer-alias-cache/create-cache-client)
+                      humanizer-report-service/humanizer-report-cache-key (humanizer-report-service/create-humanizer-report-cache-client)}
              :scheduler (jobs/create-scheduler `system-holder [jvm-info/log-jvm-statistics-job
                                                                (kf/refresh-kms-cache-job "bootstrap-kms-cache-refresh")
                                                                (provider-cache/refresh-provider-cache-job "bootstrap-provider-cache-refresh")

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -34,6 +34,7 @@
    [cmr.metadata-db.config :as mdb-config]
    [cmr.metadata-db.system :as mdb-system]
    [cmr.metadata-db.services.util :as mdb-util]
+   [cmr.search.services.humanizers.humanizer-report-service :as humanizer-report-service]
    [cmr.transmit.config :as transmit-config]))
 
 (defconfig db-batch-size
@@ -100,7 +101,8 @@
                                                                (b-coll-metadata-cache/update-collections-metadata-cache-job "bootstrap-collections-metadata-cache-update")
                                                                (coll-gran-acls-caches/refresh-collections-cache-for-granule-acls-job "bootstrap-collections-for-gran-acls-cache-refresh")
                                                                (elastic-search-index-names-cache/refresh-index-names-cache-job "bootstrap-elastic-search-index-names-cache")
-                                                               (humanizer-alias-cache/refresh-humanizer-alias-cache-job "boostrap-humanizer-alias-cache-refresh")])
+                                                               (humanizer-alias-cache/refresh-humanizer-alias-cache-job "bootstrap-humanizer-alias-cache-refresh")
+                                                               (humanizer-report-service/refresh-humanizer-report-cache-job "bootstrap-humanizer-report-cache-refresh")])
              :queue-broker queue-broker}]
     (transmit-config/system-with-connections sys [:metadata-db :echo-rest :kms :indexer :access-control :search])))
 

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -22,6 +22,7 @@
    [cmr.common-app.services.search.elastic-search-index :as search-index]
    [cmr.common-app.services.search.elastic-search-index-names-cache :as elastic-search-index-names-cache]
    [cmr.common.api.web-server :as web]
+   [cmr.common.cache]
    [cmr.common.cache.in-memory-cache :as mem-cache]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.jobs :as jobs]
@@ -34,6 +35,7 @@
    [cmr.metadata-db.config :as mdb-config]
    [cmr.metadata-db.system :as mdb-system]
    [cmr.metadata-db.services.util :as mdb-util]
+   [cmr.redis-utils.redis-cache]
    [cmr.search.services.humanizers.humanizer-report-service :as humanizer-report-service]
    [cmr.transmit.config :as transmit-config]))
 

--- a/common-app-lib/src/cmr/common_app/data/metadata_retrieval/collection_metadata_cache.clj
+++ b/common-app-lib/src/cmr/common_app/data/metadata_retrieval/collection_metadata_cache.clj
@@ -1,5 +1,5 @@
 (ns cmr.common-app.data.metadata-retrieval.collection-metadata-cache
-  "Defines common functions and defs a cache for catalog item metadata. 
+  "Defines common functions and defs a cache for catalog item metadata.
   It currently only stores collections.
   The metadata cache contains data like the following:
 
@@ -29,7 +29,7 @@
   (rhcache/create-redis-hash-cache {:keys-to-track [cache-key]}))
 
 (def incremental-since-refresh-date-key
-  "Identifies the field used in the defined cache-key to get the date represented 
+  "Identifies the field used in the defined cache-key to get the date represented
   as a string to get collections from ES the last time they where fetched."
   "incremental-since-refresh-date")
 
@@ -51,7 +51,7 @@
           (:items (qe/execute-query context query)))))
 
 (defn- data-range-condition
-  "Parses the date string into a cmr.common.joda-time and puts it into an elastic search 
+  "Parses the date string into a cmr.common.joda-time and puts it into an elastic search
    query condition so that the date can be used in an elastic search query."
   [date]
   (q/map->DateRangeCondition

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -224,8 +224,8 @@
 		"Create an instance of the bootstrap application."
 		[db-component queue-broker]
 		(let [sys-with-db (if db-component
-																						(assoc-in (bootstrap-system/create-system) [:embedded-systems :metadata-db :db] db-component)
-																						(bootstrap-system/create-system))]
+                      (assoc-in (bootstrap-system/create-system) [:embedded-systems :metadata-db :db] db-component)
+                      (bootstrap-system/create-system))]
 				(assoc sys-with-db :queue-broker queue-broker)))
 
 (defmulti create-ingest-app

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -221,9 +221,12 @@
   (assoc (access-control-system/create-system) :queue-broker queue-broker))
 
 (defn create-bootstrap-app
-  "Create an instance of the bootstrap application."
-  [queue-broker]
-  (assoc (bootstrap-system/create-system) :queue-broker queue-broker))
+		"Create an instance of the bootstrap application."
+		[db-component queue-broker]
+		(let [sys-with-db (if db-component
+																						(assoc-in (bootstrap-system/create-system) [:embedded-systems :metadata-db :db] db-component)
+																						(bootstrap-system/create-system))]
+				(assoc sys-with-db :queue-broker queue-broker)))
 
 (defmulti create-ingest-app
   "Create an instance of the ingest application."
@@ -278,7 +281,7 @@
              {:mock-echo echo-component
               :access-control (create-access-control-app queue-broker)
               :metadata-db (create-metadata-db-app db-component queue-broker)
-              :bootstrap (create-bootstrap-app queue-broker)
+              :bootstrap (create-bootstrap-app db-component queue-broker)
               :indexer (create-indexer-app queue-broker)
               :ingest (create-ingest-app db queue-broker)
               :search (create-search-app db-component queue-broker)

--- a/search-app/src/cmr/search/api/humanizer.clj
+++ b/search-app/src/cmr/search/api/humanizer.clj
@@ -5,14 +5,12 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.routes :as cr]
    [cmr.common.mime-types :as mt]
-   [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
    [cmr.search.services.humanizers.humanizer-json-schema-validation :as hv]
    [cmr.search.services.humanizers.humanizer-range-facet-service :as range-facet]
    [cmr.search.services.humanizers.humanizer-report-service :as hrs]
    [cmr.search.services.humanizers.humanizer-service :as humanizer-service]
-   [compojure.core :refer :all]
-   [compojure.route :as route]))
+   [compojure.core :refer :all]))
 
 (defn- validate-humanizer-content-type
   "Validates that content type sent with humanizer is JSON"

--- a/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
@@ -20,7 +20,7 @@
 
 (def humanizer-report-cache-key
   "The key used to store the humanizer report cache in the system cache map."
-  :humanizer-report)
+  :humanizer-report-cache)
 
 (def humanizer-not-found-error
   {:type :not-found :errors ["Humanizer does not exist."]})

--- a/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
@@ -4,10 +4,7 @@
    [clojure.data.csv :as csv]
    [cmr.common-app.humanizer :as h]
    [cmr.common-app.data.metadata-retrieval.revision-format-map :as crfm]
-   [cmr.transmit.cache.consistent-cache :as consistent-cache]
    [cmr.common.cache :as cache]
-   [cmr.common.cache.fallback-cache :as fallback-cache]
-   [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
    [cmr.common.concepts :as concepts]
    [cmr.common.config :refer [defconfig]]
    [cmr.common.jobs :refer [defjob default-job-start-delay]]
@@ -21,12 +18,8 @@
   (:import
    (java.io StringWriter)))
 
-(def report-cache-key
+(def humanizer-report-cache-key
   "The key used to store the humanizer report cache in the system cache map."
-  :humanizer-report-cache)
-
-(def csv-report-cache-key
-  "The key used when setting the cache value of the report data."
   :humanizer-report)
 
 (def humanizer-not-found-error
@@ -185,8 +178,8 @@
   (let [[report-generation-time humanizers-report] (util/time-execution
                                                     (safe-generate-humanizers-report-csv context))]
     (info (format "Humanizer report generated in %d ms." report-generation-time))
-    (cache/set-value (cache/context->cache context report-cache-key)
-                     csv-report-cache-key
+    (cache/set-value (cache/context->cache context humanizer-report-cache-key)
+                     humanizer-report-cache-key
                      humanizers-report)
     humanizers-report))
 
@@ -200,8 +193,8 @@
   [context regenerate?]
   (if regenerate?
     (create-and-save-humanizer-report context)
-    (cache/get-value (cache/context->cache context report-cache-key)
-                     csv-report-cache-key
+    (cache/get-value (cache/context->cache context humanizer-report-cache-key)
+                     humanizer-report-cache-key
                      ;; If there is a cache miss, generate the report and then
                      ;; return its value
                      #(safe-generate-humanizers-report-csv context))))
@@ -211,8 +204,10 @@
   [_ctx system]
   (create-and-save-humanizer-report {:system system}))
 
-(def humanizer-report-generator-job
+(defn refresh-humanizer-report-cache-job
+  [job-key]
   "The job definition used by the system job scheduler."
   {:job-type HumanizerReportGeneratorJob
+   :job-key job-key
    :interval (* 60 60 24) ; every 24 hours
    :start-delay (+ (default-job-start-delay) (humanizer-report-generator-job-delay))})

--- a/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
@@ -121,7 +121,7 @@
   "Returns a report on humanizers in use in collections as a CSV."
   [context]
   (let [[t1 collection-batches] (util/time-execution
-                                  (get-all-collections context)) ;; all collections from meetadata-collection-cache
+                                  (get-all-collections context))
          string-writer (StringWriter.)
          idx-atom (atom 0)]
     (info (format "get-all-collections: %d ms. Processing %d batches of size %d"

--- a/search-app/src/cmr/search/services/humanizers/humanizer_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_service.clj
@@ -4,12 +4,9 @@
    [cheshire.core :as json]
    [cmr.common.api.context :as context-util]
    [cmr.common.concepts :as cc]
-   [cmr.common.log :as log :refer [debug info warn error]]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
-   [cmr.common.util :as util]
    [cmr.search.services.humanizers.humanizer-messages :as msg]
-   [cmr.transmit.tokens :as tokens]
    [cmr.transmit.metadata-db :as mdb]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -113,49 +113,48 @@
              :nrepl (nrepl/create-nrepl-if-configured (search-nrepl-port))
              ;; Caches added to this list must be explicitly cleared in query-service/clear-cache
              :caches {elastic-search-index-names-cache/index-names-cache-key (elastic-search-index-names-cache/create-index-cache)
-                      af/acl-cache-key (af/create-acl-cache [:catalog-item :system-object :provider-object])
+                      af/acl-cache-key                                       (af/create-acl-cache [:catalog-item :system-object :provider-object])
                       ;; Caches a map of tokens to the security identifiers
-                      context-augmenter/token-sid-cache-name (context-augmenter/create-token-sid-cache)
-                      context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)
-                      :has-granules-map (hgrf/create-has-granules-map-cache)
-                      :has-granules-or-cwic-map (hgocrf/create-has-granules-or-cwic-map-cache)
-                      :has-granules-or-opensearch-map (hgocrf/create-has-granules-or-opensearch-map-cache)
-                      metadata-transformer/xsl-transformer-cache-name (mem-cache/create-in-memory-cache)
-                      acl/token-imp-cache-key (acl/create-token-imp-cache)
-                      acl/token-pc-cache-key (acl/create-token-pc-cache)
-                      launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)
-                      urs/urs-cache-key (urs/create-urs-cache)
-                      kf/kms-cache-key (kf/create-kms-cache)
-                      kl/kms-short-name-cache-key (kl/create-kms-short-name-cache)
-                      kl/kms-umm-c-cache-key (kl/create-kms-umm-c-cache)
-                      kl/kms-location-cache-key (kl/create-kms-location-cache)
-                      kl/kms-measurement-cache-key (kl/create-kms-measurement-cache)
-                      search/scroll-id-cache-key (search/create-scroll-id-cache)
-                      search/scroll-first-page-cache-key (search/create-scroll-first-page-cache)
-                      cmn-coll-metadata-cache/cache-key (cmn-coll-metadata-cache/create-cache)
-                      coll-gran-acls-caches/coll-by-concept-id-cache-key (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
-                      common-health/health-cache-key (common-health/create-health-cache)
-                      common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
-                      hrs/report-cache-key (hrs/create-report-cache)
-                      hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}
+                      context-augmenter/token-sid-cache-name                 (context-augmenter/create-token-sid-cache)
+                      context-augmenter/token-user-id-cache-name             (context-augmenter/create-token-user-id-cache)
+                      :has-granules-map                                      (hgrf/create-has-granules-map-cache)
+                      :has-granules-or-cwic-map                              (hgocrf/create-has-granules-or-cwic-map-cache)
+                      :has-granules-or-opensearch-map                        (hgocrf/create-has-granules-or-opensearch-map-cache)
+                      metadata-transformer/xsl-transformer-cache-name        (mem-cache/create-in-memory-cache)
+                      acl/token-imp-cache-key                                (acl/create-token-imp-cache)
+                      acl/token-pc-cache-key                                 (acl/create-token-pc-cache)
+                      launchpad-user-cache/launchpad-user-cache-key          (launchpad-user-cache/create-launchpad-user-cache)
+                      urs/urs-cache-key                                      (urs/create-urs-cache)
+                      kf/kms-cache-key                                       (kf/create-kms-cache)
+                      kl/kms-short-name-cache-key                            (kl/create-kms-short-name-cache)
+                      kl/kms-umm-c-cache-key                                 (kl/create-kms-umm-c-cache)
+                      kl/kms-location-cache-key                              (kl/create-kms-location-cache)
+                      kl/kms-measurement-cache-key                           (kl/create-kms-measurement-cache)
+                      search/scroll-id-cache-key                             (search/create-scroll-id-cache)
+                      search/scroll-first-page-cache-key                     (search/create-scroll-first-page-cache)
+                      cmn-coll-metadata-cache/cache-key                      (cmn-coll-metadata-cache/create-cache)
+                      coll-gran-acls-caches/coll-by-concept-id-cache-key     (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
+                      common-health/health-cache-key                         (common-health/create-health-cache)
+                      common-enabled/write-enabled-cache-key                 (common-enabled/create-write-enabled-cache)
+                      hrs/humanizer-report-cache-key                         (hrs/create-report-cache)
+                      hrfs/range-facet-cache-key                             (hrfs/create-range-facet-cache)}
              :public-conf (public-conf)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)
              ;; Note that some of these jobs only need to run on one node, but we are currently
              ;; running all jobs on all nodes
              :scheduler (jobs/create-scheduler
-                         `system-holder
-                         [(af/refresh-acl-cache-job "search-acl-cache-refresh")
-                          hgrf/refresh-has-granules-map-job
-                          hgocrf/refresh-has-granules-or-cwic-map-job
-                          hgocrf/refresh-has-granules-or-opensearch-map-job
-                          (metadata-cache/refresh-collections-metadata-cache-job)
-                          (metadata-cache/update-collections-metadata-cache-job)
-                          (cache-info/create-log-cache-info-job "search")
-                          jvm-info/log-jvm-statistics-job
-                          hrs/humanizer-report-generator-job])}]
+                          `system-holder
+                          [(af/refresh-acl-cache-job "search-acl-cache-refresh")
+                           hgrf/refresh-has-granules-map-job
+                           hgocrf/refresh-has-granules-or-cwic-map-job
+                           hgocrf/refresh-has-granules-or-opensearch-map-job
+                           (metadata-cache/refresh-collections-metadata-cache-job)
+                           (metadata-cache/update-collections-metadata-cache-job)
+                           (cache-info/create-log-cache-info-job "search")
+                           jvm-info/log-jvm-statistics-job])}]
     (transmit-config/system-with-connections
-     sys
-     [:indexer :echo-rest :metadata-db :kms :access-control :urs])))
+      sys
+      [:indexer :echo-rest :metadata-db :kms :access-control :urs])))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -113,48 +113,48 @@
              :nrepl (nrepl/create-nrepl-if-configured (search-nrepl-port))
              ;; Caches added to this list must be explicitly cleared in query-service/clear-cache
              :caches {elastic-search-index-names-cache/index-names-cache-key (elastic-search-index-names-cache/create-index-cache)
-                      af/acl-cache-key                                       (af/create-acl-cache [:catalog-item :system-object :provider-object])
+                      af/acl-cache-key (af/create-acl-cache [:catalog-item :system-object :provider-object])
                       ;; Caches a map of tokens to the security identifiers
-                      context-augmenter/token-sid-cache-name                 (context-augmenter/create-token-sid-cache)
-                      context-augmenter/token-user-id-cache-name             (context-augmenter/create-token-user-id-cache)
-                      :has-granules-map                                      (hgrf/create-has-granules-map-cache)
-                      :has-granules-or-cwic-map                              (hgocrf/create-has-granules-or-cwic-map-cache)
-                      :has-granules-or-opensearch-map                        (hgocrf/create-has-granules-or-opensearch-map-cache)
-                      metadata-transformer/xsl-transformer-cache-name        (mem-cache/create-in-memory-cache)
-                      acl/token-imp-cache-key                                (acl/create-token-imp-cache)
-                      acl/token-pc-cache-key                                 (acl/create-token-pc-cache)
-                      launchpad-user-cache/launchpad-user-cache-key          (launchpad-user-cache/create-launchpad-user-cache)
-                      urs/urs-cache-key                                      (urs/create-urs-cache)
-                      kf/kms-cache-key                                       (kf/create-kms-cache)
-                      kl/kms-short-name-cache-key                            (kl/create-kms-short-name-cache)
-                      kl/kms-umm-c-cache-key                                 (kl/create-kms-umm-c-cache)
-                      kl/kms-location-cache-key                              (kl/create-kms-location-cache)
-                      kl/kms-measurement-cache-key                           (kl/create-kms-measurement-cache)
-                      search/scroll-id-cache-key                             (search/create-scroll-id-cache)
-                      search/scroll-first-page-cache-key                     (search/create-scroll-first-page-cache)
-                      cmn-coll-metadata-cache/cache-key                      (cmn-coll-metadata-cache/create-cache)
-                      coll-gran-acls-caches/coll-by-concept-id-cache-key     (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
-                      common-health/health-cache-key                         (common-health/create-health-cache)
-                      common-enabled/write-enabled-cache-key                 (common-enabled/create-write-enabled-cache)
-                      hrs/humanizer-report-cache-key                         (hrs/create-humanizer-report-cache-client)
-                      hrfs/range-facet-cache-key                             (hrfs/create-range-facet-cache)}
+                      context-augmenter/token-sid-cache-name (context-augmenter/create-token-sid-cache)
+                      context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)
+                      :has-granules-map (hgrf/create-has-granules-map-cache)
+                      :has-granules-or-cwic-map (hgocrf/create-has-granules-or-cwic-map-cache)
+                      :has-granules-or-opensearch-map (hgocrf/create-has-granules-or-opensearch-map-cache)
+                      metadata-transformer/xsl-transformer-cache-name (mem-cache/create-in-memory-cache)
+                      acl/token-imp-cache-key (acl/create-token-imp-cache)
+                      acl/token-pc-cache-key (acl/create-token-pc-cache)
+                      launchpad-user-cache/launchpad-user-cache-key (launchpad-user-cache/create-launchpad-user-cache)
+                      urs/urs-cache-key (urs/create-urs-cache)
+                      kf/kms-cache-key (kf/create-kms-cache)
+                      kl/kms-short-name-cache-key (kl/create-kms-short-name-cache)
+                      kl/kms-umm-c-cache-key (kl/create-kms-umm-c-cache)
+                      kl/kms-location-cache-key (kl/create-kms-location-cache)
+                      kl/kms-measurement-cache-key (kl/create-kms-measurement-cache)
+                      search/scroll-id-cache-key (search/create-scroll-id-cache)
+                      search/scroll-first-page-cache-key (search/create-scroll-first-page-cache)
+                      cmn-coll-metadata-cache/cache-key (cmn-coll-metadata-cache/create-cache)
+                      coll-gran-acls-caches/coll-by-concept-id-cache-key (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
+                      common-health/health-cache-key (common-health/create-health-cache)
+                      common-enabled/write-enabled-cache-key (common-enabled/create-write-enabled-cache)
+                      hrs/humanizer-report-cache-key (hrs/create-humanizer-report-cache-client)
+                      hrfs/range-facet-cache-key (hrfs/create-range-facet-cache)}
              :public-conf (public-conf)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)
              ;; Note that some of these jobs only need to run on one node, but we are currently
              ;; running all jobs on all nodes
              :scheduler (jobs/create-scheduler
-                          `system-holder
-                          [(af/refresh-acl-cache-job "search-acl-cache-refresh")
-                           hgrf/refresh-has-granules-map-job
-                           hgocrf/refresh-has-granules-or-cwic-map-job
-                           hgocrf/refresh-has-granules-or-opensearch-map-job
-                           (metadata-cache/refresh-collections-metadata-cache-job)
-                           (metadata-cache/update-collections-metadata-cache-job)
-                           (cache-info/create-log-cache-info-job "search")
-                           jvm-info/log-jvm-statistics-job])}]
+                         `system-holder
+                         [(af/refresh-acl-cache-job "search-acl-cache-refresh")
+                          hgrf/refresh-has-granules-map-job
+                          hgocrf/refresh-has-granules-or-cwic-map-job
+                          hgocrf/refresh-has-granules-or-opensearch-map-job
+                          (metadata-cache/refresh-collections-metadata-cache-job)
+                          (metadata-cache/update-collections-metadata-cache-job)
+                          (cache-info/create-log-cache-info-job "search")
+                          jvm-info/log-jvm-statistics-job])}]
     (transmit-config/system-with-connections
-      sys
-      [:indexer :echo-rest :metadata-db :kms :access-control :urs])))
+     sys
+     [:indexer :echo-rest :metadata-db :kms :access-control :urs])))
 
 (defn start
   "Performs side effects to initialize the system, acquire resources,

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -136,7 +136,7 @@
                       coll-gran-acls-caches/coll-by-concept-id-cache-key     (coll-gran-acls-caches/create-coll-by-concept-id-cache-client)
                       common-health/health-cache-key                         (common-health/create-health-cache)
                       common-enabled/write-enabled-cache-key                 (common-enabled/create-write-enabled-cache)
-                      hrs/humanizer-report-cache-key                         (hrs/create-report-cache)
+                      hrs/humanizer-report-cache-key                         (hrs/create-humanizer-report-cache-client)
                       hrfs/range-facet-cache-key                             (hrfs/create-range-facet-cache)}
              :public-conf (public-conf)
              orbits-runtime/system-key (orbits-runtime/create-orbits-runtime)

--- a/system-int-test/src/cmr/system_int_test/utils/search_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/search_util.clj
@@ -5,9 +5,7 @@
    [cheshire.core :as json]
    [clj-http.client :as client]
    [clj-time.coerce :as tc]
-   [clj-time.core :as t]
    [clojure.data.xml :as x]
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk]
@@ -49,16 +47,6 @@
   [options]
   (let [response (client/post (url/disable-search-writes-url) options)]
     (is (= 200 (:status response)))))
-
-(defn refresh-collection-metadata-cache
-  "Triggers a full refresh of the collection metadata cache in the search application."
-  []
-  (let [response (client/post
-                  (url/refresh-collection-metadata-cache-url)
-                  {:connection-manager (s/conn-mgr)
-                   :headers {transmit-config/token-header (transmit-config/echo-system-token)}
-                   :throw-exceptions false})]
-    (is (= 200 (:status response)) (:body response))))
 
 (defn collection-metadata-cache-state
   "Fetches the state of the collection metadata cache"

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -399,8 +399,9 @@
 
 (defn refresh-collection-metadata-cache-url
   []
-  (format "http://localhost:%s/jobs/refresh-collection-metadata-cache"
-          (transmit-config/search-port)))
+  (format "http://localhost:%s/caches/refresh/collection-metadata-cache" (transmit-config/bootstrap-port)))
+
+;;collection-metadata-cache
 
 (defn refresh-humanizer-alias-cache-url
   []

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -401,8 +401,6 @@
   []
   (format "http://localhost:%s/caches/refresh/collection-metadata-cache" (transmit-config/bootstrap-port)))
 
-;;collection-metadata-cache
-
 (defn refresh-humanizer-alias-cache-url
   []
   (format "http://localhost:%s/caches/refresh/humanizer-alias-cache-by-field" (transmit-config/bootstrap-port)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
@@ -123,7 +123,7 @@
          :Platforms [(data-umm-cmn/platform {:ShortName "AM-1"})]})))
     (index/wait-until-indexed)
     ;; Refresh the metadata cache
-    (search/refresh-collection-metadata-cache)
+				(cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
     (testing "Humanizer report batches"
       (let [report-lines (str/split (search/get-humanizers-report) #"\n")]
         (is (= (count report-lines) (+ 2 updated-batch-size)))

--- a/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
@@ -12,11 +12,13 @@
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
    [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
    [cmr.system-int-test.utils.humanizer-util :as hu]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
-   [cmr.system-int-test.utils.url-helper :as url]))
+   [cmr.system-int-test.utils.url-helper :as url]
+   [cmr.transmit.config :as transmit-config]))
 
 (use-fixtures :each (join-fixtures
                       [(ingest/reset-fixture {"provguid1" "PROV1"})
@@ -87,7 +89,8 @@
 
     (index/wait-until-indexed)
     ;; Refresh the metadata cache
-    (search/refresh-collection-metadata-cache)
+    (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
+
     (testing "Humanizer report csv"
       (let [report (search/get-humanizers-report)]
         (is (= ["provider,concept_id,short_name,version,original_value,humanized_value"

--- a/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
@@ -32,14 +32,15 @@
 ;;3. Retrieve the reporting
 ;;  curl http://localhost:3003/humanizers/report
 
+;; TODO Jyna fix this test
 (defn- get-cached-report
   "Pull the report data from its cache."
   []
   (let [full-url (str (url/search-read-caches-url)
                       "/"
-                      (name hrs/report-cache-key)
+                      (name hrs/humanizer-report-cache-key)
                       "/"
-                      (name hrs/csv-report-cache-key))
+                      (name hrs/humanizer-report-cache-key))
         admin-read-group-concept-id (e/get-or-create-group (s/context)
                                                            "admin-read-group")
         admin-read-token (e/login (s/context)

--- a/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_humanized_search_test.clj
@@ -32,7 +32,6 @@
 ;;3. Retrieve the reporting
 ;;  curl http://localhost:3003/humanizers/report
 
-;; TODO Jyna fix this test
 (defn- get-cached-report
   "Pull the report data from its cache."
   []

--- a/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection_search_format_test.clj
@@ -3,7 +3,6 @@
   (:require
    [cheshire.core :as json]
    [clj-http.client :as client]
-   [clojure.data.xml :as x]
    [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.test :refer :all]
@@ -12,16 +11,13 @@
    [cmr.common.mime-types :as mt]
    [cmr.common.test.url-util :as url-util]
    [cmr.common.util :as util :refer [are2 are3]]
-   [cmr.common.xml :as cx]
    [cmr.search.validators.opendata :as opendata-json]
    [cmr.spatial.codec :as codec]
    [cmr.spatial.line-string :as l]
    [cmr.spatial.mbr :as m]
    [cmr.spatial.point :as p]
    [cmr.spatial.polygon :as poly]
-   [cmr.spatial.ring-relations :as rr]
    [cmr.system-int-test.data2.atom :as da]
-   [cmr.system-int-test.data2.atom-json :as dj]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
@@ -30,13 +26,14 @@
    [cmr.system-int-test.data2.umm-json :as du]
    [cmr.system-int-test.data2.umm-spec-collection :as umm-spec-collection]
    [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
    [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
    [cmr.system-int-test.utils.url-helper :as url]
+   [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.test.expected-conversion :as exp-conv]
-   [cmr.umm-spec.umm-spec-core :as umm-spec]
    [cmr.umm-spec.versioning :as umm-version]
    [cmr.umm.umm-core :as umm]
    [cmr.umm.umm-spatial :as umm-s]))
@@ -172,7 +169,7 @@
                                c3-dif [:dif :echo10 :dif10]}))
 
         (testing "All collections and formats cached after cache is refreshed"
-          (search/refresh-collection-metadata-cache)
+          (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
           ;; All formats excludes dif since we configured it above to not be cached
           (let [all-formats [:dif10 :echo10 :iso19115
                               {:format :umm-json :version umm-version/current-collection-version}]]

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
@@ -8,6 +8,7 @@
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.system :as system]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
    [cmr.system-int-test.utils.humanizer-util :as humanizer-util]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
@@ -209,7 +210,7 @@
 
           _ (index/wait-until-indexed)
           ;; Humanizers use the cached collection metadata - clear to make sure we have the latest
-          _ (search/refresh-collection-metadata-cache)
+          _ (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
           expected-report1 (str "provider,concept_id,short_name,version,original_value,"
                                 "humanized_value\n"
                                 "PROV1,C1-PROV1,Short,V5,Bioosphere,Biosphere\n")
@@ -244,7 +245,7 @@
                        :accept-format :json})
 
               _ (index/wait-until-indexed)
-              _ (search/refresh-collection-metadata-cache)
+              _ (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
               expected-report2 (str "provider,concept_id,short_name,version,original_value,"
                                     "humanized_value\n"
                                     "PROV1,C1-PROV1,Short,V5,Bioosphere,Biosphere\n"
@@ -273,7 +274,7 @@
         {:format :umm-json
          :accept-format :json})
     (index/wait-until-indexed)
-    (search/refresh-collection-metadata-cache)
+    (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
     (is (= 200 (:status (search/get-humanizers-report-raw)))))
   (testing "Guests cannot force the humanizer report to be regenerated"
     (is (= 401 (:status (search/get-humanizers-report-raw {:regenerate true})))))
@@ -294,7 +295,7 @@
         {:format :umm-json
          :accept-format :json})
     (index/wait-until-indexed)
-    (search/refresh-collection-metadata-cache)
+      (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
       (is (= 200 (:status (search/get-humanizers-report-raw {:regenerate true
                                                              :token admin-user-token}))))))
   (side/eval-form `(common-config/set-collection-umm-version! ~accepted-version))))

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
@@ -13,6 +13,7 @@
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
+			[cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.test.expected-conversion :as expected-conversion]
    [cmr.umm-spec.versioning :as versioning]))

--- a/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/humanizer/humanizer_test.clj
@@ -13,7 +13,7 @@
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
-			[cmr.system-int-test.utils.url-helper :as url]
+   [cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.test.expected-conversion :as expected-conversion]
    [cmr.umm-spec.versioning :as versioning]))

--- a/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
@@ -6,12 +6,13 @@
    [clojure.test :refer :all]
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.data2.core :as d]
-   [cmr.system-int-test.utils.search-util :as search]
    [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.cache-util :as cache-util]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.site-util :as site]
    [cmr.system-int-test.utils.tag-util :as tags]
+   [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.models.umm-common-models :as cm]
    [cmr.umm-spec.test.expected-conversion :as exp-conv]))
 
@@ -88,7 +89,7 @@
 (def collections-fixture
   (fn [f]
     (setup-collections)
-    (search/refresh-collection-metadata-cache)
+    (cache-util/refresh-cache (url/refresh-collection-metadata-cache-url) (transmit-config/echo-system-token))
     (f)))
 
 (use-fixtures :once (join-fixtures

--- a/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
@@ -12,7 +12,7 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.site-util :as site]
    [cmr.system-int-test.utils.tag-util :as tags]
-			[cmr.system-int-test.utils.url-helper :as url]
+   [cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.models.umm-common-models :as cm]
    [cmr.umm-spec.test.expected-conversion :as exp-conv]))

--- a/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/sitemaps_test.clj
@@ -12,6 +12,7 @@
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.site-util :as site]
    [cmr.system-int-test.utils.tag-util :as tags]
+			[cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as transmit-config]
    [cmr.umm-spec.models.umm-common-models :as cm]
    [cmr.umm-spec.test.expected-conversion :as exp-conv]))


### PR DESCRIPTION
- Moved humanizer report refresh job to be called by bootstrap only