### PR TITLE
CMR-10062: Lowering cache logs a log level to reduce size in splunk

### DIFF
--- a/common-app-lib/src/cmr/common_app/data/humanizer_alias_cache.clj
+++ b/common-app-lib/src/cmr/common_app/data/humanizer_alias_cache.clj
@@ -15,7 +15,7 @@
    [cmr.common.config :refer [defconfig]]
    [cmr.common.hash-cache :as hash-cache]
    [cmr.common.jobs :refer [defjob]]
-   [cmr.common.log :as log :refer (info warn)]
+   [cmr.common.log :as log :refer (debug info)]
    [cmr.common.redis-log-util :as rl-util]
    [cmr.common.util :as util]
    [cmr.redis-utils.config :as redis-config]
@@ -107,7 +107,8 @@
                                 (hash-cache/get-value humanizer-alias-cache humanizer-alias-cache-key humanizer-field-name))]
     (rl-util/log-redis-read-complete "get-non-humanized-source-to-aliases-map" humanizer-alias-cache-key tm)
     (when (or (nil? found-aliases-map) (empty? found-aliases-map))
-      (warn (format "cache-miss: %s could not find map with humanizer-field-name [%s]" humanizer-alias-cache-key humanizer-field-name)))
+      ;; This can be a high volume log, over a million per day
+      (debug (format "cache-miss: %s could not find map with humanizer-field-name [%s]" humanizer-alias-cache-key humanizer-field-name)))
     found-aliases-map))
 
 (defconfig humanizer-alias-cache-job-refresh-rate

--- a/common-app-lib/src/cmr/common_app/services/cache_info.clj
+++ b/common-app-lib/src/cmr/common_app/services/cache_info.clj
@@ -7,7 +7,7 @@
    [cmr.common.config :refer [defconfig]]
    [cmr.common.hash-cache :as hash-cache]
    [cmr.common.jobs :refer [defjob]]
-   [cmr.common.log :refer [info error]]))
+   [cmr.common.log :refer [debug error]]))
 
 (s/def ::cache-size-map
   (s/and map?
@@ -25,7 +25,7 @@
 
     (< size 1073741824)
     (format "%.2f MB" (double (/ size 1048576)))
-    
+
     :else
     (format "%.2f GB" (double (/ size 1073741824)))))
 
@@ -41,10 +41,12 @@
   (doseq [[cache-key size] cache-size-map]
     ;; negatives denote external cache
     (when-not (neg? size)
-      (info (format "in-memory-cache [%s] [%s] [%d bytes]" cache-key (human-readable-bytes size) size))))
+      ;; This can be a moderate volume log, 20k a day.
+      (debug (format "in-memory-cache [%s] [%s] [%d bytes]" cache-key (human-readable-bytes size) size))))
   (try
     (let [combined-size (reduce + 0 (filter pos? (vals cache-size-map)))]
-      (info (format "Total in-memory-cache usage [%s] [%d bytes]"
+      ;; This is a low volume log, over a 1000 a day, but is paired with the one above.
+      (debug (format "Total in-memory-cache usage [%s] [%d bytes]"
                     (human-readable-bytes combined-size)
                     combined-size)))
     (catch java.lang.ArithmeticException e

--- a/common-lib/src/cmr/common/cache/in_memory_cache.clj
+++ b/common-lib/src/cmr/common/cache/in_memory_cache.clj
@@ -6,7 +6,7 @@
   (:require
    [clojure.core.cache :as cc :refer [defcache]]
    [cmr.common.cache :as cache]
-   [cmr.common.log :refer [debug error]]
+   [cmr.common.log :refer [error trace]]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.dev.record-pretty-printer :as record-pretty-printer])
   (:import
@@ -19,7 +19,7 @@
 (defmethod size-in-bytes :default
   [x]
   (try
-    (debug "No handler found size-in-bytes for" (class x) " Using default on " x)
+    (trace "No handler found size-in-bytes for" (class x) " Using default on " x)
     (size-in-bytes (str x))
     (catch Exception e
       (error (str "A problem occurred calculating cache size. "


### PR DESCRIPTION
# Overview

Lowering the log levels of several logs related to caching as these are not deemed to be needed in production at this time.

### What areas of the application does this impact?

Caching info

List impacted areas.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
