### PR TITLE
Cmr 9603

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -16,7 +16,7 @@ See the [CMR Client Partner User Guide](https://wiki.earthdata.nasa.gov/display/
     * [Headers](#headers)
     * [Extensions](#extensions)
     * [Request Timeouts](#request-timeouts)
-    * [Moderating Client Request Traffic] (#request-moderation)
+    * [Moderating Client Request Traffic](#request-moderation)
   * [Supported Result Formats](#supported-result-formats)
     * [ATOM](#atom)
     * [CSV](#csv)

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -16,6 +16,7 @@ See the [CMR Client Partner User Guide](https://wiki.earthdata.nasa.gov/display/
     * [Headers](#headers)
     * [Extensions](#extensions)
     * [Request Timeouts](#request-timeouts)
+    * [Moderating Client Request Traffic] (#request-moderation)
   * [Supported Result Formats](#supported-result-formats)
     * [ATOM](#atom)
     * [CSV](#csv)
@@ -394,6 +395,10 @@ The CMR operating environment imposes a hard limit of 180 seconds on any request
 returned. To avoid this, the CMR has an internal query timeout of 170 seconds - any query taking longer will time
 out and a subset of the total hit results will be returned instead of an error. The response for queries that time
 out will include the `CMR-Time-Out` header set to `true`.
+
+#### <a name="request-moderation"></a> Moderating Client Request Traffic
+
+In order to provide robust availability and performance for all clients of the service, CMR Search deploys a set of rate throttling rules for request traffic. These rules are defined to target specific request signatures, throttling the allowed rate of these searches in an effort to prevent overall degradation of system performance and availability. If a client request should exceed one of these rate throttling rules, the request will be rejected and a `429` error status returned to the client along with a `retry-after` header value. The suggested practice for any CMR Search client is to honor the `retry-after` header value and delay accordingly before re-issuing the failed request and continuing with its CMR Search processing.
 
 ### <a name="supported-result-formats"></a> Supported Result Formats
 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Please summarize the feature or fix.
Adds "Moderating Client Request Traffic" to CMR Search API docs for WAF rate throttling description.

### What is the Solution?

Summarize what you changed.
Updated docs.
### What areas of the application does this impact?

List impacted areas.
CMR Search
# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
