### PR TITLE
CMR-10139: Updated code to remove subscription information from redis cache upon subscription delete. Updated schema to allow multiple modes.

### DIFF
--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -326,6 +326,7 @@
             (Long/parseLong (str milliseconds))
             all-value)))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn- send-time-to-visibility-log
   "Send either a JSON message as a report or the original log entry to info."
   [concept-id revision-id ms-durration all-revisions-index?]
@@ -337,15 +338,16 @@
   "Add a log message indicating the time it took to go from ingest to completed indexing."
   [{:keys [concept-id revision-id revision-date]} options]
   (let [now (tk/now)
-        {:keys [all-revisions-index?]} options
-        rev-datetime (f/parse (f/formatters :date-time) revision-date)
-        ms-duration (t/in-millis (t/interval rev-datetime now))]
-
+        rev-datetime (f/parse (f/formatters :date-time) revision-date)]
     ;; Guard against revision-date that is set to the future by a provider or a test.
+    ;; if the interval is set before with rev-datetime later an exception will be thrown.
     (if (t/before? rev-datetime now)
-      ;; WARNING: Splunk is dependent on this log message. DO NOT change this without updating
-      ;; Splunk searches used by ops.
-      (send-time-to-visibility-log concept-id revision-id ms-duration all-revisions-index?)
+      (let [{:keys [all-revisions-index?]} options
+            interval (t/interval rev-datetime now)
+            ms-duration (t/in-millis interval)]
+        ;; WARNING: Splunk is dependent on this log message. DO NOT change this without updating
+        ;; Splunk searches used by ops.
+        (send-time-to-visibility-log concept-id revision-id ms-duration all-revisions-index?))
       (warn (format
              "Cannot compute time from ingest to search visibility for [%s] with revision date [%s]."
              concept-id
@@ -833,6 +835,7 @@
          (concept-mapping-types concept-type)
          {:term {(query-field->elastic-field :provider-id concept-type) provider-id}})))))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (defn publish-provider-event
   "Put a provider event on the message queue."
   [context msg]
@@ -881,6 +884,7 @@
   (es/update-indexes context params)
   (reset-index-set-mappings-cache context))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (def health-check-fns
   "A map of keywords to functions to be called for health checks"
   {:elastic_search #(es-util/health % :db)

--- a/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/subscription.clj
@@ -15,7 +15,8 @@
                   :subscription-type (or (:Type subscription) "granule")
                   :normalized-query (:normalized-query concept)
                   :endpoint (:EndPoint subscription)
-                  :mode (:Mode subscription)}))
+                  :mode (:Mode subscription)
+                  :method (:Method subscription)}))
 
 (declare save-subscription)
 #_{:clj-kondo/ignore [:unresolved-symbol]}

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -13,6 +13,7 @@
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-oracle-lib "0.1.0-SNAPSHOT"]
+                 [nasa-cmr/cmr-redis-utils-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-schemas "0.0.1-SNAPSHOT"]
                  [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.11.2"]

--- a/metadata-db-app/src/cmr/metadata_db/api/routes.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/routes.clj
@@ -10,14 +10,14 @@
    [cmr.common.api.context :as context]
    [cmr.common.api.errors :as errors]
    [cmr.common.cache :as cache]
-   [cmr.common.log :refer (debug info warn error)]
+   [cmr.common.log :refer (info)]
    [cmr.metadata-db.api.concepts :as concepts-api]
    [cmr.metadata-db.api.provider :as provider-api]
    [cmr.metadata-db.api.subscriptions :as subscription-api]
    [cmr.metadata-db.services.concept-service :as concept-service]
    [cmr.metadata-db.services.health-service :as hs]
    [cmr.metadata-db.services.jobs :as mdb-jobs]
-   [compojure.core :refer :all]
+   [compojure.core :refer [GET POST context routes]]
    [compojure.route :as route]
    [drift.core]
    [drift.execute]
@@ -54,12 +54,12 @@
         ;; Dev dockerfile manually creates /app/cmr-files to store the unzipped cmr jar so that drift
         ;; can find the migration files correctly
         ;; we had to force method change in drift to set the correct path
-        (if (not (instance? cmr.common.memory_db.connection.MemoryStore db))
+        (when (not (instance? cmr.common.memory_db.connection.MemoryStore db))
           (try
             ;; trying non-local path to find drift migration files for external oracle db"
             (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/drift-migration-files")))]
               (drift.execute/run migrate-args))
-            (catch Exception e
+            (catch Exception _e
               (println "caught exception trying to find migration files. We are probably in local env w/ external db. Trying local route to migration files...")
               (with-redefs [drift.core/user-directory (fn [] (new File (str (.getProperty (System/getProperties) "user.dir") "/checkouts/metadata-db-app/src")))]
                 (drift.execute/run migrate-args))))))
@@ -69,12 +69,12 @@
   (common-routes/job-api-routes
     (routes
       ;; Trigger the old revision concept cleanup
-      (POST "/old-revision-concept-cleanup" {:keys [request-context params headers]}
+      (POST "/old-revision-concept-cleanup" {:keys [request-context]}
         (acl/verify-ingest-management-permission request-context :update)
         (mdb-jobs/old-revision-concept-cleanup request-context)
         {:status 204})
 
-      (POST "/expired-concept-cleanup" {:keys [request-context params headers]}
+      (POST "/expired-concept-cleanup" {:keys [request-context]}
         (acl/verify-ingest-management-permission request-context :update)
         (mdb-jobs/expired-concept-cleanup request-context)
         {:status 204}))))

--- a/metadata-db-app/src/cmr/metadata_db/api/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/subscriptions.clj
@@ -2,21 +2,23 @@
   "Defines the HTTP URL routes for the application as related to subscriptions."
   (:require
    [cmr.metadata-db.services.sub-notifications :as sub-note]
-   [compojure.core :refer :all]))
+   [cmr.metadata-db.services.subscriptions :as subscriptions]
+   [compojure.core :refer [PUT POST context]]))
 
 (defn- update-subscription-notification-time
   "Update a subscription notification time"
   [context params]
   (let [sub-id (:subscription-concept-id params)
-        result (sub-note/update-subscription-notification context sub-id)]
+        _ (sub-note/update-subscription-notification context sub-id)]
     {:status 204}))
-
-; TODO add a get interface to help with testing. CMR-6621
 
 (def subscription-api-routes
   (context "/subscription" []
     ;; receive notification to update subscription time
     (PUT "/:subscription-concept-id/notification-time"
-      {{:keys [subscription-concept-id] :as params} :params
+      {params :params
        request-context :request-context}
-      (update-subscription-notification-time request-context params))))
+      (update-subscription-notification-time request-context params))
+    (POST "/:subscription-concept-id/notification-time"
+      {request-context :request-context}
+      (subscriptions/refresh-subscription-cache request-context))))

--- a/metadata-db-app/src/cmr/metadata_db/api/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/api/subscriptions.clj
@@ -19,6 +19,6 @@
       {params :params
        request-context :request-context}
       (update-subscription-notification-time request-context params))
-    (POST "/:subscription-concept-id/notification-time"
+    (POST "/refresh-subscription-cache"
       {request-context :request-context}
       (subscriptions/refresh-subscription-cache request-context))))

--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts/subscription.clj
@@ -13,7 +13,7 @@
     subscription))
 
 (defmethod concepts/db-result->concept-map :subscription
-  [concept-type db provider-id result]
+  [_concept-type db provider-id result]
   (some-> (concepts/db-result->concept-map :default db provider-id result)
           (assoc :concept-type :subscription)
           (assoc :provider-id (:provider_id result))
@@ -52,7 +52,7 @@
   (subscription-concept->insert-args concept))
 
 (defmethod concepts/after-save :subscription
-  [db provider sub]
+  [db _provider sub]
   (when (:deleted sub)
     ;; Cascade deletion to real deletes of subscription notifications. The intended functionality
     ;; since the subscription_notification row is purged is that, if this subscription were

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -793,7 +793,8 @@
                                                       :deleted true
                                                       :extra-fields (merge extra-fields
                                                                            {:endpoint (:EndPoint metadata-edn)
-                                                                            :mode (:Mode metadata-edn)})}))
+                                                                            :mode (:Mode metadata-edn)
+                                                                            :method (:Method metadata-edn)})}))
                           (merge previous-revision {:concept-id concept-id
                                                     :revision-id revision-id
                                                     :revision-date revision-date

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -781,7 +781,6 @@
                                (= :subscription concept-type))
                          (:metadata previous-revision)
                          "")
-              _ (def metadata metadata)
               tombstone (if (= :subscription concept-type)
                           (let [metadata-edn (json/decode metadata true)
                                 extra-fields (:extra-fields previous-revision)]

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -1,6 +1,7 @@
 (ns cmr.metadata-db.services.concept-service
   "Services to support the business logic of the metadata db."
   (:require
+   [cheshire.core :as json]
    [clj-time.core :as t]
    [clojure.set :as set]
    [cmr.common.api.context :as cmn-context]
@@ -776,15 +777,29 @@
       ;; to send concept updates and deletions out of order.
       (if (and (util/is-tombstone? previous-revision) (nil? revision-id))
         previous-revision
-        (let [metadata (if (cu/generic-concept? concept-type)
+        (let [metadata (if (or (cu/generic-concept? concept-type)
+                               (= :subscription concept-type))
                          (:metadata previous-revision)
                          "")
-              tombstone (merge previous-revision {:concept-id concept-id
-                                                  :revision-id revision-id
-                                                  :revision-date revision-date
-                                                  :user-id user-id
-                                                  :metadata metadata
-                                                  :deleted true})]
+              _ (def metadata metadata)
+              tombstone (if (= :subscription concept-type)
+                          (let [metadata-edn (json/decode metadata true)
+                                extra-fields (:extra-fields previous-revision)]
+                            (merge previous-revision {:concept-id concept-id
+                                                      :revision-id revision-id
+                                                      :revision-date revision-date
+                                                      :user-id user-id
+                                                      :metadata ""
+                                                      :deleted true
+                                                      :extra-fields (merge extra-fields
+                                                                           {:endpoint (:EndPoint metadata-edn)
+                                                                            :mode (:Mode metadata-edn)})}))
+                          (merge previous-revision {:concept-id concept-id
+                                                    :revision-id revision-id
+                                                    :revision-date revision-date
+                                                    :user-id user-id
+                                                    :metadata metadata
+                                                    :deleted true}))]
           (cv/validate-concept tombstone)
           (validate-concept-revision-id db provider tombstone previous-revision)
           (let [revisioned-tombstone (->> (set-or-generate-revision-id db provider tombstone previous-revision)

--- a/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_validations.clj
@@ -96,7 +96,7 @@
   can sometimes be nil."
   [concept]
   (nil-fields-validation (apply dissoc (:extra-fields concept)
-                                [:delete-time :version-id :source-revision-id :associated-revision-id :target-provider-id :collection-concept-id :endpoint :mode])))
+                                [:delete-time :version-id :source-revision-id :associated-revision-id :target-provider-id :collection-concept-id :endpoint :mode :method])))
 
 (defn concept-id-validation
   [concept]

--- a/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
@@ -4,8 +4,11 @@
 	<collection-concept-id> --> <ingest subscription map>
 
 	Example:
-	'C12344554-PROV1' --> { 'enabled' true|false
-                          'mode'    New|Update|Delete|All} "
+  {Collection concept id 1: {\"New\" 1
+                             \"Update\" 1}
+   Collection concept id 2: {\"New\" 2
+                             \"Update\" 1
+                             \"Delete\" 3}"
   (:require
    [cmr.common.hash-cache :as hash-cache]
    [cmr.common.redis-log-util :as rl-util]
@@ -46,4 +49,13 @@
         [tm value] (util/time-execution
                     (hash-cache/remove-value cache-client subscription-cache-key collection-concept-id))]
     (rl-util/log-redis-write-complete "ingest-subscription-cache remove-value" subscription-cache-key tm)
+    value))
+
+(defn get-keys
+  "Gets the collection-concept-ids from the cache."
+  [context]
+  (let [cache-client (hash-cache/context->cache context subscription-cache-key)
+        [tm value] (util/time-execution
+                    (hash-cache/get-keys cache-client subscription-cache-key))]
+    (rl-util/log-redis-read-complete "ingest-subscription-cache get-keys" subscription-cache-key tm)
     value))

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -1,7 +1,9 @@
 (ns cmr.metadata-db.services.subscriptions
   "Buisness logic for subscription processing."
   (:require
+   [cheshire.core :as json]
    [cmr.metadata-db.config :as mdb-config]
+   [cmr.metadata-db.services.search-service :as mdb-search]
    [cmr.metadata-db.services.subscription-cache :as subscription-cache]))
 
 (def subscriptions-enabled?
@@ -13,7 +15,8 @@
   [concept-type concept]
   (and subscriptions-enabled?
        (= :subscription concept-type)
-       (some? (:endpoint (:extra-fields concept)))))
+       (some? (:endpoint (:extra-fields concept)))
+       (= "ingest" (:method (:extra-fields concept)))))
 
 (defn granule-concept?
   "Checks to see if the passed in concept-type and concept is a granule concept."
@@ -21,20 +24,119 @@
   (and subscriptions-enabled?
        (= :granule concept-type)))
 
+(defn remove-from-existing-mode
+  "Depending on the passed in new-mode ['New' 'Update'] remove from the structure
+  {Collection concept id: {\"New\" 1
+                           \"Update\" 1}}
+   either the count or the mode if count is 0."
+  [existing-mode new-mode]
+  (loop [ms new-mode
+         result existing-mode]
+    (let [mode (first ms)
+          mode-count (if (and result
+                              (result mode))
+                       (result mode) 0)
+          compare-to-one (compare mode-count 1)]
+      (if mode
+        (when (seq result)
+          (if (or (= 0 compare-to-one)
+                  (= -1 compare-to-one))
+            (recur (rest ms) (dissoc result mode))
+            (recur (rest ms) (assoc result mode (dec mode-count)))))
+        result))))
+
 (defn delete-subscription 
   "When a subscription is deleted, the collection-concept-id must be removed 
-  from the subscription cache."
+  from the subscription cache. Decrement the count if more than 1 subscription
+  uses the collection-concept-id."
   [context concept-type revisioned-tombstone]
   (when (subscription-concept? concept-type revisioned-tombstone)
-    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))]
-      (subscription-cache/remove-value context coll-concept-id))))
+    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))
+          existing-value (subscription-cache/get-value context coll-concept-id)
+          mode (:mode (:extra-fields revisioned-tombstone))
+          new-mode (remove-from-existing-mode existing-value mode)]
+      (if (seq new-mode)
+        (subscription-cache/set-value context coll-concept-id new-mode)
+        (subscription-cache/remove-value context coll-concept-id)))))
+
+(defn add-to-existing-mode
+  "Depending on the passed in new-mode ['New' 'Update'] create a structure that looks like
+  {Collection concept id: {\"New\" 1
+                           \"Update\" 1}}"
+  [existing-mode new-mode]
+  (loop [ms new-mode
+         result existing-mode]
+    (let [mode (first ms)
+          mode-count (if (and result
+                              (result mode))
+                       (result mode)
+                       0)]
+      (if mode
+        (if result
+          (recur (rest ms) (assoc result mode (inc mode-count)))
+          (recur (rest ms) (assoc {} mode (inc mode-count))))
+        result))))
 
 (defn add-subscription
   "When a subscription is added, the collection-concept-id must be put into  
-  the subscription cache."
+  the subscription cache. If the collection-concept-id already exists then another
+  subscription is also using it so increment the count. The count is used to determine
+  whether or not the entry can be deleted. The modes are concatenated so that the user
+  of the cache knows which modes to key off of."
   [context concept-type concept]
   (when (subscription-concept? concept-type concept)
     (let [coll-concept-id (:collection-concept-id (:extra-fields concept))
-          mode (:mode (:extra-fields concept))]
-      (subscription-cache/set-value context coll-concept-id {"enabled" true
-                                                             "mode" mode}))))
+          mode (:mode (:extra-fields concept))
+          existing-mode (subscription-cache/get-value context coll-concept-id)
+          new-value (add-to-existing-mode existing-mode mode)]
+      (subscription-cache/set-value context coll-concept-id new-value))))
+
+(defn create-subscription-cache-contents-for-refresh
+  "Go through all of the subscriptions and find the ones that are 
+  ingest subscriptions. Create the mode values for each collection-concept-id
+  and put those into a map. The end result looks like:
+  {Collection concept id 1: {\"New\" 1
+                           \"Update\" 1}
+   Collection concept id 2: {\"New\" 2
+                           \"Update\" 1
+                           \"Delete\" 3}
+   ...}"
+  [result sub]
+  (let [metadata (:metadata sub)
+        metadata-edn (json/decode metadata true)]
+    (if (and (some? (:EndPoint metadata-edn))
+             (= "ingest" (:Method metadata-edn)))
+      (let [coll-concept-id (:collection-concept-id (:extra-fields sub))
+            concept-map (result coll-concept-id)
+            mode (:Mode metadata-edn)]
+        (if concept-map
+          (update result coll-concept-id #(add-to-existing-mode % mode))
+          (assoc concept-map coll-concept-id (add-to-existing-mode nil mode))))
+      result)))
+
+(defn ^:dynamic get-subscriptions-from-db
+  "Get the subscriptions from the database. This function primarily exists so that
+  it can be stubbed out for unit tests."
+  [context]
+  (mdb-search/find-concepts context {:latest true
+                                     :concept-type :subscription}))
+
+(defn refresh-subscription-cache
+  "Go through all of the subscriptions and create a map of collection concept ids and
+  their mode values. Get the old keys from the cache and if the keys exist in the new structure
+  then update the cache with the new values. Otherwise delete the contents that no longer exists."
+  [context]
+  (when subscriptions-enabled?
+    (let [subs (get-subscriptions-from-db context)
+          new-contents (reduce create-subscription-cache-contents-for-refresh {} subs)
+          cache-content-keys (subscription-cache/get-keys context)]
+      ;; update the cache with the new values contained in the new-contents map.
+      (doall (map #(subscription-cache/set-value context % (new-contents %)) (keys new-contents)))
+      ;; Go through and remove any cache items that are not in the new-contents map.
+      (doall (map #(when-not (new-contents %)
+                     (subscription-cache/remove-value context %))
+                  cache-content-keys)))))
+
+(comment
+  (let [system (get-in user/system [:apps :metadata-db])]
+    (refresh-subscription-cache {:system system})))

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -1,7 +1,6 @@
 (ns cmr.metadata-db.services.subscriptions
   "Buisness logic for subscription processing."
   (:require
-   [cmr.common.log :refer [info]]
    [cmr.metadata-db.config :as mdb-config]
    [cmr.metadata-db.services.subscription-cache :as subscription-cache]))
 
@@ -12,7 +11,6 @@
 (defn subscription-concept?
   "Checks to see if the passed in concept-type and concept is a subscription concept."
   [concept-type concept]
-  (info (format "Ingest subscriptions subscription-concept? concept-type: %s concept: %s" concept-type concept))
   (and subscriptions-enabled?
        (= :subscription concept-type)
        (some? (:endpoint (:extra-fields concept)))))
@@ -27,13 +25,9 @@
   "When a subscription is deleted, the collection-concept-id must be removed 
   from the subscription cache."
   [context concept-type revisioned-tombstone]
-  (info (format "Ingest subscriptions delete-subscription subscription-concept?: %s" (subscription-concept? concept-type revisioned-tombstone)))
   (when (subscription-concept? concept-type revisioned-tombstone)
-    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))
-          _ (info (format "Ingest subscriptions delete-subscription collection-concept-id: [%s]" coll-concept-id))
-          value (subscription-cache/remove-value context coll-concept-id)
-          _ (info (format "Ingest subscriptions delete-subscription Remove worked or not: %d" value))]
-      value)))
+    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))]
+      (subscription-cache/remove-value context coll-concept-id))))
 
 (defn add-subscription
   "When a subscription is added, the collection-concept-id must be put into  

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -1,6 +1,7 @@
 (ns cmr.metadata-db.services.subscriptions
   "Buisness logic for subscription processing."
   (:require
+   [cmr.common.log :refer [info]]
    [cmr.metadata-db.config :as mdb-config]
    [cmr.metadata-db.services.subscription-cache :as subscription-cache]))
 
@@ -11,6 +12,7 @@
 (defn subscription-concept?
   "Checks to see if the passed in concept-type and concept is a subscription concept."
   [concept-type concept]
+  (info (format "Ingest subscriptions subscription-concept? concept-type: %s concept: %s" concept-type concept))
   (and subscriptions-enabled?
        (= :subscription concept-type)
        (some? (:endpoint (:extra-fields concept)))))
@@ -25,9 +27,13 @@
   "When a subscription is deleted, the collection-concept-id must be removed 
   from the subscription cache."
   [context concept-type revisioned-tombstone]
+  (info (format "Ingest subscriptions delete-subscription subscription-concept?: %s" (subscription-concept? concept-type revisioned-tombstone)))
   (when (subscription-concept? concept-type revisioned-tombstone)
-    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))]
-       (subscription-cache/remove-value context coll-concept-id))))
+    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))
+          _ (info (format "Ingest subscriptions delete-subscription collection-concept-id: [%s]" coll-concept-id))
+          value (subscription-cache/remove-value context coll-concept-id)
+          _ (info (format "Ingest subscriptions delete-subscription Remove worked or not: %d" value))]
+      value)))
 
 (defn add-subscription
   "When a subscription is added, the collection-concept-id must be put into  

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscription_cache_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscription_cache_test.clj
@@ -15,11 +15,11 @@
     (testing "Cache is empty"
       (is (nil? (hash-cache/get-map cache cache-key))))
     (testing "Add to the cache."
-      (is (= 1 (subscription-cache/set-value test-context "C12345-PROV1" {"enabled" true
-                                                                          "mode" "All"}))))
+      (is (= 1 (subscription-cache/set-value test-context "C12345-PROV1" {"New" 1
+                                                                          "Update" 2}))))
     (testing "Get a value"
-      (is (= {"enabled" true
-              "mode" "All"} 
+      (is (= {"New" 1
+              "Update" 2}
              (subscription-cache/get-value test-context "C12345-PROV1"))))
     (testing "Remove a value"
       (is (= 1 (subscription-cache/remove-value test-context "C12345-PROV1"))))

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [cmr.common.hash-cache :as hash-cache]
+   [cmr.common.util :refer [are3]]
    [cmr.metadata-db.config :as mdb-config]
    [cmr.metadata-db.services.subscription-cache :as subscription-cache]
    [cmr.metadata-db.services.subscriptions :as subscriptions] 
@@ -13,21 +14,162 @@
 (deftest subscription-cache-test
   (let [cache-key subscription-cache/subscription-cache-key
         test-context {:system {:caches {cache-key (subscription-cache/create-cache-client)}}}
-        cache (get-in test-context [:system :caches cache-key])]
-    (hash-cache/reset cache cache-key)
+        cache-client (get-in test-context [:system :caches cache-key])]
+    (hash-cache/reset cache-client cache-key)
     (testing "Cache is empty"
-      (is (nil? (hash-cache/get-map cache cache-key))))
+      (is (nil? (hash-cache/get-map cache-client cache-key))))
     (testing "Testing if cache is enabled."
       (let [value (mdb-config/ingest-subscription-enabled)]
         (is (= value subscriptions/subscriptions-enabled?))))
     (testing "Testing if a passed in concept is a subscription concept"
-      (is (subscriptions/subscription-concept? :subscription {:extra-fields {:endpoint "some-endpoint"}})))
+      (is (subscriptions/subscription-concept? :subscription {:extra-fields {:endpoint "some-endpoint" :method "ingest"}})))
     (testing "Testing if a passed in concept is a granule concept"
       (is (subscriptions/granule-concept? :granule)))
     (testing "Add a subscription"
       (is (= 1 (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
-                                                                                          :mode "All"
-                                                                                          :endpoint "some-endpoint"}}))))
+                                                                                          :mode ["New"]
+                                                                                          :endpoint "some-endpoint"
+                                                                                          :method "ingest"}}))))
     (testing "Delete a subscription"
       (is (= 1 (subscriptions/delete-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
-                                                                                             :endpoint "some-endpoint"}}))))))
+                                                                                             :mode ["New"]
+                                                                                             :endpoint "some-endpoint"
+                                                                                             :method "ingest"}}))))
+    (testing "adding and removing subscriptions."
+      (are3
+       [delete expected example-record]
+       (if delete
+         (do
+           (subscriptions/delete-subscription test-context :subscription example-record)
+           (is (= expected (hash-cache/get-map cache-client cache-key))))
+         (do
+           (subscriptions/add-subscription test-context :subscription example-record)
+           (is (= expected (hash-cache/get-map cache-client cache-key)))))
+
+       "Adding 1 update subscription"
+       false
+       {"C12345-PROV1" {"Update" 1}}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["Update"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Adding 2 update subscription"
+       false
+       {"C12345-PROV1" {"Update" 2}}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["Update"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Adding 2 update subscription"
+       false
+       {"C12345-PROV1" {"New" 1
+                        "Update" 2
+                        "Delete" 1}}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["New" "Delete"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Removing 1 subscription"
+       true
+       {"C12345-PROV1" {"New" 1
+                        "Update" 2}}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["Delete"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Removing 2 subscription"
+       true
+       {"C12345-PROV1" {"Update" 1}}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["New" "Update"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Removing last subscription"
+       true
+       nil
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["Update"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       "Try to remove something that doesn't exist"
+       true
+       nil
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["Update"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}))))
+
+(def db-result
+  '({:revision-id 1
+     :deleted "false"
+     :format "application/vnd.nasa.cmr.umm+json;version=1.1"
+     :provider-id "CMR"
+     :user-id "ECHO_SYS"
+     :transaction-id "2000000003M"
+     :native-id "erichs_subscription"
+     :concept-id SUB1200000001-CMR
+     :metadata "{\"Name\":\"someSubscription\",
+                \"Type\":\"collection\",
+                \"SubscriberId\":\"eereiter\",
+                \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
+                \"Query\":\"bounding_box=-180,-90,180,90\",
+                \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1\"}}"
+     :revision-date "2024-10-07T18:08:51.018Z"
+     :extra-fields {:normalized-query "1e9a7eaf3ed5acfb1bddb2a184658506"
+                    :subscription-type "collection"
+                    :subscription-name "someSubscription"
+                    :subscriber-id "eereiter"
+                    :collection-concept-id nil}
+     :concept-type :subscription}
+    {:revision-id 1
+     :deleted "false"
+     :format "application/vnd.nasa.cmr.umm+json;version=1.1.1"
+     :provider-id "PROV1"
+     :user-id "ECHO_SYS"
+     :transaction-id "2000000009M"
+     :native-id "erichs_ingest_subscription"
+     :concept-id "SUB1200000005-PROV1"
+     :metadata "{\"SubscriberId\":\"eereiter\",
+                \"CollectionConceptId\":\"C1200000002-PROV1\",
+                \"EndPoint\":\"arn\",
+                \"Mode\":[\"New\",\"Update\",\"Delete\"],
+                \"Method\":\"ingest\",
+                \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
+                \"Query\":\"collection-concept-id=C1200000002-PROV1\",
+                \"Name\":\"Ingest-Subscription-Test\",
+                \"Type\":\"granule\",
+                \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1.1\"}}"
+     :revision-date "2024-10-07T18:13:32.608Z"
+     :extra-fields {:normalized-query "76c6d7a828ef81efb3720638f335f65c"
+                    :subscription-type "granule"
+                    :subscription-name "Ingest-Subscription-Test"
+                    :subscriber-id "eereiter"
+                    :collection-concept-id "C1200000002-PROV1"}
+     :concept-type :subscription}))
+
+(deftest subscription-refresh-cache-test
+  (let [cache-key subscription-cache/subscription-cache-key
+        test-context {:system {:caches {cache-key (subscription-cache/create-cache-client)}}}
+        cache-client (get-in test-context [:system :caches cache-key])]
+    (hash-cache/reset cache-client cache-key)
+    (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C1200000002-PROV1"
+                                                                               :mode ["New" "Update"]
+                                                                               :endpoint "some-endpoint"
+                                                                               :method "ingest"}})
+    (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12346-PROV1"
+                                                                               :mode ["New" "Update"]
+                                                                               :endpoint "some-endpoint"
+                                                                               :method "ingest"}})
+    (testing "What is in the cache"
+      (is (= {"C1200000002-PROV1" {"New" 1 "Update" 1}
+              "C12346-PROV1" {"New" 1 "Update" 1}}
+             (hash-cache/get-map cache-client cache-key))))
+    (testing "Cache needs to be updated."
+      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context] db-result)}
+        (subscriptions/refresh-subscription-cache test-context))
+      (is (= {"C1200000002-PROV1" {"New" 1 "Update" 1 "Delete" 1}}
+             (hash-cache/get-map cache-client cache-key))))
+    (testing "Testing no subscriptions"
+      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context] '())}
+        (subscriptions/refresh-subscription-cache test-context))
+      (is (nil? (hash-cache/get-map cache-client cache-key))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/subscription/subscription_ingest_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/subscription/subscription_ingest_test.clj
@@ -5,7 +5,7 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
    [cmr.access-control.test.util :as ac-util]
    [cmr.common-app.config :as common-config]
    [cmr.common-app.test.side-api :as side]
@@ -168,7 +168,7 @@
                errors))))
 
     (testing "delete on PROV3, registered user is granted update permission for SUBSCRIPTION_MANAGEMENT ACL"
-      (let [{:keys [status errors]} (ingest/delete-concept concept {:token user1-token})]
+      (let [{:keys [status]} (ingest/delete-concept concept {:token user1-token})]
         (is (= 200 status))))))
 
 (deftest umm-sub-1_0-subscription-ingest-test
@@ -182,7 +182,7 @@
     (testing "ingest of a new subscription concept"
       (let [concept (subscription-util/make-subscription-concept-with-umm-version
                      "1.0" {:CollectionConceptId (:concept-id coll1)})
-            {:keys [concept-id revision-id status]} (ingest/ingest-concept concept)]
+            {:keys [concept-id revision-id]} (ingest/ingest-concept concept)]
         (is (mdb/concept-exists-in-mdb? concept-id revision-id))
         (is (= 1 revision-id))))))
 
@@ -571,10 +571,11 @@
       (testing "create a subscription over a subscription's tombstone"
         (let [response (subscription-util/ingest-subscription
                         (subscription-util/make-subscription-concept {:CollectionConceptId (:concept-id coll1)}))
-              {:keys [status concept-id revision-id]} response]
+              {:keys [status revision-id]} response]
           (is (= 200 status))
           (is (= 3 revision-id)))))))
 
+#_{:clj-kondo/ignore [:unresolved-var]}
 (deftest roll-your-own-subscription-tests
   ;; Use cases coming from EarthData Search wanting to allow their users to create
   ;; subscriptions without the need to have any acls
@@ -677,8 +678,7 @@
                    :Name "sub-name2"
                    :native-id "sub2"
                    :CollectionConceptId (:concept-id coll1)})
-            {:keys [concept-id revision-id status]} (ingest/ingest-concept
-                                                     sub1-user1 {:token user1-token})]
+            {:keys [status]} (ingest/ingest-concept sub1-user1 {:token user1-token})]
 
         ;; verify subscription with user1 as subscriber is created successfully
         (is (= 201 status))
@@ -1035,7 +1035,7 @@
 
 (deftest query-uniqueness-test
   (let [sub-user-group-id (echo-util/get-or-create-group (system/context) "sub-group")
-        sub-user-token (echo-util/login (system/context) "sub-user" [sub-user-group-id])
+        _ (echo-util/login (system/context) "sub-user" [sub-user-group-id])
         coll1 (data-core/ingest-umm-spec-collection "PROV1"
                                                     (data-umm-c/collection {:ShortName "coll1"
                                                                             :EntryTitle "entry-title1"})
@@ -1045,8 +1045,8 @@
                                                                             :EntryTitle "entry-title2"})
                                                     {:token "mock-echo-system-token"})
 
-        sub1 (subscription-util/create-subscription-and-index
-              coll1 "test_sub1_prov1" "sub-user" "instrument=POSEIDON-2&platform=NOAA-7")
+        _ (subscription-util/create-subscription-and-index
+           coll1 "test_sub1_prov1" "sub-user" "instrument=POSEIDON-2&platform=NOAA-7")
         ;;should fail, since normalized-query will be identical to sub1
         sub2 (subscription-util/create-subscription-and-index
               coll1 "test_sub2_prov1" "sub-user" "platform=NOAA-7&instrument=POSEIDON-2")
@@ -1054,8 +1054,8 @@
         sub3 (subscription-util/create-subscription-and-index
               coll2 "test_sub3_prov1" "sub-user" "platform=NOAA-7&instrument=POSEIDON-2")
         ;;Later on, we will delete this sub and supersede it
-        sub4 (subscription-util/create-subscription-and-index
-              coll2 "test_sub4_prov1" "sub-user" "platform=NOAA-11")
+        _ (subscription-util/create-subscription-and-index
+           coll2 "test_sub4_prov1" "sub-user" "platform=NOAA-11")
         sub4-concept {:provider-id "PROV1" :concept-type :subscription :native-id "test_sub4_prov1"}]
 
     (testing "check that only actual duplicate subscriptions failed"
@@ -1065,8 +1065,8 @@
       (let [sub3-concept {:provider-id "PROV1" :concept-type :subscription :native-id "test_sub3_prov1"}
             ;;delete sub3, and reingest it as-is.
             _ (ingest/delete-concept sub3-concept)
-            sub3-2 (subscription-util/create-subscription-and-index
-                    coll2 "test_sub3_prov1" "sub-user" "platform=NOAA-7&instrument=POSEIDON-2")]
+            _ (subscription-util/create-subscription-and-index
+               coll2 "test_sub3_prov1" "sub-user" "platform=NOAA-7&instrument=POSEIDON-2")]
         (is (not (:errors sub3)))))
     (testing "should be possible to replace a tombstoned concept with a new concept, with new native-id"
       (ingest/delete-concept sub4-concept)

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
@@ -49,9 +49,13 @@
       "maxLength": 1024
     },
     "Mode": {
-      "description": "For the type of granule subscription the mode is whether to be notified of a new,update,delete, or all granules.",
-      "type": "string",
-      "enum": ["New", "Update", "Delete", "All"]
+      "description": "For the type of granule subscription the mode is whether to be notified of a new, update, or delete, granule.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["New", "Update", "Delete"]
+      },
+      "minItems": 1
     },
     "MetadataSpecification": {
       "description": "Requires the client, or user, to add in schema information into every subscription record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",

--- a/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/subscription/umm/v1.1.1/umm-sub-json-schema.json
@@ -57,6 +57,14 @@
       },
       "minItems": 1
     },
+    "Method" : {
+      "description": "Describes how the subscription is executed. Notification send by the ingest stream. i.e. when a granule is ingested, or by a repeditive search.",
+      "type": "string",
+      "enum": [
+        "ingest",
+        "search"
+      ]
+    },
     "MetadataSpecification": {
       "description": "Requires the client, or user, to add in schema information into every subscription record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema.",
       "$ref": "#/definitions/MetadataSpecificationType"

--- a/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/migration/version/subscription.clj
@@ -30,4 +30,4 @@
   [_context subscription & _]
   (-> subscription
       (m-spec/update-version :subscription "1.1")
-      (dissoc :Mode :EndPoint)))
+      (dissoc :Mode :EndPoint :Method)))

--- a/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/migration/version/subscription.clj
@@ -33,7 +33,8 @@
    :CollectionConceptId "C1200000005-PROV1"
    :Query "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
    :EndPoint "arn:aws:sqs:us-east-1:1234455667:TestSNSQueue"
-   :Mode "All"
+   :Mode ["New" "Update"]
+   :Method "ingest"
    :MetadataSpecification
    {:URL "https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1"
     :Name "UMM-Sub"
@@ -47,7 +48,7 @@
   (is (thrown? clojure.lang.ExceptionInfo (migrate-subscription "1.1" "1.0" granule-subscription-concept-1_1))))
 
 (deftest migrate-1_1->1_1_1
-  (is (= (dissoc granule-subscription-concept-1_1_1 :Mode :EndPoint)
+  (is (= (dissoc granule-subscription-concept-1_1_1 :Mode :EndPoint :Method)
          (migrate-subscription "1.1" "1.1.1" granule-subscription-concept-1_1))))
 
 (deftest migrate-1_1_1->1_1


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Updated code to remove subscription information from redis cache upon subscription delete. Updated schema to allow multiple modes. Adding subscription to redis cache already in the code. 

### What is the Solution?

Updated code to remove subscription information from redis cache upon subscription delete. Updated schema to allow multiple modes.

### What areas of the application does this impact?

Metadata_db

# Checklist

- [X] I have updated/added unit and int tests that prove my fix is effective or that my feature works - in previous commit
- [X] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
