### PR TITLE
CMR-10000: RelatedURL subtype not accessible through ECHO10 collection

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/related_url.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/xml_to_umm_mappings/echo10/related_url.clj
@@ -109,6 +109,7 @@
   "User guide" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "USER'S GUIDE"}
   "User Support" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "GENERAL DOCUMENTATION"}
   "USER's GUIDE" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "USER'S GUIDE"}
+  "USER'S GUIDE" {:URLContentType "PublicationURL", :Type "VIEW RELATED INFORMATION", :Subtype "USER'S GUIDE"}
   "VIEW DATA SET LANDING PAGE" {:URLContentType "CollectionURL", :Type "DATA SET LANDING PAGE"}
   "VIEW IMAGES" {:URLContentType "VisualizationURL", :Type "GET RELATED VISUALIZATION"}
   "VIEW PROJECT HOME PAGE" {:URLContentType "CollectionURL", :Type "PROJECT HOME PAGE"}


### PR DESCRIPTION
# Overview

### What is the feature/fix?

RelatedURL SubType field was not translating correctly for 'User's Guide' when ingested as Echo10 and translated into UMM-C

### What is the Solution?

Add the User's Guide with 'USER'S GUIDE' spelling to translation map

### What areas of the application does this impact?

List impacted areas.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
