### PR TITLE
CMR-9842: Changing Sub/Not email to use EMCC AWS SES.

### DIFF
--- a/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
+++ b/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
@@ -56,17 +56,27 @@
 
 (defconfig email-server-port
   "The port number for email server."
-  {:default 25
+  {:default 465
    :type Long})
+
+(defconfig ses-user
+  "The port number for email server."
+  {:default ""
+   :type String})
+
+(defconfig ses-password
+  "The port number for email server."
+  {:default ""
+   :type String})
 
 (defconfig subscriptions-limit
   "The subscription limit for a single non-admin subscriber id."
   {:default 100
    :type Long})
 
-(defconfig mail-sender
+(defconfig ses-mail-sender
   "The email sender's email address."
-  {:default ""
+  {:default "noreply@nasa.gov"
    :type String})
 
 (defconfig email-subscription-processing-interval
@@ -243,8 +253,13 @@
      (when (seq subscriber-filtered-concept-refs)
        (let [concept-ref-locations (map :location subscriber-filtered-concept-refs)
              email-address (urs/get-user-email context subscriber-id)
-             email-content (create-email-content sub-type (mail-sender) email-address concept-ref-locations subscription)
-             email-settings {:host (email-server-host) :port (email-server-port)}]
+             email-content (create-email-content sub-type (ses-mail-sender) email-address concept-ref-locations subscription)
+             email-settings {:host (email-server-host)
+                             :port (email-server-port)
+                             :user (ses-user)
+                             :pass (ses-password)
+                             :ssl true
+                             :type "text/html; charset=utf-8"}]
          (try
            (send-email email-settings email-content)
            (info (str "Successfully processed subscription [" sub-id "].


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Changing Sub/Not email to use EMCC AWS SES.

### What is the Solution?

Changing Sub/Not email to use EMCC AWS SES.

### What areas of the application does this impact?

Ingest subscription_helper.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
