### PR TITLE
CMR-9839: Granule metadata with granuleSize info yields unexpected results at ingest

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_g/expected_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_g/expected_util.clj
@@ -14,6 +14,18 @@
    [cmr.umm.umm-collection :as umm-c]
    [cmr.umm.umm-granule :as umm-lib-g]))
 
+
+(defn- get-size-in-mb
+  "Get size in megabytes based on the size-unit."
+  [size size-unit]
+  (condp = size-unit
+    "KB" (/ size 1024)
+    "MB" size
+    "GB" (* size 1024)
+    "TB" (* size 1024 1024)
+    "PB" (* size 1024 1024 1024)
+    0.0))
+
 (defn- expected-qa-flags
   "Converts generated qa-flags to what is expected by using the sanitized flag values."
   [qa-flags]
@@ -67,6 +79,14 @@
       (as-> updated-umm (if (:project-refs updated-umm)
                           (update updated-umm :project-refs #(conj % umm-spec-util/not-provided))
                           updated-umm))
+      (as-> updated-umm (if (:data-granule updated-umm)
+                          (let [size (get-in updated-umm [:data-granule :size])
+                                size-unit (get-in updated-umm [:data-granule :size-unit])
+                                new-size (get-size-in-mb size size-unit)]
+                            (-> updated-umm
+                                (assoc-in [:data-granule :size] new-size)
+                                (assoc-in [:data-granule :size-unit] "MB")))
+                          updated-umm))
       umm-lib-g/map->UmmGranule))
 
 (def expected-sample-granule
@@ -92,7 +112,7 @@
                                 {:value "E51569BF48DD0FD0640C6503A46D4753"
                                  :algorithm "MD5"})
                     :size-unit "MB"
-                    :size 0.023
+                    :size (+ (/ 23552 (* 1024 1024)) (/ 11 1024))
                     :format "ZIP"
                     :files [(umm-lib-g/map->File
                              {:name "GranuleFileName1"

--- a/umm-spec-lib/src/cmr/umm_spec/test/umm_g/expected_util.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/umm_g/expected_util.clj
@@ -19,7 +19,7 @@
   "Get size in megabytes based on the size-unit."
   [size size-unit]
   (condp = size-unit
-    "KB" (/ size 1024)
+    "KB" (double (/ size 1024))
     "MB" size
     "GB" (* size 1024)
     "TB" (* size 1024 1024)
@@ -112,7 +112,7 @@
                                 {:value "E51569BF48DD0FD0640C6503A46D4753"
                                  :algorithm "MD5"})
                     :size-unit "MB"
-                    :size (+ (/ 23552 (* 1024 1024)) (/ 11 1024))
+                    :size (+ (double (/ 23552 (* 1024 1024))) (double (/ 11 1024)))
                     :format "ZIP"
                     :files [(umm-lib-g/map->File
                              {:name "GranuleFileName1"

--- a/umm-spec-lib/src/cmr/umm_spec/umm_g/data_granule.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_g/data_granule.clj
@@ -40,6 +40,33 @@
   [files]
   (when files (map umm-g-file->File files)))
 
+(def unit-megabytes-map
+  "Mapping SizeUnit to megabytes."
+  {"KB" (/ 1 1024)
+   "MB" 1 
+   "GB" 1024
+   "TB" (* 1024 1024)
+   "PB" (* 1024 1024 1024)
+   "NA" 0})
+
+(defn- get-file-size-in-megabytes
+  "Get either SizeInBytes or Size(and convert it in Bytes)"
+  [file-info]
+  (let [size-in-bytes (get file-info :SizeInBytes)
+        size (get file-info :Size 0)
+        size-unit (get file-info :SizeUnit "NA")
+        convert-to-megabytes-factor (get unit-megabytes-map size-unit)]
+    (if size-in-bytes
+      (/ size-in-bytes (* 1024 1024))
+      (* size convert-to-megabytes-factor))))
+
+(defn- add-up-granule-file-sizes
+  "Add up all the granule file sizes from ArchiveAndDistributionInformation."
+  [ArchiveAndDistributionInformation]
+  (let [sizes (map #(get-file-size-in-megabytes %) ArchiveAndDistributionInformation)
+        granule_size (apply + sizes)]
+    granule_size))
+
 (defn umm-g-data-granule->DataGranule
   "Returns the umm-lib granule model DataGranule from the given UMM-G DataGranule."
   [data-granule]
@@ -47,7 +74,8 @@
     (g/map->DataGranule
       (let [{:keys [Identifiers DayNightFlag ProductionDateTime
                     ArchiveAndDistributionInformation]} data-granule
-            first-arch-dist-info (first ArchiveAndDistributionInformation)]
+            first-arch-dist-info (first ArchiveAndDistributionInformation)
+            size (add-up-granule-file-sizes ArchiveAndDistributionInformation)]
         {:day-night (get umm-g-day-night->umm-lib-day-night DayNightFlag "UNSPECIFIED")
          :producer-gran-id (->> Identifiers
                                 (some #(when (= "ProducerGranuleId" (:IdentifierType %)) %))
@@ -61,10 +89,9 @@
                            (map :Identifier)
                            seq)
          :production-date-time ProductionDateTime
-         :size (get (first ArchiveAndDistributionInformation) :Size)
-         :size-unit (let [SizeUnit (get (first ArchiveAndDistributionInformation) :SizeUnit)]
-                      (when (not= "NA" SizeUnit)
-                        SizeUnit))
+         :size size 
+         :size-unit (when size 
+                      "MB")
          :files (umm-g-files->Files (:Files first-arch-dist-info))
          :format (get first-arch-dist-info :Format)
          :size-in-bytes (get first-arch-dist-info :SizeInBytes)

--- a/umm-spec-lib/src/cmr/umm_spec/umm_g/data_granule.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_g/data_granule.clj
@@ -42,7 +42,7 @@
 
 (def unit-megabytes-map
   "Mapping SizeUnit to megabytes."
-  {"KB" (/ 1 1024)
+  {"KB" (double (/ 1 1024))
    "MB" 1 
    "GB" 1024
    "TB" (* 1024 1024)
@@ -53,12 +53,14 @@
   "Get either SizeInBytes or Size(and convert it in Bytes)"
   [file-info]
   (let [size-in-bytes (get file-info :SizeInBytes)
-        size (get file-info :Size 0)
-        size-unit (get file-info :SizeUnit "NA")
+        size (get file-info :Size)
+        size-unit (get file-info :SizeUnit)
         convert-to-megabytes-factor (get unit-megabytes-map size-unit)]
     (if size-in-bytes
-      (/ size-in-bytes (* 1024 1024))
-      (* size convert-to-megabytes-factor))))
+      (double (/ size-in-bytes (* 1024 1024)))
+      (if (and size convert-to-megabytes-factor)
+        (* size convert-to-megabytes-factor)
+        0))))
 
 (defn- add-up-granule-file-sizes
   "Add up all the granule file sizes from ArchiveAndDistributionInformation."


### PR DESCRIPTION
# Overview

### What is the feature/fix?

CMR granule json search. Customer wants granule_size returned to be calculated differently.

### What is the Solution?

Add all the SizeInBytes (or Size if SizeInBytes is absent) in all the files when ingesting UMM-G granule and use it for granule_size.

### What areas of the application does this impact?

CMR granule search

# Checklist

- [ x] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x ] New and existing unit and int tests pass locally and remotely with my changes
- [ x] I have removed unnecessary/dead code and imports in files I have changed
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
