### PR TITLE
CMR-10100: Adding debug logging to help trouble shoot deleting granule DSEs ...

### DIFF
--- a/common-lib/src/cmr/common/mime_types.clj
+++ b/common-lib/src/cmr/common/mime_types.clj
@@ -63,7 +63,7 @@
 ;; left. To keep the linters happy, please declare any var that will be used in this namespace from
 ;; this function.
 (declare json umm-json umm-json-results legacy-umm-json timeline xml form-url-encoded echo10
-         iso-smap iso19115 dif dif10 csv html atom kml opendatastac native edn opendap octet-stream
+         iso-smap iso19115 dif dif10 csv html atom kml opendata stac native edn opendap octet-stream
          shapefile geojson multi-part-form)
 (def ^:private base-format->mime-type
   "A map of format keywords to MIME types. Each keyword will have a corresponding var def'ed in this

--- a/indexer-app/src/cmr/indexer/config.clj
+++ b/indexer-app/src/cmr/indexer/config.clj
@@ -3,6 +3,14 @@
    [cmr.common.config :as cfg :refer [defconfig]]
    [cmr.message-queue.config :as rmq-conf]))
 
+;; This is here to remove linter unresolved variable error.
+(declare index-queue-name index-queue-listener-count all-revisions-index-queue-name
+         all-revisions-index-queue-listener-count deleted-granule-index-queue-name
+         deleted-granules-index-queue-listener-count provider-queue-name provider-queue-listener-count
+         ingest-exchange-name provider-exchange-name deleted-concept-revision-exchange-name
+         deleted-granule-exchange-name indexer-nrepl-port ongoing-days reduced-indexer-log)
+
+
 ;; index name and config for storing index-set requests
 ;; index the request after creating all of the requested indices successfully
 ;; foot print of this index will remain small

--- a/indexer-app/src/cmr/indexer/services/event_handler.clj
+++ b/indexer-app/src/cmr/indexer/services/event_handler.clj
@@ -2,7 +2,9 @@
   "Provides functions for subscribing to and handling events."
   (:require
    [cmr.common.concepts :as cc]
+   [cmr.common.log :refer [debug]]
    [cmr.common.services.errors :as errors]
+   [cmr.common.util :as util]
    [cmr.indexer.config :as config]
    [cmr.indexer.data.collection-granule-aggregation-cache :as cgac]
    [cmr.indexer.data.concepts.deleted-granule :as deleted-granule]
@@ -22,10 +24,15 @@
   [context {:keys [provider-id force-version? all-revisions-index?]}]
   ;; We set the refresh acls flag to false because the ACLs should have been refreshed as part
   ;; of the ingest job that kicks this off.
-  (indexer/reindex-provider-collections
-    context [provider-id] {:all-revisions-index? all-revisions-index?
-                           :refresh-acls? false
-                           :force-version? force-version?}))
+  (let [[tm result] (util/time-execution
+                     (indexer/reindex-provider-collections
+                      context [provider-id] {:all-revisions-index? all-revisions-index?
+                                             :refresh-acls? false
+                                             :force-version? force-version?}))]
+    (debug (format (str "Timed function %s handle-provider-event provider-collection-reindexing "
+                        "all-revisions-index? %s took %d ms.") 
+                   (str *ns*) all-revisions-index? tm))
+    result))
 
 (defmethod handle-provider-event :provider-autocomplete-suggestion-reindexing
   [context {:keys [provider-id]}]
@@ -59,45 +66,67 @@
 (defmethod handle-ingest-event :concept-update
   [context all-revisions-index? {:keys [concept-id revision-id more-concepts]}]
   ;; combine concept-id revision-id with more-concepts
-  (let [all-concepts (conj more-concepts {:concept-id concept-id :revision-id revision-id})]
-    (doseq [{:keys [concept-id revision-id]} all-concepts]
-      (if (= :humanizer (cc/concept-id->type concept-id))
-        (indexer/update-humanizers context)
-        (indexer/index-concept-by-concept-id-revision-id
-         context concept-id revision-id {:ignore-conflict? true
-                                         :all-revisions-index? all-revisions-index?})))))
+  (let [all-concepts (conj more-concepts {:concept-id concept-id :revision-id revision-id})
+        [tm _result] (util/time-execution
+                     (doseq [{:keys [concept-id revision-id]} all-concepts]
+                       (if (= :humanizer (cc/concept-id->type concept-id))
+                         (indexer/update-humanizers context)
+                         (indexer/index-concept-by-concept-id-revision-id
+                          context concept-id revision-id {:ignore-conflict? true
+                                                          :all-revisions-index? all-revisions-index?}))))]
+    (debug (format (str "Timed function %s handle-ingest-event concept-update for %d concepts for concept-id %s "
+                        "revision-id %s all-revisions-index? %s took %d ms.")
+                   (str *ns*) (count all-concepts) concept-id revision-id all-revisions-index? tm))))
 
 (defmethod handle-ingest-event :concept-delete
   [context all-revisions-index? {:keys [concept-id revision-id]}]
   (when-not (= :humanizer (cc/concept-id->type concept-id))
-    (indexer/delete-concept
-      context concept-id revision-id {:ignore-conflict? true
-                                      :all-revisions-index? all-revisions-index?})))
+    (let [[tm result] (util/time-execution
+                        (indexer/delete-concept
+                         context concept-id revision-id {:ignore-conflict? true
+                                                         :all-revisions-index? all-revisions-index?}))]
+      (debug (format (str "Timed function %s handle-ingest-event concept-delete for concept-id %s "
+                          "revision-id %s all-revisions-index? %s took %d ms.")
+                     (str *ns*) concept-id revision-id all-revisions-index? tm))
+      result)))
 
 (defmethod handle-ingest-event :tombstone-delete
   [context _all-revisions-index? {:keys [concept-id revision-id]}]
   (when (= :granule (cc/concept-id->type concept-id))
-    (deleted-granule/remove-deleted-granule context concept-id revision-id
-                                            {:ignore-conflict? true})))
+    (let [[tm result] (util/time-execution
+                       (deleted-granule/remove-deleted-granule context concept-id revision-id
+                                                               {:ignore-conflict? true}))]
+      (debug (format "Timed function %s handle-ingest-event tombstone-delete for concept-id %s revision-id %s took %d ms."
+                     (str *ns*) concept-id revision-id tm))
+      result)))
 
 (defmethod handle-ingest-event :concept-revision-delete
   [context all-revisions-index? {:keys [concept-id revision-id]}]
   (when-not (= :humanizer (cc/concept-id->type concept-id))
-
-      ;; We should never receive a message that's not for the all revisions index
-      (when-not all-revisions-index?
-        (errors/internal-error!
-          (format (str "Received :concept-revision-delete event that wasn't for the all revisions "
-                       "index.  concept-id: %s revision-id: %s")
-                  concept-id revision-id)))
-      (indexer/force-delete-all-concept-revision context concept-id revision-id)))
+    ;; We should never receive a message that's not for the all revisions index
+    (when-not all-revisions-index?
+      (errors/internal-error!
+       (format (str "Received :concept-revision-delete event that wasn't for the all revisions "
+                    "index.  concept-id: %s revision-id: %s")
+               concept-id revision-id)))
+    (let [[tm result] (util/time-execution
+                       (indexer/force-delete-all-concept-revision context concept-id revision-id))]
+      (debug (format (str "Timed function %s handle-ingest-event concept-revision-delete for concept-id %s "
+                          "revision-id %s took %d ms.")
+                     (str *ns*) concept-id revision-id tm))
+      result)))
 
 (defmethod handle-ingest-event :expire-concept
   [context all-revisions-index? {:keys [concept-id revision-id]}]
   (when (= :granule (cc/concept-id->type concept-id))
-    (indexer/delete-concept
-      context concept-id revision-id {:ignore-conflict? true
-                                      :all-revisions-index? all-revisions-index?})))
+    (let [[tm result] (util/time-execution
+                       (indexer/delete-concept
+                        context concept-id revision-id {:ignore-conflict? true
+                                                        :all-revisions-index? all-revisions-index?}))]
+      (debug (format (str "Timed function %s handle-ingest-event expire-concept for concept-id %s "
+                          "revision-id %s all-revisions-index? %s took %d ms.")
+                     (str *ns*) concept-id revision-id all-revisions-index? tm))
+      result)))
 
 (defn subscribe-to-events
   "Subscribe to event messages on various queues"


### PR DESCRIPTION
Also fixed a few linting issues in the same files.

# Overview

### What is the feature/fix?

Adding debug logging to help trouble shoot deleting granule DSEs

### What is the Solution?

Adding debug logging to help trouble shoot deleting granule DSEs

### What areas of the application does this impact?

indexer/event_handler and Index_service.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
