### PR TITLE
CMR-10283: Fix styling inconsistencies from using the latest cmr-prev…

### DIFF
--- a/search-app/resources/templates/collection-base.html
+++ b/search-app/resources/templates/collection-base.html
@@ -11,6 +11,27 @@
 <div id="metadata-preview">
   <p>Fetching Collection...</p>
 </div>
+<!-- TODO we need to update a new version of EUI compliant with bootstrap-5 fix styling in the meantime -->
+<style>
+  .btn-sm  {
+    color: #fff !important;
+  }
+
+  h5 { 
+    font-weight: bold;
+    font-size: 1rem;
+  }
+
+  h4 { 
+    font-weight: bold;
+    font-size: 1.25rem;
+    color: inherit;
+  }
+
+  table, td, th {
+    border-color: #dee2e6 !important;
+  }
+</style>
 {% endblock %}
 
 {% block body-end %}

--- a/search-app/resources/templates/service-base.html
+++ b/search-app/resources/templates/service-base.html
@@ -11,6 +11,22 @@
 <div id="metadata-preview">
   <p>Fetching Service...</p>
 </div>
+  <!-- TODO we need to update a new version of EUI compliant with bootstrap-5 fix styling in the meantime -->
+  <style>
+   h5 { 
+      font-weight: bold;
+      font-size: 1rem;
+    }
+  
+    h4 { 
+      font-weight: bold;
+      font-size: 1.25rem;
+      color: inherit;
+    }
+    table, td, th {
+      border-color: #dee2e6 !important;
+    }
+  </style>
 {% endblock %}
 
 {% block body-end %}

--- a/search-app/resources/templates/tool-base.html
+++ b/search-app/resources/templates/tool-base.html
@@ -11,6 +11,19 @@
 <div id="metadata-preview">
   <p>Fetching Tool...</p>
 </div>
+<!-- TODO we need to update a new version of EUI compliant with bootstrap-5 fix styling in the meantime -->
+<style>
+  h5 { 
+     font-weight: bold;
+     font-size: 1rem;
+   }
+ 
+   h4 { 
+     font-weight: bold;
+     font-size: 1.25rem;
+     color: inherit;
+   }
+ </style>
 {% endblock %}
 
 {% block body-end %}

--- a/search-app/resources/templates/variable-base.html
+++ b/search-app/resources/templates/variable-base.html
@@ -11,6 +11,23 @@
 <div id="metadata-preview">
   <p>Fetching Variable...</p>
 </div>
+<!-- TODO we need to update a new version of EUI compliant with bootstrap-5 fix styling in the meantime -->
+<style>
+  h5 { 
+      font-weight: bold;
+      font-size: 1rem;
+  }
+
+  h4 { 
+    font-weight: bold;
+    font-size: 1.25rem;
+    color: inherit;
+  }
+
+  table, td, th {
+      border-color: #dee2e6 !important;
+  }
+</style>
 {% endblock %}
 
 {% block body-end %}


### PR DESCRIPTION
# Overview

### What is the feature/fix?

The metadata preview version was updated resulting in styling inconsistencies because the CMR landing pages use both `EUI` and the `metadata-preview` plugin

### What is the Solution?

Within those CMR landing pages I'm overriding some styling so that it looks more like the expected output from https://access.sit.earthdata.nasa.gov/ this is a somewhat temporary stopgap because the long-term fix is to pull out repeated styling from `MMT`,` edsc-meatdata-plugin`, and eventually` Earthdata Search` into an updated styling library so that we can consistently do this across the apps. For now though UX is degraded because titles are not clear, button text is miscolored, and the table formatting looks inconsistent because of borders. This PR is a hotfix to those things

### What areas of the application does this impact?


### Attachments

Current issues:
![image](https://github.com/user-attachments/assets/a9d3acea-12df-4f13-a619-8f36e71c69a9)
![image](https://github.com/user-attachments/assets/c092501a-d67a-4dae-91ee-ec34b1e513af)
![image](https://github.com/user-attachments/assets/a4f9d66a-fca7-4c2b-ae77-7f9e258be4ea)

Local Fixes:
![image](https://github.com/user-attachments/assets/1d3bc188-37c4-443a-99d7-bbe101c1ed26)
![image](https://github.com/user-attachments/assets/9a98bd55-5763-4f28-b63e-84f3f7dfb959)

Build Result (Probably not necessary since this code is really splintered off from CMR core)
![image](https://github.com/user-attachments/assets/af3a1d7f-caac-43c2-ad39-c92d13bcbeaa)

The CMR landing pages (.html endpoints) for collections, granules, tools, and services
# Checklist

- [N/A] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [N/A ] New and existing unit and int tests pass locally and remotely
- [N/A] clj-kondo has been run locally and all errors corrected
- [N/A] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ N/A] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [N/A] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
