### PR TITLE
CMR-9429: Validate collection processing level Id

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -157,6 +157,7 @@ The following fields are validated:
 * [Directory Names](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/idnnode?format=csv) - short name
 * [ISO Topic Categories](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/isotopiccategory?format=csv) - iso topic category
 * [Data Format](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/dataformat?format=csv) - Archival and Distribution File Format, and GetData Format
+* [ProcessingLevel] (https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/productlevelid?format=csv) - productlevelid
 
 **Note**: that when multiple fields are present the combination of keywords are validated to match a known combination.
 **Note**: Among the validation fields above, [Platforms], [Instruments], [Projects], [Science Keywords], [Location Keywords] and [Data Centers] are also validated when the `Cmr-Validate-Keywords` header is not set to `true` except that  validation errors will be returned to users as warnings.

--- a/ingest-app/src/cmr/ingest/services/messages.clj
+++ b/ingest-app/src/cmr/ingest/services/messages.clj
@@ -33,6 +33,11 @@
   (str "The collection given for validating the granule was invalid: "
        (util/html-escape (pr-str collection-validation-error))))
 
+(defn processing-level-id-not-matches-kms-keywords
+  [id]
+  (format "ProcessingLevel Id [%s] was not a valid keyword."
+          (util/html-escape id)))
+
 (defn platform-not-matches-kms-keywords
   [platform]
   (format "Platform short name [%s], long name [%s], and type [%s] was not a valid keyword combination."

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -182,6 +182,10 @@
                       context :spatial-keywords msg/location-keyword-not-matches-kms-keywords)
    :DataCenters (match-kms-keywords-validation
                  context :providers msg/data-center-not-matches-kms-keywords)
+   :ProcessingLevel {:Id (match-kms-keywords-validation-single
+                          context
+                          :processing-levels
+                          msg/processing-level-id-not-matches-kms-keywords)}
    :DirectoryNames (match-kms-keywords-validation
                     context :concepts msg/directory-name-not-matches-kms-keywords)
    :ISOTopicCategories (match-kms-keywords-validation

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -58,17 +58,19 @@
                                                                  :ShortName "SomeCenter"})]
                         :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "wrong"})})
 
-          response (ingest/validate-concept concept {:validate-keywords true})]
-      (is (= {:status 422
-              :errors [{:path ["Platforms" 0]
-                        :errors [(str "Platform short name [foo], long name [Airbus A340-600], "
-                                      "and type [Jet] was not a valid keyword combination.")]}
-                       {:path ["ProcessingLevel" "Id"]
-                        :errors ["ProcessingLevel Id [wrong] was not a valid keyword."]}
-                       {:path ["DataCenters" 0]
-                        :errors [(str "Data center short name [SomeCenter] was not a valid "
-                                      "keyword.")]}]}
-             response))))
+          response (ingest/validate-concept concept {:validate-keywords true})
+          status (:status response)
+          errors (set (:errors response))]
+      (is (= status 422))
+      (is (= (set [{:path ["Platforms" 0]
+                    :errors [(str "Platform short name [foo], long name [Airbus A340-600], "
+                                  "and type [Jet] was not a valid keyword combination.")]}
+                   {:path ["ProcessingLevel" "Id"]
+                    :errors ["ProcessingLevel Id [wrong] was not a valid keyword."]}
+                   {:path ["DataCenters" 0]
+                    :errors [(str "Data center short name [SomeCenter] was not a valid "
+                                  "keyword.")]}])
+             errors))))
 
   (testing "Keyword validation warnings using validation endpoint"
     (let [concept (data-umm-c/collection-concept

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -7,7 +7,8 @@
     [cmr.system-int-test.data2.core :as d]
     [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
     [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
-    [cmr.system-int-test.utils.ingest-util :as ingest]))
+    [cmr.system-int-test.utils.ingest-util :as ingest]
+    [cmr.umm-spec.models.umm-collection-models :as umm-c]))
 
 (defn assert-invalid
   ([coll-attributes field-path errors]
@@ -54,13 +55,16 @@
                                                             :LongName "Airbus A340-600"
                                                             :Type "Jet"})]
                         :DataCenters [(data-umm-cmn/data-center {:Roles ["ARCHIVER"]
-                                                                 :ShortName "SomeCenter"})]})
+                                                                 :ShortName "SomeCenter"})]
+                        :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "wrong"})})
 
           response (ingest/validate-concept concept {:validate-keywords true})]
       (is (= {:status 422
               :errors [{:path ["Platforms" 0]
                         :errors [(str "Platform short name [foo], long name [Airbus A340-600], "
                                       "and type [Jet] was not a valid keyword combination.")]}
+                       {:path ["ProcessingLevel" "Id"]
+                        :errors ["ProcessingLevel Id [wrong] was not a valid keyword."]}
                        {:path ["DataCenters" 0]
                         :errors [(str "Data center short name [SomeCenter] was not a valid "
                                       "keyword.")]}]}


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Validate Collection ProcessingLevel Id. when "Cmr-Validate-Keywords: true" header is set

### What is the Solution?

Add the validation

### What areas of the application does this impact?

CMR Ingest

# Checklist

- [ x] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ x] New and existing unit and int tests pass locally and remotely with my changes
- [ x] I have removed unnecessary/dead code and imports in files I have changed
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
