### PR TITLE
CMR-10055: Snyk Vuln - Update jackson-core

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -30,7 +30,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/access-control-app"
   :dependencies ~(concat '[[cheshire "5.12.0"]
                            [clj-time "0.15.1"]
-                           [com.fasterxml.jackson.core/jackson-core "2.13.2"]
+                           [com.fasterxml.jackson.core/jackson-core "2.15.4"]
                            [commons-codec/commons-codec "1.11"]
                            [commons-io "2.6"]
                            [compojure "1.6.1"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -9,7 +9,7 @@
                  [gov.nasa.earthdata/quartzite "2.2.1-SNAPSHOT"]
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
-                 [com.fasterxml.jackson.core/jackson-core "2.13.2"]
+                 [com.fasterxml.jackson.core/jackson-core "2.15.4"]
                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.2"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [com.gfredericks/test.chuck "0.2.9"]


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Snyk Vuln detected for common-lib

### What is the Solution?

Update jackson-core from 2.13 >> 2.15.2

### What areas of the application does this impact?

Common-Lib, Access-Control

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely with my changes
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
