### PR TITLE
CMR-9810: Embedded elastic search failing to start on some builds

### DIFF
--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -23,7 +23,7 @@
                  [org.clojure/clojure "1.10.0"]
                  [org.elasticsearch/elasticsearch ~elastic-version]
                  [org.apache.commons/commons-compress "1.26.0"]
-                 [org.testcontainers/testcontainers "1.17.2"]
+                 [org.testcontainers/testcontainers "1.19.7"]
                  [org.yaml/snakeyaml "1.31"]
                  [potemkin "0.4.5"]]
   :plugins [[lein-shell "0.5.0"]]

--- a/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
@@ -66,7 +66,7 @@
            (.withNetwork network)
            (.withNetworkAliases (into-array String ["elasticsearch"]))
            (.withFixedExposedPort (int http-port) 9200)
-           (.withStartupTimeout (Duration/ofSeconds 120))
+           (.withStartupTimeout (Duration/ofSeconds 160))
            (.waitingFor
             (.forStatusCode (Wait/forHttp "/_cat/health?v&pretty") 200)))
      {:elasticsearch container

--- a/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
@@ -66,7 +66,7 @@
            (.withNetwork network)
            (.withNetworkAliases (into-array String ["elasticsearch"]))
            (.withFixedExposedPort (int http-port) 9200)
-           (.withStartupTimeout (Duration/ofSeconds 160))
+           (.withStartupTimeout (Duration/ofSeconds 240))
            (.waitingFor
             (.forStatusCode (Wait/forHttp "/_cat/health?v&pretty") 200)))
      {:elasticsearch container

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -14,7 +14,7 @@
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [org.clojure/clojure "1.10.0"]
                  [org.apache.commons/commons-compress "1.26.0"]
-                 [org.testcontainers/testcontainers "1.17.2"]]
+                 [org.testcontainers/testcontainers "1.19.7"]]
   :plugins [[lein-exec "0.3.7"]
             [lein-shell "0.5.0"]]
   :resource-paths ["resources"]


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Resolving an issue that is causing intermittent build failures

### What is the Solution?

Saw references to higher startup timeouts than we had set, so I just increased the start timeout and bumped our version of testcontainers

### What areas of the application does this impact?

Just the embedded elastic search. Embedded Redis somewhat as well, but only by virtue of updating testcontainer version

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
