### PR TITLE
CMR-10285: Adding check before subscribing to AWS that the subscription is an ingest subscription.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -115,17 +115,19 @@
   the topic."
   [context concept]
   (when-let [concept-edn (convert-concept-to-edn concept)]
-    (let [topic (get-in context [:system :sns :external])]
-      (topic-protocol/subscribe topic concept-edn))))
+    (when (ingest-subscription-concept? concept-edn)
+      (let [topic (get-in context [:system :sns :external])]
+        (topic-protocol/subscribe topic concept-edn)))))
 
 (defn delete-subscription
   "Remove the subscription from the cache and unsubscribe the subscription from
   the topic."
   [context concept]
   (when-let [concept-edn (add-delete-subscription context concept)]
-    (let [topic (get-in context [:system :sns :external])]
-      (topic-protocol/unsubscribe topic {:concept-id (:concept-id concept-edn)
-                                         :subscription-arn (get-in concept-edn [:extra-fields :aws-arn])}))))
+    (when (ingest-subscription-concept? concept-edn)
+      (let [topic (get-in context [:system :sns :external])]
+        (topic-protocol/unsubscribe topic {:concept-id (:concept-id concept-edn)
+                                           :subscription-arn (get-in concept-edn [:extra-fields :aws-arn])})))))
 
 ;;
 ;; The functions below are for refreshing the subscription cache if needed.


### PR DESCRIPTION

# Overview

### What is the feature/fix?

Added a check if the subscription is an ingest subscription, only then add the subscription.

### What is the Solution?

Added a check if the subscription is an ingest subscription, only then add the subscription.

### What areas of the application does this impact?

Subscriptions

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
