### PR TITLE
CMR-9867: Fixing ISO temporal to only read the date value

### DIFF
--- a/umm-spec-lib/resources/example-data/iso19115/ISOExample-project.xml
+++ b/umm-spec-lib/resources/example-data/iso19115/ISOExample-project.xml
@@ -1310,10 +1310,10 @@
                     <gmd:temporalElement>
                         <gmd:EX_TemporalExtent>
                             <gmd:extent>
-                                <gml:TimePeriod gml:id="ded8dfcb1-9c2b-4eaa-8548-cdccfb708dbb">
-                                    <gml:beginPosition>2003-11-20T00:00:00.000Z</gml:beginPosition>
-                                    <gml:endPosition>2005-05-01T23:59:59.999Z</gml:endPosition>
-                                </gml:TimePeriod>
+                              <gml:TimeInstant gml:id="boundingTemporalExtent-1-2">
+                                <gml:description> | Currentness: Ground Condition</gml:description>
+                                <gml:timePosition>1971-11-20</gml:timePosition>
+                              </gml:TimeInstant>
                             </gmd:extent>
                         </gmd:EX_TemporalExtent>
                     </gmd:temporalElement>

--- a/umm-spec-lib/resources/example-data/iso19115/artificial_test_data.xml
+++ b/umm-spec-lib/resources/example-data/iso19115/artificial_test_data.xml
@@ -1255,6 +1255,7 @@ Distribution liability: NOAA and NCEI make no warranty, expressed or implied, re
                   <gmd:EX_TemporalExtent>
                     <gmd:extent>
                       <gml:TimeInstant gml:id="temporal_extent_3">
+                        <gml:description> | Currentness: Ground Condition</gml:description>
                         <gml:timePosition>2003-07-15T23:59:59.999Z</gml:timePosition>
                        </gml:TimeInstant>
                     </gmd:extent>

--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj
@@ -181,7 +181,7 @@
     (when (and element
                (or (nil? group-key)
                    (= group-key attribute-value)))
-      (date-at-str element "/"))))
+      (date-at-str (first element) "gml:timePosition"))))
 
 (defn parse-temporal-extents
   "Parses the collection temporal extents from the the collection document

--- a/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso19115_2/temporal.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso19115_2/temporal.clj
@@ -1,0 +1,20 @@
+(ns cmr.umm-spec.test.xml-to-umm-mappings.iso19115-2.temporal
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [cmr.umm-spec.xml-to-umm-mappings.iso19115-2 :as iso]))
+
+(deftest temporal-parsing-test
+  (testing "Testing parsing the temporal extent")
+  (let [value (-> (slurp (io/resource "example-data/iso19115/artificial_test_data.xml"))
+                  (iso/parse-temporal-extents))
+        value1 (-> (slurp (io/resource "example-data/iso19115/ISOExample-project.xml"))
+                  (iso/parse-temporal-extents))]
+    (is (= '("2003-07-15T23:59:59.999Z") 
+           (->> (map :SingleDateTimes value)
+               flatten 
+               (remove nil?))))
+    (is (= '("1971-11-20T00:00:00.000Z")
+           (->> (map :SingleDateTimes value1)
+                flatten
+                (remove nil?))))))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Fixing ISO temporal to only read the date value

### What is the Solution?

Fixing ISO temporal to only read the date value

### What areas of the application does this impact?

umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/iso19115_2.clj find-single-date-time

# Checklist

- [ x] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ x] New and existing unit and int tests pass locally and remotely with my changes
- [ x] I have removed unnecessary/dead code and imports in files I have changed
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
