### PR TITLE
CMR-10020 - Adding indexes to granule tables to speed up DB queries for cleaning up old concepts.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/granule_table.clj
@@ -88,8 +88,10 @@
     false (do
             (jdbc/db-do-commands db (format "CREATE INDEX idx_%s_ur ON %s(granule_ur)" table-name table-name))
             ;; This index makes it much faster to find granules that are not deleted that have a delete time.
-            (jdbc/db-do-commands db (format "create index %s_dd on %s (deleted, delete_time)" table-name table-name)))
+            (jdbc/db-do-commands db (format "create index %s_dd on %s (deleted, delete_time)" table-name table-name))
+            (jdbc/db-do-commands db (format "create index %s_dr on %s (deleted, revision_date)" table-name table-name)))
     true (do
            (jdbc/db-do-commands db (format "CREATE INDEX idx_%s_pur ON %s(provider_id, granule_ur)" table-name table-name))
            ;; This index makes it much faster to find granules that are not deleted that have a delete time.
-           (jdbc/db-do-commands db (format "create index %s_dd on %s (provider_id, deleted, delete_time)" table-name table-name)))))
+           (jdbc/db-do-commands db (format "create index %s_dd on %s (provider_id, deleted, delete_time)" table-name table-name))
+           (jdbc/db-do-commands db (format "create index %s_dr on %s (provider_id, deleted, revision_date)" table-name table-name)))))

--- a/metadata-db-app/src/cmr/metadata_db/migrations/090_add_granule_delete_revision_index.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/090_add_granule_delete_revision_index.clj
@@ -11,7 +11,7 @@
     (try
       (if (string/includes? table-name "SMALL_PROV")
         (mh/sql (format "create index %s_DR ON %s (provider_id, deleted, revision_date)" table-name table-name))
-        (mh/sql (format "create index %s_DD ON %s (deleted, revision_date)" table-name table-name)))
+        (mh/sql (format "create index %s_DR ON %s (deleted, revision_date)" table-name table-name)))
       (catch java.sql.BatchUpdateException e
         ;; If the index already exists we can ignore the error. This could
         ;; happen if a migration was moved down, then back up.'

--- a/metadata-db-app/src/cmr/metadata_db/migrations/090_add_granule_delete_revision_index.clj
+++ b/metadata-db-app/src/cmr/metadata_db/migrations/090_add_granule_delete_revision_index.clj
@@ -1,0 +1,25 @@
+(ns cmr.metadata-db.migrations.090-add-granule-delete-revision-index
+  (:require
+   [clojure.string :as string]
+   [config.mdb-migrate-helper :as mh]))
+
+(defn up
+  "Migrates the database up to version 90."
+  []
+  (println "cmr.metadata-db.migrations.090-add-granule-delete-revision-index up...")
+  (doseq [table-name (mh/get-concept-tablenames :granule)]
+    (try
+      (if (string/includes? table-name "SMALL_PROV")
+        (mh/sql (format "create index %s_DR ON %s (provider_id, deleted, revision_date)" table-name table-name))
+        (mh/sql (format "create index %s_DD ON %s (deleted, revision_date)" table-name table-name)))
+      (catch java.sql.BatchUpdateException e
+        ;; If the index already exists we can ignore the error. This could
+        ;; happen if a migration was moved down, then back up.'
+        (when-not (.contains (.getMessage e) "ORA-00955")
+          (throw e))))))
+
+(defn down
+  "Migrates the database down from version 90."
+  []
+  ;; do nothing as we want to keep the new indexes
+  (println "cmr.metadata-db.migrations.090-add-granule-delete-revision-index down..."))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Adding indexes to granule tables to speed up DB queries for cleaning up old concepts.

### What is the Solution?

Adding indexes to granule tables to speed up DB queries for cleaning up old concepts.

### What areas of the application does this impact?

Granule Tables

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [X] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
