### PR TITLE
Bugfix CMR-10079: json access log

### DIFF
--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -38,5 +38,5 @@
       params/wrap-params
       req-log/add-body-hashes
       ;; Last in line, but really first for request as they process in reverse
-      req-log/add-time-stamp
-      req-log/log-ring-request))
+      req-log/log-ring-request
+      req-log/add-time-stamp))

--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -28,6 +28,7 @@
   (-> (build-routes system)
       acl/add-authentication-handler
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
@@ -36,4 +37,5 @@
       common-routes/pretty-print-response-handler
       params/wrap-params
       req-log/add-body-hashes
-      req-log/log-ring-request))
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))

--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -38,4 +38,5 @@
       params/wrap-params
       req-log/add-body-hashes
       ;; Last in line, but really first for request as they process in reverse
-      req-log/add-time-stamp))
+      ;req-log/add-time-stamp
+      ))

--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -28,7 +28,7 @@
   (-> (build-routes system)
       acl/add-authentication-handler
       common-routes/add-request-id-response-handler
-      req-log/log-ring-request ;; Must be after request id
+      ;req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
@@ -39,4 +39,4 @@
       req-log/add-body-hashes
       ;; Last in line, but really first for request as they process in reverse
       ;req-log/add-time-stamp
-      ))
+      req-log/log-ring-request))

--- a/access-control-app/src/cmr/access_control/routes.clj
+++ b/access-control-app/src/cmr/access_control/routes.clj
@@ -28,7 +28,7 @@
   (-> (build-routes system)
       acl/add-authentication-handler
       common-routes/add-request-id-response-handler
-      ;req-log/log-ring-request ;; Must be after request id
+      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
@@ -38,5 +38,5 @@
       params/wrap-params
       req-log/add-body-hashes
       ;; Last in line, but really first for request as they process in reverse
-      ;req-log/add-time-stamp
+      req-log/add-time-stamp
       req-log/log-ring-request))

--- a/access-control-app/src/cmr/access_control/system.clj
+++ b/access-control-app/src/cmr/access_control/system.clj
@@ -25,8 +25,7 @@
    [cmr.message-queue.queue.queue-broker :as queue-broker]
    [cmr.transmit.config :as transmit-config]
    [cmr.transmit.launchpad-user-cache :as launchpad-user-cache]
-   [cmr.transmit.urs :as urs]
-   [cmr.access-control.config :as access-control-config]))
+   [cmr.transmit.urs :as urs]))
 
 (declare access-control-nrepl-port)
 (defconfig access-control-nrepl-port

--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -31,7 +31,8 @@
    [ring.middleware.json :as ring-json]
    [ring.middleware.keyword-params :as keyword-params]
    [ring.middleware.nested-params :as nested-params]
-   [ring.middleware.params :as params]))
+   [ring.middleware.params :as params]
+   [cmr.common-app.api.request-logger :as req-log]))
 
 (defn- build-routes [system]
   (routes
@@ -187,9 +188,12 @@
       errors/invalid-url-encoding-handler
       errors/exception-handler
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
       ring-json/wrap-json-body
       common-routes/pretty-print-response-handler
-      params/wrap-params))
+      params/wrap-params
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))

--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -11,6 +11,7 @@
    [cmr.bootstrap.data.metadata-retrieval.collection-metadata-cache :as cmc]
    [cmr.bootstrap.services.health-service :as hs]
    [cmr.common-app.api.health :as common-health]
+   [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
    [cmr.common-app.data.collections-for-gran-acls-by-concept-id-cache :as coll-for-gran-acls-caches]
    [cmr.common-app.data.humanizer-alias-cache :as humanizer-alias-cache]
@@ -22,8 +23,9 @@
    [cmr.common.generics :as common-generic]
    [cmr.common.log :refer [info]]
    [cmr.elastic-utils.search.es-index-name-cache :as elastic-search-index-names-cache]
-   [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as has-granules-or-cwic-results-feature]
-   [compojure.core :refer :all]
+   [cmr.search.services.query-execution.has-granules-or-cwic-results-feature
+    :as has-granules-or-cwic-results-feature]
+   [compojure.core :refer [DELETE GET POST context routes]]
    [compojure.route :as route]
    [drift.core]
    [drift.execute]
@@ -31,8 +33,7 @@
    [ring.middleware.json :as ring-json]
    [ring.middleware.keyword-params :as keyword-params]
    [ring.middleware.nested-params :as nested-params]
-   [ring.middleware.params :as params]
-   [cmr.common-app.api.request-logger :as req-log]))
+   [ring.middleware.params :as params]))
 
 (defn- build-routes [system]
   (routes
@@ -125,7 +126,7 @@
       ;; Add routes for accessing caches
       common-routes/cache-api-routes
       (context "/caches/refresh/:cache-name" [cache-name]
-        (POST "/" {:keys [params request-context headers]}
+        (POST "/" {:keys [request-context]}
           (acl/verify-ingest-management-permission request-context :update)
           (let [keyword-cache-name (keyword cache-name)]
             (cond
@@ -156,8 +157,7 @@
       ;; db migration route
       (POST "/db-migrate" {:keys [request-context params]}
         (acl/verify-ingest-management-permission request-context :update)
-        (let [db (get-in request-context [:system :db])
-              migrate-args (if-let [version (:version params)]
+        (let [migrate-args (if-let [version (:version params)]
                              ["-c" "config.bootstrap-migrate-config/app-migrate-config" "-version" version]
                              ["-c" "config.bootstrap-migrate-config/app-migrate-config"])]
           (info "Running db migration with args:" migrate-args)
@@ -169,13 +169,13 @@
               ;; trying non-local path to find drift migration files
               (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/drift-migration-files")))]
                 (drift.execute/run migrate-args))
-              (catch Exception e
+              (catch Exception _e
                 (try
-                  (println "caught exception trying to find migration files for cloud env. We are probably in local env. Trying local route to migration files...")
+                  (println "Caught exception trying to find migration files for cloud env. We are probably in local env. Trying local route to migration files...")
                   (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/checkouts/bootstrap-app/src")))]
                     (drift.execute/run migrate-args))
-                  (catch Exception e2
-                    (println "caught exception trying to find migration files with local route external, trying last resort migration local :in-memory")
+                  (catch Exception _e2
+                    (println "Caught exception trying to find migration files with local route external, trying last resort migration local :in-memory")
                     (drift.execute/run (cons migrate-args "migrate")))))))
         {:status 204})
       ;; Add routes for checking health of the application

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -8,7 +8,7 @@
    [clojure.string :as string]
    [cmr.common-app.config :as config]
    [cmr.common.date-time-parser :as dtp]
-   [cmr.common.log :as log :refer [report]]
+   [cmr.common.log :as log :refer [error report]]
    [cmr.common.util :as util]
    [cmr.common.time-keeper :as tk]
    [digest :as digest]
@@ -47,11 +47,15 @@
        (assoc data field-name (util/scrub-token token))
        data))))
 
+(def max-dump-params
+  "The maximum number of parameters to dump to logs due to the issue of storing large logs."
+  128)
+
 (defn- dump-param
   "Dump out a form post parameter or url parameter map from inside a given
    request object taking care to mask tokens and to limit the number of actual
    values that will be logged. Defaults (2 parameter call) to 128 parameters."
-  ([data field] (dump-param data field 128))
+  ([data field] (dump-param data field max-dump-params))
   ([data field limit]
    (-> data
        (get field {})
@@ -60,6 +64,26 @@
        (scrub-token-from-map "token")
        ;; Parameters in forms could be really large, don't log everything
        (as-> item (apply dissoc item (drop limit (keys item)))))))
+
+(defn- normalize-local
+  "IP 6 addresses are ugly and wildly different then IP 4, normalize these so that all localhost
+   searches can be found in logs regardless of technology used to deliver the request."
+  [raw-address]
+  (if (contains? (set ["[0:0:0:0:0:0:0:1]" "127.0.0.1"]) raw-address)
+    "localhost"
+    raw-address))
+
+(defn- add-hash-to-data
+  "Conditionally adds md5 and sha1 hashes if the log level is either debug or
+   trace. These values are pulled from the response map."
+  [data response]
+  (let [log-level (log/apparent-log-level)]
+    (if (contains? (set [:debug :trace]) log-level)
+      (-> data
+          (assoc "body-md5" (get-in response [:headers "Content-MD5"]))
+          (assoc "body-sha1" (get-in response [:headers "Content-SHA1"]))
+          (util/remove-nil-keys))
+      data)))
 
 ;; *****************************************************************************
 ;; Ring Middleware Handlers
@@ -73,7 +97,7 @@
   [handler]
   (fn [request]
     (let [response (handler request)
-            ;; This is run after all responses
+          ;; This is run after all responses
           text (str (:body response))
           body-md5 (digest/md5 text)
           body-sha1 (digest/sha-1 text)
@@ -82,17 +106,13 @@
                                (assoc-in [:headers "Content-SHA1"] body-sha1))]
       updated-response)))
 
-(defn add-hash-to-data
-  "Conditionally adds md5 and sha1 hashes if the log level is either debug or
-   trace. These values are pulled from the response map."
-  [data response]
-  (let [log-level (log/apparent-log-level)]
-    (if (contains? (set [:debug :trace]) log-level)
-      (-> data
-          (assoc "body-md5" (get-in response [:headers "Content-MD5"]))
-          (assoc "body-sha1" (get-in response [:headers "Content-SHA1"]))
-          (util/remove-nil-keys))
-      data)))
+(defn add-time-stamp
+  "Add the current time to the request"
+  [handler]
+  (fn [request]
+    (if (some? (:ring-start-time request))
+      (handler request)
+      (handler (assoc request :ring-start-time (tk/now-ms))))))
 
 ;; log-ring-request should provide the same info as a standard NCSA Log
 ;; ; 127.0.0.1 - - [2023-12-27 19:04:01.676] "GET /collections?keyword=any HTTP/1.1" 200 112 "-" "curl/8.1.2" 296
@@ -116,54 +136,59 @@
 ;; time
 
 (defn log-ring-request
-  "Log a request from Ring returning JSON data to be parsed by a log tool like
-   Splunk or ELK. This handler can be called multiple times at different positions
-   in the handlers call. When calling this function multiple times in the routes
-   list, then pass in an ID (the two arity call) and the output will include the
-   ID value in the log so that log entries can be told apart. One may want to do
-   this to see when a value logged becomes valid in the routes chain and thus
-   availible downstream.
+  "Log a request from Ring returning JSON data to be parsed by a log tool like Splunk or ELK. This
+   handler can be called multiple times at different positions in the handlers call but it does
+   depend on common-routes/add-request-id-response-handler and add-time-stamp. When calling this
+   function multiple times in the routes list, then pass in an ID (the two arity call) and the
+   output will include the ID value in the log so that log entries can be told apart. One may want
+   to do this to see when a value logged becomes valid in the routes chain and thus availible
+   downstream.
 
-   NOTE: If you pass in an ID of :ignore then no ID will be written out, the
-   same behavior if you call the single arity call."
+   NOTE: If you pass in an ID of :ignore then no ID will be written out, the same behavior if you
+   call the single arity call."
   ([handler]
    (log-ring-request handler :ignore-id))
   ([handler id]
    (fn [request]
      (if-not (config/enable-enhanced-http-logging)
        (handler request)
-       (let [start (tk/now-ms)
+       (let [response (handler request) ;; Do all the response handlers first
+             log-start (tk/now-ms) ;; After processing the other handlers, start tracking log time
+             _ (when-not (:ring-start-time request) ;; Did someone forget to setup a routes.clj
+                 (error "There is no ring start time for this service" (:uri request)))
              now (dtp/clj-time->date-time-str (tk/now))
-             response (handler request)
+             ring-start (get request :ring-start-time (tk/now))
              query-params (params/assoc-query-params request "UTF-8")
              form-params (params/assoc-form-params request "UTF-8")
-             ;; If adding or removing elements, change the log-version number so
-             ;; that reporting scripts can try to protect against change. Humans
-             ;; may be creating Splunk or ELK reports based on this content.
-             note (-> {"log-type" "action-log" "log-version" "1.0.0"}
+             note (-> {"message-type" "request-log"}
                       (add-hash-to-data response)
                       ;; As this handler can be called multiple times, if so,
                       ;; include an id showing which instance is reporting this
                       ;; information.
-                      (as-> data (if (= id :ignore-id) (assoc data "log-id" id) data))
+                      (as-> data (if (= id :ignore-id) data (assoc data "log-id" id)))
                       ;; assume that (add-body-hashes) has been run and reuse data
-                      (assoc "client-id" (get-in request [:headers "client-id"] "unknown")
+                      (into (:headers request)) ;; Bring in all the existing headers
+                      (assoc "cmr-hit" (get-in response [:headers "CMR-Hit"] "n/a")
+                             "cmr-took" (get-in response [:headers "CMR-Took"] "n/a")
                              "form-params" (dump-param form-params :form-params)
                              "method" (string/upper-case
                                        (name (get-in request [:request-method] "unknown")))
                              "now" now
-                             "protocol" (:protocol request)
+                             "now-ms" log-start
                              "query-params" (dump-param query-params :query-params)
-                             "remote-address" (:remote-addr request)
+                             "remote-address" (normalize-local (:remote-addr request))
                              "request-id" (get-in response [:headers "CMR-Request-Id"] "-to early-")
                              "status" (:status response)
-                             "took" (get-in response [:headers "CMR-Took"] "n/a")
-                             "uri" (request->uri request)
-                             "user-agent" (get-in request [:headers "user-agent"] "unknown")
-                             ;; do this last
-                             "log-cost-ms" (- (tk/now-ms) start)))]
+                             "uri" (get-in request [:uri] "/")
+                             "url" (request->uri request)
+                             ;; do these last
+                             "log-cost" (- (tk/now-ms) log-start)
+                             "duration" (- (tk/now-ms) ring-start))
+                      (util/remove-nil-keys))]
          (report (json/generate-string note))
          response)))))
+
+;; *************************************
 
 (comment
   ;; Notes on using ring code:

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -157,7 +157,7 @@
              _ (when-not (:ring-start-time request) ;; Did someone forget to setup a routes.clj
                  (error "There is no ring start time for this service" (:uri request)))
              now (dtp/clj-time->date-time-str (tk/now))
-             ring-start (get request :ring-start-time (tk/now))
+             ring-start (get request :ring-start-time (tk/now-ms))
              query-params (params/assoc-query-params request "UTF-8")
              form-params (params/assoc-form-params request "UTF-8")
              note (-> {"message-type" "request-log"}

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -155,7 +155,7 @@
        (let [response (handler request) ;; Do all the response handlers first
              log-start (tk/now-ms) ;; After processing the other handlers, start tracking log time
              _ (when-not (:ring-start-time request) ;; Did someone forget to setup a routes.clj
-                 (error "There is no ring start time for this service" (:uri request)))
+                 (error "There is no ring start time for this service" (request->uri request)))
              now (dtp/clj-time->date-time-str (tk/now))
              ring-start (get request :ring-start-time (tk/now-ms))
              query-params (params/assoc-query-params request "UTF-8")

--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -162,15 +162,16 @@
 
 (defn make-api [system]
   (-> (build-routes system)
+      common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       acl/add-authentication-handler
       errors/invalid-url-encoding-handler
       errors/exception-handler
-      common-routes/add-request-id-response-handler
-      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       handler/site
       common-routes/pretty-print-response-handler
       ring-json/wrap-json-body
       ring-json/wrap-json-response
       req-log/add-body-hashes
-      ))
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))

--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -166,10 +166,11 @@
       errors/invalid-url-encoding-handler
       errors/exception-handler
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       handler/site
       common-routes/pretty-print-response-handler
       ring-json/wrap-json-body
       ring-json/wrap-json-response
       req-log/add-body-hashes
-      req-log/log-ring-request))
+      ))

--- a/ingest-app/src/cmr/ingest/routes.clj
+++ b/ingest-app/src/cmr/ingest/routes.clj
@@ -47,9 +47,12 @@
       mp/wrap-multipart-params
       (api-errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; (must be after request id)
       common-routes/add-security-header-response-handler
       (context/build-request-context-handler system)
       common-routes/pretty-print-response-handler
       params/wrap-params
       req-log/add-body-hashes
-      req-log/log-ring-request))
+
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))

--- a/metadata-db-app/src/cmr/metadata_db/api/routes.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/routes.clj
@@ -97,10 +97,11 @@
 
 (defn make-api [system]
   (-> (build-routes system)
+      common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       acl/add-authentication-handler
       errors/invalid-url-encoding-handler
       errors/exception-handler
-      common-routes/add-request-id-response-handler
       (context/build-request-context-handler system)
       keyword-params/wrap-keyword-params
       nested-params/wrap-nested-params
@@ -108,4 +109,5 @@
       common-routes/pretty-print-response-handler
       params/wrap-params
       req-log/add-body-hashes
-      req-log/log-ring-request))
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))

--- a/search-app/src/cmr/search/routes.clj
+++ b/search-app/src/cmr/search/routes.clj
@@ -121,6 +121,7 @@
       mixed-arity-param-handler
       (errors/exception-handler default-error-format)
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       common-routes/add-security-header-response-handler
       (cmr-context/build-request-context-handler system)
       common-routes/pretty-print-response-handler
@@ -128,5 +129,6 @@
       params/wrap-params
       copy-of-body-handler
       req-log/add-body-hashes
-      req-log/log-ring-request
-      (shapefile/shapefile-upload default-error-format)))
+      (shapefile/shapefile-upload default-error-format)
+      ;;Last in line, but really first for requests
+      req-log/add-time-stamp))

--- a/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/atom_json.clj
@@ -52,17 +52,17 @@
   (fn [concept-type json-entry]
     concept-type))
 
-(defn parse-long
+(defn parse-long-local
   [^String v]
   (when-not (string/blank? v)
     (Long. v)))
 
-(defn parse-double
+(defn parse-double-local
   [^String v]
   (when-not (string/blank? v)
     (Double. v)))
 
-(defn parse-integer
+(defn parse-integer-local
   [^String v]
   (when-not (string/blank? v)
     (Integer. v)))
@@ -73,7 +73,7 @@
   (when orbit-params
     (let [result (util/remove-nil-keys
                    (into orbit-params
-                         (for [[k v] orbit-params] [k (parse-double v)])))]
+                         (for [[k v] orbit-params] [k (parse-double-local v)])))]
       ;; Don't return an empty map
       (when (seq result)
         result))))
@@ -83,20 +83,20 @@
   [orbit]
   (when orbit
     (-> orbit
-        (update-in [:ascending-crossing] parse-double)
-        (update-in [:start-lat] parse-double)
+        (update-in [:ascending-crossing] parse-double-local)
+        (update-in [:start-lat] parse-double-local)
         (update-in [:start-direction] echo-s/orbit-direction->key)
-        (update-in [:end-lat] parse-double)
+        (update-in [:end-lat] parse-double-local)
         (update-in [:end-direction] echo-s/orbit-direction->key))))
 
 (defn- parse-ocsd
   "Parse orbit-calculated-spatial-domain map"
   [ocsd]
   (into ocsd (util/remove-nil-keys
-               {:orbit-number (parse-long (:orbit-number ocsd))
-                :start-orbit-number (parse-integer (:start-orbit-number ocsd))
-                :stop-orbit-number (parse-integer (:stop-orbit-number ocsd))
-                :equator-crossing-longitude (parse-double (:equator-crossing-longitude ocsd))})))
+               {:orbit-number (parse-long-local (:orbit-number ocsd))
+                :start-orbit-number (parse-integer-local (:start-orbit-number ocsd))
+                :stop-orbit-number (parse-integer-local (:stop-orbit-number ocsd))
+                :equator-crossing-longitude (parse-double-local (:equator-crossing-longitude ocsd))})))
 
 (defmethod json-entry->entry :collection
   [concept-type json-entry]
@@ -166,7 +166,7 @@
        :dataset-id dataset-id
        :collection-concept-id collection-concept-id
        :producer-granule-id producer-granule-id
-       :size (parse-double granule-size)
+       :size (parse-double-local granule-size)
        :original-format original-format
        :data-center data-center
        :links (seq links)
@@ -177,7 +177,7 @@
        :online-access-flag online-access-flag
        :browse-flag browse-flag
        :day-night-flag day-night-flag
-       :cloud-cover (parse-double cloud-cover)
+       :cloud-cover (parse-double-local cloud-cover)
        :coordinate-system coordinate-system
        :shapes shapes})))
 

--- a/virtual-product-app/src/cmr/virtual_product/api/routes.clj
+++ b/virtual-product-app/src/cmr/virtual_product/api/routes.clj
@@ -1,19 +1,18 @@
 (ns cmr.virtual-product.api.routes
   "Defines the HTTP URL routes for the application."
-  (:require [compojure.handler :as handler]
-            [compojure.route :as route]
-            [cmr.common-app.api.health :as common-health]
-            [cmr.common-app.api.request-logger :as req-log]
-            [cmr.common-app.api.routes :as common-routes]
-            [compojure.core :refer :all]
-            [ring.middleware.json :as ring-json]
-            [cmr.common.log :refer (debug info warn error)]
-            [cmr.common.api.errors :as errors]
-            [cmr.common.api.context :as context]
-            [cmr.common.mime-types :as mt]
-            [cmr.virtual-product.services.translation-service :as ts]
-            [cmr.virtual-product.services.health-service :as hs]
-            [cmr.common-app.api.request-logger :as req-logger]))
+  (:require
+   [cmr.virtual-product.services.translation-service :as ts]
+   [compojure.core  :refer [GET POST context routes]]
+   [compojure.route :as route]
+   [ring.middleware.json :as ring-json]
+   [cmr.common-app.api.health :as common-health]
+   [cmr.common-app.api.request-logger :as req-log]
+   [cmr.common-app.api.routes :as common-routes]
+   [cmr.common.api.context :as context]
+   [cmr.common.api.errors :as errors]
+   [cmr.common.mime-types :as mt]
+   [cmr.virtual-product.services.health-service :as hs]
+   [compojure.handler :as handler]))
 
 (defn- build-routes [system]
   (routes
@@ -21,7 +20,7 @@
       ;; for NGAP deployment health check
       (GET "/" {} {:status 200})
       (context "/translate-granule-entries" []
-        (POST "/" {:keys [body content-type headers request-context]}
+        (POST "/" {:keys [body content-type _headers request-context]}
           (if (= (mt/mime-type->format content-type) :json)
             {:status 200
              :body (ts/translate request-context (slurp body))}
@@ -41,5 +40,6 @@
       handler/site
       common-routes/pretty-print-response-handler
       ring-json/wrap-json-response
+      req-log/add-body-hashes
       ;; Last in line, but really first for request as they process in reverse
       req-log/add-time-stamp))

--- a/virtual-product-app/src/cmr/virtual_product/api/routes.clj
+++ b/virtual-product-app/src/cmr/virtual_product/api/routes.clj
@@ -1,10 +1,6 @@
 (ns cmr.virtual-product.api.routes
   "Defines the HTTP URL routes for the application."
   (:require
-   [cmr.virtual-product.services.translation-service :as ts]
-   [compojure.core  :refer [GET POST context routes]]
-   [compojure.route :as route]
-   [ring.middleware.json :as ring-json]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
@@ -12,7 +8,11 @@
    [cmr.common.api.errors :as errors]
    [cmr.common.mime-types :as mt]
    [cmr.virtual-product.services.health-service :as hs]
-   [compojure.handler :as handler]))
+   [cmr.virtual-product.services.translation-service :as ts]
+   [compojure.core  :refer [GET POST context routes]]
+   [compojure.handler :as handler]
+   [compojure.route :as route]
+   [ring.middleware.json :as ring-json]))
 
 (defn- build-routes [system]
   (routes

--- a/virtual-product-app/src/cmr/virtual_product/api/routes.clj
+++ b/virtual-product-app/src/cmr/virtual_product/api/routes.clj
@@ -3,6 +3,7 @@
   (:require [compojure.handler :as handler]
             [compojure.route :as route]
             [cmr.common-app.api.health :as common-health]
+            [cmr.common-app.api.request-logger :as req-log]
             [cmr.common-app.api.routes :as common-routes]
             [compojure.core :refer :all]
             [ring.middleware.json :as ring-json]
@@ -11,7 +12,8 @@
             [cmr.common.api.context :as context]
             [cmr.common.mime-types :as mt]
             [cmr.virtual-product.services.translation-service :as ts]
-            [cmr.virtual-product.services.health-service :as hs]))
+            [cmr.virtual-product.services.health-service :as hs]
+            [cmr.common-app.api.request-logger :as req-logger]))
 
 (defn- build-routes [system]
   (routes
@@ -34,7 +36,10 @@
       errors/invalid-url-encoding-handler
       errors/exception-handler
       common-routes/add-request-id-response-handler
+      req-log/log-ring-request ;; Must be after request id
       (context/build-request-context-handler system)
       handler/site
       common-routes/pretty-print-response-handler
-      ring-json/wrap-json-response))
+      ring-json/wrap-json-response
+      ;; Last in line, but really first for request as they process in reverse
+      req-log/add-time-stamp))


### PR DESCRIPTION
# Overview

The JSON Access log does not calculate duration correctly.

### What is the Solution?
The solution was to create a new Ring handler to capture the start time of a request. This handler is called as soon as possible in the Ring chain. Then the Log handler is to be called at the end of the chain and it uses the value to calculate duration.

While in the code, cleaned up the values populated:
* Removed values which are already in the headers
* Added all headers in bulk
* Added now-ms (current time as milliseconds)
* renamed uri to url
* added actual uri from system
* changed remote address so that IP6 and IP4 localhost addresses report as "localhost"

### What areas of the application does this impact?
Common
metadata-db, ingest, search, indexer, bootstrap, virtual-product, access-control

Not changed: mock-echo (port 2999)

A test was changed so as to not issue warnings locally about using command function names (parse-double).

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
