### PR TITLE
CMR-10134 Adding in the new subscription schema and setting the subscription cache when the ingest subscriptions are added or deleted.

### DIFF
--- a/common-lib/src/cmr/common/hash_cache.clj
+++ b/common-lib/src/cmr/common/hash_cache.clj
@@ -57,6 +57,10 @@
     [cache cache-key field-value-map]
      "Inserts a set of fields and values into a hashmap.")
 
+  (remove-value
+   [cache cache-key field]
+   "Removes the field from the hash cache.")
+
   (cache-size
    [cache cache-key]
    "Returns the size of the cache in bytes."))

--- a/ingest-app/src/cmr/ingest/api/routes.clj
+++ b/ingest-app/src/cmr/ingest/api/routes.clj
@@ -42,7 +42,7 @@
         ;; Dev dockerfile manually creates /app/cmr-files to store the unzipped cmr jar so that drift
         ;; can find the migration files correctly
         ;; we had to force method change in drift to set the correct path
-        (if (not (instance? cmr.ingest.data.memory_db.ACLHashMemoryStore db))
+        (when (not (instance? cmr.ingest.data.memory_db.ACLHashMemoryStore db))
           (try
             ;; trying non-local path to find drift migration files
             (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/drift-migration-files")))]
@@ -242,21 +242,17 @@
        (context ["/subscriptions"] []
          (POST "/"
            request
-           (subscriptions/create-subscription
-            provider-id request)))
+           (subscriptions/create-subscription request)))
        (context ["/subscriptions/:native-id" :native-id #".*$"] [native-id]
          (POST "/"
            request
-           (subscriptions/create-subscription-with-native-id
-            provider-id native-id request))
+           (subscriptions/create-subscription-with-native-id native-id request))
          (PUT "/"
            request
-           (subscriptions/create-or-update-subscription-with-native-id
-            provider-id native-id request))
+           (subscriptions/create-or-update-subscription-with-native-id native-id request))
          (DELETE "/"
            request
-           (subscriptions/delete-subscription
-            provider-id native-id request)))
+           (subscriptions/delete-subscription native-id request)))
 
        ;; Generic documents are by pattern: /providers/{prov_id}/{concept-type}/{native_id}
        (context ["/:concept-type"

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -311,7 +311,6 @@
   (let [parsed (json/parse-string (:metadata sub-concept) true)
         provider-id (get-provider-id parsed)
         subscriber-id (get-subscriber-id context parsed)
-        _ (println "The parsed subscription is:" parsed)
         parsed (if (and (= nil (:Query parsed))
                         (= "granule" (:Type parsed)))
                  (assoc parsed :Query (str "collection-concept-id=" (:CollectionConceptId parsed)))

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -310,7 +310,12 @@
   (perform-basic-validations sub-concept)
   (let [parsed (json/parse-string (:metadata sub-concept) true)
         provider-id (get-provider-id parsed)
-        subscriber-id (get-subscriber-id context parsed)]
+        subscriber-id (get-subscriber-id context parsed)
+        _ (println "The parsed subscription is:" parsed)
+        parsed (if (and (= nil (:Query parsed))
+                        (= "granule" (:Type parsed)))
+                 (assoc parsed :Query (str "collection-concept-id=" (:CollectionConceptId parsed)))
+                 parsed)]
     (when-not (= CMR_PROVIDER provider-id)
       (api-core/verify-provider-exists context provider-id))
     (validate-user-id context subscriber-id)
@@ -325,72 +330,66 @@
 
 (defn create-subscription
   "Processes a request to create a subscription. A native id will be generated."
-  ([request]
-   (create-subscription nil request))
-  ([_provider-id request]
-   (let [{:keys [body content-type headers request-context]} request]
-     (common-ingest-checks request-context)
-     (let [tmp-subscription (body->subscription (str (UUID/randomUUID)) body content-type headers)
-           {:keys [concept parsed]} (validate-and-prepare-subscription-concept
-                                     request-context tmp-subscription)
-           provider-id (:provider-id concept)
-           subscriber-id (:SubscriberId parsed)
-           native-id (get-unique-native-id request-context parsed)
-           final-sub (assoc concept :native-id native-id)]
-       (check-ingest-permission request-context provider-id subscriber-id)
-       (perform-subscription-ingest request-context headers final-sub parsed)))))
+  [request]
+  (let [{:keys [body content-type headers request-context]} request]
+    (common-ingest-checks request-context)
+    (let [tmp-subscription (body->subscription (str (UUID/randomUUID)) body content-type headers)
+          {:keys [concept parsed]} (validate-and-prepare-subscription-concept
+                                    request-context tmp-subscription)
+          provider-id (:provider-id concept)
+          subscriber-id (:SubscriberId parsed)
+          native-id (get-unique-native-id request-context parsed)
+          final-sub (assoc concept :native-id native-id)]
+      (check-ingest-permission request-context provider-id subscriber-id)
+      (perform-subscription-ingest request-context headers final-sub parsed))))
 
 (defn create-subscription-with-native-id
   "Processes a request to create a subscription using the native-id provided."
-  ([native-id request]
-   (create-subscription-with-native-id nil native-id request))
-  ([_provider-id native-id request]
-   (validate-native-id-not-blank native-id)
-   (let [{:keys [body content-type headers request-context]} request]
-     (common-ingest-checks request-context)
-     (let [tmp-subscription (body->subscription native-id body content-type headers)
-           {:keys [concept parsed]} (validate-and-prepare-subscription-concept
-                                     request-context tmp-subscription)
-           provider-id (:provider-id concept)
-           subscriber-id (:SubscriberId parsed)]
-       (check-ingest-permission request-context provider-id subscriber-id)
-       (when (native-id-collision? request-context native-id)
-         (errors/throw-service-error
-          :conflict
-          (format "Subscription with native-id [%s] already exists." (util/html-escape native-id))))
-       (perform-subscription-ingest request-context headers concept parsed)))))
+  [native-id request]
+  (validate-native-id-not-blank native-id)
+  (let [{:keys [body content-type headers request-context]} request]
+    (common-ingest-checks request-context)
+    (let [tmp-subscription (body->subscription native-id body content-type headers)
+          {:keys [concept parsed]} (validate-and-prepare-subscription-concept
+                                    request-context tmp-subscription)
+          provider-id (:provider-id concept)
+          subscriber-id (:SubscriberId parsed)]
+      (check-ingest-permission request-context provider-id subscriber-id)
+      (when (native-id-collision? request-context native-id)
+        (errors/throw-service-error
+         :conflict
+         (format "Subscription with native-id [%s] already exists." (util/html-escape native-id))))
+      (perform-subscription-ingest request-context headers concept parsed))))
 
 (defn create-or-update-subscription-with-native-id
   "Processes a request to create or update a subscription. This function
   does NOT fail on collisions. This is mapped to PUT methods to preserve
   existing functionality."
-  ([native-id request]
-   (create-or-update-subscription-with-native-id nil native-id request))
-  ([_provider-id native-id request]
-   (validate-native-id-not-blank native-id)
-   (let [{:keys [body content-type headers request-context]} request
-         _ (common-ingest-checks request-context)
-         tmp-subscription (body->subscription native-id body content-type headers)
-         {:keys [concept parsed]} (validate-and-prepare-subscription-concept
-                                   request-context tmp-subscription)
-         provider-id (:provider-id concept)
-         subscriber-id (:SubscriberId parsed)
-         original-subscription (->> (mdb/find-concepts request-context
-                                                       {:native-id native-id
-                                                        :exclude-metadata false
-                                                        :latest true}
-                                                       :subscription)
-                                    (remove :deleted)
-                                    first)
-         old-subscriber (when original-subscription
-                          (get-in original-subscription [:extra-fields :subscriber-id]))]
-     (check-ingest-permission request-context provider-id subscriber-id old-subscriber)
-     (perform-subscription-ingest request-context headers concept parsed))))
+  [native-id request]
+  (validate-native-id-not-blank native-id)
+  (let [{:keys [body content-type headers request-context]} request
+        _ (common-ingest-checks request-context)
+        tmp-subscription (body->subscription native-id body content-type headers)
+        {:keys [concept parsed]} (validate-and-prepare-subscription-concept
+                                  request-context tmp-subscription)
+        provider-id (:provider-id concept)
+        subscriber-id (:SubscriberId parsed)
+        original-subscription (->> (mdb/find-concepts request-context
+                                                      {:native-id native-id
+                                                       :exclude-metadata false
+                                                       :latest true}
+                                                      :subscription)
+                                   (remove :deleted)
+                                   first)
+        old-subscriber (when original-subscription
+                         (get-in original-subscription [:extra-fields :subscriber-id]))]
+    (check-ingest-permission request-context provider-id subscriber-id old-subscriber)
+    (perform-subscription-ingest request-context headers concept parsed)))
 
 (defn- prepare-delete-request
   "Validate the native-id for delete,
   return [provider-id subscriber-id] if the delete request can be processed."
-  [context provider-id native-id]
+  [context native-id]
   (let [sub-concepts (mdb/find-concepts context
                                         {:native-id native-id
                                          :exclude-metadata false
@@ -402,9 +401,7 @@
           ;; there is a concept to delete, figure out the provider-id and subscriber-id
           (let [provider-id (if (= "collection" (get-in sub-concept [:extra-fields :subscription-type]))
                               CMR_PROVIDER
-                              (if provider-id
-                                provider-id
-                                (get-provider-id (json/parse-string (:metadata sub-concept) true))))
+                              (get-provider-id (json/parse-string (:metadata sub-concept) true)))
                 subscriber-id (get-in sub-concept [:extra-fields :subscriber-id])]
             [provider-id subscriber-id])
           (errors/throw-service-error
@@ -416,22 +413,20 @@
 
 (defn delete-subscription
   "Deletes the subscription with the given provider id and native id."
-  ([native-id request]
-   (delete-subscription nil native-id request))
-  ([provider-id native-id request]
-   (let [{:keys [headers request-context]} request
-         _ (common-ingest-checks request-context)
-         [provider-id subscriber-id] (prepare-delete-request request-context provider-id native-id)
-         concept-attribs (-> {:provider-id provider-id
-                              :native-id native-id
-                              :concept-type :subscription}
-                             (api-core/set-revision-id headers)
-                             (api-core/set-user-id request-context headers))]
-     (check-ingest-permission request-context provider-id subscriber-id)
-     (info (format "Deleting subscription %s from client %s"
-                   (pr-str concept-attribs) (:client-id request-context)))
-     (api-core/generate-ingest-response headers
-                                        (api-core/format-and-contextualize-warnings-existing-errors
-                                          (ingest/delete-concept
-                                           request-context
-                                           concept-attribs))))))
+  [native-id request]
+  (let [{:keys [headers request-context]} request
+        _ (common-ingest-checks request-context)
+        [provider-id subscriber-id] (prepare-delete-request request-context native-id)
+        concept-attribs (-> {:provider-id provider-id
+                             :native-id native-id
+                             :concept-type :subscription}
+                            (api-core/set-revision-id headers)
+                            (api-core/set-user-id request-context headers))]
+    (check-ingest-permission request-context provider-id subscriber-id)
+    (info (format "Deleting subscription %s from client %s"
+                  (pr-str concept-attribs) (:client-id request-context)))
+    (api-core/generate-ingest-response headers
+                                       (api-core/format-and-contextualize-warnings-existing-errors
+                                        (ingest/delete-concept
+                                         request-context
+                                         concept-attribs)))))

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -59,7 +59,7 @@
 (defconfig subscription-umm-version
   "Defines the latest subscription umm version accepted by ingest - it's the latest official version.
    This environment variable needs to be manually set when newer UMM version becomes official"
-  {:default "1.1"})
+  {:default "1.1.1"})
 
 (defn ingest-accept-umm-version
   "Returns the latest umm version accepted by ingest for the given concept-type."

--- a/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
@@ -13,7 +13,9 @@
                   :collection-concept-id (:CollectionConceptId subscription)
                   :subscriber-id (:SubscriberId subscription)
                   :subscription-type (or (:Type subscription) "granule")
-                  :normalized-query (:normalized-query concept)}))
+                  :normalized-query (:normalized-query concept)
+                  :endpoint (:EndPoint subscription)
+                  :mode (:Mode subscription)}))
 
 (declare save-subscription)
 #_{:clj-kondo/ignore [:unresolved-symbol]}

--- a/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
+++ b/ingest-app/src/cmr/ingest/services/subscriptions_helper.clj
@@ -280,6 +280,7 @@
   ([context revision-date-range]
    (let [subscriptions (->> (mdb/find-concepts context {:latest true} :subscription)
                             (remove :deleted)
+                            (remove #(:endpoint (:extra-fields %)))
                             (map #(select-keys % [:concept-id :extra-fields :metadata])))]
      (send-subscription-emails context (process-subscriptions context subscriptions revision-date-range) (nil? revision-date-range)))))
 

--- a/metadata-db-app/src/cmr/metadata_db/config.clj
+++ b/metadata-db-app/src/cmr/metadata_db/config.clj
@@ -101,3 +101,7 @@
                      (ingest-exchange-name)
                      (access-control-exchange-name)
                      (deleted-granule-exchange-name)]))
+
+(defconfig ingest-subscription-enabled
+  "This indicates whether or not ingest granule subscriptions are enabled."
+  {:default true :type Boolean})

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -22,6 +22,7 @@
    [cmr.metadata-db.services.provider-service :as provider-service]
    [cmr.metadata-db.services.provider-validation :as pv]
    [cmr.metadata-db.services.search-service :as search]
+   [cmr.metadata-db.services.subscriptions :as subscriptions]
    [cmr.metadata-db.services.util :as util])
   ;; Required to get code loaded
   ;; XXX This is really awful, and we do it a lot in the CMR. What we've got
@@ -828,6 +829,7 @@
                       (= concept-type :tool-association))
               (ingest-events/publish-event
                context (ingest-events/concept-delete-event revisioned-tombstone)))
+            (subscriptions/delete-subscription context concept-type revisioned-tombstone)
             revisioned-tombstone)))
       (if revision-id
         (cmsg/data-error :not-found
@@ -915,6 +917,8 @@
       (ingest-events/publish-event
        context
        (ingest-events/concept-update-event concept))
+
+      (subscriptions/add-subscription context concept-type concept)
       concept)))
 
 (defn- delete-associated-tag-associations

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
@@ -96,7 +96,7 @@
   can sometimes be nil."
   [concept]
   (nil-fields-validation (apply dissoc (:extra-fields concept)
-                                [:delete-time :version-id :source-revision-id :associated-revision-id :target-provider-id :collection-concept-id])))
+                                [:delete-time :version-id :source-revision-id :associated-revision-id :target-provider-id :collection-concept-id :endpoint :mode])))
 
 (defn concept-id-validation
   [concept]

--- a/metadata-db-app/src/cmr/metadata_db/services/sub_notifications.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/sub_notifications.clj
@@ -22,7 +22,6 @@
   "update a subscription notification record, creating one if needed, complain
   if subscription id is not valid or not found"
   [context subscription-id]
-  (def context context)
   (let [errors (common-concepts/concept-id-validation subscription-id)
         db (mdb-util/context->db context)]
     (if (nil? errors)

--- a/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
@@ -1,0 +1,49 @@
+(ns cmr.metadata-db.services.subscription-cache
+  "Defines common functions and defs for the subscription cache.
+	Structure of the hash-cache is as follows:
+	<collection-concept-id> --> <ingest subscription map>
+
+	Example:
+	'C12344554-PROV1' --> { 'enabled' true|false
+                          'mode'    New|Update|Delete|All} "
+  (:require
+   [cmr.common.hash-cache :as hash-cache]
+   [cmr.common.redis-log-util :as rl-util]
+   [cmr.common.util :as util]
+   [cmr.redis-utils.config :as redis-config]
+   [cmr.redis-utils.redis-hash-cache :as redis-hash-cache]))
+
+(def subscription-cache-key
+  "The cache key to use when storing with caches in the system."
+  "subscription-cache")
+
+(defn create-cache-client
+  "Creates an instance of the cache."
+  []
+  (redis-hash-cache/create-redis-hash-cache {:keys-to-track [subscription-cache-key]
+                                             :read-connection (redis-config/redis-read-conn-opts)
+                                             :primary-connection (redis-config/redis-conn-opts)}))
+
+(defn set-value
+  "Set the collection concept id and its subscription map described at the top."
+  [context field value]
+  (let [cache-client (hash-cache/context->cache context subscription-cache-key)]
+    (hash-cache/set-value cache-client subscription-cache-key field value)))
+
+(defn get-value
+  "Returns the collection-concept-id subscription map which is described at the top."
+  [context collection-concept-id]
+  (let [cache-client (hash-cache/context->cache context subscription-cache-key)
+        [tm value] (util/time-execution
+                    (hash-cache/get-value cache-client subscription-cache-key collection-concept-id))]
+    (rl-util/log-redis-read-complete "ingest-subscription-cache get-value" subscription-cache-key tm)
+    value))
+
+(defn remove-value
+  "Removes the collection-concept-id and its subscription map."
+  [context collection-concept-id]
+  (let [cache-client (hash-cache/context->cache context subscription-cache-key)
+        [tm value] (util/time-execution
+                    (hash-cache/remove-value cache-client subscription-cache-key collection-concept-id))]
+    (rl-util/log-redis-write-complete "ingest-subscription-cache remove-value" subscription-cache-key tm)
+    value))

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -1,0 +1,40 @@
+(ns cmr.metadata-db.services.subscriptions
+  "Buisness logic for subscription processing."
+  (:require
+   [cmr.metadata-db.config :as mdb-config]
+   [cmr.metadata-db.services.subscription-cache :as subscription-cache]))
+
+(def subscriptions-enabled?
+  "Checks to see if ingest subscriptions are enabled."
+  (mdb-config/ingest-subscription-enabled))
+
+(defn subscription-concept?
+  "Checks to see if the passed in concept-type and concept is a subscription concept."
+  [concept-type concept]
+  (and subscriptions-enabled?
+       (= :subscription concept-type)
+       (some? (:endpoint (:extra-fields concept)))))
+
+(defn granule-concept?
+  "Checks to see if the passed in concept-type and concept is a granule concept."
+  [concept-type]
+  (and subscriptions-enabled?
+       (= :granule concept-type)))
+
+(defn delete-subscription 
+  "When a subscription is deleted, the collection-concept-id must be removed 
+  from the subscription cache."
+  [context concept-type revisioned-tombstone]
+  (when (subscription-concept? concept-type revisioned-tombstone)
+    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))]
+       (subscription-cache/remove-value context coll-concept-id))))
+
+(defn add-subscription
+  "When a subscription is added, the collection-concept-id must be put into  
+  the subscription cache."
+  [context concept-type concept]
+  (when (subscription-concept? concept-type concept)
+    (let [coll-concept-id (:collection-concept-id (:extra-fields concept))
+          mode (:mode (:extra-fields concept))]
+      (subscription-cache/set-value context coll-concept-id {"enabled" true
+                                                             "mode" mode}))))

--- a/metadata-db-app/src/cmr/metadata_db/system.clj
+++ b/metadata-db-app/src/cmr/metadata_db/system.clj
@@ -19,6 +19,7 @@
    [cmr.metadata-db.api.routes :as routes]
    [cmr.metadata-db.config :as config]
    [cmr.metadata-db.services.jobs :as mdb-jobs]
+   [cmr.metadata-db.services.subscription-cache :as subscription-cache]
    [cmr.metadata-db.services.util :as mdb-util]
    [cmr.oracle.config :as oracle-config]
    [cmr.oracle.connection :as oracle]
@@ -52,7 +53,8 @@
               :nrepl (nrepl/create-nrepl-if-configured (config/metadata-db-nrepl-port))
               :parallel-chunk-size (config/parallel-chunk-size)
               :caches {acl/token-imp-cache-key (acl/create-token-imp-cache)
-                       common-health/health-cache-key (common-health/create-health-cache)}
+                       common-health/health-cache-key (common-health/create-health-cache)
+                       subscription-cache/subscription-cache-key (subscription-cache/create-cache-client)}
               :scheduler (jobs/create-clustered-scheduler `system-holder :db mdb-jobs/jobs)
               :unclustered-scheduler (jobs/create-scheduler
                                       `system-holder [jvm-info/log-jvm-statistics-job

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscription_cache_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscription_cache_test.clj
@@ -1,0 +1,27 @@
+(ns cmr.metadata-db.test.services.subscription-cache-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [cmr.metadata-db.services.subscription-cache :as subscription-cache]
+   [cmr.common.hash-cache :as hash-cache]
+   [cmr.redis-utils.test.test-util :as test-util]))
+
+(use-fixtures :once test-util/embedded-redis-server-fixture)
+
+(deftest subscription-cache-test
+  (let [cache-key subscription-cache/subscription-cache-key
+        test-context {:system {:caches {cache-key (subscription-cache/create-cache-client)}}}
+        cache (get-in test-context [:system :caches cache-key])]
+    (hash-cache/reset cache cache-key)
+    (testing "Cache is empty"
+      (is (nil? (hash-cache/get-map cache cache-key))))
+    (testing "Add to the cache."
+      (is (= 1 (subscription-cache/set-value test-context "C12345-PROV1" {"enabled" true
+                                                                          "mode" "All"}))))
+    (testing "Get a value"
+      (is (= {"enabled" true
+              "mode" "All"} 
+             (subscription-cache/get-value test-context "C12345-PROV1"))))
+    (testing "Remove a value"
+      (is (= 1 (subscription-cache/remove-value test-context "C12345-PROV1"))))
+    (testing "Validate cache is empty again."
+      (is (is (nil? (hash-cache/get-map cache cache-key)))))))

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
@@ -1,0 +1,33 @@
+(ns cmr.metadata-db.test.services.subscriptions-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [cmr.common.hash-cache :as hash-cache]
+   [cmr.metadata-db.config :as mdb-config]
+   [cmr.metadata-db.services.subscription-cache :as subscription-cache]
+   [cmr.metadata-db.services.subscriptions :as subscriptions] 
+   [cmr.redis-utils.test.test-util :as test-util]))
+
+(use-fixtures :once test-util/embedded-redis-server-fixture)
+
+#_{:clj-kondo/ignore [:unresolved-var]}
+(deftest subscription-cache-test
+  (let [cache-key subscription-cache/subscription-cache-key
+        test-context {:system {:caches {cache-key (subscription-cache/create-cache-client)}}}
+        cache (get-in test-context [:system :caches cache-key])]
+    (hash-cache/reset cache cache-key)
+    (testing "Cache is empty"
+      (is (nil? (hash-cache/get-map cache cache-key))))
+    (testing "Testing if cache is enabled."
+      (let [value (mdb-config/ingest-subscription-enabled)]
+        (is (= value subscriptions/subscriptions-enabled?))))
+    (testing "Testing if a passed in concept is a subscription concept"
+      (is (subscriptions/subscription-concept? :subscription {:extra-fields {:endpoint "some-endpoint"}})))
+    (testing "Testing if a passed in concept is a granule concept"
+      (is (subscriptions/granule-concept? :granule)))
+    (testing "Add a subscription"
+      (is (= 1 (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
+                                                                                          :mode "All"
+                                                                                          :endpoint "some-endpoint"}}))))
+    (testing "Delete a subscription"
+      (is (= 1 (subscriptions/delete-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
+                                                                                             :endpoint "some-endpoint"}}))))))

--- a/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
+++ b/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
@@ -156,5 +156,8 @@
                (set [(get full-map "C1200000003-PROV1") (get full-map "C1200000002-PROV1")]))
              (set (h-cache/get-values rhcache cache-key '("C1200000003-PROV1" "C1200000002-PROV1"))))))
 
-    (testing "Testing getting size back from redis.")
-      (is (= java.lang.Long (type (h-cache/cache-size rhcache cache-key))))))
+    (testing "Testing getting size back from redis."
+      (is (= java.lang.Long (type (h-cache/cache-size rhcache cache-key)))))
+
+    (testing "Testing removing a field from redis."
+      (is (= 1 (h-cache/remove-value rhcache cache-key "C1200000003-PROV1"))))))

--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_subscription.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_subscription.clj
@@ -23,7 +23,16 @@
                :MetadataSpecification
                {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1"
                 :Name "UMM-Sub"
-                :Version "1.1"}}}
+                :Version "1.1"}}
+        "1.1.1" {:Name "someSub"
+                 :Type "granule"
+                 :SubscriberId "someSubId"
+                 :CollectionConceptId "C123-PROV1"
+                 :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+                 :MetadataSpecification
+                 {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1"
+                  :Name "UMM-Sub"
+                  :Version "1.1.1"}}}
        version))
 
 

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -3,14 +3,14 @@
   (:require
    [cheshire.core :as json]
    [clj-http.client :as client]
-   [clojure.test :refer :all]
+   [clojure.test :refer [are deftest is testing use-fixtures]]
    [cmr.common.config :as common-config]
    [cmr.common.util :as util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as e]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.system :as s]
-   [cmr.system-int-test.utils.cache-util :refer :all]
+   [cmr.system-int-test.utils.cache-util :refer [get-cache-value list-cache-keys list-caches-for-app refresh-cache]]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as t-config]))
@@ -19,13 +19,14 @@
   :each (ingest/reset-fixture
          {"prov1guid" "PROV1" "prov2guid" "PROV2" "prov3guid" "PROV3"}))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (deftest cache-apis
   ;; login as a member of group 1
   (let [admin-read-group-concept-id (e/get-or-create-group (s/context) "admin-read-group")
         admin-read-token (e/login (s/context) "admin" [admin-read-group-concept-id])
         normal-user-token (e/login (s/context) "user")
         _ (e/grant-group-admin (s/context) admin-read-group-concept-id :read)
-        coll1 (d/ingest "PROV1" (dc/collection {:entry-title "coll1"}))
+        _ (d/ingest "PROV1" (dc/collection {:entry-title "coll1"}))
         _ (refresh-cache  (url/refresh-index-names-cache-url) (t-config/echo-system-token))]
 
     (testing "list caches"
@@ -46,7 +47,8 @@
                                        "acls"
                                        "indexer-index-set-cache"
                                        "humanizer-cache"]
-        (url/mdb-read-caches-url) ["health"
+        (url/mdb-read-caches-url) ["subscription-cache"
+                                   "health"
                                    "token-imp"]
         (url/ingest-read-caches-url) ["token-user-ids"
                                       "launchpad-user"

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/subscriptions_test.clj
@@ -2,7 +2,7 @@
   "Integration test for CMR bulk index subscription operations."
   (:require
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.bootstrap.bulk-index.core :as core]
    [cmr.system-int-test.data2.core :as d]
@@ -57,11 +57,11 @@
                                                              1)
            ;; create a subscription on a different provider PROV2
            ;; and this subscription won't be indexed as a result of indexing subscriptions of PROV1
-           sub2 (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
-                                                              :Query "instrument=POSEIDON-3"
-                                                              :CollectionConceptId (:concept-id coll1)}
-                                                             {}
-                                                             1)]
+           _ (subscription/ingest-subscription-with-attrs {:provider-id "PROV2"
+                                                           :Query "instrument=POSEIDON-3"
+                                                           :CollectionConceptId (:concept-id coll1)}
+                                                          {}
+                                                          1)]
 
        ;; no index, no hits.
        (is (zero? (:hits (search/find-refs :subscription {}))))
@@ -154,7 +154,7 @@
        (index/wait-until-indexed)
 
        (testing "Subscription concepts are indexed."
-         (let [{:keys [hits refs] :as response} (search/find-refs :subscription {})]
+         (let [{:keys [hits refs]} (search/find-refs :subscription {})]
            (is (= 6 hits))
            (is (= 6 (count refs)))
            ))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/provider/provider_ingest_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider/provider_ingest_permissions_test.clj
@@ -2,7 +2,7 @@
   "Verifies the correct provider ingest permissions are enforced"
   (:require
    [clojure.string :as string]
-   [clojure.test :refer :all]
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]
    [cmr.common.util :refer [are3]]
    [cmr.mock-echo.client.echo-util :as echo-util]
    [cmr.system-int-test.data2.collection :as dc]

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UMM-Sub",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "Name": {
+      "description": "The name of the subscription.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "Type": {
+      "description": "The type of the subscription.",
+      "type": "string",
+      "enum": [
+        "collection",
+        "granule"
+      ]
+    },
+    "SubscriberId": {
+      "description": "The userid of the subscriber.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 30
+    },
+    "EmailAddress": {
+      "description": "The email address of the subscriber.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "CollectionConceptId": {
+      "description": "The collection concept id of the granules subscribed.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "Query": {
+      "description": "The search query for the granules that matches the subscription.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40000
+    },
+    "EndPoint": {
+      "description": "The subscription endpoint receiver that will consume the messages from CMRs topic.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "Mode": {
+      "description": "For the type of granule subscription the mode is whether to be notified of a new,update,delete, or all granules.",
+      "type": "string",
+      "enum": ["New", "Update", "Delete", "All"]
+    },
+    "MetadataSpecification": {
+      "description": "Requires the client, or user, to add in schema information into every subscription record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
+      "$ref": "#/definitions/MetadataSpecificationType"
+    }
+  },
+  "required": [
+    "Name",
+    "Type",
+    "MetadataSpecification"
+  ],
+  "if": {
+    "properties": {
+      "Type": {
+        "const": "granule"
+      }
+    },
+    "required": [
+      "Type"
+    ]
+  },
+  "then": {
+    "required": [
+      "CollectionConceptId"
+    ]
+  },
+  "else": {
+    "not": {
+      "required": [
+        "CollectionConceptId"
+      ]
+    }
+  },
+  "definitions": {
+    "MetadataSpecificationType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object requires any metadata record that is validated by this schema to provide information about the schema.",
+      "properties": {
+        "URL": {
+          "description": "This element represents the URL where the schema lives. The schema can be downloaded.",
+          "type": "string",
+          "enum": ["https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1"]
+        },
+        "Name": {
+          "description": "This element represents the name of the schema.",
+          "type": "string",
+          "enum": ["UMM-Sub"]
+        },
+        "Version": {
+          "description": "This element represents the version of the schema.",
+          "type": "string",
+          "enum": ["1.1.1"]
+        }
+      },
+      "required": ["URL","Name","Version"]
+    }
+  }
+}

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-search-results-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-search-results-json-schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "ItemType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Represents a single item found in search results. It contains some metadata about the item found along with the UMM representing the item. umm won't be present if the item represents a tombstone.",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/MetaType"
+        },
+        "umm": {
+          "$ref": "umm-sub-json-schema.json"
+        }
+      },
+      "required": ["meta"]
+    },
+    "MetaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "CMR level metadata about the item found. This represents data not found in the actual metadata.",
+      "properties": {
+        "provider-id": {
+          "description": "The identity of the provider in the CMR",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[A-Z0-9_]+"
+        },
+        "concept-type": {
+          "description": "The type of item found.",
+          "type": "string",
+          "enum": ["subscription"]
+        },
+        "native-id": {
+          "description": "The id used by the provider to identify this item during ingest.",
+          "type": "string",
+          "minLength": 1
+        },
+        "concept-id": {
+          "description": "The concept id of the item found.",
+          "type": "string",
+          "minLength": 4,
+          "pattern": "[A-Z]+\\d+-[A-Z0-9_]+"
+        },
+        "creation-date": {
+          "description": "The date this concept was created. This would be the creation date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "revision-id": {
+          "description": "A number >= 1 that indicates which revision of the item.",
+          "type": "number"
+        },
+        "revision-date": {
+          "description": "The date this revision was created. This would be the creation or update date of the item in the CMR.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "user-id": {
+          "description": "The id of the user who created this item revision.",
+          "type": "string",
+          "minLength": 1
+        },
+        "deleted": {
+          "description": "Indicates if the item represents a tombstone",
+          "type": "boolean"
+        },
+        "format": {
+          "description": "The mime type of the original metadata",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["provider-id", "concept-type", "creation-date", "native-id", "concept-id", "revision-id", "revision-date"]
+    }
+  },
+  "title": "UMM Search Results",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "hits": {
+      "description": "The total number of items that matched the search.",
+      "type": "number"
+    },
+    "took": {
+      "description": "How long the search took in milliseconds from the time the CMR received the request until it had generated the response. This does not include network traffic time to send the request or return the response.",
+      "type": "number"
+    },
+    "items": {
+      "description": "The list of items matching the result in this page.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ItemType"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["hits", "took", "items"]
+}

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
@@ -21,3 +21,13 @@
   (errors/throw-service-errors
    :bad-request
    [(str "Cannot migrate UMM-Sub v1.1 to v1.0.")]))
+
+(defmethod interface/migrate-umm-version [:subscription "1.1" "1.1.1"]
+  [_context subscription & _]
+  (m-spec/update-version subscription :subscription "1.1.1"))
+
+(defmethod interface/migrate-umm-version [:subscription "1.1.1" "1.1"]
+  [_context subscription & _]
+  (-> subscription
+      (m-spec/update-version :subscription "1.1")
+      (dissoc :Mode :EndPoint)))

--- a/umm-spec-lib/src/cmr/umm_spec/versioning.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/versioning.clj
@@ -18,7 +18,7 @@
    :variable ["1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6" "1.7" "1.8" "1.8.1" "1.8.2" "1.9.0"]
    :service ["1.0" "1.1" "1.2" "1.3" "1.3.1" "1.3.2" "1.3.3" "1.3.4" "1.4" "1.4.1" "1.5.0" "1.5.1" "1.5.2" "1.5.3"]
    :tool ["1.0" "1.1" "1.1.1" "1.2.0"]
-   :subscription ["1.0" "1.1"]})
+   :subscription ["1.0" "1.1" "1.1.1"]})
 
 (def current-collection-version
   "The current version of the collection UMM schema."

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
@@ -25,9 +25,31 @@
     :Name "UMM-Sub"
     :Version "1.1"}})
 
+(def granule-subscription-concept-1_1_1
+  {:Name "subscription-1"
+   :Type "granule"
+   :SubscriberId "subscriber-id-1"
+   :EmailAddress "email-address@cmr.gov"
+   :CollectionConceptId "C1200000005-PROV1"
+   :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+   :EndPoint "arn:aws:sqs:us-east-1:1234455667:TestSNSQueue"
+   :Mode "All"
+   :MetadataSpecification
+   {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1"
+    :Name "UMM-Sub"
+    :Version "1.1.1"}})
+
 (deftest migrate-1_0->1_1
   (is (= granule-subscription-concept-1_1
          (migrate-subscription "1.0" "1.1" granule-subscription-concept-1_0))))
 
 (deftest migrate-1_1->1_0
   (is (thrown? clojure.lang.ExceptionInfo (migrate-subscription "1.1" "1.0" granule-subscription-concept-1_1))))
+
+(deftest migrate-1_1->1_1_1
+  (is (= (dissoc granule-subscription-concept-1_1_1 :Mode :EndPoint)
+         (migrate-subscription "1.1" "1.1.1" granule-subscription-concept-1_1))))
+
+(deftest migrate-1_1_1->1_1
+  (is (= granule-subscription-concept-1_1
+         (migrate-subscription "1.1.1" "1.1" granule-subscription-concept-1_1_1))))


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Adding in the new subscription schema and setting the subscription cache when the ingest subscriptions are added or deleted.

### What is the Solution?

Adding in the new subscription schema and setting the subscription cache when the ingest subscriptions are added or deleted.

### What areas of the application does this impact?

Ingest, subscriptions, metadata_db

# Checklist

- [X] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [X] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [X] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
