### PR TITLE
CMR-10058: job-utilities/job-router bumping up urllib3 from version 1.26.18 to version 1.26.19

### DIFF
--- a/job-utilities/job_router/requirements.txt
+++ b/job-utilities/job_router/requirements.txt
@@ -1,3 +1,3 @@
 boto3
-urllib3==1.26.18
+urllib3==1.26.19
 jmespath


### PR DESCRIPTION
# Overview

### What is the feature/fix?

 job-utilities/job-router bumping up urllib3 from version 1.26.18 to version 1.26.19

### What is the Solution?

 job-utilities/job-router bumping up urllib3 from version 1.26.18 to version 1.26.19

### What areas of the application does this impact?

job-utilities/job-router

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [X] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
