### PR TITLE
CMR-9268: Log Volume for Elasticsearch Index Search is Too High

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -230,7 +230,7 @@
                       ;; rename search-after to search_after for ES execution
                       (set/rename-keys {:search-after :search_after})
                       util/remove-nil-keys)]
-    (info "Executing against indexes [" (:index-name index-info) "] the elastic query:"
+    (debug "Executing against indexes [" (:index-name index-info) "] the elastic query:"
           (pr-str elastic-query)
           "with sort" (pr-str sort-params)
           "with aggregations" (pr-str aggregations)


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Log Volume for Elasticsearch Index Search is Too High

### What is the Solution?

Switch log from info to debug

### What areas of the application does this impact?

Elastic_utils

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
