### PR TITLE
CMR-10071: Fixing the Time To Visibility Log

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -5,6 +5,7 @@
    [clj-time.core :as t]
    [clj-time.format :as f]
    [clojure.set :as set]
+   [clojure.string :as string]
    [cmr.acl.acl-fetcher :as acl-fetcher]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as cs]
@@ -307,22 +308,27 @@
    Values in log:
    * fv : Format Version
    * mg : MessaGe type
+   * ct : Concept Type (from Concept Id)
    * ci : Concept Id
    * ri : Revision Id (number)
-   * vm : Visibility Milliseconds
-   * ar : All Revisions (0 or 1)
+   * vm : Visibility Milliseconds (number)
+   * ar : All Revisions (0 for false or 1 for true)
 
    NOTE: Changes to this text may break reports."
   [concept-id revision-id milliseconds all-revisions-index?]
-  (let [all-value (if all-revisions-index? 1 0)]
-    (format (str "{\"fv\": 1 \"mg\": \"index-vis\", "
-                 "\"ci\": \"%s\", "
-                 "\"ri\": \"%s\", "
-                 "\"vm\": \"%d\", "
-                 "\"ar\": %d}")
+  (let [all-value (if all-revisions-index? 1 0)
+        concept-type (re-find (re-pattern "^[A-Z]+") concept-id)]
+    (format (str "{\"fv\":1,"
+                 "\"mg\":\"index-vis\","
+                 "\"ct\":\"%s\","
+                 "\"ci\":\"%s\","
+                 "\"ri\":%d,"
+                 "\"vm\":%d,"
+                 "\"ar\":%d}")
+            concept-type
             concept-id
-            revision-id
-            milliseconds
+            (Long/parseLong (str revision-id))
+            (Long/parseLong (str milliseconds))
             all-value)))
 
 (defn- send-time-to-visibility-log

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -301,12 +301,9 @@
   "This is a replacement log to be used by Splunk to report on time to index. Features of this log
    are: JSON, more values, smaller content. Content size is such an issue that short names are given
    for fields which may not be as human readable as possible. This log can be output in the millions
-   per day. Scripts can use the version (v) value if needed to judge what content may be in the
-   log. Future developers should change this value if adding or removing values so as to inform
-   scripts of a change.
+   per day.
 
    Values in log:
-   * fv : Format Version
    * mg : MessaGe type
    * ct : Concept Type (from Concept Id)
    * ci : Concept Id
@@ -318,8 +315,7 @@
   [concept-id revision-id milliseconds all-revisions-index?]
   (let [all-value (if all-revisions-index? 1 0)
         concept-type (re-find (re-pattern "^[A-Z]+") concept-id)]
-    (format (str "{\"fv\":1,"
-                 "\"mg\":\"index-vis\","
+    (format (str "{\"mg\":\"index-vis\","
                  "\"ct\":\"%s\","
                  "\"ci\":\"%s\","
                  "\"ri\":%d,"

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -54,5 +54,4 @@
           data (json/parse-string raw-json true)]
       (is (some? data) "time-to-visibility-json parsing test")
       (is (= "ACL" (:ct data)) "Checking concept type")
-      (is (= 1 (:fv data)) "Checking format version")
       (is (= "index-vis" (:mg data)) "Checking message id"))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -1,6 +1,7 @@
 (ns cmr.indexer.test.services.index-service
   "Tests for index service"
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3]]
    [cmr.indexer.services.index-service :as index-svc]))
@@ -45,3 +46,13 @@
           json (time-to-visibility-json concept-id revision-id milliseconds all-revisions-index?)]
 
       (is (<= (count json) (count text))))))
+
+(deftest time-to-visibility-json-test
+  (testing "Ensure that the output of the time-to-vilibility-json function is in fact JSON"
+    (let [time-to-visibility-json (var index-svc/time-to-visibility-json) ;; private function
+          raw-json (time-to-visibility-json "ACL123-CMR", 1, 1234, false)
+          data (json/parse-string raw-json true)]
+      (is (some? data) "time-to-visibility-json parsing test")
+      (is (= "ACL" (:ct data)) "Checking concept type")
+      (is (= 1 (:fv data)) "Checking format version")
+      (is (= "index-vis" (:mg data)) "Checking message id"))))


### PR DESCRIPTION
Removing fv field and adding a concept type to ease parsing. Test also added.

# Overview

### What is the feature/fix?

1. This change will correct the JSON output in the time to visibility log so that it is parsable by Splunk.
2. Added Concept Type so that splunk queries do not have to do a regex to discover it
3. Removed spaces for even more space savings

### What areas of the application does this impact?

This should impact anything that relies on the new time to visibility log.

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
