### PR TITLE
CMR-10070: Update documentation and process for local job-router

### DIFF
--- a/job-utilities/job_router/Dockerfile
+++ b/job-utilities/job_router/Dockerfile
@@ -1,6 +1,7 @@
 FROM public.ecr.aws/lambda/python:3.12
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
+COPY service-ports.json ${LAMBDA_TASK_ROOT}
 
 RUN pip3 install -r requirements.txt
 

--- a/job-utilities/job_router/README.md
+++ b/job-utilities/job_router/README.md
@@ -22,9 +22,17 @@ A manual deployment of the zip package is easy. Simply go to the job-router Lamb
 
 ## Testing/Running locally
 
-The job-router Lambda can be tested locally by building the docker image and using the run-docker.sh script. Testing from local is fine,
-but there's not much reason to actually use this code as a regular part of local dev, since it just routes to endpoints that are directly
-available to local development.
+Build the docker image with `docker build . -t job-router` then run it with `./run-docker.sh`. Job-router will now be running on a locally running docker container built upon the AWS lambda image.
+With the docker container running, commands need to be sent as 
+```curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '
+        {                         
+            "endpoint" : "endpoint",
+            "service" : "service",
+            "single-target" : true|false,
+            "request-type" : "POST|GET"
+        }'```
+Available payloads can be found in the `../job-details.json` file as the `"target"` item in each job listing.
+
 
 ## Invoking
 
@@ -33,11 +41,12 @@ When the Lambda is invoked there are certain fields that are required in the eve
 {
     "service": "service-name",
     "endpoint": "job-endpoint",
-    "single-target": true/false
+    "single-target": true/false,
+    "request-type": "REST request type"
 }
 ```
 
 service - The service that the job needs to be run for (Bootstrap, Ingest, Search, etc.)
 endpoint - The endpoint for the job to be run (i.e, if the service is "bootstrap" and the KMS cache needs to be refreshed, the endpoint is "caches/refresh/kms")
-single-target - Some jobs need to run on a single instance of a service, others need to be run on all instances of a service. true will run on a single instance,
-                false will hit each instance
+single-target - Some jobs need to run on a single instance of a service, others need to be run on all instances of a service. true will run on a single instance, false will hit each instance
+request-type - The REST request type required for the service endpoint

--- a/job-utilities/job_router/lambda_function.py
+++ b/job-utilities/job_router/lambda_function.py
@@ -4,11 +4,12 @@ an AWS EventBridge rule and make a call to an endpoint
 for running scheduled jobs. These endpoints could be through
 a load balancer or directly to an ECS service
 """
+import json
 import os
 import sys
+
 import boto3
 import urllib3
-import json
 import jmespath
 
 def handler(event, _):
@@ -36,11 +37,13 @@ def handler(event, _):
         sys.exit(1)
 
     if environment == 'local':
-        json_file = open('service-ports.json')
+        json_file = open('service-ports.json', encoding="UTF-8")
         service_ports = json.load(json_file)
 
         token = 'mock-echo-system-token'
-        pool_manager = urllib3.PoolManager(num_pools=1, headers={"Authorization": token}, timeout=urllib3.Timeout(15))
+        pool_manager = urllib3.PoolManager(num_pools=1, \
+                                           headers={"Authorization": token}, \
+                                           timeout=urllib3.Timeout(15))
 
         print("Sending to: " + "host.docker.internal:" + service_ports[service] + "/" + endpoint)
         try:

--- a/job-utilities/job_router/lambda_function.py
+++ b/job-utilities/job_router/lambda_function.py
@@ -18,7 +18,7 @@ def handler(event, _):
     Some environment variables are required.
     These should be set on the deployed Lambda.
     CMR_ENVIRONMENT - Where the Lambda is deployed
-    CMR_LB_URL - The LB used for routing calls to CMR
+    CMR_LB_NAME - The LB used for routing calls to CMR
     """
     environment = os.getenv('CMR_ENVIRONMENT')
     cmr_lb_name = os.getenv('CMR_LB_NAME')

--- a/job-utilities/job_router/run-docker.sh
+++ b/job-utilities/job_router/run-docker.sh
@@ -1,4 +1,6 @@
-docker run --platform linux/amd64 \
+docker run \
 -p 9000:8080 \
 -e AWS_DEFAULT_REGION=us-east-1 \
+-e CMR_ENVIRONMENT=local \
+-e CMR_LB_NAME=https://localhost \
 job-router

--- a/job-utilities/job_router/service-ports.json
+++ b/job-utilities/job_router/service-ports.json
@@ -1,0 +1,9 @@
+{
+    "metadata-db" : "3001",
+    "ingest" : "3002",
+    "search" : "3003",
+    "indexer" : "3004",
+    "bootstrap" : "3006",
+    "virtual-product" : "3009",
+    "access-control" : "3011"
+}


### PR DESCRIPTION
# Overview
Update documentation and process for local job-router
### What is the feature/fix?

Documentation for local usage of job-router was poor, and the code was in fact not set up properly for testing it locally

### What is the Solution?

Documentation has been updated and code added to allow for basic local testing

### What areas of the application does this impact?

job-router

# Checklist

- [N/A] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [N/A] clj-kondo has been run locally and all errors corrected
- [N/A] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [N/A] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
