### PR TITLE
CMR-9783: Lint message-queue-lib

### DIFF
--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -101,8 +101,8 @@
   (print-all-configs-docs))
 
 
-
-(defn parse-boolean
+;; not currently used, either find some uses or delete when the linter ticket gets here
+(defn parse-bool
   "Helper for parsing boolean strings."
   [s]
   (cond
@@ -185,9 +185,9 @@
                     (some? default-value#)
                     (not= (type default-value#) ~config-type))
            (throw
-             (Exception.
-               (format "The type of the default value %s does not match the specified config type %s"
-                       (type default-value#) ~config-type))))
+            (Exception.
+             (format "The type of the default value %s does not match the specified config type %s"
+                     (type default-value#) ~config-type))))
 
          ;; Register the config
          (register-config ~(str *ns*) ~config-name-key doc-string-value#

--- a/common-lib/src/cmr/common/config.clj
+++ b/common-lib/src/cmr/common/config.clj
@@ -100,8 +100,6 @@
 (comment
   (print-all-configs-docs))
 
-
-;; not currently used, either find some uses or delete when the linter ticket gets here
 (defn parse-bool
   "Helper for parsing boolean strings."
   [s]
@@ -122,7 +120,7 @@
   {String identity
    Long #(Long. ^String %)
    Double #(Double. ^String %)
-   Boolean parse-boolean
+   Boolean parse-bool
    :edn edn/read-string})
 
 (defmacro defconfig

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -57,10 +57,10 @@
              ;; level directory.
              :lint {:source-paths ^:replace ["src"]
                     :test-paths ^:replace []
-                    :plugins [[jonase/eastwood "0.2.5"]
-                              [lein-ancient "0.6.15"]
-                              [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]]}
+                    :plugins [[jonase/eastwood "1.4.2"]
+                              [lein-ancient "0.7.0"]
+                              [lein-bikeshed "0.5.2"]
+                              [lein-kibit "0.1.8"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}
@@ -82,7 +82,7 @@
              ["shell" "echo" "== Kibit =="]
              ["with-profile" "lint" "kibit"]]
             "eastwood"
-            ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths]}"]
+            ["with-profile" "lint" "eastwood" "{:namespaces [:source-paths] :exclude-linters [:reflection]}"]
             "bikeshed"
             ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
             "check-deps"

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -87,6 +87,7 @@
             ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
             "check-deps"
             ["with-profile" "lint" "ancient" ":all"]
+            "ancient" ["with-profile" "lint" "ancient"]
             "check-sec"
             ["with-profile" "security" "dependency-check"]
             "lint"

--- a/message-queue-lib/src/cmr/message_queue/config.clj
+++ b/message-queue-lib/src/cmr/message_queue/config.clj
@@ -4,25 +4,30 @@
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.services.errors :as errors]))
 
+(declare app-environment)
 (defconfig app-environment
   "The environment in which the application is running in NGAP (wl, sit, uat, ops)"
   {:default "local"})
 
+(declare time-to-live-s)
 (defconfig time-to-live-s
   "The Time-To-Live (TTL) for each retry queue (in seconds)."
   {:default [5, 50, 500, 5000, 50000]
    :parser #(json/decode ^String %)})
 
+(declare publish-queue-timeout-ms set-publish-queue-timeout-ms!)
 (defconfig publish-queue-timeout-ms
   "Number of milliseconds to wait for a publish request to be confirmed before considering the
   request timed out."
   {:default 10000 :type Long})
 
+(declare queue-type)
 (defconfig queue-type
   "This indicates which type of queue to use. Valid types are \"memory\",
   and \"aws\""
   {:default "memory"})
 
+(declare messaging-retry-delay)
 (defconfig messaging-retry-delay
   "This configuration value is used to determine how long to wait before
   retrying a messaging operation."

--- a/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
@@ -79,16 +79,12 @@
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   lifecycle/Lifecycle
 
-  ;; param 1 is 'this'
-  ;; param 2 is system
   (start
-    [this _]
+    [this _system]
     this)
 
-  ;; param 1 is 'this'
-  ;; param 2 is system
   (stop
-    [this _]
+    [this _system]
     (drain-channels (vals queues-to-channels))
 
     ;; Wait for go blocks to finish
@@ -104,18 +100,16 @@
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   queue-protocol/Queue
 
-  ;; parameters are 'this', queue-name, and message
   (publish-to-queue
-    [_ queue-name msg]
+    [_this queue-name msg]
     ;; Puts the message on the channel. It is encoded as json to simulate the Rabbit MQ behavior
     (if-let [chan (queues-to-channels queue-name)]
       (a/>!! chan (json/generate-string msg))
       (throw (IllegalArgumentException.
               (str "Could not find channel bound to queue " queue-name)))))
 
-  ;; parameters are 'this' and exchange-name
   (get-queues-bound-to-exchange
-    [_ exchange-name]
+    [_this exchange-name]
     (seq (exchanges-to-queue-sets exchange-name)))
 
   (publish-to-exchange
@@ -128,9 +122,8 @@
     (swap! handler-channels-atom conj (create-async-handler this queue-name handler))
     nil)
 
-  ;; parameter is 'this'
   (reset
-    [_]
+    [_this]
     ;; clear all channels
     (drain-channels (vals queues-to-channels)))
 
@@ -143,9 +136,8 @@
     (lifecycle/start this nil)
     this)
 
-  ;; parameter is 'this'
   (health
-    [_]
+    [_this]
     {:ok? true}))
 (record-pretty-printer/enable-record-pretty-printing MemoryQueueBroker)
 

--- a/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/memory_queue.clj
@@ -1,5 +1,6 @@
 (ns cmr.message-queue.queue.memory-queue
-  "Defines an in memory implementation of the Queue protocol. It uses core.async for message passing."
+  "Defines an in memory implementation of the Queue protocol. It uses core.async
+   for message passing."
   (:require
    [cheshire.core :as json]
    [clojure.core.async :as a]
@@ -30,8 +31,8 @@
 
 (declare msg)
 (defn- create-async-handler
-  "Creates a go block that will asynchronously pull messages off the queue, pass them to the handler,
-  and process the response."
+  "Creates a go block that will asynchronously pull messages off the queue, pass
+   them to the handler, and process the response."
   [queue-broker queue-name handler]
   (let [queue-ch (get-in queue-broker [:queues-to-channels queue-name])]
     (a/go
@@ -70,7 +71,8 @@
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Running State
 
-   ;; An atom containing a sequence of channels returned by the go block processors for each handler.
+   ;; An atom containing a sequence of channels returned by the go block processors
+   ;; for each handler.
   handler-channels-atom]
 
 
@@ -108,7 +110,8 @@
     ;; Puts the message on the channel. It is encoded as json to simulate the Rabbit MQ behavior
     (if-let [chan (queues-to-channels queue-name)]
       (a/>!! chan (json/generate-string msg))
-      (throw (IllegalArgumentException. (str "Could not find channel bound to queue " queue-name)))))
+      (throw (IllegalArgumentException.
+              (str "Could not find channel bound to queue " queue-name)))))
 
   ;; parameters are 'this' and exchange-name
   (get-queues-bound-to-exchange

--- a/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/queue_protocol.clj
@@ -15,8 +15,8 @@
 
   (publish-to-exchange
     [this exchange-name msg]
-    "Publishes a message on the exchange with the given exchange name. Returns true if the message was
-    successfully enqueued. Otherwise returns false.")
+    "Publishes a message on the exchange with the given exchange name. Returns
+     true if the message was successfully enqueued. Otherwise returns false.")
 
   (subscribe
     [this queue-name handler-fn]

--- a/message-queue-lib/src/cmr/message_queue/services/queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/services/queue.clj
@@ -19,10 +19,11 @@
 (defn- try-to-publish
   "Attempts to publish messages to the given exchange.
 
-  When the messaging service is down or unreachable, calls to publish will throw an exception. Rather
-  than raise an error to the caller immediately, the publication will be retried indefinitely.
-  By retrying, routine maintenance such as restarting the RabbitMQ server will not result in any
-  ingest errors returned to the provider.
+  When the messaging service is down or unreachable, calls to publish will throw
+   an exception. Rather than raise an error to the caller immediately, the
+   publication will be retried indefinitely. By retrying, routine maintenance
+   such as restarting the RabbitMQ server will not result in any ingest errors
+   returned to the provider.
 
   Returns true if the message was successfully enqueued and false otherwise."
   [queue-broker exchange-name msg]
@@ -54,5 +55,6 @@
       (catch java.util.concurrent.TimeoutException e
         (errors/throw-service-error
           :service-unavailable
-          (str "Request timed out when attempting to publish message " (- (System/currentTimeMillis) start-time) ": " msg)
+          (format "Request timed out when attempting to publish message %s: %s"
+                  (- (System/currentTimeMillis) start-time) msg)
           e)))))

--- a/message-queue-lib/src/cmr/message_queue/services/queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/services/queue.clj
@@ -3,7 +3,7 @@
   a queue listener"
   (:require
    [clojail.core :as timeout]
-   [cmr.common.log :as log :refer [debug error info warn]]
+   [cmr.common.log :as log :refer [debug error warn]]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util :refer [defn-timed]]
    [cmr.message-queue.config :as config]
@@ -37,6 +37,8 @@
     (Thread/sleep (config/messaging-retry-delay))
     (recur queue-broker exchange-name msg)))
 
+(declare publish-message)
+(declare queue-broker exchange-name msg)
 (defn-timed publish-message
   "Publishes a message to an exchange Throws a service unavailable error if the message
   fails to be put on the queue.
@@ -52,5 +54,5 @@
       (catch java.util.concurrent.TimeoutException e
         (errors/throw-service-error
           :service-unavailable
-          (str "Request timed out when attempting to publish message: " msg)
+          (str "Request timed out when attempting to publish message " (- (System/currentTimeMillis) start-time) ": " msg)
           e)))))

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_side_api.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_side_api.clj
@@ -1,13 +1,14 @@
 (ns cmr.message-queue.test.queue-broker-side-api
   "Defines routes for accessing a controlling the queue broker in testing through a side api and
   function for accessing those routes."
-  (:require [compojure.core :refer  [GET POST context routes]]
-            [clj-http.client :as client]
-            [cheshire.core :as json]
-            [cmr.common.log :refer (debug)]
-            [cmr.message-queue.test.queue-broker-wrapper :as wrapper]
-            [cmr.message-queue.config :as config]
-            [cmr.common-app.test.side-api :as side-api]))
+  (:require
+   [compojure.core :refer  [GET POST context routes]]
+   [clj-http.client :as client]
+   [cheshire.core :as json]
+   [cmr.common.log :refer (debug)]
+   [cmr.message-queue.test.queue-broker-wrapper :as wrapper]
+   [cmr.message-queue.config :as config]
+   [cmr.common-app.test.side-api :as side-api]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Functions for defining the API

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_side_api.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_side_api.clj
@@ -1,11 +1,10 @@
 (ns cmr.message-queue.test.queue-broker-side-api
   "Defines routes for accessing a controlling the queue broker in testing through a side api and
   function for accessing those routes."
-  (:require [compojure.core :refer :all]
+  (:require [compojure.core :refer  [GET POST context routes]]
             [clj-http.client :as client]
             [cheshire.core :as json]
-            [clojure.string :as str]
-            [cmr.common.log :refer (debug info warn error)]
+            [cmr.common.log :refer (debug)]
             [cmr.message-queue.test.queue-broker-wrapper :as wrapper]
             [cmr.message-queue.config :as config]
             [cmr.common-app.test.side-api :as side-api]))

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -9,7 +9,7 @@
    [clojure.set :as set]
    [cmr.common.dev.record-pretty-printer :as record-pretty-printer]
    [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :as log :refer (debug trace info warn error)]
+   [cmr.common.log :as log :refer (trace info warn)]
    [cmr.common.util :as util]
    [cmr.message-queue.config :as iconfig]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
@@ -262,8 +262,9 @@
       (finally
         (reset! resetting?-atom false))))
 
+  ;; Parameter is 'this'
   (health
-    [this]
+    [_]
     (queue-protocol/health queue-broker)))
 
 (record-pretty-printer/enable-record-pretty-printing BrokerWrapper)

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -265,9 +265,8 @@
       (finally
         (reset! resetting?-atom false))))
 
-  ;; Parameter is 'this'
   (health
-    [_]
+    [_this]
     (queue-protocol/health queue-broker)))
 
 (record-pretty-printer/enable-record-pretty-printing BrokerWrapper)

--- a/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
+++ b/message-queue-lib/src/cmr/message_queue/test/queue_broker_wrapper.clj
@@ -103,10 +103,12 @@
          (Thread/sleep 10)
          (if (< (- (System/currentTimeMillis) start-time) ms-to-wait)
            (recur (set (current-message-states broker-wrapper)))
-           (warn (format "Waited %d ms for messages to complete, but they did not complete. In progress: %s"
-                         ms-to-wait
-                         (pr-str (remove #(contains? terminal-states (:state %))
-                                         (current-messages broker-wrapper)))))))))))
+           (warn
+            (format
+             "Waited %d ms for messages to complete, but they did not complete. In progress: %s"
+             ms-to-wait
+             (pr-str (remove #(contains? terminal-states (:state %))
+                             (current-messages broker-wrapper)))))))))))
 
 (defn- publish-to-queue
   "Publishes a message to the queue and captures the actions with the queue history."
@@ -119,7 +121,8 @@
     (update-message-queue-history broker queue-name :enqueue tagged-msg :initial)
     (trace "Updated message queue history")
     ;; Mark the enqueue as failed if we are timing things out or it fails
-    (if (or @timeout?-atom (not (queue-protocol/publish-to-queue queue-broker queue-name tagged-msg)))
+    (if (or @timeout?-atom
+            (not (queue-protocol/publish-to-queue queue-broker queue-name tagged-msg)))
       (do
         (trace "Published; preparing to update history ...")
         (update-message-queue-history broker queue-name :enqueue tagged-msg :failure)


### PR DESCRIPTION
# Overview
updated the lint tools and made changes to work with these tools and also the clj-kondo tool

### What is the feature
Use this ticket to investigate the level of effort needed to bring a project up to code against clj-kondo.

Please summarize the feature or fix.
Mostly changes made to remove code or define code in such a way as to be clearly declared by the run time in advance. (declare) statements all over the place now.

### What is the Solution?
adding declare statements, removing unused variables. I did tell eastwood to ignore reflection warnings as I don't understand those yet

### What areas of the application does this impact?
This is almost exclusively in message-queue-lib, one file in common.

# Checklist

- [n/a] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
