### PR TITLE
CMR-9665: Add HTTP response event to access control app, indexer app, metadata-db app

### DIFF
--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -8,6 +8,7 @@
    [cmr.access-control.api.routes :as api-routes]
    [cmr.access-control.site.routes :as site-routes]
    [cmr.acl.core :as acl]
+   [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.site.pages :as common-pages]
    [cmr.common.api.context :as context]
@@ -33,4 +34,6 @@
       api-errors/invalid-url-encoding-handler
       api-errors/exception-handler
       common-routes/pretty-print-response-handler
-      params/wrap-params))
+      params/wrap-params
+      req-log/add-body-hashes
+      req-log/log-ring-request))

--- a/common-app-lib/src/cmr/common_app/config.clj
+++ b/common-app-lib/src/cmr/common_app/config.clj
@@ -41,22 +41,9 @@
   {:default 200000
    :type Long})
 
-(defconfig custom-request-log
+(defconfig enable-enhanced-http-logging
   "True issues an additional custom request log for all activity received from
    this server"
-  {:default true
-   :type Boolean})
-
-(defconfig custom-request-log-error
-  "True issues an additional custom request log for all activity received from
-   this server and sends it to standard error. custom-request-log must be true
-   as well."
-  {:default false
-   :type Boolean})
-
-(defconfig add-hash-headers
-  "True will add MD5 and SHA-1 hash values to the response headers and include
-   them in the custome request log controlled by custom-request-log"
   {:default true
    :type Boolean})
 

--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -14,6 +14,7 @@
    [cmr.common.cache :as cache]
    [cmr.common.log :as log :refer [debug info warn error]]
    [cmr.common-app.api.health :as common-health]
+   [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.indexer.data.concepts.collection]
    [cmr.indexer.data.concepts.granule]
@@ -173,4 +174,6 @@
       handler/site
       common-routes/pretty-print-response-handler
       ring-json/wrap-json-body
-      ring-json/wrap-json-response))
+      ring-json/wrap-json-response
+      req-log/add-body-hashes
+      req-log/log-ring-request))

--- a/metadata-db-app/src/cmr/metadata_db/api/routes.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/routes.clj
@@ -3,6 +3,7 @@
   (:require
    [cmr.acl.core :as acl]
    [cmr.common-app.api.health :as common-health]
+   [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common.api.context :as context]
    [cmr.common.api.errors :as errors]
@@ -87,4 +88,6 @@
       nested-params/wrap-nested-params
       ring-json/wrap-json-body
       common-routes/pretty-print-response-handler
-      params/wrap-params))
+      params/wrap-params
+      req-log/add-body-hashes
+      req-log/log-ring-request))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Add remaining HTTP response event logs to access control app, indexer ap, and metadata db app. They were already existing in search and ingest and we originally had stated that after a couple months if we liked the logs they would be added to all.

### What is the Solution?

Added necessary handlers

### What areas of the application does this impact?

Logging

# Checklist

- [x ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x ] New and existing unit and int tests pass locally and remotely with my changes
- [x ] I have removed unnecessary/dead code and imports in files I have changed
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
