### PR TITLE
CMR-9877 Downgrade log-level from INFO to DEBUG for 3 transform strategy log events

### DIFF
--- a/search-app/src/cmr/search/data/metadata_retrieval/metadata_transformer.clj
+++ b/search-app/src/cmr/search/data/metadata_retrieval/metadata_transformer.clj
@@ -128,7 +128,7 @@
                                                        (legacy/generate-metadata context umm target-format)))
                                               {}
                                               target-formats))]
-    (info "transform-with-strategy umm-lib: "
+    (debug "transform-with-strategy umm-lib: "
           "legacy/parse-concept time: " t1
           "reduce w/ legacy/generate-metadata time: " t2
           "concept-mime-type: " concept-mime-type
@@ -167,7 +167,7 @@
                                                                         (json/decode metadata true))))))
                                              {}
                                              target-formats))]
-    (info "transform-with-strategy migrate-umm-json: "
+    (debug "transform-with-strategy migrate-umm-json: "
           "time: " t
           "concept-mime-type: " concept-mime-type
           "concept-type: " concept-type
@@ -206,7 +206,7 @@
     (let [strategy (transform-strategy concept target-format)
           target-format-result-map (transform-with-strategy
                                     context concept strategy [target-format])]
-      (info (format "transform: concept: [%s] target-format: [%s] transform-strategy: [%s]"
+      (debug (format "transform: concept: [%s] target-format: [%s] transform-strategy: [%s]"
                     (:concept-id concept)
                     target-format
                     strategy))


### PR DESCRIPTION

# Overview
https://github.com/nasa/Common-Metadata-Repository/pull/1978 added several new logs to track transform strategy. This has added too much overhead to our event log creation and egress to the Splunk engine. 

### What is the feature/fix?


### What is the Solution?
Downgrade 3 of the new logs from INFO to DEBUG to reduce log traffic 
Summarize what you changed.

### What areas of the application does this impact?

List impacted areas.

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
