### PR TITLE
CMR-9878: CodeSystemIdentifierMeaning maxlength to 1024, minItems to 1

### DIFF
--- a/umm-spec-lib/resources/json-schemas/variable/umm/v1.9.0/umm-var-json-schema.json
+++ b/umm-spec-lib/resources/json-schemas/variable/umm/v1.9.0/umm-var-json-schema.json
@@ -348,9 +348,9 @@
           "items": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 120
+            "maxLength": 1024
           },
-          "minItems": 0
+          "minItems": 1
         },
         "CodeSystemIdentifierValue": {
           "description": "The code system identifier value is the textual or numerical value assigned to each meaning.",


### PR DESCRIPTION
# Overview

### What is the feature/fix?
Update length of Variable - CodeSystemIdentifierMeaning field from 60 to 1024 and minItems to 1.

### What is the Solution?

Update json schema file for Variable.

### What areas of the application does this impact?

Ingest of Variable - field CodeSystemIdentifierMeaning.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
