### PR TITLE
Feature: CMR-10025 - Condensed Index Event logs

### DIFF
--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -40,8 +40,8 @@
                     :test-paths ^:replace []
                     :plugins [[jonase/eastwood "1.4.2"]
                               [lein-ancient "0.7.0"]
-                              [lein-bikeshed "0.5.0"]
-                              [lein-kibit "0.1.6"]]}
+                              [lein-bikeshed "0.5.2"]
+                              [lein-kibit "0.1.8"]]}
              ;; The following profile is overriden on the build server or in the user's
              ;; ~/.lein/profiles.clj file.
              :internal-repos {}

--- a/indexer-app/src/cmr/indexer/config.clj
+++ b/indexer-app/src/cmr/indexer/config.clj
@@ -110,3 +110,10 @@
   "Number of days where collection end-date counts as ongoing"
   {:default 30
    :type Long})
+
+(defconfig reduced-indexer-log
+  "When true only one log entry will be written for every index action performed by index-service.
+   The single log entry will also be in JSON and be as short as possible to cut down on log
+   retention requirements. Turning this feature on may break Splunk reports."
+  {:default false
+   :type Boolean})

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -13,8 +13,7 @@
    [cmr.common.cache.fallback-cache :as fallback-cache]
    [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
    [cmr.common.config :refer [defconfig]]
-   [cmr.common.jobs :refer [def-stateful-job]]
-   [cmr.common.log :refer [debug info error]]
+   [cmr.common.log :refer [info]]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as tk]
    [cmr.common.util :as util]
@@ -238,7 +237,7 @@
 (defn refresh-cache
   "Refreshes the collection granule aggregates in the cache."
   [context granules-updated-in-last-n]
-  (let [cache (c/context->cache context coll-gran-aggregate-cache-key)]
+  (let [_cache (c/context->cache context coll-gran-aggregate-cache-key)]
     (if granules-updated-in-last-n
       (partial-cache-refresh context granules-updated-in-last-n)
       (full-cache-refresh context))))

--- a/indexer-app/src/cmr/indexer/data/concept_parser.clj
+++ b/indexer-app/src/cmr/indexer/data/concept_parser.clj
@@ -1,6 +1,6 @@
 (ns cmr.indexer.data.concept-parser
   "Contains helper functions to parse a concept for indexing."
-  (:require 
+  (:require
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.string :as string]
@@ -11,15 +11,15 @@
 (defmulti parse-concept
   "Parse the metadata from a concept map into a UMM model or map containing data needed for
   indexing."
-  (fn [context concept]
+  (fn [_context concept]
     (keyword (:concept-type concept))))
 
 (defmethod parse-concept :tag
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (defmethod parse-concept :tag-association
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (defmethod parse-concept :variable
@@ -27,7 +27,7 @@
   (umm/parse-metadata context concept))
 
 (defmethod parse-concept :variable-association
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (defmethod parse-concept :service
@@ -35,7 +35,7 @@
   (umm/parse-metadata context concept))
 
 (defmethod parse-concept :service-association
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (defmethod parse-concept :collection
@@ -48,19 +48,20 @@
 
 (defmethod parse-concept :tool
   [context concept]
+  (println "here in tool handler")
   (umm/parse-metadata context concept))
- 
+
 (defmethod parse-concept :tool-association
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (defmethod parse-concept :generic-association
-  [context concept]
+  [_context concept]
   (edn/read-string (:metadata concept)))
 
 (doseq [concept-type concepts/get-generic-non-draft-concept-types-array]
   (defmethod parse-concept concept-type
-    [context concept]
+    [_context concept]
     (json/parse-string (:metadata concept) true)))
 
 (doseq [concept-type concepts/get-draft-concept-types-array]
@@ -79,5 +80,5 @@
           (umm/parse-metadata context concept))))))
 
 (defmethod parse-concept :default
- [context concept]
- (umm-legacy/parse-concept context concept))
+  [context concept]
+  (umm-legacy/parse-concept context concept))

--- a/indexer-app/src/cmr/indexer/data/concepts/attribute.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/attribute.clj
@@ -11,28 +11,28 @@
 
 (defmulti value->elastic-value
   "Converts a attribute value into the elastic value that should be transmitted"
-  (fn [type value]
+  (fn [type _value]
     type))
 
 (defmethod value->elastic-value :default
-  [type value]
+  [_type value]
   (or value ""))
 
 (defmethod value->elastic-value :boolean
-  [type value]
+  [_type value]
   (if (nil? value) "" value))
 
 (defmethod value->elastic-value :datetime
-  [type value]
+  [_type value]
   (when value (p/clj-time->date-time-str value)))
 
 (defmethod value->elastic-value :time
-  [type value]
+  [_type value]
   ;; This relies on the fact that times are parsed into times on day 1970-01-01
   (when value (p/clj-time->date-time-str value)))
 
 (defmethod value->elastic-value :date
-  [type value]
+  [_type value]
   (when value (p/clj-time->date-time-str value)))
 
 (def type->field-name

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -158,7 +158,7 @@
 (defn- cloud-hosted?
   "Test if the collection meets the criteria for being cloud hosted"
   [collection tags]
-  (or (not (empty? (:DirectDistributionInformation collection)))
+  (or (seq (:DirectDistributionInformation collection))
       (tag/has-cloud-s3-tag? tags)))
 
 (defn- standard-product?
@@ -214,7 +214,7 @@
   "Get all the fields for a normal collection index operation."
   [context concept collection]
   (let [{:keys [concept-id revision-id provider-id user-id native-id
-                created-at revision-date deleted format extra-fields tag-associations
+                created-at revision-date deleted format tag-associations
                 variable-associations service-associations tool-associations generic-associations]} concept
         consortiums-str (some #(when (= provider-id (:provider-id %)) (:consortiums %))
                               (metadata-db/get-providers context))
@@ -319,8 +319,8 @@
         data-center-names (keep meaningful-short-name-fn data-centers)
         atom-links (map json/generate-string (ru/atom-links related-urls))
         ;; not empty is used below to get a real true/false value
-        downloadable (not (empty? (ru/downloadable-urls related-urls)))
-        browsable (not (empty? (ru/browse-urls related-urls)))
+        downloadable (seq (ru/downloadable-urls related-urls))
+        browsable (seq (ru/browse-urls related-urls))
         update-time (date-util/data-update-date collection)
         update-time (index-util/date->elastic update-time)
         index-time (index-util/date->elastic (tk/now))
@@ -369,10 +369,10 @@
                                    (contains? (set consortiums) "CWIC"))
             :has-granules-or-opensearch (or
                                          has-granules
-                                         (not (empty?
+                                         (seq
                                                (set/intersection
                                                 (set consortiums)
-                                                (set (common-config/opensearch-consortiums))))))
+                                                (set (common-config/opensearch-consortiums)))))
             :granule-data-format granule-data-format
             :granule-data-format-lowercase (map string/lower-case granule-data-format)
             :entry-id entry-id
@@ -449,7 +449,7 @@
             :summary summary
             :metadata-format (name (mt/format-key format))
             :related-urls (map json/generate-string opendata-related-urls)
-            :has-opendap-url (not (empty? (filter opendap-util/opendap-url? related-urls)))
+            :has-opendap-url (seq (filter opendap-util/opendap-url? related-urls))
             :cloud-hosted (cloud-hosted? collection tags)
             :standard-product (standard-product? collection tags)
             :publication-references opendata-references

--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -158,7 +158,7 @@
 (defn- cloud-hosted?
   "Test if the collection meets the criteria for being cloud hosted"
   [collection tags]
-  (or (seq (:DirectDistributionInformation collection))
+  (or (not (empty? (:DirectDistributionInformation collection)))
       (tag/has-cloud-s3-tag? tags)))
 
 (defn- standard-product?
@@ -319,8 +319,8 @@
         data-center-names (keep meaningful-short-name-fn data-centers)
         atom-links (map json/generate-string (ru/atom-links related-urls))
         ;; not empty is used below to get a real true/false value
-        downloadable (seq (ru/downloadable-urls related-urls))
-        browsable (seq (ru/browse-urls related-urls))
+        downloadable (not (empty? (ru/downloadable-urls related-urls)))
+        browsable (not (empty? (ru/browse-urls related-urls)))
         update-time (date-util/data-update-date collection)
         update-time (index-util/date->elastic update-time)
         index-time (index-util/date->elastic (tk/now))
@@ -369,10 +369,10 @@
                                    (contains? (set consortiums) "CWIC"))
             :has-granules-or-opensearch (or
                                          has-granules
-                                         (seq
+                                         (not (empty?
                                                (set/intersection
                                                 (set consortiums)
-                                                (set (common-config/opensearch-consortiums)))))
+                                                (set (common-config/opensearch-consortiums))))))
             :granule-data-format granule-data-format
             :granule-data-format-lowercase (map string/lower-case granule-data-format)
             :entry-id entry-id
@@ -449,7 +449,7 @@
             :summary summary
             :metadata-format (name (mt/format-key format))
             :related-urls (map json/generate-string opendata-related-urls)
-            :has-opendap-url (seq (filter opendap-util/opendap-url? related-urls))
+            :has-opendap-url (not (empty? (filter opendap-util/opendap-url? related-urls)))
             :cloud-hosted (cloud-hosted? collection tags)
             :standard-product (standard-product? collection tags)
             :publication-references opendata-references

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/platform.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/platform.clj
@@ -75,7 +75,7 @@
   (let [full-platform
         (merge default-platform-values
                (kms-lookup/lookup-by-short-name context :platforms short-name))
-        {:keys [basis category sub-category short-name long-name uuid]
+        {:keys [category sub-category short-name long-name uuid]
          ;; Use the short-name from KMS if present, otherwise use the metadata short-name
          :or {short-name short-name}} full-platform]
     {:category category

--- a/indexer-app/src/cmr/indexer/data/concepts/generic_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/generic_util.clj
@@ -10,7 +10,7 @@
    generating elastic values. If an index does not specify what type it is for,
    then assume elastic"
   [list-of-indexes]
-  (keep #(when (not (nil? %)) %)
+  (keep #(if (not (nil? %)) %)
         (map
          (fn [x] (when (or (nil? (:Type x)) (= "elastic" (:Type x))) x))
          list-of-indexes)))

--- a/indexer-app/src/cmr/indexer/data/concepts/generic_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/generic_util.clj
@@ -3,16 +3,14 @@
    complying to a schema supported by the Generic Document system) to and object
    that can be indexed in lucine."
   (:require
-   [cheshire.core :as json]
-   [clojure.string :as string]
-   [cmr.common.log :refer (debug info warn error)]))
+   [clojure.string :as string]))
 
 (defn only-elastic-preferences
-  "Go through all the index configurations and return only the ones related to 
+  "Go through all the index configurations and return only the ones related to
    generating elastic values. If an index does not specify what type it is for,
    then assume elastic"
   [list-of-indexes]
-  (keep #(if (not (nil? %)) %)
+  (keep #(when (not (nil? %)) %)
         (map
          (fn [x] (when (or (nil? (:Type x)) (= "elastic" (:Type x))) x))
          list-of-indexes)))

--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -137,8 +137,8 @@
         atom-links (map json/generate-string (ru/atom-links related-urls))
         ocsd-json (granule->ocsd-json umm-granule)
         ;; not empty is used below to get a real true false value
-        downloadable (seq (ru/downloadable-urls related-urls))
-        browsable (seq (ru/browse-urls related-urls))
+        downloadable (not (empty? (ru/downloadable-urls related-urls)))
+        browsable (not (empty? (ru/browse-urls related-urls)))
         update-time (get-in umm-granule [:data-provider-timestamps :update-time])
         update-time (index-util/date->elastic update-time)
         track (get-in umm-granule [:spatial-coverage :track])

--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -6,7 +6,6 @@
    [clojure.string :as string]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
@@ -21,6 +20,7 @@
    [cmr.umm.echo10.spatial :as umm-spatial]
    [cmr.umm.related-url-helper :as ru]
    [cmr.umm.start-end-date :as sed])
+  #_{:clj-kondo/ignore [:unused-import]}
   (:import
    (cmr.spatial.mbr Mbr)))
 
@@ -137,8 +137,8 @@
         atom-links (map json/generate-string (ru/atom-links related-urls))
         ocsd-json (granule->ocsd-json umm-granule)
         ;; not empty is used below to get a real true false value
-        downloadable (not (empty? (ru/downloadable-urls related-urls)))
-        browsable (not (empty? (ru/browse-urls related-urls)))
+        downloadable (seq (ru/downloadable-urls related-urls))
+        browsable (seq (ru/browse-urls related-urls))
         update-time (get-in umm-granule [:data-provider-timestamps :update-time])
         update-time (index-util/date->elastic update-time)
         track (get-in umm-granule [:spatial-coverage :track])

--- a/indexer-app/src/cmr/indexer/data/concepts/orbit_calculated_spatial_domain.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/orbit_calculated_spatial_domain.clj
@@ -1,7 +1,6 @@
 (ns cmr.indexer.data.concepts.orbit-calculated-spatial-domain
   "Contains functions for converting orbit calcuated spatial domains into a elastic documents"
-  (:require [cmr.indexer.data.concepts.attribute :as attr]
-            [cmr.common.services.errors :as errors]))
+  (:require [cmr.indexer.data.concepts.attribute :as attr]))
 
 (defn ocsd->elastic-doc
   "Converts a OCSD into the portion going in an elastic document"

--- a/indexer-app/src/cmr/indexer/data/concepts/subscription.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/subscription.clj
@@ -7,7 +7,7 @@
    [cmr.indexer.data.elasticsearch :as es]))
 
 (defmethod es/parsed-concept->elastic-doc :subscription
-  [context concept parsed-concept]
+  [_context concept parsed-concept]
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields created-at]} concept
         {:keys [subscription-name subscriber-id collection-concept-id]} extra-fields

--- a/indexer-app/src/cmr/indexer/data/concepts/tag.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/tag.clj
@@ -6,7 +6,7 @@
    [cmr.indexer.data.elasticsearch :as es]))
 
 (defmethod es/parsed-concept->elastic-doc :tag
-  [context concept parsed-concept]
+  [_context concept parsed-concept]
   (let [{:keys [concept-id deleted]} concept
         {:keys [tag-key description originator-id]} parsed-concept]
     (if deleted

--- a/indexer-app/src/cmr/indexer/data/concepts/tool.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/tool.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.string :as string]
    [cmr.common.mime-types :as mt]
-   [cmr.common.util :as util]
    [cmr.indexer.data.concept-parser :as concept-parser]
    [cmr.indexer.data.concepts.keyword-util :as keyword-util]
    [cmr.indexer.data.concepts.association-util :as assoc-util]
@@ -11,7 +10,7 @@
    [cmr.transmit.metadata-db :as mdb]))
 
 (defmethod es/parsed-concept->elastic-doc :tool
-  [context concept parsed-concept]
+  [_context concept parsed-concept]
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields tool-associations generic-associations]} concept
         {:keys [tool-name]} extra-fields

--- a/indexer-app/src/cmr/indexer/data/concepts/variable.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/variable.clj
@@ -4,7 +4,6 @@
    [clojure.string :as string]
    [cheshire.core :as json]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :refer (debug info warn error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.util :as util]
    [cmr.indexer.data.concepts.association-util :as assoc-util]
@@ -34,7 +33,7 @@
       [base-doc])))
 
 (defmethod es/parsed-concept->elastic-doc :variable
-  [context concept parsed-concept]
+  [_context concept parsed-concept]
   (let [{:keys [concept-id revision-id deleted provider-id native-id user-id
                 revision-date format extra-fields variable-associations generic-associations]} concept
         {:keys [variable-name measurement]} extra-fields
@@ -94,9 +93,9 @@
                                         (:MeasurementIdentifiers parsed-concept))
        ;; associated collections and generic concepts saved in elasticsearch for retrieving purpose in the format of:
        ;; [{"concept_id":"C1200000007-PROV1"}, {"concept_id":"C1200000008-PROV1","revision_id":5}]
-       :associations-gzip-b64 (assoc-util/associations->gzip-base64-str all-assocs concept-id) 
+       :associations-gzip-b64 (assoc-util/associations->gzip-base64-str all-assocs concept-id)
        :instance-information-gzip-b64 (util/string->gzip-base64 (pr-str instance-information))
-       :science-keywords-gzip-b64 (util/string->gzip-base64 (pr-str science-keywords))}))) 
+       :science-keywords-gzip-b64 (util/string->gzip-base64 (pr-str science-keywords))})))
 
 (defn- variable-associations->variable-concepts
   "Returns the variable concepts for the given variable associations."
@@ -115,7 +114,7 @@
   [variable-concept]
   (let [{:keys [variable-association extra-fields]} variable-concept
         {:keys [variable-name measurement]} extra-fields
-        {:keys [originator-id data]} variable-association]
+        {:keys [originator-id]} variable-association]
     {:measurement measurement
      :measurement-lowercase (string/lower-case measurement)
      :variable variable-name

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -357,7 +357,7 @@
                                                      :client-id t-config/cmr-client-id}
                                            :throw-exceptions false}))
            status (:status response)]
-       (when-not (some #{200 404} [status])
+       (if-not (some #{200 404} [status])
          (if (= 409 status)
            (if ignore-conflict?
              (info (str "Ignore conflict: " (str response)))

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -96,7 +96,7 @@
 (defmulti parsed-concept->elastic-doc
   "Returns elastic json that can be used to insert into Elasticsearch for the
   given concept"
-  (fn [context concept parsed-concept]
+  (fn [_context concept _parsed-concept]
     (cs/concept-id->type (:concept-id concept))))
 
 (defn requires-update?
@@ -179,13 +179,13 @@
   lifecycle/Lifecycle
 
   (start
-    [this system]
+    [this _system]
     (let [conn (es/try-connect (:config this))
           this (assoc this :conn conn)]
       (index-set-es/create-index this config/idx-cfg-for-index-sets)
       this))
 
-  (stop [this system]
+  (stop [this _system]
     this))
 
 (defn create-elasticsearch-store
@@ -211,11 +211,6 @@
               msg (str "Call to Elasticsearch caught exception " err-msg)]
           (errors/internal-error! msg))))))
 
-(defn- concept->type
-  "Returns concept type for the given concept"
-  [concept]
-  (cs/concept-id->type (:concept-id concept)))
-
 (defn- context->es-config
   "Returns the elastic config in the context"
   [context]
@@ -238,7 +233,6 @@
   [context concept {:keys [all-revisions-index?] :as options}]
   (try
     (let [{:keys [concept-id revision-id]} concept
-          type (name (concept->type concept))
           elastic-version (get-elastic-version concept)
           concept (-> concept
                       (update :tag-associations #(parse-non-tombstone-associations context %))
@@ -345,7 +339,7 @@
   "Delete the document from Elasticsearch, raise error if failed."
   ([context es-indexes es-type concept-id revision-id elastic-version]
    (delete-document context es-indexes es-type concept-id revision-id elastic-version nil))
-  ([context es-indexes es-type concept-id revision-id elastic-version options]
+  ([context es-indexes _es-type concept-id revision-id elastic-version options]
    (doseq [es-index es-indexes]
      ;; Cannot use elastisch for deletion as we require special headers on delete
      (let [{:keys [admin-token]} (context->es-config context)
@@ -363,7 +357,7 @@
                                                      :client-id t-config/cmr-client-id}
                                            :throw-exceptions false}))
            status (:status response)]
-       (if-not (some #{200 404} [status])
+       (when-not (some #{200 404} [status])
          (if (= 409 status)
            (if ignore-conflict?
              (info (str "Ignore conflict: " (str response)))
@@ -372,7 +366,7 @@
 
 (defn delete-by-query
   "Delete document that match the given query"
-  [context es-index es-type query]
+  [context es-index _es-type query]
   (let [{:keys [admin-token]} (context->es-config context)
         {:keys [uri http-opts]} (context->conn context)
         delete-url (format "%s/%s/_delete_by_query" uri es-index)]

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -1150,7 +1150,7 @@
          (get-granule-index-names-for-collection context coll-concept-id target-index-key))
 
        ;; Default
-       (when (some? (concept-type (common-generic/latest-approved-documents)))
+       (if (some? (concept-type (common-generic/latest-approved-documents)))
          ;; Generics are a bunch of document types, find out which one to work with
          ;; and return the index name for those
          (if all-revisions-index?

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -5,8 +5,6 @@
    [cmr.common.concepts :as cs]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.generics :as common-generic]
-   [cmr.common.log :as log :refer (debug info warn error)]
-   [cmr.common.services.errors :as errors]
    [cmr.elastic-utils.index-util :as m :refer [defmapping defnestedmapping]]
    [cmr.indexer.data.index-set-generics :as index-set-gen]
    [cmr.indexer.data.index-set-elasticsearch :as index-set-es]
@@ -122,6 +120,7 @@
                              :number_of_replicas 1,
                              :refresh_interval "1s"}})
 
+(declare attributes-field-mapping)
 (defnestedmapping attributes-field-mapping
   "Defines mappings for attributes."
   {:name m/string-field-mapping
@@ -135,6 +134,7 @@
    :time-value m/date-field-mapping
    :date-value m/date-field-mapping})
 
+(declare science-keywords-field-mapping)
 (defnestedmapping science-keywords-field-mapping
   "Defines mappings for science keywords."
   {:category m/string-field-mapping
@@ -154,12 +154,14 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare tag-associations-mapping)
 (defnestedmapping tag-associations-mapping
   "Defines mappings for tag associations."
   {:tag-key-lowercase m/string-field-mapping
    :originator-id-lowercase m/string-field-mapping
    :tag-value-lowercase m/string-field-mapping})
 
+(declare variables-mapping)
 (defnestedmapping variables-mapping
   "Defines mappings for variables."
   {:measurement m/string-field-mapping
@@ -169,6 +171,7 @@
    :originator-id-lowercase m/string-field-mapping})
 
 ;;DEPRECATED see :platforms2
+(declare platform-hierarchical-mapping)
 (defnestedmapping platform-hierarchical-mapping
   "Defines hierarchical mappings for platforms."
   {:category m/string-field-mapping
@@ -182,6 +185,7 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare platform2-hierarchical-mapping)
 (defnestedmapping platform2-hierarchical-mapping
   "Defines hierarchical mappings for platforms."
   {:basis m/string-field-mapping
@@ -197,6 +201,7 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare instrument-hierarchical-mapping)
 (defnestedmapping instrument-hierarchical-mapping
   "Defines hierarchical mappings for instruments."
   {:category m/string-field-mapping
@@ -214,6 +219,7 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare data-center-hierarchical-mapping)
 (defnestedmapping data-center-hierarchical-mapping
   "Defines hierarchical mappings for any type of data center."
   {:level-0 m/string-field-mapping
@@ -233,6 +239,7 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare location-keywords-hierarchical-mapping)
 (defnestedmapping location-keywords-hierarchical-mapping
   "Defines hierarchical mappings for location keywords."
   {:category m/string-field-mapping
@@ -250,6 +257,7 @@
    :uuid m/string-field-mapping
    :uuid-lowercase m/string-field-mapping})
 
+(declare orbit-calculated-spatial-domain-mapping)
 (defnestedmapping orbit-calculated-spatial-domain-mapping
   "Defines mappings for storing orbit calculated spatial domains."
   {:orbital-model-name m/string-field-mapping
@@ -259,27 +267,32 @@
    :equator-crossing-longitude m/double-field-mapping
    :equator-crossing-date-time m/date-field-mapping})
 
+(declare track-pass-mapping)
 (defnestedmapping track-pass-mapping
   "Defines mappings for storing track pass."
   {:pass (m/doc-values m/int-field-mapping)
    :tiles (m/doc-values m/string-field-mapping)})
 
+(declare prioritized-humanizer-mapping)
 (defnestedmapping prioritized-humanizer-mapping
   "Defines a string value and priority for use in boosting facets."
   {:value m/string-field-mapping
    :value-lowercase m/string-field-mapping
    :priority m/int-field-mapping})
 
+(declare float-prioritized-mapping)
 (defnestedmapping float-prioritized-mapping
   "Defines a float value and priority for use in boosting facets."
   {:value m/float-field-mapping
    :priority m/int-field-mapping})
 
+(declare temporal-mapping)
 (defnestedmapping temporal-mapping
   "Defines mappings for TemporalExtents."
   {:start-date m/date-field-mapping
    :end-date m/date-field-mapping})
 
+(declare measurement-identifiers-mapping)
 (defnestedmapping measurement-identifiers-mapping
   "Defines mappings for variable measurement identifiers."
   {:contextmedium m/string-field-mapping
@@ -325,6 +338,7 @@
    ;; ords contains longitude latitude pairs (ordinates) of all the shapes
    :ords (m/not-indexed (m/stored m/int-field-mapping))})
 
+(declare collection-mapping)
 (defmapping collection-mapping :collection
   "Defines the elasticsearch mapping for storing collections. These are the
   fields that will be stored in an Elasticsearch document. Note, fields can only
@@ -560,6 +574,7 @@
           :s3-bucket-and-object-prefix-names m/string-field-mapping}
          spatial-coverage-fields))
 
+(declare deleted-granule-mapping)
 (defmapping deleted-granule-mapping :deleted-granule
   "Defines the elasticsearch mapping for storing granules. These are the
   fields that will be stored in an Elasticsearch document."
@@ -569,6 +584,7 @@
    :granule-ur (m/doc-values m/string-field-mapping)
    :parent-collection-id (m/doc-values m/string-field-mapping)})
 
+(declare granule-mapping)
 (defmapping granule-mapping :granule
   "Defines the elasticsearch mapping for storing collections. These are the
   fields that will be stored in an Elasticsearch document."
@@ -732,6 +748,7 @@
 
    spatial-coverage-fields))
 
+(declare tag-mapping)
 (defmapping tag-mapping :tag
   "Defines the elasticsearch mapping for storing tags. These are the fields
   that will be stored in an Elasticsearch document."
@@ -740,6 +757,7 @@
    :description (m/not-indexed m/string-field-mapping)
    :originator-id-lowercase m/string-field-mapping})
 
+(declare autocomplete-mapping)
 (defmapping autocomplete-mapping :suggestion
   "Defines the elasticsearch mapping for storing autocomplete suggestions.
    These are the fields that will be stored in an Elasticsearch document."
@@ -750,6 +768,7 @@
    :permitted-group-ids (m/doc-values m/string-field-mapping)
    :modified (m/doc-values m/date-field-mapping)})
 
+(declare variable-mapping)
 (defmapping variable-mapping :variable
   "Defines the elasticsearch mapping for storing variables. These are the
   fields that will be stored in an Elasticsearch document."
@@ -782,6 +801,7 @@
    :science-keywords-gzip-b64 m/binary-field-mapping
    :instance-information-gzip-b64 m/binary-field-mapping})
 
+(declare service-mapping)
 (defmapping service-mapping :service
   "Defines the elasticsearch mapping for storing services. These are the
   fields that will be stored in an Elasticsearch document."
@@ -804,6 +824,7 @@
    ;; associations with the service stored as EDN gzipped and base64 encoded for retrieving purpose
    :associations-gzip-b64 m/binary-field-mapping})
 
+(declare tool-mapping)
 (defmapping tool-mapping :tool
   "Defines the elasticsearch mapping for storing tools. These are the
   fields that will be stored in an Elasticsearch document."
@@ -826,6 +847,7 @@
    ;; associations with the tool stored as EDN gzipped and base64 encoded for retrieving purpose
    :associations-gzip-b64 m/binary-field-mapping})
 
+(declare subscription-mapping)
 (defmapping subscription-mapping :subscription
   "Defines the elasticsearch mapping for storing subscriptions. These are the
   fields that will be stored in an Elasticsearch document."
@@ -1085,7 +1107,7 @@
          concept (when (= :granule concept-type)
                    (meta-db/get-concept context concept-id revision-id))]
      (get-concept-index-names context concept-id revision-id options concept)))
-  ([context concept-id revision-id {:keys [target-index-key all-revisions-index?]} concept]
+  ([context concept-id _revision-id {:keys [target-index-key all-revisions-index?]} concept]
    (let [concept-type (cs/concept-id->type concept-id)
          index-concept-type (resolve-generic-concept-type concept-type)
          indexes (get-in (get-concept-type-index-names context) [:index-names index-concept-type])]
@@ -1128,7 +1150,7 @@
          (get-granule-index-names-for-collection context coll-concept-id target-index-key))
 
        ;; Default
-       (if (some? (concept-type (common-generic/latest-approved-documents)))
+       (when (some? (concept-type (common-generic/latest-approved-documents)))
          ;; Generics are a bunch of document types, find out which one to work with
          ;; and return the index name for those
          (if all-revisions-index?
@@ -1139,7 +1161,7 @@
   "Return the granule index names for the input provider id"
   [context provider-id]
   (let [indexes (get-in (get-concept-type-index-names context) [:index-names :granule])
-        filter-fn (fn [[k v]]
+        filter-fn (fn [[k _v]]
                     (or
                       (.endsWith (name k) (str "_" provider-id))
                       (= :small_collections k)))]

--- a/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
@@ -77,8 +77,7 @@
 (defn get-index-set
   "Fetch index-set associated with an id."
   [context index-set-id]
-  (let [conn (get-in context [:system :db :conn])
-        {:keys [index-name mapping]} config/idx-cfg-for-index-sets
+  (let [{:keys [index-name mapping]} config/idx-cfg-for-index-sets
         idx-mapping-type (first (keys mapping))]
     (when-let [result (index-set-exists?
                        (get-in context [:system :db]) index-name idx-mapping-type index-set-id)]
@@ -114,7 +113,7 @@
                                              :client-id t-config/cmr-client-id}
                                    :throw-exceptions false})
           status (:status response)]
-      (if-not (some #{200 202 204} [status])
+      (when-not (some #{200 202 204} [status])
         (errors/internal-error! (m/index-delete-failure-msg response))))))
 
 (defn save-document-in-elastic
@@ -136,7 +135,7 @@
 
 (defn delete-document
   "Delete the document from elastic, raise error on failure."
-  [context index-name mapping-type id]
+  [context index-name _mapping-type id]
   (let [{:keys [host port admin-token]} (get-in context [:system :db :config])
         delete-doc-url (format "http://%s:%s/%s/_doc/%s?refresh=true" host port index-name id)
         result (client/delete delete-doc-url

--- a/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
@@ -113,7 +113,7 @@
                                              :client-id t-config/cmr-client-id}
                                    :throw-exceptions false})
           status (:status response)]
-      (when-not (some #{200 202 204} [status])
+      (if-not (some #{200 202 204} [status])
         (errors/internal-error! (m/index-delete-failure-msg response))))))
 
 (defn save-document-in-elastic

--- a/indexer-app/src/cmr/indexer/data/metrics_fetcher.clj
+++ b/indexer-app/src/cmr/indexer/data/metrics_fetcher.clj
@@ -3,7 +3,6 @@
   (:require
    [cmr.common.cache :as c]
    [cmr.common.cache.single-thread-lookup-cache :as stl-cache]
-   [cmr.common.jobs :refer [def-stateful-job]]
    [cmr.transmit.community-usage-metrics :as metrics]))
 
 (defn- get-and-prepare-community-usage-metrics

--- a/indexer-app/src/cmr/indexer/runner.clj
+++ b/indexer-app/src/cmr/indexer/runner.clj
@@ -1,16 +1,14 @@
 (ns cmr.indexer.runner
   "Entry point for the application. Defines a main method that accepts arguments."
-  (:require [cmr.indexer.system :as system]
-            [clojure.string :as string]
-            [cmr.common.log :as log :refer (debug info warn error)]
-            [cmr.indexer.api.routes :as routes]
-            [cmr.common.api.web-server :as web]
-            [cmr.common.config :as cfg])
+  (:require
+   [cmr.indexer.system :as system]
+   [cmr.common.log :as log :refer (info)]
+   [cmr.common.config :as cfg])
   (:gen-class))
 
 (defn -main
   "Starts the App."
-  [& args]
-  (let [system (system/start (system/create-system))]
+  [& _args]
+  (let [_system (system/start (system/create-system))]
     (info "Running...")
     (cfg/check-env-vars)))

--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -5,7 +5,7 @@
    [clj-time.core :refer [now]]
    [clojure.string :as string]
    [cmr.common.config :refer [defconfig]]
-   [cmr.common.log :as log :refer [debug info warn error]]
+   [cmr.common.log :as log :refer [info error]]
    [cmr.common.util :as util :refer [defn-timed]]
    [cmr.indexer.data.concept-parser :as cp]
    [cmr.indexer.data.concepts.collection.collection-util :as collection-util]
@@ -13,8 +13,7 @@
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.data.index-set :as idx-set]
    [cmr.indexer.services.index-service :as service]
-   [cmr.transmit.metadata-db :as meta-db]
-   [cmr.transmit.search :as search]))
+   [cmr.transmit.metadata-db :as meta-db]))
 
 (defconfig autocomplete-suggestion-age-limit
   "Age in hours that we allow autocomplete suggestions to persist to avoid stale data."
@@ -203,6 +202,8 @@
          flatten
          (remove anti-value-suggestion?))))
 
+(declare reindex-autocomplete-suggestions-for-provider)
+(declare context provider-id)
 (defn-timed reindex-autocomplete-suggestions-for-provider
   "Reindex autocomplete suggestion for a given provider"
   [context provider-id]

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -610,7 +610,7 @@
                 (concept-mapping-types :granule)
                 {:term {(query-field->elastic-field :collection-concept-id :granule)
                         concept-id}})]
-      (when (not= (get resp :status) 200)
+      (if (not= (get resp :status) 200)
         (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response. Elastic delete by query resp = %s" concept-id revision-id resp)))))
   ;; reindex variables associated with the collection
   (reindex-associated-variables context concept-id revision-id))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -303,17 +303,27 @@
    per day. Scripts can use the version (v) value if needed to judge what content may be in the
    log. Future developers should change this value if adding or removing values so as to inform
    scripts of a change.
+
+   Values in log:
+   * fv : Format Version
+   * mg : MessaGe type
+   * ci : Concept Id
+   * ri : Revision Id (number)
+   * vm : Visibility Milliseconds
+   * ar : All Revisions (0 or 1)
+
    NOTE: Changes to this text may break reports."
   [concept-id revision-id milliseconds all-revisions-index?]
-  (format (str "{\"v\": \"1\", \"msg\": \"index-visible-time\", "
-               "\"c-id\": \"%s\", "
-               "\"r-id\": \"%s\", "
-               "\"v-ms\": \"%s\", "
-               "\"all\": \"%s\"}")
-          concept-id
-          revision-id
-          milliseconds
-          all-revisions-index?))
+  (let [all-value (if all-revisions-index? 1 0)]
+    (format (str "{\"fv\": 1 \"mg\": \"index-vis\", "
+                 "\"ci\": \"%s\", "
+                 "\"ri\": \"%s\", "
+                 "\"vm\": \"%d\", "
+                 "\"ar\": %d}")
+            concept-id
+            revision-id
+            milliseconds
+            all-value)))
 
 (defn- send-time-to-visibility-log
   "Send either a JSON message as a report or the original log entry to info."

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -1,4 +1,4 @@
-(ns cmr.indexer.services.index-set-service 
+(ns cmr.indexer.services.index-set-service
   "Provide functions to store, retrieve, delete index-sets"
   (:require
    [cheshire.core :as json]
@@ -199,9 +199,7 @@
   [context index-set]
   (info "Updating index-set" (pr-str index-set))
   (validate-requested-index-set context index-set true)
-  (let [index-names (get-index-names index-set)
-        indices-w-config (build-indices-list-w-config index-set)
-        idx-name-of-index-sets (:index-name config/idx-cfg-for-index-sets)
+  (let [indices-w-config (build-indices-list-w-config index-set)
         es-store (context->es-store context)]
 
     (doseq [idx indices-w-config]
@@ -366,7 +364,7 @@
   "Put elastic in a clean state after deleting indices associated with index-
   sets and index-set docs."
   [context]
-  (let [{:keys [index-name mapping]} config/idx-cfg-for-index-sets
+  (let [{:keys [index-name]} config/idx-cfg-for-index-sets
         index-set-ids (es/get-index-set-ids
                        (context->es-store context)
                        index-name

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -26,3 +26,22 @@
 
       "Testing a provider that has large sized collections."
       (index-svc/collection-large-file-providers-reindex-batch-size) "GHRSSTCWIC")))
+
+(deftest index-log-size-test
+  (testing "Make sure that any new time to visibility index log is not larger then the original"
+
+    ;; The time to visibility log can print in the millions per day and there are two different
+    ;; versions of this log depending on the value of defconfig reduced-indexer-log. When true a
+    ;; JSON version of this log is printed which contains more information but should still be
+    ;; shorter as Splunk storage is expensive.
+
+    (let [concept-id "G1001055217-ASF"
+          revision-id "123"
+          milliseconds 1024
+          all-revisions-index? true
+          time-to-visibility-text (var index-svc/time-to-visibility-text) ;; private function
+          time-to-visibility-json (var index-svc/time-to-visibility-json) ;; private function
+          text (time-to-visibility-text concept-id milliseconds)
+          json (time-to-visibility-json concept-id revision-id milliseconds all-revisions-index?)]
+
+      (is (<= (count json) (count text))))))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Please summarize the feature or fix.

### What is the Solution?

There are three logs which generate logs in the millions per day. These three logs are for the same indexing event and represent: Start, finish, time to visibility.

The change here is to introduce a new configuration allowing Indexer to issue a single log entry when reporting time to visibility with additional information found in the start/stop log entries. This new log is also in json and is as short as possible.

There are also Kondo updates in this change.

# Checklist

- [x] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
