### PR TITLE
CMR-9443: Reduce size of Elasticsearch query return on some calls with unlimited page size

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -85,7 +85,8 @@
                 highlights
                 scroll
                 scroll-id
-                search-after]} query
+                search-after
+                remove-source]} query
         scroll-timeout (when scroll (es-config/elastic-scroll-timeout))
         search-type (if scroll
                       (es-config/elastic-scroll-search-type)
@@ -100,7 +101,7 @@
      :sort sort-params
      :size page-size
      :from offset
-     :_source fields
+     :_source (if (nil? remove-source) fields false)
      :aggs aggregations
      :scroll scroll-timeout
      :scroll-id scroll-id

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -57,7 +57,8 @@
   (let [condition (qm/string-conditions :consortiums ["CWIC"])
         query (qm/query {:concept-type :collection
                          :condition condition
-                         :page-size :unlimited})
+                         :page-size :unlimited
+                         :remove-source true})
         results (common-esi/execute-query context query)]
     (into {}
           (for [coll-id (map :_id (get-in results [:hits :hits]))]
@@ -70,7 +71,8 @@
                                     (common-config/opensearch-consortiums)))
         query (qm/query {:concept-type :collection
                          :condition condition
-                         :page-size :unlimited})
+                         :page-size :unlimited
+                         :remove-source true})
         results (common-esi/execute-query context query)]
     (into {}
           (for [coll-id (map :_id (get-in results [:hits :hits]))]


### PR DESCRIPTION
# Overview
Reduce size of Elasticsearch query return on some calls with unlimited page size
### What is the feature/fix?

Elasticsearch queries in get-cwic-collections and get-opensearch-collections are sometimes returning really large batches of data that cause memory issues

### What is the Solution?

Added an option in the CMR query setup that allows for `_source` to be set to `false`, which causes Elasticsearch to not return the data body as it isn't needed for the changed functions

### What areas of the application does this impact?

Search app

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
