### PR TITLE
CMR-10215: REPORT Logs Emitting Security Token in Clear Text

### DIFF
--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -189,10 +189,8 @@
                              ;; do these last
                              "log-cost" (- (tk/now-ms) log-start)
                              "duration" (- (tk/now-ms) ring-start))
-                      (util/remove-nil-keys))
-             note (if (contains? note "authorization")
-                    (assoc note "authorization" "****")
-                    note)]
+                      (as-> data (if (contains? data "authorization") (assoc data "authorization" "*****") data))
+                      (util/remove-nil-keys))]
          (report (json/generate-string note))
          response)))))
 

--- a/common-app-lib/src/cmr/common_app/api/request_logger.clj
+++ b/common-app-lib/src/cmr/common_app/api/request_logger.clj
@@ -189,7 +189,10 @@
                              ;; do these last
                              "log-cost" (- (tk/now-ms) log-start)
                              "duration" (- (tk/now-ms) ring-start))
-                      (util/remove-nil-keys))]
+                      (util/remove-nil-keys))
+             note (if (contains? note "authorization")
+                    (assoc note "authorization" "****")
+                    note)]
          (report (json/generate-string note))
          response)))))
 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

REPORT Logs Emitting Security Token in Clear Text

### What is the Solution?

If the token exists, will obfuscate with ****. If it does not exist, will do nothing.

### What areas of the application does this impact?

Logs across all apps

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
