### PR TITLE
Feature CMR-10024 : Less Timed Logs from Ingest

### DIFF
--- a/ingest-app/src/cmr/db.clj
+++ b/ingest-app/src/cmr/db.clj
@@ -1,7 +1,7 @@
 (ns cmr.db
   "Entry point for the db related operations. Defines a main method that accepts arguments."
   (:import [java.io File])
-  (:require [cmr.common.log :refer (debug info warn error)]
+  (:require [cmr.common.log :refer (info error)]
             [cmr.oracle.user :as o]
             [cmr.oracle.config :as oracle-config]
             [cmr.ingest.config :as ingest-config]
@@ -44,7 +44,7 @@
           ;; trying non-local path to find drift migration files
           (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/drift-migration-files")))]
             (drift.execute/run (conj (vec args) "-c" "config.ingest_migrate_config/app-migrate-config")))
-          (catch Exception e
+          (catch Exception _e
             (println "caught exception trying to find migration files in db.clj file for ingest-app. We are probably in local env. Trying local route to migration files...")
             (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/src")))]
               (drift.execute/run (conj (vec args) "-c" "config.ingest_migrate_config/app-migrate-config")))))

--- a/ingest-app/src/cmr/ingest/api/bulk.clj
+++ b/ingest-app/src/cmr/ingest/api/bulk.clj
@@ -2,20 +2,16 @@
   "Bulk ingest functions in support of the ingest API."
   (:require
    [clojure.data.xml :as xml]
-   [clojure.string :as string]
    [cmr.acl.core :as acl]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
-   [cmr.common.log :refer [debug info warn error]]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as srvc-errors]
-   [cmr.common.xml.gen :refer :all]
    [cmr.ingest.api.core :as api-core]
    [cmr.ingest.config :as ingest-config]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.granule-bulk-update :as data-gran-bulk-update]
    [cmr.ingest.services.bulk-update-service :as bulk-update]
    [cmr.ingest.services.granule-bulk-update-service :as gran-bulk-update]
-   [cmr.ingest.services.ingest-service :as ingest]
    [cmr.common.util :as util]))
 
 (defn bulk-update-collections
@@ -93,7 +89,7 @@
 
 (defmulti generate-provider-tasks-response
   "Convert a result to a proper response format"
-  (fn [headers result]
+  (fn [headers _result]
     (api-core/get-ingest-result-format headers :xml)))
 
 (defmethod generate-provider-tasks-response :json
@@ -102,7 +98,7 @@
   (api-core/generate-ingest-response headers result))
 
 (defmethod generate-provider-tasks-response :xml
-  [headers result]
+  [_headers result]
   ;; Create an xml response for a list of tasks
   {:status (api-core/ingest-status-code result)
    :headers {"Content-Type" (mt/format->mime-type :xml)}
@@ -114,7 +110,7 @@
 
 (defmulti get-provider-tasks*
   "Get bulk update tasks status based on concept type"
-  (fn [context provider-id concept-type params]
+  (fn [_context _provider-id concept-type _params]
     concept-type))
 
 (defmethod get-provider-tasks* :collection
@@ -138,7 +134,7 @@
 
 (defmulti generate-provider-task-status-response
   "Convert a result to a proper response format"
-  (fn [headers result]
+  (fn [headers _result]
     (api-core/get-ingest-result-format headers :xml)))
 
 (defmethod generate-provider-task-status-response :json
@@ -147,7 +143,7 @@
   (api-core/generate-ingest-response headers result))
 
 (defmethod generate-provider-task-status-response :xml
-  [headers result]
+  [_headers result]
   ;; Create an xml response for a list of tasks
   {:status (api-core/ingest-status-code result)
    :headers {"Content-Type" (mt/format->mime-type :xml)}

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -4,7 +4,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [info]]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
    [cmr.ingest.services.ingest-service :as ingest]))
@@ -22,7 +22,7 @@
 
 (defn validate-collection
   [provider-id native-id request]
-  (let [{:keys [body content-type params headers request-context]} request
+  (let [{:keys [body content-type _params headers request-context]} request
         concept (api-core/body->concept! :collection provider-id native-id body content-type headers)
         validation-options (get-validation-options headers)]
     (api-core/verify-provider-exists request-context provider-id)
@@ -39,7 +39,7 @@
 
 (defn ingest-collection
   [provider-id native-id request]
-  (let [{:keys [body content-type params headers request-context]} request]
+  (let [{:keys [body content-type _params headers request-context]} request]
     (lt-validation/validate-launchpad-token request-context)
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)

--- a/ingest-app/src/cmr/ingest/api/generic_documents.clj
+++ b/ingest-app/src/cmr/ingest/api/generic_documents.clj
@@ -185,6 +185,8 @@
                (util/html-escape version)
                (.getMessage e))))))
 
+(declare save-document)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-document
   "Store a concept in mdb and indexer. Return concept-id, and revision-id."
   [context concept]
@@ -270,7 +272,7 @@
              request-context :read :provider-object provider-id))]
     (api-core/delete-concept concept-type provider-id native-id request)))
 
-(defn- extract-info-from-concept-id 
+(defn- extract-info-from-concept-id
   "Extract concept info from concept-id."
   [concept-id]
   (let [draft-concept-type (common-concepts/concept-id->type concept-id)

--- a/ingest-app/src/cmr/ingest/api/granules.clj
+++ b/ingest-app/src/cmr/ingest/api/granules.clj
@@ -4,7 +4,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [info]]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as srvc-errors]
    [cmr.ingest.api.core :as api-core]
@@ -14,7 +14,7 @@
 (defmulti validate-granule
   "Validates the granule in the request. It can handle a granule and collection sent as multipart-params
   or a normal request with the XML as the body."
-  (fn [provider-id native-id request]
+  (fn [_provider-id _native-id request]
     (if (seq (:multipart-params request))
       :multipart-params
       :default)))
@@ -60,7 +60,7 @@
 
 (defn ingest-granule
   [provider-id native-id request]
-  (let [{:keys [body content-type params headers request-context]} request]
+  (let [{:keys [body content-type headers request-context]} request]
     (lt-validation/validate-launchpad-token request-context)
     (api-core/verify-provider-exists request-context provider-id)
     (acl/verify-ingest-management-permission request-context :update :provider-object provider-id)
@@ -78,7 +78,7 @@
 
 (defn delete-granule
   [provider-id native-id request]
-  (let [{:keys [request-context params headers]} request
+  (let [{:keys [request-context headers]} request
         concept-attribs (api-core/set-revision-id
                          {:provider-id provider-id
                           :native-id native-id

--- a/ingest-app/src/cmr/ingest/api/multipart.clj
+++ b/ingest-app/src/cmr/ingest/api/multipart.clj
@@ -23,11 +23,11 @@
   {:tag UploadContext}
   [request encoding]
   (reify UploadContext
-    (getContentType [this]       (get-in request [:headers "content-type"]))
-    (getContentLength [this]     (or (req/content-length request) -1))
-    (contentLength [this]        (or (req/content-length request) -1))
-    (getCharacterEncoding [this] encoding)
-    (getInputStream [this]       (:body request))))
+    (getContentType [_this]       (get-in request [:headers "content-type"]))
+    (getContentLength [_this]     (or (req/content-length request) -1))
+    (contentLength [_this]        (or (req/content-length request) -1))
+    (getCharacterEncoding [_this] encoding)
+    (getInputStream [_this]       (:body request))))
 
 (defn- file-item-iterator-seq
   "Create a lazy seq from a FileItemIterator instance."

--- a/ingest-app/src/cmr/ingest/api/provider.clj
+++ b/ingest-app/src/cmr/ingest/api/provider.clj
@@ -22,7 +22,7 @@
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as srvc-errors]
    [cmr.ingest.services.provider-service :as provider-service]
-   [compojure.core :refer :all]))
+   [compojure.core :refer [DELETE GET POST PUT context]]))
 
 (defn- drop-metadata
   "Look for and remove metadata field from the body returned by the metadata db
@@ -122,7 +122,7 @@
   (context "/providers" []
 
     ;; create a new provider
-    (POST "/" {:keys [request-context body params headers]}
+    (POST "/" {:keys [request-context body headers]}
       (acl/verify-ingest-management-permission request-context :update)
       (common-enabled/validate-write-enabled request-context "ingest")
       (one-result->response-map
@@ -131,14 +131,12 @@
                                            (read-body headers body)))))
 
     ;; read a provider
-    (GET "/:provider-id" {{:keys [provider-id] :as params} :params
-                          request-context :request-context
-                          headers :headers}
+    (GET "/:provider-id" {{:keys [provider-id]} :params
+                          request-context :request-context}
       (one-result->response-map (provider-service/read-provider request-context provider-id)))
 
     ;; update an existing provider
-    (PUT "/:provider-id" {{:keys [provider-id] :as params} :params
-                          request-context :request-context
+    (PUT "/:provider-id" {request-context :request-context
                           body :body
                           headers :headers}
       (acl/verify-ingest-management-permission request-context :update)
@@ -149,7 +147,7 @@
                                           (read-body headers body)))))
 
     ;; delete a provider
-    (DELETE "/:provider-id" {{:keys [provider-id] :as params} :params
+    (DELETE "/:provider-id" {{:keys [provider-id]} :params
                              request-context :request-context
                              headers :headers}
       (acl/verify-ingest-management-permission request-context :update)

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -47,7 +47,7 @@
             ;; trying non-local path to find drift migration files
             (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/drift-migration-files")))]
               (drift.execute/run migrate-args))
-            (catch Exception e
+            (catch Exception _e
               (println "caught exception trying to find migration files. We are probably in local env. Trying local route to migration files...")
               (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/checkouts/ingest-app/src")))]
                 (drift.execute/run migrate-args))))))
@@ -68,7 +68,7 @@
             ctx (= "true" (:force_version params)))
            {:status 200})
      (POST "/reindex-autocomplete-suggestions"
-           {ctx :request-context params :params}
+           {ctx :request-context _params :params}
            (acl/verify-ingest-management-permission ctx :update)
            (jobs/trigger-autocomplete-suggestions-reindex ctx)
            {:status 200})
@@ -259,8 +259,10 @@
             provider-id native-id request)))
 
        ;; Generic documents are by pattern: /providers/{prov_id}/{concept-type}/{native_id}
-       (context ["/:concept-type" :concept-type (re-pattern common-generic/plural-generic-concept-types-reg-ex)] [concept-type]
-         (context ["/:native-id" :native-id #".*$"] [native-id]
+       (context ["/:concept-type"
+                 :concept-type
+                 (re-pattern common-generic/plural-generic-concept-types-reg-ex)] [_concept-type]
+         (context ["/:native-id" :native-id #".*$"] [_native-id]
            (POST "/" request (gen-doc/crud-generic-document request :create))
            (GET "/" request (gen-doc/crud-generic-document request :read))
            (PUT "/" request (gen-doc/crud-generic-document request :update))

--- a/ingest-app/src/cmr/ingest/api/services.clj
+++ b/ingest-app/src/cmr/ingest/api/services.clj
@@ -4,24 +4,24 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [info]]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
    [cmr.ingest.services.ingest-service :as ingest]
-   [cmr.ingest.validation.validation :as v]))
+   [cmr.ingest.validation.validation :as validation]))
 
 (defn- validate-and-prepare-service-concept
   "Validate service concept, set the concept format and returns the concept;
   throws error if the metadata is not a valid against the UMM service JSON schema."
   [concept]
   (let [concept (update-in concept [:format] (partial ingest/fix-ingest-concept-format :service))]
-    (v/validate-concept-request concept)
-    (v/validate-concept-metadata concept)
+    (validation/validate-concept-request concept)
+    (validation/validate-concept-metadata concept)
     concept))
 
 (defn validate-service
   [provider-id native-id request]
-  (let [{:keys [body content-type params headers request-context]} request
+  (let [{:keys [body content-type headers request-context]} request
         concept (api-core/body->concept! :service provider-id native-id body content-type headers)]
     (api-core/verify-provider-exists request-context provider-id)
     (info (format "Validating Service %s from client %s"

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -7,7 +7,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [info warn]]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
@@ -50,7 +50,7 @@
             (subscriber-collection-permission-error
              subscriber-id
              concept-id)))
-        (catch Exception e
+        (catch Exception _e
           (subscriber-collection-permission-error
            subscriber-id
            concept-id))))))
@@ -104,7 +104,6 @@
    subscriber-id, normalized-query, subscription-type."
   [request-context subscription parsed]
   (let [native-id (:native-id subscription)
-        provider-id (:provider-id subscription)
         normalized-query (:normalized-query subscription)
         collection-id (:CollectionConceptId parsed)
         subscriber-id (:SubscriberId parsed)
@@ -328,7 +327,7 @@
   "Processes a request to create a subscription. A native id will be generated."
   ([request]
    (create-subscription nil request))
-  ([provider-id request]
+  ([_provider-id request]
    (let [{:keys [body content-type headers request-context]} request]
      (common-ingest-checks request-context)
      (let [tmp-subscription (body->subscription (str (UUID/randomUUID)) body content-type headers)
@@ -345,7 +344,7 @@
   "Processes a request to create a subscription using the native-id provided."
   ([native-id request]
    (create-subscription-with-native-id nil native-id request))
-  ([provider-id native-id request]
+  ([_provider-id native-id request]
    (validate-native-id-not-blank native-id)
    (let [{:keys [body content-type headers request-context]} request]
      (common-ingest-checks request-context)
@@ -367,7 +366,7 @@
   existing functionality."
   ([native-id request]
    (create-or-update-subscription-with-native-id nil native-id request))
-  ([provider-id native-id request]
+  ([_provider-id native-id request]
    (validate-native-id-not-blank native-id)
    (let [{:keys [body content-type headers request-context]} request
          _ (common-ingest-checks request-context)
@@ -420,7 +419,7 @@
   ([native-id request]
    (delete-subscription nil native-id request))
   ([provider-id native-id request]
-   (let [{:keys [body content-type headers request-context]} request
+   (let [{:keys [headers request-context]} request
          _ (common-ingest-checks request-context)
          [provider-id subscriber-id] (prepare-delete-request request-context provider-id native-id)
          concept-attribs (-> {:provider-id provider-id

--- a/ingest-app/src/cmr/ingest/api/tools.clj
+++ b/ingest-app/src/cmr/ingest/api/tools.clj
@@ -4,7 +4,7 @@
    [cmr.acl.core :as acl]
    [cmr.common-app.api.enabled :as common-enabled]
    [cmr.common-app.api.launchpad-token-validation :as lt-validation]
-   [cmr.common.log :refer [debug info warn error]]
+   [cmr.common.log :refer [info]]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
    [cmr.ingest.services.ingest-service :as ingest]
@@ -21,7 +21,7 @@
 
 (defn validate-tool
   [provider-id native-id request]
-  (let [{:keys [body content-type params headers request-context]} request
+  (let [{:keys [body content-type headers request-context]} request
         concept (api-core/body->concept! :tool provider-id native-id body content-type headers)]
     (api-core/verify-provider-exists request-context provider-id)
     (info (format "Validating Tool %s from client %s"

--- a/ingest-app/src/cmr/ingest/api/variables.clj
+++ b/ingest-app/src/cmr/ingest/api/variables.clj
@@ -44,7 +44,7 @@
      (v/validate-variable-associated-collection
       request-context coll-concept-id coll-revision-id)
      (let [concept (validate-and-prepare-variable-concept concept)
-           {concept-format :format metadata :metadata data :data} concept
+           {concept-format :format metadata :metadata} concept
            variable (spec/parse-metadata request-context :variable concept-format metadata)
            validate-var-result (v/umm-spec-validate-variable
                                 variable request-context (not (ingest-config/validate-umm-var-keywords)))

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -184,9 +184,7 @@
   [context]
   (get-in context [:system :db]))
 
-(declare get-collection-tasks)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed get-collection-tasks
+(defn get-collection-tasks
   "Returns bulk update statuses with task ids by provider"
   [context provider-id]
   (get-provider-bulk-update-status (context->db context) provider-id))

--- a/ingest-app/src/cmr/ingest/data/bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/bulk_update.clj
@@ -3,12 +3,9 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.jdbc :as j]
-   [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.util :refer [defn-timed] :as util]
    [cmr.ingest.config :as config]
-   [cmr.oracle.connection]
    [cmr.oracle.connection :as oracle]
    [cmr.oracle.sql-utils :as su]))
 
@@ -152,7 +149,7 @@
    [db task-id concept-id status status-message]
    (try
      (j/with-db-transaction
-      [conn db]
+      [_conn db]
       (let [statement (str "UPDATE bulk_update_coll_status "
                            "SET status = ?, status_message = ?"
                            "WHERE task_id = ? AND concept_id = ?")
@@ -187,25 +184,35 @@
   [context]
   (get-in context [:system :db]))
 
+(declare get-collection-tasks)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-collection-tasks
   "Returns bulk update statuses with task ids by provider"
   [context provider-id]
   (get-provider-bulk-update-status (context->db context) provider-id))
 
+(declare get-bulk-update-task-status-for-provider)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-bulk-update-task-status-for-provider
   [context task-id provider-id]
   (get-bulk-update-task-status (context->db context) task-id provider-id))
 
+(declare get-bulk-update-collection-statuses-for-task)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-bulk-update-collection-statuses-for-task
   [context task-id]
   (get-bulk-update-task-collection-status (context->db context) task-id))
 
+(declare create-bulk-update-task)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed create-bulk-update-task
   "Creates all the rows for bulk update status tables - task status and collection
   status. Returns task id"
   [context provider-id json-body concept-ids]
   (create-and-save-bulk-update-status (context->db context) provider-id json-body concept-ids))
 
+(declare update-bulk-update-task-collection-status)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed update-bulk-update-task-collection-status
   "For the task and concept id, update the collection to the given status with the
   given status message"

--- a/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
@@ -341,7 +341,7 @@
 
 (declare mark-task-complete)
 #_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed-level debug mark-task-complete
+(defn mark-task-complete
   "Marks a granule bulk task as COMPLETE and sets the status message.
   It will throw an exception if there still granules marked as PENDING."
   [context task-id]

--- a/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
@@ -8,7 +8,7 @@
    [cmr.common.log :refer (info error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
-   [cmr.common.util :refer [defn-timed] :as util]
+   [cmr.common.util :refer [defn-timed defn-timed-level] :as util]
    [cmr.ingest.config :as config]
    [cmr.oracle.connection :as oracle]
    [cmr.oracle.sql-utils :as sql-utils]))
@@ -240,9 +240,7 @@
  [context]
  (get-in context [:system :db]))
 
-(declare cleanup-bulk-granule-tasks)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed cleanup-bulk-granule-tasks
+(defn cleanup-bulk-granule-tasks
   "Run a delete operation in the database to delete bulk granule update
   tasks older than the retention period."
   [context]
@@ -265,15 +263,12 @@
   [context provider-id params]
   (get-granule-tasks-by-provider-id (context->db context) provider-id params))
 
-(declare get-granule-task-by-id)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed get-granule-task-by-id
+(defn get-granule-task-by-id
   "Returns the granule bulk update task by id"
   [context task-id]
   (get-granule-task-by-task-id (context->db context) task-id))
 
-(declare get-bulk-update-granule-statuses-for-task)
-(defn-timed get-bulk-update-granule-statuses-for-task
+(defn get-bulk-update-granule-statuses-for-task
   [context task-id]
   (get-bulk-update-task-granule-status (context->db context) task-id))
 
@@ -298,6 +293,7 @@
    (context->db context) task-id granule-ur status status-message))
 
 (declare get-incomplete-granule-task-ids)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-incomplete-granule-task-ids
   "Returns a list of granule bulk update task ids where the status is not COMPELTE."
   [context]
@@ -345,7 +341,7 @@
 
 (declare mark-task-complete)
 #_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed mark-task-complete
+(defn-timed-level debug mark-task-complete
   "Marks a granule bulk task as COMPLETE and sets the status message.
   It will throw an exception if there still granules marked as PENDING."
   [context task-id]

--- a/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
+++ b/ingest-app/src/cmr/ingest/data/granule_bulk_update.clj
@@ -3,10 +3,9 @@
   (:require
    [cheshire.core :as json]
    [clj-time.coerce :as time-coerce]
-   [clj-time.local :as l]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as string]
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer (info error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.util :refer [defn-timed] :as util]
@@ -76,7 +75,7 @@
   ;;the valid date should be either like "2000-01-01T10:00:00Z,2000-01-02T10:00:00Z"
   ;;or just one date like "2000-01-01T10:00:00Z".
   (when date
-    (let [date-trimmed (string/replace date #"^,|,$| " "") 
+    (let [date-trimmed (string/replace date #"^,|,$| " "")
           dates (string/split date-trimmed #",")
           begin-date (first dates)
           end-date (second dates)]
@@ -116,7 +115,7 @@
                      [:created-at :name :task-id :status :status-message :request-json-body]
                      (sql-utils/from "granule_bulk_update_tasks")
                      (sql-utils/where `(and (= :provider-id ~provider-id)
-                                            (<= :created-at (:to_utc_timestamp_tz ~end-date)) 
+                                            (<= :created-at (:to_utc_timestamp_tz ~end-date))
                                             (>= :created-at (:to_utc_timestamp_tz ~begin-date))))
                      (sql-utils/order-by (sql-utils/desc `(+ :task-id 0)))))
                    (if begin-date
@@ -133,7 +132,7 @@
                        (sql-utils/from "granule_bulk_update_tasks")
                        (sql-utils/where `(= :provider-id ~provider-id))
                        (sql-utils/order-by (sql-utils/desc `(+ :task-id 0)))))))
-            ;; Note: the column selected out of the database is created_at, instead of created-at. 
+            ;; Note: the column selected out of the database is created_at, instead of created-at.
             statuses (doall (map #(update % :created_at (partial oracle/oracle-timestamp->str-time conn))
                                  (take max-rows (sql-utils/query conn stmt))))
             statuses (map util/map-keys->kebab-case statuses)]
@@ -217,7 +216,7 @@
     [db task-id granule-ur status status-message]
     (try
       (jdbc/with-db-transaction
-        [conn db]
+        [_conn db]
         (let [statement (str "UPDATE bulk_update_gran_status "
                              "SET status = ?, status_message = ?, updated_at = ?"
                              "WHERE task_id = ? AND granule_ur = ?")
@@ -241,6 +240,8 @@
  [context]
  (get-in context [:system :db]))
 
+(declare cleanup-bulk-granule-tasks)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed cleanup-bulk-granule-tasks
   "Run a delete operation in the database to delete bulk granule update
   tasks older than the retention period."
@@ -257,21 +258,27 @@
       (errors/throw-service-error :invalid-data
                                   [(str "Error cleaning up bulk granule update task table "
                                         (.getMessage e))]))))
-
+(declare get-granule-tasks-by-provider)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-granule-tasks-by-provider
   "Returns granule bulk update tasks by provider"
   [context provider-id params]
   (get-granule-tasks-by-provider-id (context->db context) provider-id params))
 
+(declare get-granule-task-by-id)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-granule-task-by-id
   "Returns the granule bulk update task by id"
   [context task-id]
   (get-granule-task-by-task-id (context->db context) task-id))
 
+(declare get-bulk-update-granule-statuses-for-task)
 (defn-timed get-bulk-update-granule-statuses-for-task
   [context task-id]
   (get-bulk-update-task-granule-status (context->db context) task-id))
 
+(declare create-granule-bulk-update-task)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed create-granule-bulk-update-task
   "Create all rows for granule bulk update status tables - task status and granule status.
   Returns task id."
@@ -279,6 +286,8 @@
   (create-and-save-bulk-granule-update-status
    (context->db context) provider-id user-id request-json-body instructions))
 
+(declare update-bulk-update-task-granule-status)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed update-bulk-update-task-granule-status
   "For the task and concept id, update the granule to the given status with the
    given status message"
@@ -288,6 +297,7 @@
   (update-bulk-update-granule-status
    (context->db context) task-id granule-ur status status-message))
 
+(declare get-incomplete-granule-task-ids)
 (defn-timed get-incomplete-granule-task-ids
   "Returns a list of granule bulk update task ids where the status is not COMPELTE."
   [context]
@@ -318,6 +328,8 @@
               (util/html-escape task-id))]))
   task-id)
 
+(declare task-completed?)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed task-completed?
   "Returns false if there are any granule updates marked PENDING."
   [context task-id]
@@ -331,6 +343,8 @@
             (sql-utils/where `(and (= :status "PENDING")
                                    (= :task-id ~task-id))))))))
 
+(declare mark-task-complete)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed mark-task-complete
   "Marks a granule bulk task as COMPLETE and sets the status message.
   It will throw an exception if there still granules marked as PENDING."

--- a/ingest-app/src/cmr/ingest/data/memory_db.clj
+++ b/ingest-app/src/cmr/ingest/data/memory_db.clj
@@ -2,12 +2,10 @@
   "Stores and retrieves the hashes of the ACLs for a provider."
   (:require
    [cheshire.core :as json]
-   [clojure.edn :as edn]
    [clojure.string :as string]
    [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :refer (debug info warn error)]
    [cmr.common.time-keeper :as time-keeper]
-   [cmr.common.util :refer [defn-timed] :as util]
+   [cmr.common.util :as util]
    [cmr.ingest.data.bulk-update :as data-bulk-update]
    [cmr.ingest.data.granule-bulk-update :as granule-data-bulk-update]
    [cmr.ingest.data.provider-acl-hash :as acl-hash]))
@@ -38,13 +36,13 @@
   data-bulk-update/BulkUpdateStore
 
   (get-provider-bulk-update-status
-   [this provider-id]
+   [_this provider-id]
    (some->> @task-status-atom
             (filter #(= provider-id (:provider-id %)))
             (map #(select-keys % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-bulk-update-task-status
-   [this task-id provider-id]
+   [_this task-id provider-id]
    (let [task-status (some->> @task-status-atom
                               (some #(when (and (= provider-id (str (:provider-id %)))
                                                 (= task-id (str (:task-id %))))
@@ -52,14 +50,14 @@
      (select-keys task-status [:created-at :name :task-id :status :status-message :request-json-body])))
 
   (get-bulk-update-task-collection-status
-   [this task-id]
+   [_this task-id]
    (some->> @collection-status-atom
             (into [])
             (filter #(= (str task-id) (str (:task-id %))))
             (map #(select-keys % [:concept-id :status :status-message]))))
 
   (get-bulk-update-collection-status
-   [this task-id concept-id]
+   [_this task-id concept-id]
    (let [coll-status (some->> @collection-status-atom
                               (some #(when (and (= concept-id (:concept-id %))
                                                 (= (str task-id) (:task-id %)))
@@ -67,7 +65,7 @@
      (select-keys coll-status [:concept-id :status :status-message])))
 
   (create-and-save-bulk-update-status
-   [this provider-id json-body concept-ids]
+   [_this provider-id json-body concept-ids]
    (swap! task-id-atom inc)
    (let [task-id (str @task-id-atom)
          name (get (json/parse-string json-body) "name" task-id)]
@@ -136,14 +134,14 @@
   granule-data-bulk-update/GranBulkUpdateStore
 
   (get-granule-tasks-by-provider-id
-   [this provider-id params]
+   [_this provider-id _params]
    (some->> @granule-task-status-atom
             (filter #(= provider-id (:provider-id %)))
             (map #(select-keys
                    % [:created-at :name :task-id :status :status-message :request-json-body]))))
 
   (get-granule-task-by-task-id
-   [this task-id]
+   [_this task-id]
    (let [task-status (some->> @granule-task-status-atom
                               (some #(when (= task-id (str (:task-id %)))
                                        %)))]
@@ -151,7 +149,7 @@
                   [:created-at :name :provider-id :status :status-message :request-json-body])))
 
   (get-bulk-update-task-granule-status
-   [this task-id]
+   [_this task-id]
    (some->> @granule-status-atom
             (into [])
             (filter #(= (str task-id) (str (:task-id %))))
@@ -159,7 +157,7 @@
             (map util/remove-nil-keys)))
 
   (get-bulk-update-granule-status
-   [this task-id granule-ur]
+   [_this task-id granule-ur]
    (let [gran-status (some->> @granule-status-atom
                               (some #(when (and (= granule-ur (:granule-ur %))
                                                 (= (str task-id) (:task-id %)))
@@ -167,7 +165,7 @@
      (select-keys gran-status [:granule-ur :status :status-message])))
 
   (create-and-save-bulk-granule-update-status
-   [this provider-id user-id request-json-body instructions]
+   [_this provider-id user-id request-json-body instructions]
    (swap! granule-task-id-atom inc)
    (let [task-id (str @granule-task-id-atom)
          parsed-json (json/parse-string request-json-body true)
@@ -243,13 +241,13 @@
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   (reset-bulk-update
-   [this]
+   [_this]
    (reset! task-status-atom [])
    (reset! collection-status-atom [])
    (reset! task-id-atom 0))
 
   (reset-bulk-granule-update
-   [this]
+   [_this]
    (reset! granule-task-status-atom [])
    (reset! granule-status-atom [])
    (reset! granule-task-id-atom 0))
@@ -258,10 +256,10 @@
   lifecycle/Lifecycle
 
   (start
-   [this system]
+   [this _system]
    this)
   (stop
-   [this system]
+   [this _system]
    this))
 
 (defn create-db

--- a/ingest-app/src/cmr/ingest/data/provider_acl_hash.clj
+++ b/ingest-app/src/cmr/ingest/data/provider_acl_hash.clj
@@ -3,8 +3,7 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.jdbc :as j]
-   [cmr.common.lifecycle :as lifecycle]
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer (debug)]
    [cmr.common.util :refer [defn-timed] :as util]
    [cmr.oracle.connection]))
 
@@ -38,11 +37,15 @@
   [context]
   (get-in context [:system :db]))
 
+(declare get-provider-id-acl-hashes)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed get-provider-id-acl-hashes
   "Returns a map of provider ids to hash values."
   [context]
   (some-> context context->db get-acl-hash edn/read-string))
 
+(declare save-provider-id-acl-hashes)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-provider-id-acl-hashes
   "Saves the map of provider id acl hash values"
   [context provider-hashes]

--- a/ingest-app/src/cmr/ingest/data/provider_acl_hash.clj
+++ b/ingest-app/src/cmr/ingest/data/provider_acl_hash.clj
@@ -37,16 +37,12 @@
   [context]
   (get-in context [:system :db]))
 
-(declare get-provider-id-acl-hashes)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed get-provider-id-acl-hashes
+(defn get-provider-id-acl-hashes
   "Returns a map of provider ids to hash values."
   [context]
   (some-> context context->db get-acl-hash edn/read-string))
 
-(declare save-provider-id-acl-hashes)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed save-provider-id-acl-hashes
+(defn save-provider-id-acl-hashes
   "Saves the map of provider id acl hash values"
   [context provider-hashes]
   (save-acl-hash (context->db context) (pr-str provider-hashes)))

--- a/ingest-app/src/cmr/ingest/migrations/003_update_provider_acl_hash_table.clj
+++ b/ingest-app/src/cmr/ingest/migrations/003_update_provider_acl_hash_table.clj
@@ -7,7 +7,7 @@
   []
   (try
     (j/db-do-commands (config/db) "DROP TABLE CMR_INGEST.provider_acl_hash")
-    (catch Exception e)))
+    (catch Exception _e)))
 
 (defn up
   "Migrates the database up to version 3."

--- a/ingest-app/src/cmr/ingest/runner.clj
+++ b/ingest-app/src/cmr/ingest/runner.clj
@@ -7,7 +7,7 @@
 
 (defn -main
   "Starts the App."
-  [& args]
+  [& _args]
   (let [system (system/start (system/create-system))]
     (cfg/check-env-vars)
     (events/stop-on-exit-hook (:instance-name system) #(system/stop system))

--- a/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/bulk_update_service.clj
@@ -6,7 +6,6 @@
    [clojure.string :as string]
    [cmr.common-app.config :as common-config]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :as log :refer (debug info warn error)]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.validations.json-schema :as js]

--- a/ingest-app/src/cmr/ingest/services/event_handler.clj
+++ b/ingest-app/src/cmr/ingest/services/event_handler.clj
@@ -7,7 +7,7 @@
 
 (defmulti handle-provider-event
   "Handle the various actions that can be requested for a provider via the provider-queue"
-  (fn [context msg]
+  (fn [_context msg]
     (keyword (:action msg))))
 
 (defmethod handle-provider-event :bulk-update
@@ -48,7 +48,7 @@
    (:user-id message)))
 
 (defmethod handle-provider-event :granule-bulk-update-task-cleanup
-  [context message]
+  [context _message]
   (granule-bulk-update-service/cleanup-bulk-granule-task-table context))
 
 ;; Default ignores the provider event. There may be provider events we don't care about.
@@ -59,11 +59,11 @@
   "Subscribe to event messages on various queues"
   [context]
   (let [queue-broker (get-in context [:system :queue-broker])]
-    (dotimes [n (config/ingest-queue-listener-count)]
+    (dotimes [_ (config/ingest-queue-listener-count)]
       (queue-protocol/subscribe queue-broker
                                 (config/ingest-queue-name)
                                 #(handle-provider-event context %)))
-    (dotimes [n (config/bulk-update-queue-listener-count)]
+    (dotimes [_ (config/bulk-update-queue-listener-count)]
       (queue-protocol/subscribe queue-broker
                                 (config/bulk-update-queue-name)
                                 #(handle-provider-event context %)))))

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/mime_type/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/mime_type/umm_g.clj
@@ -1,7 +1,6 @@
 (ns cmr.ingest.services.granule-bulk-update.mime-type.umm-g
   "Contains functions to update UMM-G granule metadata for MimeType granule bulk update."
   (:require
-   [clojure.string :as string]
    [cmr.common.services.errors :as errors]))
 
 (defn- update-link-mime-type

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/echo10.clj
@@ -2,6 +2,7 @@
   "Contains functions to update ECHO10 granule xml for S3 url bulk update."
   (:require
    [clojure.data.xml :as xml]
+   [clojure.set :as set]
    [clojure.string :as string]
    [clojure.zip :as zip]
    [cmr.common.xml :as cx]
@@ -55,7 +56,7 @@
   into online-accesses and appends them."
   [online-accesses urls]
   (let [s3-resources (filter #(is-s3? (:url %)) online-accesses)
-        new-s3-urls (clojure.set/difference (set urls) (set (map :url s3-resources)))
+        new-s3-urls (set/difference (set urls) (set (map :url s3-resources)))
         new-s3-resources (urls->s3-urls (set new-s3-urls))]
     (concat new-s3-resources online-accesses)))
 

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/s3/umm_g.clj
@@ -1,6 +1,7 @@
 (ns cmr.ingest.services.granule-bulk-update.s3.umm-g
   "Contains functions to update UMM-G granule metadata for s3 url bulk update."
   (:require
+   [clojure.set :as set]
    [cmr.ingest.services.granule-bulk-update.s3.s3-util :as s3-util]))
 
 (def ^:private S3_RELATEDURL_TYPE
@@ -31,7 +32,7 @@
   returning a new list of related-urls."
   [related-urls urls]
   (let [s3-resources (filter is-s3? related-urls)
-        new-s3-urls (clojure.set/difference (set urls) (set (map :URL s3-resources)))
+        new-s3-urls (set/difference (set urls) (set (map :URL s3-resources)))
         new-s3-resources (urls->s3-urls new-s3-urls)]
     (concat related-urls new-s3-resources)))
 

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update/size/echo10.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update/size/echo10.clj
@@ -4,8 +4,7 @@
    [clojure.data.xml :as xml]
    [clojure.string :as string]
    [clojure.zip :as zip]
-   [cmr.common.services.errors :as errors]
-   [cmr.common.xml :as cx]))
+   [cmr.common.services.errors :as errors]))
 
 (def ^:private tags-after-data-granule
   "Defines the element tags that come after DataGranule in ECHO10 Granule xml schema"

--- a/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
+++ b/ingest-app/src/cmr/ingest/services/granule_bulk_update_service.clj
@@ -5,7 +5,7 @@
    [clojure.string :as string]
    [cmr.common-app.config :as common-app-config]
    [cmr.common.config :refer [defconfig]]
-   [cmr.common.log :as log :refer (debug info warn error)]
+   [cmr.common.log :as log :refer (debug info error)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
@@ -609,4 +609,4 @@
     (catch Exception e
       ;; not sure if this is the best way to handle this error, looks like a
       ;; bunch of noise during tests which has no impact.
-      (comment println (.getMessage e)))))
+      (debug (.getMessage e)))))

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -68,6 +68,7 @@
       :warnings warnings
       :existing-errors existing-errors})))
 
+(declare validate-and-prepare-collection context concept validation-options)
 (defn-timed validate-and-prepare-collection
   "Validates the collection and adds extra fields needed for metadata db. Throws a service error
   if any validation issues are found and errors are enabled, otherwise returns errors as warnings."
@@ -90,26 +91,27 @@
      :warnings warnings
      :existing-errors existing-errors}))
 
+(declare save-collection)
 (defn-timed save-collection
   "Store a concept in mdb and indexer.
    Return entry-titile, concept-id, revision-id, and warnings."
   [context concept validation-options]
   (let [{:keys [concept warnings existing-errors]} (validate-and-prepare-collection context
                                                                                     concept
-                                                                                    validation-options)]
-    (let [{:keys [concept-id revision-id]} (mdb/save-concept context concept)
-          entry-title (get-in concept [:extra-fields :entry-title])]
+                                                                                    validation-options)
+        {:keys [concept-id revision-id]} (mdb/save-concept context concept)
+        entry-title (get-in concept [:extra-fields :entry-title])]
       ;; if ingested with existing errors, log the existing errors and warnings for the collection
       ;; and the user
-      (when (seq existing-errors)
-        (warn "Ingest with existing errors info:  "
-              (format "Collection[%s] has the existing errors: %s and warnings: %s by user: [%s]"
-                      concept-id (pr-str existing-errors) (pr-str warnings)
-                      (if (:token context)
-                        (common-context/context->user-id context)
-                        "unknown user"))))
-      {:entry-title entry-title
-       :concept-id concept-id
-       :revision-id revision-id
-       :warnings warnings
-       :existing-errors existing-errors})))
+    (when (seq existing-errors)
+      (warn "Ingest with existing errors info:  "
+            (format "Collection[%s] has the existing errors: %s and warnings: %s by user: [%s]"
+                    concept-id (pr-str existing-errors) (pr-str warnings)
+                    (if (:token context)
+                      (common-context/context->user-id context)
+                      "unknown user"))))
+    {:entry-title entry-title
+     :concept-id concept-id
+     :revision-id revision-id
+     :warnings warnings
+     :existing-errors existing-errors}))

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -68,7 +68,8 @@
       :warnings warnings
       :existing-errors existing-errors})))
 
-(declare validate-and-prepare-collection context concept validation-options)
+(declare validate-and-prepare-collection)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed validate-and-prepare-collection
   "Validates the collection and adds extra fields needed for metadata db. Throws a service error
   if any validation issues are found and errors are enabled, otherwise returns errors as warnings."
@@ -92,9 +93,10 @@
      :existing-errors existing-errors}))
 
 (declare save-collection)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-collection
   "Store a concept in mdb and indexer.
-   Return entry-titile, concept-id, revision-id, and warnings."
+   Return entry-title, concept-id, revision-id, and warnings."
   [context concept validation-options]
   (let [{:keys [concept warnings existing-errors]} (validate-and-prepare-collection context
                                                                                     concept

--- a/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/service.clj
@@ -12,7 +12,7 @@
 (defn- add-extra-fields-for-service
   "Returns service concept with fields necessary for ingest into metadata db
   under :extra-fields."
-  [context concept service]
+  [_context concept service]
   (assoc concept :extra-fields {:service-name (:Name service)
                                 :service-type (:Type service)}))
 
@@ -52,6 +52,8 @@
   (let [errors (seq (umm-spec-validation/validate-service service (match-kms-related-url-content-type-type-and-subtype context)))]
     (if-errors-throw :bad-request errors)))
 
+(declare save-service)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-service
   "Store a service concept in mdb and indexer. Return concept-id, and revision-id."
   [context concept]

--- a/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
@@ -7,7 +7,7 @@
 (defn- add-extra-fields-for-subscription
   "Returns subscription concept with fields necessary for ingest into metadata db
   under :extra-fields."
-  [context concept subscription]
+  [_context concept subscription]
   (assoc concept :extra-fields
                  {:subscription-name (:Name subscription)
                   :collection-concept-id (:CollectionConceptId subscription)
@@ -15,6 +15,8 @@
                   :subscription-type (or (:Type subscription) "granule")
                   :normalized-query (:normalized-query concept)}))
 
+(declare save-subscription)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-subscription
   "Store a subscription concept in mdb and indexer."
   [context concept]

--- a/ingest-app/src/cmr/ingest/services/ingest_service/tool.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/tool.clj
@@ -12,7 +12,7 @@
 (defn- add-extra-fields-for-tool
   "Returns tool concept with fields necessary for ingest into metadata db
   under :extra-fields."
-  [context concept tool]
+  [_context concept tool]
   (assoc concept :extra-fields {:tool-name (:Name tool)
                                 :tool-type (:Type tool)}))
 
@@ -49,6 +49,8 @@
   (let [errors (seq (umm-spec-validation/validate-tool tool (match-kms-content-type-type-and-subtype context)))]
     (if-errors-throw :bad-request errors)))
 
+(declare save-tool)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-tool
   "Store a tool concept in mdb and indexer."
   [context concept]

--- a/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/util.clj
@@ -20,8 +20,8 @@
   "Fixes formats"
   [concept-type fmt]
   (if (or
-        (not (mt/umm-json? fmt))
-        (mt/version-of fmt))
+       (not (mt/umm-json? fmt))
+       (mt/version-of fmt))
     fmt
     (str fmt ";version=" (config/ingest-accept-umm-version concept-type))))
 
@@ -49,6 +49,8 @@
     {:ok? ok?
      :dependencies dep-health}))
 
+(declare delete-concept)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed delete-concept
   "Delete a concept from mdb and indexer. Throws a 404 error if the concept does not exist or
   the latest revision for the concept is already a tombstone."
@@ -63,11 +65,11 @@
         concept-id (:concept-id existing-concept)]
     (when-not concept-id
       (errors/throw-service-error
-        :not-found (cmsg/invalid-native-id-msg concept-type provider-id native-id)))
+       :not-found (cmsg/invalid-native-id-msg concept-type provider-id native-id)))
     (when (:deleted existing-concept)
       (errors/throw-service-error
-        :not-found (format "Concept with native-id [%s] and concept-id [%s] is already deleted."
-                           (util/html-escape native-id) (util/html-escape concept-id))))
+       :not-found (format "Concept with native-id [%s] and concept-id [%s] is already deleted."
+                          (util/html-escape native-id) (util/html-escape concept-id))))
     (let [concept (-> concept-attribs
                       (dissoc :provider-id :native-id)
                       (assoc :concept-id concept-id :deleted true))

--- a/ingest-app/src/cmr/ingest/services/ingest_service/variable.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/variable.clj
@@ -8,13 +8,15 @@
 (defn add-extra-fields-for-variable
   "Returns collection concept with fields necessary for ingest into metadata db
   under :extra-fields."
-  [context concept variable]
+  [_context concept variable]
   (assoc concept
          :extra-fields
          {:variable-name (:Name variable)
           :measurement (:LongName variable)
           :fingerprint (fingerprint/get-variable-fingerprint (:metadata concept))}))
 
+(declare save-variable)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed save-variable
   "Store a variable concept in mdb and indexer. Return name, long-name, concept-id, and
   revision-id."

--- a/ingest-app/src/cmr/ingest/services/jobs.clj
+++ b/ingest-app/src/cmr/ingest/services/jobs.clj
@@ -5,7 +5,7 @@
    [cmr.acl.acl-fetcher :as acl-fetcher]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.jobs :as jobs :refer [def-stateful-job]]
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer (info)]
    [cmr.ingest.data.bulk-update :as bulk-update]
    [cmr.ingest.data.granule-bulk-update :as granule-bulk-update]
    [cmr.ingest.data.ingest-events :as ingest-events]
@@ -107,7 +107,7 @@
 ;; Periodically checks the acls for a provider. When they change reindexes all the collections in a
 ;; provider.
 (def-stateful-job ReindexCollectionPermittedGroups
-  [ctx system]
+  [_ctx system]
   (let [context {:system system}]
     (reindex-collection-permitted-groups context)))
 
@@ -115,7 +115,7 @@
 ;; This is done as a temporary fix for CMR-1311 but we may keep it around to help temper other race
 ;; conditions that may occur.
 (def-stateful-job ReindexAllCollections
-  [ctx system]
+  [_ctx system]
   (let [context {:system system}]
     (reindex-all-collections context false)))
 
@@ -131,7 +131,7 @@
        (mdb/save-concept context {:concept-id concept-id :deleted true})))))
 
 (def-stateful-job CleanupExpiredCollections
-  [ctx system]
+  [_ctx system]
   (let [context {:system system}]
     (cleanup-expired-collections context)))
 

--- a/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
+++ b/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
@@ -8,8 +8,8 @@
    [cmr.common-app.config :as common-app-config]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.date-time-range-parser :as date-time-range-parser]
-   [cmr.common.log :refer (debug info warn error)]
-   [cmr.common.services.errors :as errors] 
+   [cmr.common.log :refer (debug info error)]
+   [cmr.common.services.errors :as errors]
    [cmr.transmit.access-control :as access-control]
    [cmr.transmit.config :as config]
    [cmr.transmit.metadata-db :as mdb]
@@ -97,6 +97,7 @@
         end-time (last parts)]
     (assoc raw :start-time start-time :end-time end-time)))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn- send-update-subscription-notification-time!
   "Fires off an http call to update the time which the subscription last was processed"
   [context sub-id]
@@ -123,6 +124,7 @@
                 (t/minus end (t/seconds amount-in-sec)))]
     (str begin "," end)))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn- search-gran-refs-by-collection-id
   [context params sub-id]
   (try
@@ -132,6 +134,7 @@
              (dissoc params :token) "\n\n" (.getMessage e) "\n\n" e)
       [])))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn- search-collection-refs
   [context params sub-id]
   (try
@@ -176,11 +179,11 @@
   (postal-core/send-message email-settings email-content))
 
 (defmulti create-email-content
-  (fn [sub-type from-email-address to-email-address concept-ref-locations subscription]
+  (fn [sub-type _from-email-address _to-email-address _concept-ref-locations _subscription]
     sub-type))
 
 (defmethod create-email-content :granule
-  [sub-type from-email-address to-email-address concept-ref-locations subscription]
+  [_sub-type from-email-address to-email-address concept-ref-locations subscription]
   (let [metadata (json/parse-string (:metadata subscription))
         concept-id (get-in subscription [:extra-fields :collection-concept-id])
         meta-query (get metadata "Query")
@@ -206,7 +209,7 @@
                             ").\n"))}]}))
 
 (defmethod create-email-content :collection
-  [sub-type from-email-address to-email-address concept-ref-locations subscription]
+  [_sub-type from-email-address to-email-address concept-ref-locations subscription]
   (let [metadata (json/parse-string (:metadata subscription))
         meta-query (get metadata "Query")
         sub-start-time (:start-time subscription)

--- a/ingest-app/src/cmr/ingest/site/routes.clj
+++ b/ingest-app/src/cmr/ingest/site/routes.clj
@@ -2,8 +2,6 @@
   "Defines the HTTP URL routes for the ingest web site."
   (:require
    [cmr.common-app.static :as static]
-   [cmr.common-app.site.data :as common-data]
-   [cmr.common-app.site.pages :as common-pages]
    [cmr.ingest.site.pages :as pages]
    [cmr.transmit.config :as config]
    [compojure.core :refer [GET context routes]]

--- a/ingest-app/src/cmr/ingest/system.clj
+++ b/ingest-app/src/cmr/ingest/system.clj
@@ -29,7 +29,6 @@
    [cmr.ingest.services.providers-cache :as pc]
    [cmr.message-queue.queue.queue-broker :as queue-broker]
    [cmr.metadata-db.services.util :as mdb-util]
-   [cmr.oracle.connection :as oracle]
    [cmr.transmit.config :as transmit-config]
    [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]
    [cmr.transmit.urs :as urs]))

--- a/ingest-app/src/cmr/ingest/validation/additional_attribute_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/additional_attribute_validation.clj
@@ -94,7 +94,7 @@
   - additional attribute is removed but has existing granules referencing it
   - additional attribute type changed but has existing granules referencing it
   - additional attribute range changed but has existing granules outside of the new range"
-  [context concept-id concept prev-concept]
+  [_context concept-id concept prev-concept]
   (let [{aas :AdditionalAttributes} concept
         {prev-aas :AdditionalAttributes} prev-concept]
     (->> (concat (build-aa-deleted-searches aas prev-aas)

--- a/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/business_rule_validation.clj
@@ -58,6 +58,8 @@
    tv/out-of-range-temporal-searches
    sv/spatial-param-change-searches])
 
+
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn- has-granule-search-error
   "Execute the given has-granule search, returns the error message if there are granules found
   by the search."

--- a/ingest-app/src/cmr/ingest/validation/spatial_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/spatial_validation.clj
@@ -1,8 +1,5 @@
 (ns cmr.ingest.validation.spatial-validation
-  "Provides functions to validate the spatial attributes of a collection during its update."
-  (:require
-   [camel-snake-kebab.core :as csk]
-   [cmr.common.util :as util]))
+  "Provides functions to validate the spatial attributes of a collection during its update.")
 
 (defn- extract-granule-spatial-representation
   "Returns the granule spatial representation of the collection or a default of :no-spatial."
@@ -15,7 +12,7 @@
   representation and would be indexed based on that. We can't allow this change if there are any
   granules. Returns a search that will see if the collection contains any granules if the gsr
   changes."
-  [context concept-id concept prev-concept]
+  [_context concept-id concept prev-concept]
   (let [prev-gsr (extract-granule-spatial-representation prev-concept)
         new-gsr (extract-granule-spatial-representation concept)]
     (when-not (= prev-gsr new-gsr)

--- a/ingest-app/src/cmr/ingest/validation/temporal_validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/temporal_validation.clj
@@ -36,7 +36,7 @@
 (defn out-of-range-temporal-searches
   "Returns the search parameters for identifying granules which fall outside
   the temporal range defined for the collection"
-  [context concept-id concept prev-concept]
+  [_context concept-id concept prev-concept]
   (let [updated-start-time (spec-time/collection-start-date concept)
         updated-end-time (spec-time/collection-end-date concept)
         prev-start-time (spec-time/collection-start-date prev-concept)

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -51,6 +51,8 @@
   (when (<= (count (:metadata concept)) 4)
     (errors/throw-service-error :bad-request "Request content is too short.")))
 
+(declare validate-concept-request)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed validate-concept-request
   "Validates the initial request to ingest a concept."
   [concept]
@@ -105,7 +107,7 @@
                                   context
                                   :mime-type
                                   msg/mime-type-not-matches-kms-keywords)
-                       :Format (match-kms-keywords-validation-single 
+                       :Format (match-kms-keywords-validation-single
                                 context
                                 :granule-data-format
                                 msg/getdata-format-not-matches-kms-keywords)}})})
@@ -316,6 +318,8 @@
                                 (:format concept)
                                 (:metadata concept))))
 
+(declare validate-concept-metadata)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed validate-concept-metadata
   ([concept]
    (validate-concept-metadata concept true))
@@ -420,6 +424,8 @@
         (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
         err-messages))))
 
+(declare validate-granule-umm-spec)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed validate-granule-umm-spec
   "Validates a UMM granule record using rules defined in UMM Spec with a UMM Spec collection record,
   updated with platform aliases whoes shortnames don't exist in the platforms."
@@ -442,6 +448,8 @@
                                   granule
                                   (granule-keyword-validations context))))
 
+(declare validate-business-rules)
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn-timed validate-business-rules
   "Validates the concept against CMR ingest rules."
   ([context concept]
@@ -511,18 +519,16 @@
         (errors/throw-service-errors :invalid-data err-messages)
          ;; throw warnings when error doesn't exist.
         (when warning-messages
-          (do
-            (warn "UMM-Var UMM Spec Validation Errors: " (pr-str (vec warning-messages)))
-            warning-messages)))
+          (warn "UMM-Var UMM Spec Validation Errors: " (pr-str (vec warning-messages)))
+          warning-messages))
        ;; when we are supposed to return errors as warnings as well,
        ;; return both errors and warnings as warnings.
       (when-let [all-warning-messages (seq (umm-spec-validation/validate-variable
-                                              variable
-                                              [(variable-keyword-validations context)
-                                               (variable-keyword-validations-warnings context)]))]
-        (do
-          (warn "UMM-Var UMM Spec Validation Errors: " (pr-str (vec all-warning-messages)))
-          all-warning-messages)))))
+                                            variable
+                                            [(variable-keyword-validations context)
+                                             (variable-keyword-validations-warnings context)]))]
+        (warn "UMM-Var UMM Spec Validation Errors: " (pr-str (vec all-warning-messages)))
+        all-warning-messages))))
 
 (defn validate-variable-associated-collection
   "Validate the collection being associated to is accessible."

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -51,9 +51,7 @@
   (when (<= (count (:metadata concept)) 4)
     (errors/throw-service-error :bad-request "Request content is too short.")))
 
-(declare validate-concept-request)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed validate-concept-request
+(defn validate-concept-request
   "Validates the initial request to ingest a concept."
   [concept]
   (validate-format concept)
@@ -318,9 +316,7 @@
                                 (:format concept)
                                 (:metadata concept))))
 
-(declare validate-concept-metadata)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed validate-concept-metadata
+(defn validate-concept-metadata
   ([concept]
    (validate-concept-metadata concept true))
   ([concept throw-error?]
@@ -424,9 +420,7 @@
         (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
         err-messages))))
 
-(declare validate-granule-umm-spec)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed validate-granule-umm-spec
+(defn validate-granule-umm-spec
   "Validates a UMM granule record using rules defined in UMM Spec with a UMM Spec collection record,
   updated with platform aliases whoes shortnames don't exist in the platforms."
   [context collection granule]
@@ -448,9 +442,7 @@
                                   granule
                                   (granule-keyword-validations context))))
 
-(declare validate-business-rules)
-#_{:clj-kondo/ignore [:unresolved-symbol]}
-(defn-timed validate-business-rules
+(defn validate-business-rules
   "Validates the concept against CMR ingest rules."
   ([context concept]
    (validate-business-rules context concept nil))

--- a/ingest-app/src/config/ingest_migrate_config.clj
+++ b/ingest-app/src/config/ingest_migrate_config.clj
@@ -22,7 +22,7 @@
 
 (defn- maybe-create-schema-table
   "Creates the schema table if it doesn't already exist."
-  [args]
+  [_args]
   ;; wrap in a try-catch since there is not easy way to check for the existence of the DB
   (try
     (j/db-do-commands (db) "CREATE TABLE CMR_INGEST.schema_version (version INTEGER NOT NULL, created_at TIMESTAMP(9) WITH TIME ZONE DEFAULT sysdate NOT NULL)")
@@ -41,8 +41,9 @@
   ; sleep a second to workaround timestamp precision issue
   (Thread/sleep 1000))
 
-(defn app-migrate-config []
+(defn app-migrate-config
   "Drift migrate configuration used by CMR app's db-migrate endpoint."
+  []
   {:directory "/ingest/migrations"
    :ns-content "\n  (:require [clojure.java.jdbc :as j]\n            [config.ingest-migrate-config :as config])"
    :namespace-prefix "cmr.ingest.migrations"
@@ -51,8 +52,9 @@
    :current-version current-db-version
    :update-version update-db-version})
 
-(defn app-migrate-config-lein []
+(defn app-migrate-config-lein
   "Drift migrate configuration used by CMR app's db-migrate endpoint for running with lein."
+  []
   {:directory "src/cmr/ingest/migrations"
    :ns-content "\n  (:require [clojure.java.jdbc :as j]\n            [config.ingest-migrate-config :as config])"
    :namespace-prefix "cmr.ingest.migrations"
@@ -61,7 +63,8 @@
    :current-version current-db-version
    :update-version update-db-version})
 
-(defn migrate-config []
+(defn migrate-config
   "Drift migrate configuration used by lein migrate.
    Calling shutdown-agents allows lein migrate command to terminate faster."
+  []
   (assoc (app-migrate-config) :finished shutdown-agents))


### PR DESCRIPTION
# Overview

Remove large quantities of logs which are not helpful.

### What is the feature/fix?

1. Removing defn-timed calls for functions which are either fast enough to not worry about, infrequent, or fast and frequent but inside another defn-timed.

2. Added a new macro, defn-timed-level which allows code to specify the log level to send timed info to. Using this for one log.

### What is the Solution?

removing defn-timed macro from function definition.

### What areas of the application does this impact?

Most changes are in ingest, one change is in common.

I have also run clj-kondo on ingest and made significant changes.

# Checklist

- [-] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
