### PR TITLE
CMR-9185: Require clj-kondo in GitHub

### DIFF
--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,10 +27,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         run: |
+          pwd > report.log
+          ls -l >> report.log
           docker run \
             -v $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            clj-kondo --parallel --lint src > report.log
+            clj-kondo --parallel --lint src >> report.log
       - name: Report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -41,6 +41,8 @@ jobs:
               es-spatial-plugin \
               message-queue-lib \
             >> report.log
+          cat report.log
+        id: list-report
       - name: Report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -3,7 +3,7 @@ name: CMR Checks
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master, main ]
+    branches: [ master, main , features/**]
 jobs:
   cloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -33,8 +33,7 @@ jobs:
             sh -c '\
               cd /src && \
               clj-kondo --parallel --lint \
-                access-control-app/src \
-                acl-lib/src \
+                access-control-app/src acl-lib/src \
                 common-app-lib/src \
                 common-lib/src \
                 elastic-utils-lib/src \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -32,7 +32,7 @@ jobs:
           docker run \
             -v $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            clj-kondo --parallel --lint \
+            pwd ; ls ; clj-kondo --parallel --lint \
               /src/access-control-app \
               /src/acl-lib \
               common-app-lib \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,10 +30,16 @@ jobs:
           pwd > report.log
           ls -l >> report.log
           echo -done- >> report.log
+          
           docker run \
             --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            "ls ; pwd ; \
+            ls \
+            >> report.log
+          
+          docker run \
+            --volume $PWD/src:/src \
+            --rm cljkondo/clj-kondo \
             clj-kondo --parallel --lint \
               /src/access-control-app \
               /src/acl-lib \
@@ -42,7 +48,7 @@ jobs:
               /src/elastic-utils-lib \
               /src/es-spatial-plugin \
               /src/message-queue-lib \
-            >> report.log"
+            >> report.log
           cat report.log
         id: list-report
       - name: Report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -1,10 +1,9 @@
 name: CMR Checks
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ master, main ]
-  workflow_dispatch:
-
 jobs:
   cloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,15 +30,17 @@ jobs:
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
-            cd /src && clj-kondo --parallel --lint \
-              access-control-app/src \
-              acl-lib/src \
-              common-app-lib/src \
-              common-lib/src \
-              elastic-utils-lib/src \
-              es-spatial-plugin/src \
-              message-queue-lib/src \
-            >> report.log
+            ssh -c '\
+              cd /src && \
+              clj-kondo --parallel --lint \
+                access-control-app/src \
+                acl-lib/src \
+                common-app-lib/src \
+                common-lib/src \
+                elastic-utils-lib/src \
+                es-spatial-plugin/src \
+                message-queue-lib/src \
+            ' >> report.log
           cat report.log
         id: list-report
       - name: Report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -34,7 +34,7 @@ jobs:
           docker run \
             --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            ls \
+            tree -d -L 2 \
             >> report.log
           
           docker run \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -32,7 +32,15 @@ jobs:
           docker run \
             -v $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            clj-kondo --parallel --lint src >> report.log
+            clj-kondo --parallel --lint \
+              access-control-app \
+              acl-lib \
+              common-app-lib \
+              common-lib \
+              elastic-utils-lib \
+              es-spatial-plugin \
+              message-queue-lib \
+            >> report.log
       - name: Report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -42,7 +42,7 @@ jobs:
                 es-spatial-plugin/src \
                 message-queue-lib/src \
             ' >> report.log
-      - Name: Show
+      - name: Show
         id: show-report
         if: always()
         run: cat report.log

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,15 +30,14 @@ jobs:
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
-            cd /src && \
-            clj-kondo --parallel --lint \
+            sh -s "cd /src && clj-kondo --parallel --lint \
               access-control-app/src \
               acl-lib/src \
               common-app-lib/src \
               common-lib/src \
               elastic-utils-lib/src \
               es-spatial-plugin/src \
-              message-queue-lib/src \
+              message-queue-lib/src" \
             >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -43,13 +43,13 @@ jobs:
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
             clj-kondo --parallel --lint \
-              /src/access-control-app \
-              /src/acl-lib \
-              /src/common-app-lib \
-              /src/common-lib \
-              /src/elastic-utils-lib \
-              /src/es-spatial-plugin \
-              /src/message-queue-lib \
+              /src/access-control-app/src \
+              /src/acl-lib/src \
+              /src/common-app-lib/src \
+              /src/common-lib/src \
+              /src/elastic-utils-lib/src \
+              /src/es-spatial-plugin/src \
+              /src/message-queue-lib/src \
             >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -2,9 +2,9 @@ name: CMR Checks
 on:
   workflow_dispatch:
   push:
-    branches: [ master, main, feature/**]
+    branches: [ master, main, feature/**, *CMR-**, *cmr-**]
   pull_request:
-    branches: [ master, main , features/**]
+    branches: [ master, main , features/**, *CMR-**, *cmr-**]
 jobs:
   cloc:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
           rm -rf tea-config-generator
           rm -rf token-service-client
       - name: Count Lines of Code (cloc)
-        uses: djdefi/cloc-action@5
+        uses: djdefi/cloc-action@6
   kondo:
     runs-on: ubuntu-latest
     steps:
@@ -42,11 +42,11 @@ jobs:
                 es-spatial-plugin/src \
                 message-queue-lib/src \
             ' >> report.log
-      - name: Show
+      - name: Show Kondo Report
         id: show-report
         if: always()
         run: cat report.log
-      - name: Report
+      - name: Publish Kondo Report
         id: pub-report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -2,6 +2,8 @@ name: CMR Checks
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ master, main, feature/**]
   pull_request:
     branches: [ master, main , features/**]
 jobs:

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,29 +27,18 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         run: |
-          pwd > report.log
-          ls -l >> report.log
-          echo -done- >> report.log
-          
-          docker run \
-            --volume $PWD/src:/src \
-            --rm cljkondo/clj-kondo \
-            ls /src \
-            >> report.log
-          
-          echo -done- >> report.log
-          
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
+            cd /src && ls && \
             clj-kondo --parallel --lint \
-              /src/access-control-app/src \
-              /src/acl-lib/src \
-              /src/common-app-lib/src \
-              /src/common-lib/src \
-              /src/elastic-utils-lib/src \
-              /src/es-spatial-plugin/src \
-              /src/message-queue-lib/src \
+              access-control-app/src \
+              acl-lib/src \
+              common-app-lib/src \
+              common-lib/src \
+              elastic-utils-lib/src \
+              es-spatial-plugin/src \
+              message-queue-lib/src \
             >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -40,7 +40,7 @@ jobs:
           echo -done- >> report.log
           
           docker run \
-            --volume $PWD/src:/src \
+            --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
             clj-kondo --parallel --lint \
               /src/access-control-app \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -42,6 +42,7 @@ jobs:
               message-queue-lib \
             >> report.log
       - name: Report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: Kondo-Report.txt

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -34,7 +34,7 @@ jobs:
           docker run \
             --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            tree -d -L 2 \
+            ls /src \
             >> report.log
           
           docker run \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -33,12 +33,7 @@ jobs:
             sh -c '\
               cd /src && \
               clj-kondo --parallel --lint \
-                access-control-app/src acl-lib/src \
-                common-app-lib/src \
-                common-lib/src \
-                elastic-utils-lib/src \
-                es-spatial-plugin/src \
-                message-queue-lib/src \
+                access-control-app/src acl-lib/src common-app-lib/src common-lib/src elastic-utils-lib/src es-spatial-plugin/src message-queue-lib/src \
             ' >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,7 +30,7 @@ jobs:
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
-            cd /src && ls && \
+            cd /src && \
             clj-kondo --parallel --lint \
               access-control-app/src \
               acl-lib/src \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -33,7 +33,7 @@ jobs:
             sh -c '\
               cd /src && \
               clj-kondo --parallel --lint \
-                access-control-app/src acl-lib/src common-app-lib/src common-lib/src elastic-utils-lib/src es-spatial-plugin/src message-queue-lib/src \
+                acl-lib/src access-control-app/src common-app-lib/src common-lib/src elastic-utils-lib/src es-spatial-plugin/src message-queue-lib/src \
             ' >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           docker run \
             -v $PWD/src:/src \
-            --r cljkondo/clj-kondo \
+            --rm cljkondo/clj-kondo \
             clj-kondo --parallel --lint src > report.log
       - name: Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -45,7 +45,7 @@ jobs:
       - Name: Show
         id: show-report
         if: always()
-        -run: cat report.log
+        run: cat report.log
       - name: Report
         id: pub-report
         if: always()

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -37,6 +37,8 @@ jobs:
             ls /src \
             >> report.log
           
+          echo -done- >> report.log
+          
           docker run \
             --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         id: gen-report
-        run: pwd && ls
+        run: ./dev-setup/support/run-kondo.sh >> report.log
       - name: Show Kondo Report
         id: show-report
         if: always()

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,14 +30,14 @@ jobs:
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
-            sh -s "cd /src && clj-kondo --parallel --lint \
+            cd /src && clj-kondo --parallel --lint \
               access-control-app/src \
               acl-lib/src \
               common-app-lib/src \
               common-lib/src \
               elastic-utils-lib/src \
               es-spatial-plugin/src \
-              message-queue-lib/src" \
+              message-queue-lib/src \
             >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -30,7 +30,7 @@ jobs:
           docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
-            ssh -c '\
+            sh -c '\
               cd /src && \
               clj-kondo --parallel --lint \
                 access-control-app/src \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -33,8 +33,8 @@ jobs:
             -v $PWD/src:/src \
             --rm cljkondo/clj-kondo \
             clj-kondo --parallel --lint \
-              access-control-app \
-              acl-lib \
+              /src/access-control-app \
+              /src/acl-lib \
               common-app-lib \
               common-lib \
               elastic-utils-lib \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -3,6 +3,7 @@ name: CMR Checks
 on:
   pull_request:
     branches: [ master, main ]
+  workflow_dispatch:
 
 jobs:
   cloc:

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -2,9 +2,9 @@ name: CMR Checks
 on:
   workflow_dispatch:
   push:
-    branches: [ master, main, feature/**, *CMR-**, *cmr-**]
+    branches: [ master, main, feature/**, CMR-**, cmr-**]
   pull_request:
-    branches: [ master, main , features/**, *CMR-**, *cmr-**]
+    branches: [ master, main , features/**, CMR-**, cmr-**]
 jobs:
   cloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,8 +27,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         id: gen-report
+        run: ./dev-setup/support/run-kondo.sh
         run: |
-          docker run \
+          :docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \
             sh -c '\

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         id: gen-report
-        run: ./dev-setup/support/run-kondo.sh >> report.log
+        run: ./dev-system/support/run-kondo.sh >> report.log
       - name: Show Kondo Report
         id: show-report
         if: always()

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -9,7 +9,7 @@ jobs:
   cloc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Remove non-CMR directories
         run: |
           rm -rf browse-scaler
@@ -33,14 +33,16 @@ jobs:
             --rm cljkondo/clj-kondo \
             sh -c '\
               cd /src && \
-              clj-kondo --parallel --lint \
-                access-control-app/src \
-                acl-lib/src \
-                common-app-lib/src \
-                common-lib/src \
-                elastic-utils-lib/src \
-                es-spatial-plugin/src \
-                message-queue-lib/src \
+              clj-kondo --parallel \
+                --fail-level error \
+                --lint \
+                  access-control-app/src \
+                  acl-lib/src \
+                  common-app-lib/src \
+                  common-lib/src \
+                  elastic-utils-lib/src \
+                  es-spatial-plugin/src \
+                  message-queue-lib/src \
             ' >> report.log
       - name: Show Kondo Report
         id: show-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -29,17 +29,18 @@ jobs:
         run: |
           pwd > report.log
           ls -l >> report.log
+          echo -done- >> report.log
           docker run \
-            -v $PWD/src:/src \
+            --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \
-            pwd ; ls ; clj-kondo --parallel --lint \
+            clj-kondo --parallel --lint \
               /src/access-control-app \
               /src/acl-lib \
-              common-app-lib \
-              common-lib \
-              elastic-utils-lib \
-              es-spatial-plugin \
-              message-queue-lib \
+              /src/common-app-lib \
+              /src/common-lib \
+              /src/elastic-utils-lib \
+              /src/es-spatial-plugin \
+              /src/message-queue-lib \
             >> report.log
           cat report.log
         id: list-report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -33,6 +33,7 @@ jobs:
           docker run \
             --volume $PWD/src:/src \
             --rm cljkondo/clj-kondo \
+            "ls ; pwd ; \
             clj-kondo --parallel --lint \
               /src/access-control-app \
               /src/acl-lib \
@@ -41,7 +42,7 @@ jobs:
               /src/elastic-utils-lib \
               /src/es-spatial-plugin \
               /src/message-queue-lib \
-            >> report.log
+            >> report.log"
           cat report.log
         id: list-report
       - name: Report

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -19,3 +19,19 @@ jobs:
           rm -rf token-service-client
       - name: Count Lines of Code (cloc)
         uses: djdefi/cloc-action@5
+  kondo:
+    runs-on: checkout
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Run Kondo Report
+        run: |
+          docker run \
+            -v $PWD/src:/src \
+            --r cljkondo/clj-kondo \
+            clj-kondo --parallel --lint src > report.log
+      - name: Report
+        users: actions/upload-artifact@v4
+        with:
+          name: Kondo-Report.txt
+          path: report.log

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -28,23 +28,6 @@ jobs:
       - name: Run Kondo Report
         id: gen-report
         run: pwd && ls
-          :./dev-setup/support/run-kondo.sh
-          :docker run \
-            --volume $PWD:/src \
-            --rm cljkondo/clj-kondo \
-            sh -c '\
-              cd /src && \
-              clj-kondo --parallel \
-                --fail-level error \
-                --lint \
-                  access-control-app/src \
-                  acl-lib/src \
-                  common-app-lib/src \
-                  common-lib/src \
-                  elastic-utils-lib/src \
-                  es-spatial-plugin/src \
-                  message-queue-lib/src \
-            ' >> report.log
       - name: Show Kondo Report
         id: show-report
         if: always()

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -27,7 +27,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Kondo Report
         id: gen-report
-        run: ./dev-setup/support/run-kondo.sh
+        run: pwd && ls
+          :./dev-setup/support/run-kondo.sh
           :docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -31,7 +31,7 @@ jobs:
             --r cljkondo/clj-kondo \
             clj-kondo --parallel --lint src > report.log
       - name: Report
-        users: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: Kondo-Report.txt
           path: report.log

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -26,6 +26,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: Run Kondo Report
+        id: gen-report
         run: |
           docker run \
             --volume $PWD:/src \
@@ -33,11 +34,20 @@ jobs:
             sh -c '\
               cd /src && \
               clj-kondo --parallel --lint \
-                acl-lib/src access-control-app/src common-app-lib/src common-lib/src elastic-utils-lib/src es-spatial-plugin/src message-queue-lib/src \
+                access-control-app/src \
+                acl-lib/src \
+                common-app-lib/src \
+                common-lib/src \
+                elastic-utils-lib/src \
+                es-spatial-plugin/src \
+                message-queue-lib/src \
             ' >> report.log
-          cat report.log
-        id: list-report
+      - Name: Show
+        id: show-report
+        if: always()
+        -run: cat report.log
       - name: Report
+        id: pub-report
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Run Kondo Report
         id: gen-report
         run: ./dev-setup/support/run-kondo.sh
-        run: |
           :docker run \
             --volume $PWD:/src \
             --rm cljkondo/clj-kondo \

--- a/.github/workflows/cmr-checks.yml
+++ b/.github/workflows/cmr-checks.yml
@@ -1,5 +1,4 @@
 name: CMR Checks
-
 on:
   workflow_dispatch:
   push:
@@ -22,7 +21,7 @@ jobs:
       - name: Count Lines of Code (cloc)
         uses: djdefi/cloc-action@5
   kondo:
-    runs-on: checkout
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/dev-system/support/run-kondo.sh
+++ b/dev-system/support/run-kondo.sh
@@ -11,7 +11,7 @@
 # error or warning
 fail_level=error
 
-# true or anything but true
+# set to the string true to always pass, anything else will be considered a false
 always_pass=false
 
 # A list of directories to run kondo on

--- a/dev-system/support/run-kondo.sh
+++ b/dev-system/support/run-kondo.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# **************************************************************************************************
+# This script is meant to be run from the CMR project root by Github.com as a workflow action step.
+# The purpouse of this script is to run all the linter checks using clj-kondo in a docker image and
+# to return a failed error code if there are any errors.
+
+fail_level=error
+always_pass=false
+projects_to_check='access-control-app/src \
+            acl-lib/src \
+            common-app-lib/src \
+            common-lib/src \
+            elastic-utils-lib/src \
+            es-spatial-plugin/src \
+            message-queue-lib/src'
+
+work() {
+  docker run \
+    --volume $PWD:/src \
+    --rm cljkondo/clj-kondo \
+    sh -c "cd /src && clj-kondo --parallel --fail-level ${fail_level} --lint ${projects_to_check}"
+    result=$?
+
+    if [ "${always_pass}" == "true" ]; then
+      exit 0
+    fi
+    exit $result
+}
+
+usage() {
+  printf "Run clj-kondo in a docker image\nUsage:\n\n"
+  format="%4s %-4s : %s\n"
+  printf "$format" Flag Arg Description
+  printf "$format" ---- --- -----------
+  printf "$format" -p list 'A space deliminated list of projects to check'
+  printf "$format" -w '' 'Fail on warnings'
+  printf "$format" -a '' 'Always pass, just report'
+}
+
+# Process the command line arguments
+while getopts "p:wW" opt
+do
+    case ${opt} in
+        p) projects_to_check=$OPTARG ;;
+        w) fail_level=warning ;;
+        a) always_pass=true ;;
+        *) usage ; exit ;;
+    esac
+done
+
+work

--- a/dev-system/support/run-kondo.sh
+++ b/dev-system/support/run-kondo.sh
@@ -4,17 +4,27 @@
 # This script is meant to be run from the CMR project root by Github.com as a workflow action step.
 # The purpouse of this script is to run all the linter checks using clj-kondo in a docker image and
 # to return a failed error code if there are any errors.
+#
+# This script is designed to be called from inside a docker image by github action step like this:
+#     run: ./dev-system/support/run-kondo.sh >> report.log
 
+# error or warning
 fail_level=error
+
+# true or anything but true
 always_pass=false
+
+# A list of directories to run kondo on
 projects_to_check='access-control-app/src \
             acl-lib/src \
             common-app-lib/src \
             common-lib/src \
             elastic-utils-lib/src \
             es-spatial-plugin/src \
-            message-queue-lib/src'
+            message-queue-lib/src \
+            umm-lib/src'
 
+# Call kondo from inside a docker image and then check the exit code for success
 work() {
   docker run \
     --volume $PWD:/src \
@@ -28,6 +38,7 @@ work() {
     exit $result
 }
 
+# Explain all the flags the script uses
 usage() {
   printf "Run clj-kondo in a docker image\nUsage:\n\n"
   format="%4s %-4s : %s\n"
@@ -38,7 +49,7 @@ usage() {
   printf "$format" -a '' 'Always pass, just report'
 }
 
-# Process the command line arguments
+# Process the command line arguments then do the "work" of the script
 while getopts "p:wW" opt
 do
     case ${opt} in


### PR DESCRIPTION
# Overview

Require that code passed clj-kondo before allowing a merge into master

### What is the feature/

This change will add clj-kondo as a step to a GitHub action which will be successful if there are no errors from clj-kondo. Warnings will be allowed to pass.

### What is the Solution?

The solution is to call clj-kondo in a docker container against the 7 sub-projects that have been cleaned up. The list of sub projects is expected to increase to all. To do this, a new script has been added to dev-system/support/run-kondo.sh to be run by the clj-kondo docker container. 

### What areas of the application does this impact?

This should impact changes made to access-control-app/src, acl-lib/src, common-app-lib/src, common-lib/src, elastic-utils-lib/src, es-spatial-plugin/src, message-queue-lib/src

# Checklist

- [-] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [-] New and existing unit and int tests pass locally and remotely with my changes
- [-] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
