### PR TITLE
Feature/cmr 9706 token docs b

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -240,7 +240,7 @@ The CORS headers are supported on search endpoints. Check [CORS Documentation](h
  * `scroll` - A boolean flag (true/false) that allows all results to be retrieved efficiently. `page_size` is supported with `scroll` while `page_num` and `offset` are not. If `scroll` is `true` then the first call of a scroll session sets the page size; `page_size` is ignored on subsequent calls.
  * `sort_key` - Indicates one or more fields to sort on. Described below.
  * `pretty` - Return formatted results if set to true.
- * `token` - Specifies a user token from EDL or Launchpad for use as authentication. Using the standard [Authorization header](#header) is the prefered way to supply a token. This parameter may be deprecated in the future.
+ * `token` - Specifies a user token from EDL or Launchpad for use as authentication. Using the standard [Authorization header](#headers) is the prefered way to supply a token. This parameter may be deprecated in the future.
  * `echo_compatible` - When set to true results will be returned in an ECHO compatible format. This mostly removes fields and features specific to the CMR such as revision id, granule counts and facets in collection results. Metadata format style results will also use ECHO style names for concept ids such as `echo_granule_id` and `echo_dataset_id`.
 
 #### <a name="paging-details"></a> Paging Details
@@ -5695,7 +5695,7 @@ The [cmr-graphql](https://github.com/nasa/cmr-graphql) API can handle POST reque
 
 ```
 
-curl -XPOST '%GRAPHQL-ENDPOINT%' \ 
+curl -XPOST '%GRAPHQL-ENDPOINT%' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Bearer XXXXX' \
 -d '{"query":"{ collections{ count}}"}'
@@ -5801,8 +5801,8 @@ __Response__
 ```
 
 ### <a name="cmr-graphql-addtional-information"></a> Additional Information
-The [cmr-graphql](https://github.com/nasa/cmr-graphql) is maintained separately from the CMR REST API, it is expected that new fields added to CMR concepts will lag behind changes to the CMR REST API. Though these should be periodically updated to match the latest changes in the CMR API, requested changes can be made by adding an issue to the [cmr-graphql](https://github.com/nasa/cmr-graphql) repository on 
+The [cmr-graphql](https://github.com/nasa/cmr-graphql) is maintained separately from the CMR REST API, it is expected that new fields added to CMR concepts will lag behind changes to the CMR REST API. Though these should be periodically updated to match the latest changes in the CMR API, requested changes can be made by adding an issue to the [cmr-graphql](https://github.com/nasa/cmr-graphql) repository on
 ``` https://github.com/nasa/cmr-graphql/issues```.
 
-For additional information on the cmr-graphql as well as more example queries please visit 
+For additional information on the cmr-graphql as well as more example queries please visit
 ``` https://github.com/nasa/cmr-graphql#readme ```

--- a/transmit-lib/project.clj
+++ b/transmit-lib/project.clj
@@ -34,8 +34,8 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "1.4.2"]
                               [lein-ancient "0.7.0"]
-                              [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]]}
+                              [lein-bikeshed "0.5.2"]
+                              [lein-kibit "0.1.8"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}

--- a/transmit-lib/src/cmr/transmit/association.clj
+++ b/transmit-lib/src/cmr/transmit/association.clj
@@ -17,7 +17,7 @@
 
 (defmulti associations-url
   "Returns the url to associate a concept with the given concept id to collections."
-  (fn [context concept-id]
+  (fn [_context concept-id]
     (:concept-type (concepts/parse-concept-id concept-id))))
 
 (defmethod associations-url :service
@@ -33,7 +33,7 @@
   (associations-by-concept-ids-url context :variable concept-id))
 
 (defmulti single-association-url
-  (fn [context concept-id associated-concept-id]
+  (fn [_context concept-id associated-concept-id]
     (->> [concept-id associated-concept-id]
          (map #(concepts/parse-concept-id %))
          (map :concept-type))))

--- a/transmit-lib/src/cmr/transmit/cache/consistent_cache.clj
+++ b/transmit-lib/src/cmr/transmit/cache/consistent_cache.clj
@@ -77,7 +77,7 @@
 
   c/CmrCache
   (get-keys
-    [this]
+    [_this]
     ;; This is an expensive operation. Any keys that we return here must have a value in memory cache
     ;; and a value in the hash cache. The hash code of the value in the memory cache must match
     ;; the value in the hash cache.
@@ -87,12 +87,12 @@
       k))
 
   (key-exists
-    [this key]
+    [_this key]
     ;; key is the cache-key. Checks to see if the cache has been setup.
     (c/key-exists memory-cache key))
 
   (get-value
-    [this key]
+    [_this key]
     (let [mem-value (c/get-value memory-cache key)]
       (when (and (not (nil? mem-value))
                  (= (hash mem-value)
@@ -109,15 +109,15 @@
         c-value)))
 
   (reset
-    [this]
+    [_this]
     (c/reset memory-cache)
     (c/reset hash-cache))
 
   (set-value
-    [this key value]
+    [_this key value]
     (c/set-value memory-cache key value)
     (c/set-value hash-cache (key->hash-cache-key key) (hash value)))
-  
+
   (cache-size
    [_]
    (+ (c/cache-size memory-cache)
@@ -154,7 +154,7 @@
    (create-consistent-cache nil))
   ([options]
    (let [timeout (get options :hash-timeout-seconds (consistent-cache-default-hash-timeout-seconds))
-         hash-cache (redis-cache/create-redis-cache 
+         hash-cache (redis-cache/create-redis-cache
                      (merge options
                             {:read-connection (cmr.redis-utils.config/redis-read-conn-opts)
                              :primary-connection (cmr.redis-utils.config/redis-conn-opts)}))

--- a/transmit-lib/src/cmr/transmit/cache/consistent_cache_spec.clj
+++ b/transmit-lib/src/cmr/transmit/cache/consistent_cache_spec.clj
@@ -134,5 +134,3 @@
     (c/reset cache-b)
     (testing (:name (meta test-fn-var))
       ((var-get test-fn-var) cache-a cache-b hash-timeout))))
-
-

--- a/transmit-lib/src/cmr/transmit/community_usage_metrics.clj
+++ b/transmit-lib/src/cmr/transmit/community_usage_metrics.clj
@@ -1,11 +1,10 @@
 (ns cmr.transmit.community-usage-metrics
   "This contains functions for interacting with the humanizers API."
   (:require
-   [cheshire.core :as json]
    [cmr.common.mime-types :as mt]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]))
+   [cmr.transmit.http-helper :as hh]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -26,7 +25,7 @@
   ([context content {:keys [raw? http-options token]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn community-usage-metrics-url
                  :method :put
                  :raw? raw?
@@ -48,7 +47,7 @@
   ([context {:keys [raw? http-options token]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn community-usage-metrics-url
                  :method :get
                  :raw? raw?

--- a/transmit-lib/src/cmr/transmit/connection.clj
+++ b/transmit-lib/src/cmr/transmit/connection.clj
@@ -2,11 +2,10 @@
   "Contains functions that allow creating application connections. We'll eventually use this for
   implementing CMR-538"
   (:require
-   [camel-snake-kebab.core :as csk]
    [clj-http.conn-mgr :as conn-mgr]
    [cmr.common.api.web-server :as web-server]
    [cmr.common.config :refer [defconfig]]
-   [cmr.common.log :refer [debug info error]]))
+   [cmr.common.log :refer [error]]))
 
 (defn create-app-connection
   "Creates a 'connection' to an application"

--- a/transmit-lib/src/cmr/transmit/generic_association.clj
+++ b/transmit-lib/src/cmr/transmit/generic_association.clj
@@ -2,10 +2,9 @@
   "This contains functions for interacting with the generic association API."
   (:require
    [cheshire.core :as json]
-   [cmr.common.concepts :as concepts]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]))
+   [cmr.transmit.http-helper :as hh]))
 
 (defn- generic-association-url-for-concept-revision
   "Returns the generic association url for the given concept-id and revision-id."
@@ -32,7 +31,7 @@
   ([context concept-id revision-id content {:keys [raw? token http-options]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn #(generic-association-url-for-concept-revision % concept-id revision-id)
                  :method :post
                  :raw? raw?
@@ -55,7 +54,7 @@
   ([context concept-id revision-id content {:keys [raw? token http-options]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn #(generic-association-url-for-concept-revision % concept-id revision-id)
                  :method :delete
                  :raw? raw?

--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -1,13 +1,14 @@
 (ns cmr.transmit.http-helper
   "Contains helpers for handling making http requests and processing responses."
-  (:require [clj-http.client :as client]
-            [cmr.common.api.context :as context]
-            [cmr.common.mime-types :as mt]
-            [cheshire.core :as json]
-            [cmr.transmit.config :as config]
-            [cmr.transmit.connection :as conn]
-            [cmr.common.services.errors :as errors]
-            [cmr.common.services.health-helper :as hh]))
+  (:require
+   [cheshire.core :as json]
+   [clj-http.client :as client]
+   [cmr.common.api.context :as context]
+   [cmr.common.mime-types :as mt]
+   [cmr.common.services.errors :as errors]
+   [cmr.common.services.health-helper :as hh]
+   [cmr.transmit.config :as config]
+   [cmr.transmit.connection :as conn]))
 
 (defn reset-url
   [conn]
@@ -127,18 +128,19 @@
 
   * :url-fn - A function taking a transmit connection and returning the URL to use.
   * :method - the HTTP method. :get, :post, etc.
-  * :raw? - indicates whether the raw HTTP response (as returned by http-response->raw-response ) is
+  * :raw? - indicates whether the raw HTTP response (as returned by http-response->raw-response) is
   desired. Defaults to false.
   * :use-system-token? - indicates if the ECHO system token should be put in the header
-  * :http-options - a map of additional HTTP options to send to the clj-http.client/request function.
+  * :http-options - map of additional HTTP options to send to the clj-http.client/request function.
   * :response-handler - a function to handle the response. Defaults to default-response-handler"
-  [context app-name {:keys [url-fn method http-options response-handler use-system-token?] :as request}]
+  [context app-name {:keys [url-fn method http-options response-handler use-system-token?] :as _request}]
   (let [conn (config/context->app-connection context app-name)
-        response-handler (or response-handler default-response-handler)
+        _response-handler (or response-handler default-response-handler)
         connection-params (config/conn-params conn)
         ;; Validate that a connection manager is always present. This can cause poor performance if not.
         _ (when-not (:connection-manager connection-params)
-            (errors/internal-error! (format "No connection manager created for [%s] in current application" app-name)))
+            (errors/internal-error!
+             (format "No connection manager created for [%s] in current application" app-name)))
         response (http-response->raw-response-with-headers
                    (client/request
                      (merge connection-params

--- a/transmit-lib/src/cmr/transmit/humanizer.clj
+++ b/transmit-lib/src/cmr/transmit/humanizer.clj
@@ -2,10 +2,9 @@
   "This contains functions for interacting with the humanizers API."
   (:require
    [cheshire.core :as json]
-   [cmr.common.mime-types :as mt]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]))
+   [cmr.transmit.http-helper :as hh]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -26,7 +25,7 @@
   ([context content {:keys [raw? http-options token]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn humanizers-url
                  :method :put
                  :raw? raw?
@@ -48,7 +47,7 @@
   ([context {:keys [raw? http-options token]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn humanizers-url
                  :method :get
                  :raw? raw?

--- a/transmit-lib/src/cmr/transmit/indexer.clj
+++ b/transmit-lib/src/cmr/transmit/indexer.clj
@@ -9,8 +9,10 @@
    [cmr.transmit.connection :as conn]))
 
 ;; Defines health check function
+(declare get-indexer-health)
 (h/defhealther get-indexer-health :indexer {:timeout-secs 2})
 
+(declare clear-cache)
 (h/defcacheclearer clear-cache :indexer)
 
 (defn- rebalance-collection-url

--- a/transmit-lib/src/cmr/transmit/ingest.clj
+++ b/transmit-lib/src/cmr/transmit/ingest.clj
@@ -3,9 +3,7 @@
   (:require [cmr.transmit.connection :as conn]
             [ring.util.codec :as codec]
             [cmr.transmit.http-helper :as h]
-            [camel-snake-kebab.core :as csk]
             [cmr.common.util :as util :refer [defn-timed]]))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -23,20 +21,16 @@
           (concept-type->url-part concept-type)
           (codec/url-encode native-id)))
 
-(defn- health-url
-  [conn]
-  (format "%s/health" (conn/root-url conn)))
-
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Request functions
 
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed ingest-concept
   "Send a request to ingest service to ingest a concept using the optional headers"
   ([context concept headers]
    (ingest-concept context concept headers false))
   ([context concept headers raw]
-   (let [{:keys [provider-id concept-type metadata native-id revision-id]} concept]
+   (let [{:keys [provider-id concept-type metadata native-id]} concept]
      (h/request context :ingest
                 {:url-fn #(concept-ingest-url provider-id concept-type native-id %)
                  :method :put
@@ -45,12 +39,13 @@
                                 :content-type (:format concept)
                                 :headers headers
                                 :accept :json}}))))
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed delete-concept
   "Send a request to ingest service to delete a concept using the optional headers"
   ([context concept headers]
    (ingest-concept context concept headers false))
   ([context concept headers raw]
-   (let [{:keys [provider-id concept-type native-id revision-id]} concept]
+   (let [{:keys [provider-id concept-type native-id]} concept]
      (h/request context :ingest
                 {:url-fn #(concept-ingest-url provider-id concept-type native-id %)
                  :method :delete
@@ -59,4 +54,5 @@
                                 :accept :json}}))))
 
 ;; Defines health check function
+(declare get-ingest-health)
 (h/defhealther get-ingest-health :ingest {:timeout-secs 2})

--- a/transmit-lib/src/cmr/transmit/kms.clj
+++ b/transmit-lib/src/cmr/transmit/kms.clj
@@ -16,13 +16,11 @@
     [cheshire.core :as json]
     [clj-http.client :as client]
     [clojure.data.csv :as csv]
-    [clojure.data.xml :as xml]
     [clojure.java.io :as jio]
     [clojure.set :as set]
-    [clojure.string :as str]
-    [cmr.common.log :as log :refer (debug info warn error)]
+    [clojure.string :as string]
+    [cmr.common.log :as log :refer (info warn error)]
     [cmr.common.util :as util]
-    [cmr.common.xml.simple-xpath :refer [select]]
     [cmr.transmit.config :as config]
     [cmr.transmit.connection :as conn]))
 
@@ -176,7 +174,7 @@
   "Remove any keys from a map which have nil or empty string values."
   [m]
   (util/remove-map-keys
-    (fn [v] (or (nil? v) (and (string? v) (str/blank? v))))
+    (fn [v] (or (nil? v) (and (string? v) (string/blank? v))))
     m))
 
 (def NUM_HEADER_LINES
@@ -261,13 +259,13 @@
   ;;     "{\"platforms\":\"static\"}"
   (let [gcmd-resource-name (keyword-scheme->kms-resource keyword-scheme)]
     (info (format "Loading KMS resource [%s] for [%s]..." gcmd-resource-name keyword-scheme))
-    (if (= "static" (str/lower-case gcmd-resource-name))
+    (if (= "static" (string/lower-case gcmd-resource-name))
       ;; load the static file from the resource directory under indexer
       (let [gcmd-resource-path (str (format "static_kms_keywords/%s.csv" (name keyword-scheme)))
             data (slurp (jio/resource gcmd-resource-path))
-            data-as-rows (str/split-lines (or data ""))
-            version-info (first (str/split (first data-as-rows) #","))
-            header (str/split-lines (second data-as-rows))]
+            data-as-rows (string/split-lines (or data ""))
+            version-info (first (string/split (first data-as-rows) #","))
+            header (string/split-lines (second data-as-rows))]
         (info (format "Loading static KMS resource from %s for %s. %s. Found keys [%s]."
                       gcmd-resource-path
                       gcmd-resource-name

--- a/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
+++ b/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
@@ -3,10 +3,9 @@
   launchpad tokens to avoid needing to call out to EDL for authentication every time.  Launchpad tokens have a lifetime currently of 60 minutes."
   (:require
    [clj-time.core :as t]
-   [clj-time.format :as t-format]
    [cmr.common.cache :as cache]
    [cmr.common.cache.in-memory-cache :as mem-cache]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [error]]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.util :as common-util]

--- a/transmit-lib/src/cmr/transmit/ordering.clj
+++ b/transmit-lib/src/cmr/transmit/ordering.clj
@@ -7,7 +7,7 @@
   (:require
    [clj-http.client :as client]
    [cmr.common.api.context :as ctxt]
-   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.log :as log :refer (debug info)]
    [cmr.common.mime-types :as mime]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]

--- a/transmit-lib/src/cmr/transmit/search.clj
+++ b/transmit-lib/src/cmr/transmit/search.clj
@@ -2,7 +2,7 @@
   "Provide functions to invoke search app"
   (:require
    [clj-http.client :as client]
-   [clojure.data.xml :as x]
+   [clojure.data.xml :as xml]
    [cmr.common.api.context :as ch]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
@@ -10,7 +10,7 @@
    [cmr.common.xml :as cx]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]
+   [cmr.transmit.http-helper :as hh]
    [ring.util.codec :as codec]))
 
 (defn token-header
@@ -18,6 +18,7 @@
  (assoc (ch/context->http-headers context)
    config/token-header (config/echo-system-token)))
 
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-subscription-notification-time
  "make an http call to the database application"
  [context sub-id]
@@ -29,12 +30,13 @@
                               {:accept :xml
                                :headers (token-header context)
                                :throw-exceptions false}))
-       {:keys [headers body]} response
+       {:keys [body]} response
        status (int (:status response))]
    (when-not (= status 204)
      (errors/internal-error!
        (format "Subscription update failed. status: %s body: %s" status body)))))
 
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed find-granule-hits
   "Returns granule hits that match the given search parameters."
   [context params]
@@ -60,7 +62,7 @@
 (defn- parse-granule-response
   "Parse xml search response body and return the granule references"
   [xml]
-  (let [parsed (x/parse-str xml)
+  (let [parsed (xml/parse-str xml)
         ref-elems (cx/elements-at-path parsed [:references :reference])]
     (map #(util/remove-nil-keys
             {:concept-id (cx/string-at-path % [:id])
@@ -70,13 +72,14 @@
 (defn parse-collection-response
   "Parse xml search response body and return the collection references"
   [xml]
-  (let [parsed (x/parse-str xml)
+  (let [parsed (xml/parse-str xml)
         ref-elems (cx/elements-at-path parsed [:references :reference])]
     (map #(util/remove-nil-keys
             {:concept-id (cx/string-at-path % [:id])
              :name (cx/string-at-path % [:name])
              :location (cx/string-at-path % [:location])}) ref-elems)))
 
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed find-concept-references
   "Find granules by parameters in a post request. The function returns an array of granule
   references, each reference being a map having concept-id and granule-ur as the fields"
@@ -99,6 +102,7 @@
       (errors/internal-error!
         (format "Granule search failed. status: %s body: %s" status body)))))
 
+(declare validate-search-params)
 (defn-timed validate-search-params
   "Attempts to search granules using given params via a POST request. If the response contains a
   non-200 http code, returns the response body."
@@ -123,22 +127,27 @@
     (when-not (= status 200)
       body)))
 
-(h/defsearcher search-for-collections :search
+(declare search-for-collections)
+(hh/defsearcher search-for-collections :search
   (fn [conn]
     (format "%s/collections" (conn/root-url conn))))
 
-(h/defsearcher search-for-variables :search
+(declare search-for-variables)
+(hh/defsearcher search-for-variables :search
   (fn [conn]
     (format "%s/variables" (conn/root-url conn))))
 
-(h/defsearcher search-for-services :search
+(declare search-for-services)
+(hh/defsearcher search-for-services :search
   (fn [conn]
     (format "%s/services" (conn/root-url conn))))
 
-(h/defsearcher search-for-tools :search
+(declare search-for-tools)
+(hh/defsearcher search-for-tools :search
   (fn [conn]
     (format "%s/tools" (conn/root-url conn))))
 
-(h/defsearcher search-for-subscriptions :search
+(declare search-for-subscriptions)
+(hh/defsearcher search-for-subscriptions :search
   (fn [conn]
     (format "%s/subscriptions" (conn/root-url conn))))

--- a/transmit-lib/src/cmr/transmit/tag.clj
+++ b/transmit-lib/src/cmr/transmit/tag.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as h]))
+   [cmr.transmit.http-helper :as hh]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -28,24 +28,26 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Request functions
 
-(h/defcreator create-tag :search tags-url)
-(h/defsearcher search-for-tags :search tags-url)
-(h/defupdater update-tag :search tag-url)
-(h/defdestroyer delete-tag :search tag-url)
-(h/defgetter get-tag :search tag-url)
+(declare create-tag search-for-tags update-tag delete-tag get-tag)
+
+(hh/defcreator create-tag :search tags-url)
+(hh/defsearcher search-for-tags :search tags-url)
+(hh/defupdater update-tag :search tag-url)
+(hh/defdestroyer delete-tag :search tag-url)
+(hh/defgetter get-tag :search tag-url)
 
 (defmulti tag-associations-url
   "Returns the url to associate a tag based on the association type.
   Valid association types are :query and :concept-ids."
-  (fn [context tag-key association-type]
+  (fn [_context _tag-key association-type]
     association-type))
 
 (defmethod tag-associations-url :query
-  [context tag-key _]
+  [context tag-key _association-type]
   (tag-associations-by-query-url context tag-key))
 
 (defmethod tag-associations-url :concept-ids
-  [context tag-key _]
+  [context tag-key _association-type]
   (tag-associations-by-concept-ids-url context tag-key))
 
 (defn associate-tag
@@ -62,7 +64,7 @@
   ([association-type context tag-key content {:keys [raw? token http-options]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn #(tag-associations-url % tag-key association-type)
                  :method :post
                  :raw? raw?
@@ -81,12 +83,12 @@
   * token - the user token to use when creating the token. If not set the token in the context will
   be used.
   * http-options - Other http-options to be sent to clj-http."
-  ([association-type context concept-id content]
+  ([_association-type context concept-id content]
    (dissociate-tag context concept-id content nil))
   ([association-type context concept-id content {:keys [raw? token http-options]}]
    (let [token (or token (:token context))
          headers (when token {config/token-header token})]
-     (h/request context :search
+     (hh/request context :search
                 {:url-fn #(tag-associations-url % concept-id association-type)
                  :method :delete
                  :raw? raw?

--- a/transmit-lib/src/cmr/transmit/tokens.clj
+++ b/transmit-lib/src/cmr/transmit/tokens.clj
@@ -8,7 +8,7 @@
    [clj-http.client :as client]
    [clojure.string :as string]
    [cmr.common.date-time-parser :as date-time-parser]
-   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.log :as log :refer (info warn)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]

--- a/transmit-lib/src/cmr/transmit/urs.clj
+++ b/transmit-lib/src/cmr/transmit/urs.clj
@@ -2,13 +2,12 @@
   (:require
    [cmr.common.cache :as cache]
    [cmr.common.cache.in-memory-cache :as mem-cache]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [error]]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as common-util]
    [cmr.transmit.config :as config]
    [cmr.transmit.connection :as conn]
-   [cmr.transmit.http-helper :as http-helper]
-   [ring.util.codec :as codec]))
+   [cmr.transmit.http-helper :as http-helper]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; URL functions
@@ -24,10 +23,6 @@
 (defn- user-info-url
   [conn username]
   (format "%s/api/users/%s" (conn/root-url conn) username))
-
-(defn- group-search-url
-  [conn]
-  (format "%s/api/user_groups/search" (conn/root-url conn)))
 
 (defn- groups-for-user-url
   [conn username]


### PR DESCRIPTION
# Overview

Correcting one letter in a link

### What is the Solution?

Adding the letter 's'

### What areas of the application does this impact?

the link from parameters to headers sections

# Checklist

- [- ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [-] New and existing unit and int tests pass locally and remotely with my changes
- [-] I have removed unnecessary/dead code and imports in files I have changed
- [-] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
