### PR TITLE
Feature: CMR-10013 - Removal of sha/md5 by default

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -141,7 +141,7 @@
              ;; that reporting scripts can try to protect against change. Humans
              ;; may be creating Splunk or ELK reports based on this content.
              note (-> {"log-type" "action-log" "log-version" "1.0.0"}
-                      ;(assoc-hashes response)
+                      (assoc-hashes response)
                       ;; As this handler can be called multiple times, if so,
                       ;; include an id showing which instance is reporting this
                       ;; information.
@@ -149,7 +149,8 @@
                       ;; assume that (add-body-hashes) has been run and reuse data
                       (assoc "client-id" (get-in request [:headers "client-id"] "unknown")
                              "form-params" (dump-param form-params :form-params)
-                             "method" (string/upper-case (name (:request-method request)))
+                             "method" (string/upper-case
+                                       (name (get-in request [:request-method] "unknown")))
                              "now" now
                              "protocol" (:protocol request)
                              "query-params" (dump-param query-params :query-params)
@@ -173,7 +174,9 @@
   ;; and what you will get back.
   (let [body-stream (clojure.java.io/reader (char-array "p1=a&p2=b"))
         request {:headers {"content-type" "application/x-www-form-urlencoded;anything-allowed-here"}
-                 :body body-stream}]
+                 :body body-stream}
+        foo (log-ring-request {})]
+    ;;(foo {}) ;;uncomment this to run the log-ring-request and test it out
     (ring.middleware.params/assoc-form-params request "UTF-8"))
 
   ;; and query paramas are simple and can be done as the following:

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -8,7 +8,7 @@
    [clojure.string :as string]
    [cmr.common-app.config :as config]
    [cmr.common.date-time-parser :as dtp]
-   [cmr.common.log :refer [report]]
+   [cmr.common.log :as log :refer [report]]
    [cmr.common.util :as util]
    [cmr.common.time-keeper :as tk]
    [digest :as digest]
@@ -82,6 +82,18 @@
                                (assoc-in [:headers "Content-SHA1"] body-sha1))]
       updated-response)))
 
+(defn assoc-hashes
+  "Conditionally adds md5 and sha1 hashes if the log level is either debug or
+   trace. These values are pulled from the response map."
+  [data response]
+  (let [log-level (log/apparent-log-level)]
+    (if (contains? (set [:debug :trace]) log-level)
+      (-> data
+          (assoc "body-md5" (get-in response [:headers "Content-MD5"]))
+          (assoc "body-sha1" (get-in response [:headers "Content-SHA1"]))
+          (util/remove-nil-keys))
+      data)))
+
 ;; log-ring-request should provide the same info as a standard NCSA Log
 ;; ; 127.0.0.1 - - [2023-12-27 19:04:01.676] "GET /collections?keyword=any HTTP/1.1" 200 112 "-" "curl/8.1.2" 296
 
@@ -129,14 +141,13 @@
              ;; that reporting scripts can try to protect against change. Humans
              ;; may be creating Splunk or ELK reports based on this content.
              note (-> {"log-type" "action-log" "log-version" "1.0.0"}
+                      (assoc-hashes response)
                       ;; As this handler can be called multiple times, if so,
                       ;; include an id showing which instance is reporting this
                       ;; information.
                       (as-> data (if (= id :ignore-id) (assoc data "log-id" id) data))
                       ;; assume that (add-body-hashes) has been run and reuse data
-                      (assoc "body-md5" (get-in response [:headers "Content-MD5"])
-                             "body-sha1" (get-in response [:headers "Content-SHA1"])
-                             "client-id" (get-in request [:headers "client-id"] "unknown")
+                      (assoc "client-id" (get-in request [:headers "client-id"] "unknown")
                              "form-params" (dump-param form-params :form-params)
                              "method" (string/upper-case (name (:request-method request)))
                              "now" now

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -141,7 +141,7 @@
              ;; that reporting scripts can try to protect against change. Humans
              ;; may be creating Splunk or ELK reports based on this content.
              note (-> {"log-type" "action-log" "log-version" "1.0.0"}
-                      (assoc-hashes response)
+                      ;(assoc-hashes response)
                       ;; As this handler can be called multiple times, if so,
                       ;; include an id showing which instance is reporting this
                       ;; information.

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -82,7 +82,7 @@
                                (assoc-in [:headers "Content-SHA1"] body-sha1))]
       updated-response)))
 
-(defn assoc-hashes
+(defn add-hash-to-data
   "Conditionally adds md5 and sha1 hashes if the log level is either debug or
    trace. These values are pulled from the response map."
   [data response]
@@ -141,7 +141,7 @@
              ;; that reporting scripts can try to protect against change. Humans
              ;; may be creating Splunk or ELK reports based on this content.
              note (-> {"log-type" "action-log" "log-version" "1.0.0"}
-                      (assoc-hashes response)
+                      (add-hash-to-data response)
                       ;; As this handler can be called multiple times, if so,
                       ;; include an id showing which instance is reporting this
                       ;; information.

--- a/common-app-lib/test/cmr/common_app/test/services/kms_fetcher_errors_test.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_fetcher_errors_test.clj
@@ -6,7 +6,7 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches {kms-fetcher/kms-cache-key (kms-fetcher/create-kms-cache)}}})
+   {:system {:caches {kms-fetcher/kms-cache-key (kms-fetcher/create-kms-cache)}}})
 
 (deftest fetch-gcmd-keywords-map-test
   (testing "cache connection error"

--- a/common-lib/src/cmr/common/log.clj
+++ b/common-lib/src/cmr/common/log.clj
@@ -174,4 +174,6 @@
    this api to get the current version. We could query the level here, but it can change if using
    taoensso.timbre/with-log-level"
   []
-  (:min-level tiber/*config*))
+  (if-some [_ tiber/*config*]
+    (:min-level tiber/*config*)
+    :warn))

--- a/common-lib/src/cmr/common/log.clj
+++ b/common-lib/src/cmr/common/log.clj
@@ -168,3 +168,10 @@
   (let [options (when level
                   {:level (keyword (string/lower-case level))})]
     (create-logger options)))
+
+(defn apparent-log-level
+  "Return the internal log level used by timber directly from timbre as there is no set function in
+   this api to get the current version. We could query the level here, but it can change if using
+   taoensso.timbre/with-log-level"
+  []
+  (:min-level tiber/*config*))

--- a/transmit-lib/src/cmr/transmit/kms.clj
+++ b/transmit-lib/src/cmr/transmit/kms.clj
@@ -248,7 +248,6 @@
   "Makes a get request to the GCMD KMS. Returns the controlled vocabulary map for the given
   keyword scheme."
   [context keyword-scheme]
-
   ;; From time to time KMS will not be ready to host a set of keywords as the
   ;; population of that system happens on it's team's own schedule. In the case
   ;; where a standard list is ready before the KMS sever is, load that list from


### PR DESCRIPTION
# Overview

The inclusion of SHA1 and MD5 output in the request logs really have no practical use for every day logs and are of minor interest outside of debugging.

This change will push these values to debug only status, meaning they will only display when logs are set to debug or more verbose.

### What areas of the application does this impact?

This impacts the custom access log

- [-] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
