### PR TITLE
Cmr 8454 return warning for related url get data format

### DIFF
--- a/ingest-app/src/cmr/ingest/services/messages.clj
+++ b/ingest-app/src/cmr/ingest/services/messages.clj
@@ -33,11 +33,6 @@
   (str "The collection given for validating the granule was invalid: "
        (util/html-escape (pr-str collection-validation-error))))
 
-(defn processing-level-id-not-matches-kms-keywords
-  [id]
-  (format "ProcessingLevel Id [%s] was not a valid keyword."
-          (util/html-escape id)))
-
 (defn platform-not-matches-kms-keywords
   [platform]
   (format "Platform short name [%s], long name [%s], and type [%s] was not a valid keyword combination."

--- a/ingest-app/src/cmr/ingest/services/messages.clj
+++ b/ingest-app/src/cmr/ingest/services/messages.clj
@@ -33,6 +33,11 @@
   (str "The collection given for validating the granule was invalid: "
        (util/html-escape (pr-str collection-validation-error))))
 
+(defn processing-level-id-not-matches-kms-keywords
+  [id]
+  (format "ProcessingLevel Id [%s] was not a valid keyword."
+          (util/html-escape id)))
+
 (defn platform-not-matches-kms-keywords
   [platform]
   (format "Platform short name [%s], long name [%s], and type [%s] was not a valid keyword combination."

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -104,7 +104,11 @@
    (v/every {:GetData {:MimeType (match-kms-keywords-validation-single
                                   context
                                   :mime-type
-                                  msg/mime-type-not-matches-kms-keywords)}})})
+                                  msg/mime-type-not-matches-kms-keywords)
+                       :Format (match-kms-keywords-validation-single 
+                                context
+                                :granule-data-format
+                                msg/getdata-format-not-matches-kms-keywords)}})})
 
 (defn- related-url-validator
   "Return a validator that checks a ContentType, Type, and Subtype keyword combo

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -182,10 +182,6 @@
                       context :spatial-keywords msg/location-keyword-not-matches-kms-keywords)
    :DataCenters (match-kms-keywords-validation
                  context :providers msg/data-center-not-matches-kms-keywords)
-   :ProcessingLevel {:Id (match-kms-keywords-validation-single
-                          context
-                          :processing-levels
-                          msg/processing-level-id-not-matches-kms-keywords)}
    :DirectoryNames (match-kms-keywords-validation
                     context :concepts msg/directory-name-not-matches-kms-keywords)
    :ISOTopicCategories (match-kms-keywords-validation

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -182,6 +182,10 @@
                       context :spatial-keywords msg/location-keyword-not-matches-kms-keywords)
    :DataCenters (match-kms-keywords-validation
                  context :providers msg/data-center-not-matches-kms-keywords)
+   :ProcessingLevel {:Id (match-kms-keywords-validation-single
+                          context
+                          :processing-levels
+                          msg/processing-level-id-not-matches-kms-keywords)}
    :DirectoryNames (match-kms-keywords-validation
                     context :concepts msg/directory-name-not-matches-kms-keywords)
    :ISOTopicCategories (match-kms-keywords-validation

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -106,7 +106,7 @@
 
           response (ingest/validate-concept concept {:validate-keywords false})]
       (is (= {:status 200
-              :warnings "After translating item to UMM-C the metadata had the following issue(s): [:DataCenters 0 :ContactInformation :RelatedUrls 0] URLContentType must be DataCenterURL for DataCenter RelatedUrls;; [:RelatedUrls 0 :GetData :MimeType] MimeType [RelatedUrls: BadMimeType2] was not a valid keyword.;; [:Platforms 0] Platform short name [foo], long name [Airbus A340-600], and type [Jet] was not a valid keyword combination.;; [:DataCenters 0] Data center short name [SomeCenter] was not a valid keyword.;; [:DataCenters 0 :ContactInformation :RelatedUrls 0 :GetData :MimeType] MimeType [RelatedUrls: BadMimeType1] was not a valid keyword."}
+              :warnings "After translating item to UMM-C the metadata had the following issue(s): [:DataCenters 0 :ContactInformation :RelatedUrls 0] URLContentType must be DataCenterURL for DataCenter RelatedUrls;; [:RelatedUrls 0 :GetData :MimeType] MimeType [RelatedUrls: BadMimeType2] was not a valid keyword.;; [:RelatedUrls 0 :GetData :Format] Format [RelatedUrls: BadFormat2] was not a valid keyword.;; [:Platforms 0] Platform short name [foo], long name [Airbus A340-600], and type [Jet] was not a valid keyword combination.;; [:DataCenters 0] Data center short name [SomeCenter] was not a valid keyword.;; [:DataCenters 0 :ContactInformation :RelatedUrls 0 :GetData :MimeType] MimeType [RelatedUrls: BadMimeType1] was not a valid keyword.;; [:DataCenters 0 :ContactInformation :RelatedUrls 0 :GetData :Format] Format [RelatedUrls: BadFormat1] was not a valid keyword."}
              response))))
 
  (testing "ArchiveAndDistributionInformation and RelatedUrls keyword validation"

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -2,9 +2,9 @@
   "CMR Ingest keyword validation integration tests"
   (:require
     [clojure.test :refer :all]
-    [cmr.common.util :refer [are2 are3]]
+    [cmr.common.util :refer [are3]]
     [cmr.ingest.services.messages :as msg]
-    [cmr.system-int-test.data2.core :as d]
+    [cmr.system-int-test.data2.core :as data-core]
     [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
     [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
     [cmr.system-int-test.utils.ingest-util :as ingest]
@@ -14,7 +14,7 @@
   ([coll-attributes field-path errors]
    (assert-invalid coll-attributes field-path errors nil))
   ([coll-attributes field-path errors options]
-   (let [response (d/ingest-umm-spec-collection
+   (let [response (data-core/ingest-umm-spec-collection
                    "PROV1"
                    (data-umm-c/collection coll-attributes)
                    (merge {:allow-failure? true} options))]
@@ -30,7 +30,7 @@
    (let [collection (assoc (data-umm-c/collection coll-attributes)
                            :native-id (:native-id coll-attributes))
          provider-id (get coll-attributes :provider-id "PROV1")
-         response (d/ingest-umm-spec-collection provider-id collection options)]
+         response (data-core/ingest-umm-spec-collection provider-id collection options)]
      (is (#{{:status 200} {:status 201}} (select-keys response [:status :errors]))))))
 
 (defn assert-invalid-keywords
@@ -268,7 +268,7 @@
             :Subtype "MAP"}]})
 
   (testing "Project keyword validation"
-    (are2 [short-name long-name]
+    (are3 [short-name long-name]
           (assert-invalid-keywords
             {:Projects [(assoc (data-umm-cmn/project short-name "") :LongName long-name)]}
             ["Projects" 0]
@@ -291,7 +291,7 @@
           "Invalid combination"
           "SEDAC/GISS CROP-CLIM DBQ" "European Digital Archive of Soil Maps")
 
-    (are2 [short-name long-name]
+    (are3 [short-name long-name]
           (assert-valid-keywords
             {:Projects [(assoc (data-umm-cmn/project short-name "") :LongName long-name)]})
           "Exact match"
@@ -304,7 +304,7 @@
           "EUDaSM" "European DIgItal ArchIve of SoIl MAps"))
 
   (testing "Platform keyword validation"
-    (are2 [short-name long-name type]
+    (are3 [short-name long-name type]
           (assert-invalid-keywords
             {:Platforms [(data-umm-cmn/platform {:ShortName short-name
                                                  :LongName long-name
@@ -333,7 +333,7 @@
           "Long name is in Platform and nil in KMS"
           "ALTUS" "foo" "Aircraft")
 
-    (are2 [short-name long-name type]
+    (are3 [short-name long-name type]
           (assert-valid-keywords
             {:Platforms [(data-umm-cmn/platform {:ShortName short-name
                                                  :LongName long-name
@@ -431,7 +431,7 @@
           "bIoTa"))
 
   (testing "Instrument keyword validation"
-    (are2 [short-name long-name]
+    (are3 [short-name long-name]
           (assert-invalid-keywords
             {:Platforms
              [(data-umm-cmn/platform
@@ -456,7 +456,7 @@
           "Invalid combination"
           "ATM" "Land, Vegetation, and Ice Sensor")
 
-    (are2 [short-name long-name]
+    (are3 [short-name long-name]
           (assert-valid-keywords
             {:Platforms
              [(data-umm-cmn/platform

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -7,7 +7,8 @@
     [cmr.system-int-test.data2.core :as d]
     [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
     [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
-    [cmr.system-int-test.utils.ingest-util :as ingest]))
+    [cmr.system-int-test.utils.ingest-util :as ingest]
+    [cmr.umm-spec.models.umm-collection-models :as umm-c]))
 
 (defn assert-invalid
   ([coll-attributes field-path errors]
@@ -54,13 +55,16 @@
                                                             :LongName "Airbus A340-600"
                                                             :Type "Jet"})]
                         :DataCenters [(data-umm-cmn/data-center {:Roles ["ARCHIVER"]
-                                                                 :ShortName "SomeCenter"})]})
+                                                                 :ShortName "SomeCenter"})]
+                        :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "wrong"})})
 
           response (ingest/validate-concept concept {:validate-keywords true})]
       (is (= {:status 422
               :errors [{:path ["Platforms" 0]
                         :errors [(str "Platform short name [foo], long name [Airbus A340-600], "
                                       "and type [Jet] was not a valid keyword combination.")]}
+                       {:path ["ProcessingLevel" "Id"]
+                        :errors ["ProcessingLevel Id [wrong] was not a valid keyword."]}
                        {:path ["DataCenters" 0]
                         :errors [(str "Data center short name [SomeCenter] was not a valid "
                                       "keyword.")]}]}

--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -7,8 +7,7 @@
     [cmr.system-int-test.data2.core :as d]
     [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
     [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
-    [cmr.system-int-test.utils.ingest-util :as ingest]
-    [cmr.umm-spec.models.umm-collection-models :as umm-c]))
+    [cmr.system-int-test.utils.ingest-util :as ingest]))
 
 (defn assert-invalid
   ([coll-attributes field-path errors]
@@ -55,16 +54,13 @@
                                                             :LongName "Airbus A340-600"
                                                             :Type "Jet"})]
                         :DataCenters [(data-umm-cmn/data-center {:Roles ["ARCHIVER"]
-                                                                 :ShortName "SomeCenter"})]
-                        :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "wrong"})})
+                                                                 :ShortName "SomeCenter"})]})
 
           response (ingest/validate-concept concept {:validate-keywords true})]
       (is (= {:status 422
               :errors [{:path ["Platforms" 0]
                         :errors [(str "Platform short name [foo], long name [Airbus A340-600], "
                                       "and type [Jet] was not a valid keyword combination.")]}
-                       {:path ["ProcessingLevel" "Id"]
-                        :errors ["ProcessingLevel Id [wrong] was not a valid keyword."]}
                        {:path ["DataCenters" 0]
                         :errors [(str "Data center short name [SomeCenter] was not a valid "
                                       "keyword.")]}]}


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Return warnings for the RelatedUrl/GetData/Format validation failure when validation header is not set to true.

### What is the Solution?

Return warnings for the RelatedUrl/GetData/Format validation failure when validation header is not set to true.


### What areas of the application does this impact?

List impacted areas.

CMR ingest
# Checklist

- [x ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x ] New and existing unit and int tests pass locally and remotely with my changes
- [x ] I have removed unnecessary/dead code and imports in files I have changed
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
