### PR TITLE
CMR-9684: Part 2 - Switching humanizer report from 24 hr interval to daily schedule

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/data/metadata_retrieval/collection_metadata_cache.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/metadata_retrieval/collection_metadata_cache.clj
@@ -101,6 +101,8 @@
   (refresh-cache {:system system}))
 
 (defn refresh-collections-metadata-cache-job
+  "This job definition for refreshing the entire collection metadata cache. This cache is relied upon by the humanizer-report cache job.
+  If you change the daily schedule of this cache, you must change the daily schedule of the humanizer-report generator as well."
   [job-key]
   {:job-type RefreshCollectionsMetadataCache
    :job-key job-key

--- a/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
+++ b/search-app/src/cmr/search/services/humanizers/humanizer_report_service.clj
@@ -197,8 +197,10 @@
 
 (defn refresh-humanizer-report-cache-job
   [job-key]
-  "The job definition used by the system job scheduler."
+  "The job definition used by the system job scheduler to refresh the humanizer report cache.
+  This cache is directly reliant on the collection-metadata-cache being refreshed and present (refresh-collections-metadata-cache-job).
+  Currently the collection metadata cache is refreshed daily at 6 AM UTC. So we will start this job an hour after that."
   {:job-type HumanizerReportGeneratorJob
    :job-key job-key
-   :interval (* 60 60 24) ; every 24 hours
-   :start-delay (+ (default-job-start-delay) (humanizer-report-generator-job-delay))})
+   :start-delay (* 10 60) ;; 10 minutes delay
+   :daily-at-hour-and-minute [07 00]})


### PR DESCRIPTION
Updating the humanizer-report to trigger an hour after the collection metadata cache does