### PR TITLE
CMR-9889: Adding in a new index to make it faster to delete granules and to not stop the job if one provider's granule deletion fails.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/migrations/021_setup_provider_services_tables.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/021_setup_provider_services_tables.clj
@@ -1,8 +1,8 @@
 (ns cmr.metadata-db.migrations.021-setup-provider-services-tables
-  (:require [clojure.java.jdbc :as j]
-            [config.mdb-migrate-config :as config]
-            [config.mdb-migrate-helper :as h]
-            [cmr.metadata-db.data.oracle.concept-tables :as ct]))
+  (:require
+   [config.mdb-migrate-config :as config]
+   [config.mdb-migrate-helper :as h]
+   [cmr.metadata-db.data.oracle.concept-tables :as ct]))
 
 (defn up
   "Migrates the database up to version 21."

--- a/metadata-db-app/src/cmr/metadata_db/migrations/088_add_meta_to_provider.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/088_add_meta_to_provider.clj
@@ -19,4 +19,4 @@
   []
   ;; do nothing as we don't want to loose the metadata documents when migrating
   ;; down and then back up
-  (println "cmr.metadata-db.migrations.087-update-generic-document-name-length down..."))
+  (println "cmr.metadata-db.migrations.088-add-meta-to-provider down..."))

--- a/metadata-db-app/src/cmr/metadata_db/migrations/089_add_granule_delete_index.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/089_add_granule_delete_index.clj
@@ -1,0 +1,22 @@
+(ns cmr.metadata-db.migrations.089-add-granule-delete-index
+  (:require
+   [config.mdb-migrate-helper :as mh]))
+
+(defn up
+  "Migrates the database up to version 89."
+  []
+  (println "cmr.metadata-db.migrations.089-add-granule-delete-index up...")
+  (doseq [table-name (mh/get-concept-tablenames :granule)]
+    (try
+      (mh/sql (format "create index %s_DD ON %s (deleted, delete_time)" table-name table-name))
+      (catch java.sql.BatchUpdateException e
+        ;; If the index already exists we can ignore the error. This could
+        ;; happen if a migration was moved down, then back up.'
+        (when-not (.contains (.getMessage e) "ORA-00955")
+          (throw e))))))
+
+(defn down
+  "Migrates the database down from version 89."
+  []
+  ;; do nothing as we want to keep the new indexes
+  (println "cmr.metadata-db.migrations.089-add-granule-delete-index down..."))

--- a/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/jobs.clj
@@ -19,10 +19,13 @@
   (doseq [provider (provider-service/get-providers context)]
     ;; Only granule are cleaned up here. Ingest cleans up expired collections because it
     ;; must remove granules from the index that belong to the collections.
-    (concept-service/delete-expired-concepts context provider :granule)))
+    (try
+      (concept-service/delete-expired-concepts context provider :granule)
+      (catch Exception e
+        (error (format "ExpiredConceptCleanupJob for provider %s failed; error: %s" (:provider-id provider) (.getMessage e)))))))
 
 (def-stateful-job ExpiredConceptCleanupJob
-  [ctx system]
+  [_ctx system]
   (expired-concept-cleanup {:system system}))
 
 (defn old-revision-concept-cleanup
@@ -45,7 +48,7 @@
     (concept-service/delete-old-revisions context provider :access-group)))
 
 (def-stateful-job OldRevisionConceptCleanupJob
-  [ctx system]
+  [_ctx system]
   (old-revision-concept-cleanup {:system system}))
 
 (def jobs

--- a/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
@@ -1,6 +1,6 @@
 (ns cmr.metadata-db.services.provider-service
   (:require
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer (info)]
    [cmr.common.services.errors :as errors]
    [cmr.common.services.messages :as cmsg]
    [cmr.common.util :as util]

--- a/metadata-db-app/src/config/mdb_migrate_config.clj
+++ b/metadata-db-app/src/config/mdb_migrate_config.clj
@@ -4,10 +4,7 @@
    [clojure.java.jdbc :as j]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.metadata-db.config :as mdb-config]
-   [cmr.metadata-db.data.oracle.concept-tables :as concept-tables]
    [cmr.metadata-db.services.util :as mdb-util]
-   [cmr.oracle.config :as oracle-config]
-   [cmr.oracle.connection :as oracle]
    [drift.builder :refer [incremental-migration-number-generator]])
   (:import
    (java.sql SQLException)))
@@ -24,7 +21,7 @@
 
 (defn- maybe-create-schema-table
   "Creates the schema table if it doesn't already exist."
-  [args]
+  [_args]
   ;; wrap in a try-catch since there is not easy way to check for the existence of the DB
   (try
     (j/db-do-commands (db) "CREATE TABLE METADATA_DB.schema_version (version INTEGER NOT NULL, created_at TIMESTAMP(9) WITH TIME ZONE DEFAULT sysdate NOT NULL)")
@@ -43,8 +40,9 @@
   ; sleep a second to workaround timestamp precision issue
   (Thread/sleep 1000))
 
-(defn app-migrate-config []
+(defn app-migrate-config
   "Drift migrate configuration used by CMR app's db-migrate endpoint."
+  []
   {:directory "src/cmr/metadata_db/migrations"
    :ns-content "\n  (:require [clojure.java.jdbc :as j]\n            [config.mdb-migrate-config :as config])"
    :namespace-prefix "cmr.metadata-db.migrations"
@@ -53,7 +51,8 @@
    :current-version current-db-version
    :update-version update-db-version})
 
-(defn migrate-config []
+(defn migrate-config
   "Drift migrate configuration used by lein migrate.
    Calling shutdown-agents allows lein migrate command to terminate faster."
+  []
   (assoc (app-migrate-config) :finished shutdown-agents))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Adding in a new index to make it faster to delete granules and to not stop the job if one provider's granule deletion fails.

### What is the Solution?

Adding in a new index to make it faster to delete granules and to not stop the job if one provider's granule deletion fails.

### What areas of the application does this impact?

job of deleting expired granules.

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
