### PR TITLE
CMR-10063: adding ingest and indexer to kondo check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,14 +14,16 @@ List impacted areas.
 
 # Checklist
 
-- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit and int tests pass locally and remotely with my changes
+- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit and int tests pass locally and remotely
+- [ ] clj-kondo has been run locally and all errors corrected
 - [ ] I have removed unnecessary/dead code and imports in files I have changed
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have cleaned up integration tests by doing one or more of the following:
+  - migrated any are2 tests to are3 in files I have changed
   - de-duped, consolidated, removed dead int tests
   - transformed applicable int tests into unit tests
   - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each

--- a/dev-system/support/run-kondo.sh
+++ b/dev-system/support/run-kondo.sh
@@ -21,6 +21,8 @@ projects_to_check='access-control-app/src \
             common-lib/src \
             elastic-utils-lib/src \
             es-spatial-plugin/src \
+            indexer-app/src \
+            ingest-app/src \
             message-queue-lib/src \
             umm-lib/src'
 


### PR DESCRIPTION
# Overview

updating the GitHub action to include indexer and ingest as both have been cleaned up

### What is the Solution?
Updating the kondo script to include these services

# Checklist

- [-] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [-] New and existing unit and int tests pass locally and remotely with my changes
- [-] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
