### PR TITLE
CMR-10026: Reduce metadata-db logs

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/search.clj
@@ -273,7 +273,7 @@
                    (do
                      (info "Couldn't find batch so searching for more from" start-index)
                      (when-let [next-id (find-batch-starting-id db table params start-index)]
-                       (info "Found next-id of" next-id)
+                       (debug "Found next-id of" next-id)
                        (lazy-find next-id)))
                    ;; We found a batch. Return it and the next batch lazily
                    (cons batch (lazy-seq (lazy-find (+ start-index batch-size)))))))]
@@ -311,7 +311,7 @@
                   (do
                     (info "Couldn't find batch so searching for more from" start-index)
                     (when-let [next-id (find-batch-starting-id-with-stmt db stmt start-index)]
-                      (info "Found next-id of" next-id)
+                      (debug "Found next-id of" next-id)
                       (lazy-find next-id)))
                   ;; We found a batch. Return it and the next batch lazily
                   (cons batch (lazy-seq (lazy-find (+ start-index batch-size)))))))]

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -7,7 +7,7 @@
    [cmr.common.concepts :as cu]
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.common.date-time-parser :as p]
-   [cmr.common.log :refer (info warn trace)]
+   [cmr.common.log :refer (debug info warn trace)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.services.messages :as cmsg]
@@ -528,7 +528,7 @@
 (defn get-concepts
   "Get multiple concepts by concept-id and revision-id. Returns concepts in order requested"
   [context concept-id-revision-id-tuples allow-missing?]
-  (info (format "Getting [%d] concepts by concept-id/revision-id"
+  (debug (format "Getting [%d] concepts by concept-id/revision-id"
                 (count concept-id-revision-id-tuples)))
   (let [start (System/currentTimeMillis)
         parallel-chunk-size (get-in context [:system :parallel-chunk-size])
@@ -1060,7 +1060,7 @@
                         (c/get-expired-concepts db provider concept-type)))]
     (loop []
       (when-let [expired-concepts (seq (get-expired))]
-        (info "Deleting expired" (name concept-type) "concepts:" (pr-str (map :concept-id expired-concepts)))
+        (debug "Deleting expired" (name concept-type) "concepts:" (pr-str (map :concept-id expired-concepts)))
         (doseq [c expired-concepts]
           (let [tombstone (-> c
                               (update-in [:revision-id] inc)
@@ -1124,7 +1124,7 @@
     ;; We only want to publish the deleted-tombstone event in the case where a granule tombstone is
     ;; being cleaned up, not when an old revision is being removed, because the case of old revision,
     ;; a deleted-tombstone even would have been published already.
-    (info "Starting deletion of old" concept-type-name "for provider" (:provider-id provider))
+    (debug "Starting deletion of old" concept-type-name "for provider" (:provider-id provider))
     (force-delete-with
       context provider concept-type false
       #(c/get-old-concept-revisions
@@ -1136,7 +1136,7 @@
          concept-truncation-batch-size)
       concept-truncation-batch-size)
 
-    (info "Starting deletion of tombstoned" concept-type-name "for provider" (:provider-id provider))
+    (debug "Starting deletion of tombstoned" concept-type-name "for provider" (:provider-id provider))
     (force-delete-with
       context provider concept-type true
       #(c/get-tombstoned-concept-revisions

--- a/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/provider_service.clj
@@ -1,6 +1,6 @@
 (ns cmr.metadata-db.services.provider-service
   (:require
-   [cmr.common.log :refer (info)]
+   [cmr.common.log :refer (debug info)]
    [cmr.common.services.errors :as errors]
    [cmr.common.services.messages :as cmsg]
    [cmr.common.util :as util]
@@ -27,7 +27,7 @@
   Returns a clojure.lang.APersistentMap$ValSeq; list of maps"
   ([context] (get-providers context nil))
   ([context params]
-   (info "Getting provider list.")
+   (debug "Getting provider list.")
   (let [db (mdb-util/context->db context)
         providers (providers/get-providers db)
         providers (if (:meta params)


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Reduce metadata-db logs

### What is the Solution?

Change unnecessary logs from info to debug level

### What areas of the application does this impact?

metadata-db

# Checklist

- [ ] I have updated/added unit and integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely with my changes
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
