### PR TITLE
CMR-8976: Add 401 handling to transmit response handler for POST, PUT requests

### DIFF
--- a/transmit-lib/src/cmr/transmit/http_helper.clj
+++ b/transmit-lib/src/cmr/transmit/http_helper.clj
@@ -77,6 +77,7 @@
   [{:keys [status body] :as resp}]
   (cond
     (<= 200 status 299) body
+    (= 401 status) (errors/throw-service-errors :unauthorized (:errors body))
     (= 409 status) (errors/throw-service-errors :conflict (:errors body))
     (= 422 status) (errors/throw-service-errors :invalid-data (:errors body))
     :else (errors/internal-error!


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Add 401 error handling to gracefully respond to POST/PUT requests with invalid Launchpad tokens

### What is the Solution?

Added a 401 error handler

### What areas of the application does this impact?

Search, Access Control, Ingest

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
