### PR TITLE
CMR-9736: Updating aws-java-sdk in message-queue-lib

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -1,6 +1,6 @@
 (def aws-java-sdk-version
   "The java aws sdk version to use."
-  "1.11.525")
+  "1.12.663")
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."


### PR DESCRIPTION
# Overview

### What is the feature/fix?

`software.amazon.ion:ion-java@1.0.2` needed to be patched to a newer version

### What is the Solution?

Updating `aws-java-sdk` to a newer version, as that controls the underlying `software.amazon.ion:ion-java` version.

### What areas of the application does this impact?

- Access Control App

# Checklist

- [x] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
