### PR TITLE
CMR-10009: Fix job-router load balancer referencing issues

### DIFF
--- a/job-utilities/job-details.json
+++ b/job-utilities/job-details.json
@@ -4,7 +4,8 @@
         "target" : {
             "endpoint" : "caches/refresh/kms",
             "service" : "bootstrap",
-            "single-target" : true
+            "single-target" : true,
+            "request-type" : "POST"
         },
         "scheduling" : {
             "type" : "cron",

--- a/job-utilities/job_router/lambda_function.py
+++ b/job-utilities/job_router/lambda_function.py
@@ -30,8 +30,8 @@ def handler(event, _):
     if environment is None:
         print("ERROR: Environment variable not set!")
         error_state = True
-    if cmr_url is None:
-        print("ERROR: CMR_URL variable not set!")
+    if cmr_lb_name is None:
+        print("ERROR: CMR_LB_NAME variable not set!")
         error_state = True
     if error_state:
         sys.exit(1)
@@ -44,8 +44,6 @@ def handler(event, _):
 
     token_param_name = '/'+environment+'/'+service+'/CMR_ECHO_SYSTEM_TOKEN'
     token = ssm_client.get_parameter(Name=token_param_name, WithDecryption=True)['Parameter']['Value']
-
-    cmr_url = ec2_client.
 
     pool_manager = urllib3.PoolManager(headers={"Authorization": token}, timeout=urllib3.Timeout(15))
 

--- a/job-utilities/job_router/lambda_function.py
+++ b/job-utilities/job_router/lambda_function.py
@@ -40,7 +40,7 @@ def handler(event, _):
     ssm_client = boto3.client('ssm')
     elb_client = boto3.client('elbv2')
 
-    cmr_url = elb_client.describe_load_balancers(Names=[cmr_lb_name])[0]["DNSName"]
+    cmr_url = elb_client.describe_load_balancers(Names=[cmr_lb_name])["LoadBalancers"][0]["DNSName"]
 
     token_param_name = '/'+environment+'/'+service+'/CMR_ECHO_SYSTEM_TOKEN'
     token = ssm_client.get_parameter(Name=token_param_name, WithDecryption=True)['Parameter']['Value']

--- a/job-utilities/job_router/lambda_function.py
+++ b/job-utilities/job_router/lambda_function.py
@@ -52,7 +52,7 @@ def handler(event, _):
 
         response = pool_manager.request(request_type, cmr_url + '/' + service + '/' + endpoint)
         if response.status != 200:
-            print("Error received sending request to " + cmr_url + '/' + service + '/' + endpoint + ": " + response.status + " reason: " + response.reason)
+            print("Error received sending request to " + cmr_url + '/' + service + '/' + endpoint + ": " + str(response.status) + " reason: " + response.reason)
             exit(-1)
     else:
         #Multi-target functionality is not fully implemented.
@@ -74,5 +74,5 @@ def handler(event, _):
 
             response = pool_manager.request(request_type, task + '/' + service + '/' + endpoint)
             if response.status != 200:
-                print("Error received sending " + request_type + " to " + task + '/' + service + '/' + endpoint + ": " + response.status + " reason: " + response.reason)
+                print("Error received sending " + request_type + " to " + task + '/' + service + '/' + endpoint + ": " + str(response.status) + " reason: " + response.reason)
                 exit(-1)

--- a/job-utilities/local_development/local_scheduler.py
+++ b/job-utilities/local_development/local_scheduler.py
@@ -10,7 +10,8 @@ import os
 import schedule
 import urllib3
 
-service_ports_file_name = os.getenv("SERVICE_PORTS_FILE", "service_ports_file.json")
+service_ports_file_name = os.getenv("SERVICE_PORTS_FILE", "service-ports.json")
+job_details_file_name = os.getenv("JOB_DETAILS_FILE", "../job-details.json")
 
 pool_manager = urllib3.PoolManager(headers={"Authorization" : "mock-echo-system-token"})
 
@@ -27,17 +28,17 @@ def build_endpoint(job):
 
 def run_job(details, name):
     """
-    Takes the job details and runs a POST request on the job endpoint.
+    Takes the job details and runs a REST request on the job endpoint.
     """
-    print('send POST to ' + details["target"]["endpoint"] + ' for job ' + name)
-    pool_manager.request("POST", build_endpoint(details),)
+    print('send ' + details["target"]["request-type"] + ' to ' + details["target"]["endpoint"] + ' for job ' + name)
+    pool_manager.request(details["target"]["request-type"], build_endpoint(details))
 
 def create_schedule():
     """
     Uses the job-details file to create local schedule using
     the schedule python library
     """
-    with open('../job-details.json', encoding="UTF-8") as json_file:
+    with open(job_details_file_name, encoding="UTF-8") as json_file:
         jobs_map = json.load(json_file)
         for job_name, job_details in jobs_map.items():
             #Cron scheduling will assume it is scheduled to run at a certain time every day

--- a/job-utilities/local_development/local_scheduler.py
+++ b/job-utilities/local_development/local_scheduler.py
@@ -30,7 +30,8 @@ def run_job(details, name):
     """
     Takes the job details and runs a REST request on the job endpoint.
     """
-    print('send ' + details["target"]["request-type"] + ' to ' + details["target"]["endpoint"] + ' for job ' + name)
+    print('send ' + details["target"]["request-type"] + \
+          ' to ' + details["target"]["endpoint"] + ' for job ' + name)
     pool_manager.request(details["target"]["request-type"], build_endpoint(details))
 
 def create_schedule():


### PR DESCRIPTION
# Overview

### What is the feature/fix?

If some infrastructure change causes the LB to be remade with the same name, it might not have the same DNS name, which requires job-router to need it's variables updated

### What is the Solution?

Changed job-router to use the name of the LB to query AWS for the DNS name, so it isn't reliant on a more-likely-to-change value

### What areas of the application does this impact?

job-router

# Checklist

- [x ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
