### PR TITLE
Fix curl example in the `Specifying facet fields` section

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -3048,7 +3048,7 @@ Example: `science_keywords_h[0][topic]=Oceans`
 
 Example curl calls:
 
-    %CMR-ENDPOINT%/search/collections.json?include_facets=v2&hierarchical_facets=true&science_keywords_h%5B0%5D%5Btopic%5D=Oceans
+    %CMR-ENDPOINT%/collections.json?include_facets=v2&hierarchical_facets=true&science_keywords_h%5B0%5D%5Btopic%5D=Oceans
 
 ##### Responses
 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Fix curl example in the `Specifying facet fields` section.

### What is the Solution?

remove duplicate "/search" from url string.

### What areas of the application does this impact?

The public docs.

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
