### PR TITLE
CMR-10139: Re-writing the cache contents to cover when the same subscription is updated.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -852,7 +852,7 @@
                       (= concept-type :tool-association))
               (ingest-events/publish-event
                context (ingest-events/concept-delete-event revisioned-tombstone)))
-            (subscriptions/delete-subscription context concept-type revisioned-tombstone)
+            (subscriptions/change-subscription context concept-type revisioned-tombstone)
             revisioned-tombstone)))
       (if revision-id
         (cmsg/data-error :not-found
@@ -940,8 +940,7 @@
       (ingest-events/publish-event
        context
        (ingest-events/concept-update-event concept))
-
-      (subscriptions/add-subscription context concept-type concept)
+      (subscriptions/change-subscription context concept-type concept)
       concept)))
 
 (defn- delete-associated-tag-associations

--- a/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscription_cache.clj
@@ -1,14 +1,11 @@
 (ns cmr.metadata-db.services.subscription-cache
   "Defines common functions and defs for the subscription cache.
 	Structure of the hash-cache is as follows:
-	<collection-concept-id> --> <ingest subscription map>
+	<collection-concept-id> --> <ingest subscription vector>
 
 	Example:
-  {Collection concept id 1: {\"New\" 1
-                             \"Update\" 1}
-   Collection concept id 2: {\"New\" 2
-                             \"Update\" 1
-                             \"Delete\" 3}"
+  {Collection concept id 1: [\"New\" \"Update\"]
+   Collection concept id 2: [\"New\" \"Update\" \"Delete\"]"
   (:require
    [cmr.common.hash-cache :as hash-cache]
    [cmr.common.redis-log-util :as rl-util]

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -24,82 +24,64 @@
   (and subscriptions-enabled?
        (= :granule concept-type)))
 
-(defn remove-from-existing-mode
-  "Depending on the passed in new-mode ['New' 'Update'] remove from the structure
-  {Collection concept id: {\"New\" 1
-                           \"Update\" 1}}
-   either the count or the mode if count is 0."
-  [existing-mode new-mode]
-  (loop [ms new-mode
-         result existing-mode]
-    (let [mode (first ms)
-          mode-count (if (and result
-                              (result mode))
-                       (result mode) 0)
-          compare-to-one (compare mode-count 1)]
-      (if mode
-        (when (seq result)
-          (if (or (= 0 compare-to-one)
-                  (= -1 compare-to-one))
-            (recur (rest ms) (dissoc result mode))
-            (recur (rest ms) (assoc result mode (dec mode-count)))))
-        result))))
-
-(defn delete-subscription 
-  "When a subscription is deleted, the collection-concept-id must be removed 
-  from the subscription cache. Decrement the count if more than 1 subscription
-  uses the collection-concept-id."
-  [context concept-type revisioned-tombstone]
-  (when (subscription-concept? concept-type revisioned-tombstone)
-    (let [coll-concept-id (:collection-concept-id (:extra-fields revisioned-tombstone))
-          existing-value (subscription-cache/get-value context coll-concept-id)
-          mode (:mode (:extra-fields revisioned-tombstone))
-          new-mode (remove-from-existing-mode existing-value mode)]
-      (if (seq new-mode)
-        (subscription-cache/set-value context coll-concept-id new-mode)
-        (subscription-cache/remove-value context coll-concept-id)))))
+(defn ^:dynamic get-subscriptions-from-db
+  "Get the subscriptions from the database. This function primarily exists so that
+  it can be stubbed out for unit tests."
+  ([context]
+   (mdb-search/find-concepts context {:latest true
+                                      :concept-type :subscription
+                                      :subscription-type "granule"}))
+  ([context coll-concept-id]
+   (mdb-search/find-concepts context {:latest true
+                                      :concept-type :subscription
+                                      :collection-concept-id coll-concept-id})))
 
 (defn add-to-existing-mode
-  "Depending on the passed in new-mode ['New' 'Update'] create a structure that looks like
-  {Collection concept id: {\"New\" 1
-                           \"Update\" 1}}"
-  [existing-mode new-mode]
-  (loop [ms new-mode
-         result existing-mode]
-    (let [mode (first ms)
-          mode-count (if (and result
-                              (result mode))
-                       (result mode)
-                       0)]
-      (if mode
+  "Depending on the passed in new-mode [\"New\" \"Update\"] create a structure that merges
+  the new mode to the existing mode. The result looks like [\"New\" \"Update\"]"
+  [existing-modes new-modes]
+  (loop [ms new-modes
+         result existing-modes]
+    (let [mode (first ms)]
+      (if (nil? mode)
+        result
         (if result
-          (recur (rest ms) (assoc result mode (inc mode-count)))
-          (recur (rest ms) (assoc {} mode (inc mode-count))))
-        result))))
+          (if (some #(= mode %) result)
+            (recur (rest ms) result)
+            (recur (rest ms) (merge result mode)))
+          (recur (rest ms) [mode]))))))
 
-(defn add-subscription
-  "When a subscription is added, the collection-concept-id must be put into  
-  the subscription cache. If the collection-concept-id already exists then another
-  subscription is also using it so increment the count. The count is used to determine
-  whether or not the entry can be deleted. The modes are concatenated so that the user
-  of the cache knows which modes to key off of."
+(defn merge-modes
+  "Go through the list of subscriptions to see if any exist that match the
+  passed in collection-concept-id. Return true if any subscription exists
+  otherwise return false."
+  [subscriptions]
+  (loop [subs subscriptions
+         result []]
+    (let [sub (first subs)]
+      (if (nil? sub)
+        result
+        (recur (rest subs) (add-to-existing-mode result (get-in sub [:extra-fields :mode])))))))
+
+(defn change-subscription
+  "When a subscription is added or deleted, the collection-concept-id must be put into
+  or deleted from the subscription cache. Get the subscriptions that match the collection-concept-id
+  from the database and rebuild the modes list."
   [context concept-type concept]
   (when (subscription-concept? concept-type concept)
     (let [coll-concept-id (:collection-concept-id (:extra-fields concept))
-          mode (:mode (:extra-fields concept))
-          existing-mode (subscription-cache/get-value context coll-concept-id)
-          new-value (add-to-existing-mode existing-mode mode)]
-      (subscription-cache/set-value context coll-concept-id new-value))))
+          subs (filter #(subscription-concept? (get % :concept-type) %)
+                       (get-subscriptions-from-db context coll-concept-id))]
+      (if (seq subs)
+        (subscription-cache/set-value context coll-concept-id (merge-modes subs))
+        (subscription-cache/remove-value context coll-concept-id)))))
 
 (defn create-subscription-cache-contents-for-refresh
   "Go through all of the subscriptions and find the ones that are 
   ingest subscriptions. Create the mode values for each collection-concept-id
   and put those into a map. The end result looks like:
-  {Collection concept id 1: {\"New\" 1
-                           \"Update\" 1}
-   Collection concept id 2: {\"New\" 2
-                           \"Update\" 1
-                           \"Delete\" 3}
+  {Collection concept id 1: [\"New\" \"Update\"]
+   Collection concept id 2: [\"New\" \"Update\" \"Delete\"]
    ...}"
   [result sub]
   (let [metadata (:metadata sub)
@@ -111,15 +93,8 @@
             mode (:Mode metadata-edn)]
         (if concept-map
           (update result coll-concept-id #(add-to-existing-mode % mode))
-          (assoc concept-map coll-concept-id (add-to-existing-mode nil mode))))
+          (assoc result coll-concept-id (add-to-existing-mode nil mode))))
       result)))
-
-(defn ^:dynamic get-subscriptions-from-db
-  "Get the subscriptions from the database. This function primarily exists so that
-  it can be stubbed out for unit tests."
-  [context]
-  (mdb-search/find-concepts context {:latest true
-                                     :concept-type :subscription}))
 
 (defn refresh-subscription-cache
   "Go through all of the subscriptions and create a map of collection concept ids and

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
@@ -10,6 +10,14 @@
 
 (use-fixtures :once test-util/embedded-redis-server-fixture)
 
+(defn create-value-set
+  "Take a map result set and turn the vector values into set values."
+  [cache-map]
+  (when-let [map-keys (keys cache-map)]
+    (reduce (fn [result k]
+              (into result
+                    {k (set (get cache-map k))})) {} map-keys)))
+
 #_{:clj-kondo/ignore [:unresolved-var]}
 (deftest subscription-cache-test
   (let [cache-key subscription-cache/subscription-cache-key
@@ -26,102 +34,177 @@
     (testing "Testing if a passed in concept is a granule concept"
       (is (subscriptions/granule-concept? :granule)))
     (testing "Add a subscription"
-      (is (= 1 (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
-                                                                                          :mode ["New"]
-                                                                                          :endpoint "some-endpoint"
-                                                                                          :method "ingest"}}))))
+      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] '({:extra-fields {:subscription-type "granule"
+                                                                                                                  :endpoint "some-endpoint"
+                                                                                                                  :method "ingest"
+                                                                                                                  :mode ["New"]
+                                                                                                                  :collection-concept-id "C12345-PROV1"}
+                                                                                                   :concept-type :subscription}))}
+        (is (= 1 (subscriptions/change-subscription test-context :subscription {:extra-fields {:subscription-type "granule"
+                                                                                               :endpoint "some-endpoint"
+                                                                                               :method "ingest"
+                                                                                               :mode ["New"]
+                                                                                               :collection-concept-id "C12345-PROV1"}})))))
     (testing "Delete a subscription"
-      (is (= 1 (subscriptions/delete-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
-                                                                                             :mode ["New"]
-                                                                                             :endpoint "some-endpoint"
-                                                                                             :method "ingest"}}))))
+      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] '())}
+        (is (= 1 (subscriptions/change-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12345-PROV1"
+                                                                                               :mode ["New"]
+                                                                                               :endpoint "some-endpoint"
+                                                                                               :method "ingest"}})))))
+    (testing "Add-to-existing-mode"
+      (are3
+       [expected existing-modes new-modes]
+       (is (= expected (subscriptions/add-to-existing-mode existing-modes new-modes)))
+
+       "new subscription with no existing modes in cache."
+       ["New" "Update" "Delete"]
+       nil
+       ["New" "Update" "Delete"]
+
+       "new subscription with empty existing modes in cache."
+       ["New" "Update" "Delete"]
+       []
+       ["New" "Update" "Delete"]
+
+       "Adding new subscription with existing modes."
+       ["New" "Delete"]
+       ["New"]
+       ["New" "Delete"]
+
+       "Adding duplicate subscription with existing modes."
+       ["New" "Delete"]
+       ["New" "Delete"]
+       ["New" "Delete"]))
+
+    (testing "Merge modes"
+      (are3
+       [expected subscriptions]
+       (is (= (set expected) (set (subscriptions/merge-modes subscriptions))))
+
+       "merge 1 mode."
+       ["Update"]
+       '({:extra-fields {:mode ["Update"]}})
+
+       "Merge several modes"
+       ["New" "Update" "Delete"]
+       '({:extra-fields {:mode ["Update"]}}
+         {:extra-fields {:mode ["New"]}}
+         {:extra-fields {:mode ["Delete"]}})
+
+       "Merge several modes 2"
+       ["New" "Update" "Delete"]
+       '({:extra-fields {:mode ["Update"]}}
+         {:extra-fields {:mode ["New" "Delete"]}})
+
+       "Merge several modes 3 with duplicates."
+       ["New" "Update" "Delete"]
+       '({:extra-fields {:mode ["Update"]}}
+         {:extra-fields {:mode ["New" "Delete"]}}
+         {:extra-fields {:mode ["New"]}}
+         {:extra-fields {:mode ["New" "Update"]}})))
+
     (testing "adding and removing subscriptions."
       (are3
-       [delete expected example-record]
-       (if delete
-         (do
-           (subscriptions/delete-subscription test-context :subscription example-record)
-           (is (= expected (hash-cache/get-map cache-client cache-key))))
-         (do
-           (subscriptions/add-subscription test-context :subscription example-record)
-           (is (= expected (hash-cache/get-map cache-client cache-key)))))
+       [expected example-record db-contents]
+       (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] db-contents)}
+         (subscriptions/change-subscription test-context :subscription example-record)
+         (is (= expected (create-value-set (hash-cache/get-map cache-client cache-key)))))
 
-       "Adding 1 update subscription"
-       false
-       {"C12345-PROV1" {"Update" 1}}
+       "Adding 1 subscription"
+       {"C12345-PROV1" (set ["Update"])}
        {:extra-fields {:collection-concept-id "C12345-PROV1"
                        :mode ["Update"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
-       "Adding 2 update subscription"
-       false
-       {"C12345-PROV1" {"Update" 2}}
+       '({:extra-fields {:subscription-type "granule"
+                         :endpoint "some-endpoint"
+                         :method "ingest"
+                         :mode ["Update"]
+                         :collection-concept-id "C12345-PROV1"}
+          :concept-type :subscription})
+
+       "Adding duplicate subscription"
+       {"C12345-PROV1" (set ["Update"])}
        {:extra-fields {:collection-concept-id "C12345-PROV1"
                        :mode ["Update"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
-       "Adding 2 update subscription"
-       false
-       {"C12345-PROV1" {"New" 1
-                        "Update" 2
-                        "Delete" 1}}
+       '({:extra-fields {:subscription-type "granule"
+                         :endpoint "some-endpoint"
+                         :method "ingest"
+                         :mode ["Update"]
+                         :collection-concept-id "C12345-PROV1"}
+          :concept-type :subscription})
+
+       "Adding override subscription"
+       {"C12345-PROV1" (set ["New" "Delete"])}
        {:extra-fields {:collection-concept-id "C12345-PROV1"
                        :mode ["New" "Delete"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
-       "Removing 1 subscription"
-       true
-       {"C12345-PROV1" {"New" 1
-                        "Update" 2}}
-       {:extra-fields {:collection-concept-id "C12345-PROV1"
-                       :mode ["Delete"]
+       '({:extra-fields {:subscription-type "granule"
+                         :endpoint "some-endpoint"
+                         :method "ingest"
+                         :mode ["New" "Delete"]
+                         :collection-concept-id "C12345-PROV1"}
+          :concept-type :subscription})
+
+       "Adding new subscription that matches the one from before."
+       {"C12345-PROV1" (set ["New" "Delete"])
+        "C12346-PROV1" (set ["New" "Delete"])}
+       {:extra-fields {:collection-concept-id "C12346-PROV1"
+                       :mode ["New" "Delete"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
-       "Removing 2 subscription"
-       true
-       {"C12345-PROV1" {"Update" 1}}
+       '({:extra-fields {:subscription-type "granule"
+                         :endpoint "some-endpoint"
+                         :method "ingest"
+                         :mode ["New" "Delete"]
+                         :collection-concept-id "C12345-PROV1"}
+          :concept-type :subscription}
+         {:extra-fields {:subscription-type "granule"
+                         :collection-concept-id "C12346-PROV1"
+                         :mode ["New" "Delete"]
+                         :endpoint "some-endpoint"
+                         :method "ingest"}
+          :concept-type :subscription})
+
+       "Removing 1 subscription"
+       {"C12346-PROV1" (set ["New" "Delete"])}
+       {:extra-fields {:collection-concept-id "C12345-PROV1"
+                       :mode ["New" "Delete"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       ;; even though C12346-PROV1 is in the db, we are search only for
+       ;; concepts with the collection-concept-id.
+       '()
+
+       "Removing same subscription"
+       {"C12346-PROV1" (set ["New" "Delete"])}
        {:extra-fields {:collection-concept-id "C12345-PROV1"
                        :mode ["New" "Update"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
+       '()
+
        "Removing last subscription"
-       true
+       nil
+       {:extra-fields {:collection-concept-id "C12346-PROV1"
+                       :mode ["New" "Delete"]
+                       :endpoint "some-endpoint"
+                       :method "ingest"}}
+       '()
+
+       "Try to remove something that doesn't exist"
        nil
        {:extra-fields {:collection-concept-id "C12345-PROV1"
                        :mode ["Update"]
                        :endpoint "some-endpoint"
                        :method "ingest"}}
-       "Try to remove something that doesn't exist"
-       true
-       nil
-       {:extra-fields {:collection-concept-id "C12345-PROV1"
-                       :mode ["Update"]
-                       :endpoint "some-endpoint"
-                       :method "ingest"}}))))
+       '()))))
 
-(def db-result
+(def db-result-1
   '({:revision-id 1
-     :deleted "false"
-     :format "application/vnd.nasa.cmr.umm+json;version=1.1"
-     :provider-id "CMR"
-     :user-id "ECHO_SYS"
-     :transaction-id "2000000003M"
-     :native-id "erichs_subscription"
-     :concept-id SUB1200000001-CMR
-     :metadata "{\"Name\":\"someSubscription\",
-                \"Type\":\"collection\",
-                \"SubscriberId\":\"eereiter\",
-                \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
-                \"Query\":\"bounding_box=-180,-90,180,90\",
-                \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1\"}}"
-     :revision-date "2024-10-07T18:08:51.018Z"
-     :extra-fields {:normalized-query "1e9a7eaf3ed5acfb1bddb2a184658506"
-                    :subscription-type "collection"
-                    :subscription-name "someSubscription"
-                    :subscriber-id "eereiter"
-                    :collection-concept-id nil}
-     :concept-type :subscription}
-    {:revision-id 1
      :deleted "false"
      :format "application/vnd.nasa.cmr.umm+json;version=1.1.1"
      :provider-id "PROV1"
@@ -131,8 +214,8 @@
      :concept-id "SUB1200000005-PROV1"
      :metadata "{\"SubscriberId\":\"eereiter\",
                 \"CollectionConceptId\":\"C1200000002-PROV1\",
-                \"EndPoint\":\"arn\",
-                \"Mode\":[\"New\",\"Update\",\"Delete\"],
+                \"EndPoint\":\"some-endpoint\",
+                \"Mode\":[\"New\",\"Delete\"],
                 \"Method\":\"ingest\",
                 \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
                 \"Query\":\"collection-concept-id=C1200000002-PROV1\",
@@ -144,7 +227,99 @@
                     :subscription-type "granule"
                     :subscription-name "Ingest-Subscription-Test"
                     :subscriber-id "eereiter"
-                    :collection-concept-id "C1200000002-PROV1"}
+                    :collection-concept-id "C1200000002-PROV1"
+                    :endpoint "some-endpoint"
+                    :mode ["New", "Delete"]
+                    :method "ingest"}
+     :concept-type :subscription}))
+
+(def db-result-2
+  '({:revision-id 1
+     :deleted "false"
+     :format "application/vnd.nasa.cmr.umm+json;version=1.1.1"
+     :provider-id "PROV1"
+     :user-id "ECHO_SYS"
+     :transaction-id "2000000010M"
+     :native-id "erichs_ingest_subscription2"
+     :concept-id "SUB1200000006-PROV1"
+     :metadata "{\"SubscriberId\":\"eereiter\",
+                 \"CollectionConceptId\":\"C12346-PROV1\",
+                 \"EndPoint\":\"some-endpoint\",
+                 \"Mode\":[\"New\",\"Update\"],
+                 \"Method\":\"ingest\",
+                 \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
+                 \"Query\":\"collection-concept-id=C12346-PROV1\",
+                 \"Name\":\"Ingest-Subscription-Test\",
+                 \"Type\":\"granule\",
+                 \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1.1\"}}"
+     :revision-date "2024-10-07T18:13:32.608Z"
+     :extra-fields {:normalized-query "76c6d7a828ef81efb3720638f335f65c"
+                    :subscription-type "granule"
+                    :subscription-name "Ingest-Subscription-Test"
+                    :subscriber-id "eereiter"
+                    :endpoint "some-endpoint"
+                    :mode ["New", "Update"]
+                    :method "ingest"
+                    :collection-concept-id "C12346-PROV1"}
+     :concept-type :subscription}))
+
+(def db-result-3
+ (concat db-result-1
+         db-result-2
+         '({:revision-id 1
+            :deleted "false"
+            :format "application/vnd.nasa.cmr.umm+json;version=1.1.1"
+            :provider-id "PROV1"
+            :user-id "ECHO_SYS"
+            :transaction-id "2000000011M"
+            :native-id "erichs_ingest_subscription3"
+            :concept-id "SUB1200000008-PROV1"
+            :metadata "{\"SubscriberId\":\"eereiter\",
+                          \"CollectionConceptId\":\"C1200000002-PROV1\",
+                          \"EndPoint\":\"some-endpoint\",
+                          \"Mode\":[\"Update\"],
+                          \"Method\":\"ingest\",
+                          \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
+                          \"Query\":\"collection-concept-id=C1200000002-PROV1\",
+                          \"Name\":\"Ingest-Subscription-Test\",
+                          \"Type\":\"granule\",
+                          \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1.1\"}}"
+            :revision-date "2024-10-07T18:13:32.608Z"
+            :extra-fields {:normalized-query "76c6d7a828ef81efb3720638f335f65c"
+                           :subscription-type "granule"
+                           :subscription-name "Ingest-Subscription-Test"
+                           :subscriber-id "eereiter"
+                           :collection-concept-id "C1200000002-PROV1"}
+            :concept-type :subscription})))
+
+(def db-result-4
+  '({:revision-id 1
+     :deleted "false"
+     :format "application/vnd.nasa.cmr.umm+json;version=1.1.1"
+     :provider-id "PROV1"
+     :user-id "ECHO_SYS"
+     :transaction-id "20000000013M"
+     :native-id "erichs_ingest_subscription9"
+     :concept-id "SUB1200000009-PROV1"
+     :metadata "{\"SubscriberId\":\"eereiter\",
+                \"CollectionConceptId\":\"C1200000003-PROV1\",
+                \"EndPoint\":\"some-endpoint\",
+                \"Mode\":[\"New\",\"Delete\"],
+                \"Method\":\"ingest\",
+                \"EmailAddress\":\"erich.e.reiter@nasa.gov\",
+                \"Query\":\"collection-concept-id=C1200000003-PROV1\",
+                \"Name\":\"Ingest-Subscription-Test\",
+                \"Type\":\"granule\",
+                \"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/subscription/v1.1.1\",\"Name\":\"UMM-Sub\",\"Version\":\"1.1.1\"}}"
+     :revision-date "2024-10-07T18:13:32.608Z"
+     :extra-fields {:normalized-query "76c6d7a828ef81efb3720638f335f65c"
+                    :subscription-type "granule"
+                    :subscription-name "Ingest-Subscription-Test"
+                    :subscriber-id "eereiter"
+                    :collection-concept-id "C1200000003-PROV1"
+                    :endpoint "some-endpoint"
+                    :mode ["New", "Delete"]
+                    :method "ingest"}
      :concept-type :subscription}))
 
 (deftest subscription-refresh-cache-test
@@ -152,23 +327,32 @@
         test-context {:system {:caches {cache-key (subscription-cache/create-cache-client)}}}
         cache-client (get-in test-context [:system :caches cache-key])]
     (hash-cache/reset cache-client cache-key)
-    (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C1200000002-PROV1"
-                                                                               :mode ["New" "Update"]
-                                                                               :endpoint "some-endpoint"
-                                                                               :method "ingest"}})
-    (subscriptions/add-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12346-PROV1"
-                                                                               :mode ["New" "Update"]
-                                                                               :endpoint "some-endpoint"
-                                                                               :method "ingest"}})
+    (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] db-result-1)}
+      (subscriptions/change-subscription test-context :subscription {:extra-fields {:collection-concept-id "C1200000002-PROV1"
+                                                                                    :mode ["New" "Delete"]
+                                                                                    :endpoint "some-endpoint"
+                                                                                    :method "ingest"}}))
+    (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] db-result-2)}
+      (subscriptions/change-subscription test-context :subscription {:extra-fields {:collection-concept-id "C12346-PROV1"
+                                                                                    :mode ["New" "Update"]
+                                                                                    :endpoint "some-endpoint"
+                                                                                    :method "ingest"}}))
+    (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context _coll-concept-id] db-result-4)}
+      (subscriptions/change-subscription test-context :subscription {:extra-fields {:collection-concept-id "C1200000003-PROV1"
+                                                                                    :mode ["New", "Delete"]
+                                                                                    :endpoint "some-endpoint"
+                                                                                    :method "ingest"}}))
     (testing "What is in the cache"
-      (is (= {"C1200000002-PROV1" {"New" 1 "Update" 1}
-              "C12346-PROV1" {"New" 1 "Update" 1}}
-             (hash-cache/get-map cache-client cache-key))))
+      (is (= {"C1200000002-PROV1" (set ["New" "Delete"])
+              "C12346-PROV1" (set ["New" "Update"])
+              "C1200000003-PROV1" (set ["New" "Delete"])}
+             (create-value-set (hash-cache/get-map cache-client cache-key)))))
     (testing "Cache needs to be updated."
-      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context] db-result)}
+      (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context] db-result-3)}
         (subscriptions/refresh-subscription-cache test-context))
-      (is (= {"C1200000002-PROV1" {"New" 1 "Update" 1 "Delete" 1}}
-             (hash-cache/get-map cache-client cache-key))))
+      (is (= {"C1200000002-PROV1" (set ["New" "Update" "Delete"])
+              "C12346-PROV1" (set ["New" "Update"])}
+             (create-value-set (hash-cache/get-map cache-client cache-key)))))
     (testing "Testing no subscriptions"
       (with-bindings {#'subscriptions/get-subscriptions-from-db (fn [_context] '())}
         (subscriptions/refresh-subscription-cache test-context))


### PR DESCRIPTION

# Overview

### What is the feature/fix?

When a subscription is created or deleted update the subscription cache so that granule ingest subscriptions can be filtered out quickly.

### What is the Solution?

Changed Metadata_db concept_service and subscriptions to call to cache or remove subscription information needed to get granule CRUD events for notifications.

### What areas of the application does this impact?

Metadata_db concept_service and subscriptions

# Checklist

- [Z] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [X] New and existing unit and int tests pass locally and remotely
- [X] clj-kondo has been run locally and all errors corrected
- [X] I have removed unnecessary/dead code and imports in files I have changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
