### PR TITLE
CMR-10173: Update dataset progress enum

### DIFF
--- a/umm-spec-lib/resources/xml-schemas/dif10/UmmCommon_1.2.xsd
+++ b/umm-spec-lib/resources/xml-schemas/dif10/UmmCommon_1.2.xsd
@@ -457,6 +457,9 @@ technical contact
             <xs:enumeration value="PLANNED"/>
             <xs:enumeration value="IN WORK"/>
             <xs:enumeration value="COMPLETE"/>
+            <xs:enumeration value="PREPRINT"/>
+            <xs:enumeration value="INREVIEW"/>
+            <xs:enumeration value="SUPERSEDED"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Adding the missing dif 10 dataset progress that was supposed to go into the first CMR-10173 PR

### What is the Solution?

same as above

### What areas of the application does this impact?

All translations

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
