### PR TITLE
CMR-10287: Create feature toggle for cmr-validate-keyword default behavior change

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -159,8 +159,10 @@ The following fields are validated:
 * [Data Format](https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/dataformat?format=csv) - Archival and Distribution File Format, and GetData Format
 * [ProcessingLevel] (https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/productlevelid?format=csv) - productlevelid
 
-**Note**: cmr-validate-keywords is set to TRUE by default
+**Note**: if cmr-validate-keywords header is not set explicitly, it will behave as if it was set to FALSE by default behind the scenes
+
 **Note**: that when multiple fields are present the combination of keywords are validated to match a known combination.
+
 **Note**: Among the validation fields above, [Platforms], [Instruments], [Projects], [Science Keywords], [Location Keywords] and [Data Centers] are also validated when the `Cmr-Validate-Keywords` header is not set to `true` except that  validation errors will be returned to users as warnings.
 
 **Note**: the following fields are always checked:

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -7,18 +7,27 @@
    [cmr.common.log :refer [info]]
    [cmr.common.util :as util]
    [cmr.ingest.api.core :as api-core]
+   [cmr.ingest.config :as ingest-config]
    [cmr.ingest.services.ingest-service :as ingest]))
 
 (def VALIDATE_KEYWORDS_HEADER "cmr-validate-keywords")
 (def ENABLE_UMM_C_VALIDATION_HEADER "cmr-validate-umm-c")
 (def TESTING_EXISTING_ERRORS_HEADER "cmr-test-existing-errors")
 
+(def validate-keywords-default-true-enabled?
+  "Checks to see if the feature toggle for validate-keywords-default-true is enabled."
+  (ingest-config/validate-keywords-default-true-enabled))
+
 (defn get-validation-options
   "Returns a map of validation options with boolean values"
   [headers]
-  {:validate-keywords? (if (= "false" (get headers VALIDATE_KEYWORDS_HEADER)) false true)
-   :validate-umm? (= "true" (get headers ENABLE_UMM_C_VALIDATION_HEADER))
-   :test-existing-errors? (= "true" (get headers TESTING_EXISTING_ERRORS_HEADER))})
+  (let [_ (println "validate-keywords-default-true-enabled = " validate-keywords-default-true-enabled?)
+        validate-keywords-value (if validate-keywords-default-true-enabled?
+                                  (if (= "false" (get headers VALIDATE_KEYWORDS_HEADER)) false true)
+                                  (= "true" (get headers VALIDATE_KEYWORDS_HEADER)))]
+    {:validate-keywords? validate-keywords-value
+     :validate-umm? (= "true" (get headers ENABLE_UMM_C_VALIDATION_HEADER))
+     :test-existing-errors? (= "true" (get headers TESTING_EXISTING_ERRORS_HEADER))}))
 
 (defn validate-collection
   [provider-id native-id request]

--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -21,8 +21,7 @@
 (defn get-validation-options
   "Returns a map of validation options with boolean values"
   [headers]
-  (let [_ (println "validate-keywords-default-true-enabled = " validate-keywords-default-true-enabled?)
-        validate-keywords-value (if validate-keywords-default-true-enabled?
+  (let [validate-keywords-value (if validate-keywords-default-true-enabled?
                                   (if (= "false" (get headers VALIDATE_KEYWORDS_HEADER)) false true)
                                   (= "true" (get headers VALIDATE_KEYWORDS_HEADER)))]
     {:validate-keywords? validate-keywords-value

--- a/ingest-app/src/cmr/ingest/config.clj
+++ b/ingest-app/src/cmr/ingest/config.clj
@@ -7,6 +7,10 @@
    [cmr.oracle.config :as oracle-config]
    [cmr.oracle.connection :as conn]))
 
+(defconfig validate-keywords-default-true-enabled
+   "Flag for whether or not cmr-validate-keywords value is defaulted to true or false in backend when missing in ingest api headers"
+   {:default true :type Boolean})
+
 (defconfig progressive-update-enabled
   "Flag for whether or not collection progressive update is enabled."
   {:default true :type Boolean})


### PR DESCRIPTION
# Overview

### What is the feature/fix?

[CMR-10182](https://bugs.earthdata.nasa.gov/browse/CMR-10182) changed api behavior for ingesting collections by making cmr-validate-keywords default to true instead of its previous default behavior of false.

### What is the Solution?

A feature toggle on top of this behavior change so we can control when this feature become public or not in all envs

### What areas of the application does this impact?

Ingest

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
