### PR TITLE
CMR-10323: Int test periodically failing

### DIFF
--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
@@ -247,19 +247,16 @@
 (def minimal-umm-c
   "This is the minimal valid UMM-C."
   {:Platforms [(umm-cmn/map->PlatformType
-                 {:ShortName "Airplane"
-                  :LongName "Airplane"
-                  :Type "Jet"})]
-   :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "1T"})
+                 {:ShortName "A340-600" :LongName "Airbus A340-600" :Type "Jet"})]
+   :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "3"})
    :DataCenters [(umm-cmn/map->DataCenterType
                    {:Roles ["ARCHIVER"]
                     :ShortName "AARHUS-HYDRO"
                     :LongName "Hydrogeophysics Group, Aarhus University "})]
    :ScienceKeywords [(umm-cmn/map->ScienceKeywordType
-                       {:Category "EARTH SCIENCE"
-                        :Topic "ATMOSPHERE"
-                        :Term "AIR QUALITY",
-                        :VariableLevel1 "CARBON MONOXIDE"})]
+                      {:Category "EARTH SCIENCE SERVICES"
+                       :Topic "DATA ANALYSIS AND VISUALIZATION"
+                       :Term "GEOGRAPHIC INFORMATION SYSTEMS"})]
    :SpatialExtent (umm-c/map->SpatialExtentType {:GranuleSpatialRepresentation "NO_SPATIAL"})
    :ShortName "short"
    :Version "V1"

--- a/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
+++ b/system-int-test/src/cmr/system_int_test/data2/umm_spec_collection.clj
@@ -247,16 +247,19 @@
 (def minimal-umm-c
   "This is the minimal valid UMM-C."
   {:Platforms [(umm-cmn/map->PlatformType
-                 {:ShortName "A340-600" :LongName "Airbus A340-600" :Type "Jet"})]
-   :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "3"})
+                 {:ShortName "Airplane"
+                  :LongName "Airplane"
+                  :Type "Jet"})]
+   :ProcessingLevel (umm-c/map->ProcessingLevelType {:Id "1T"})
    :DataCenters [(umm-cmn/map->DataCenterType
                    {:Roles ["ARCHIVER"]
                     :ShortName "AARHUS-HYDRO"
                     :LongName "Hydrogeophysics Group, Aarhus University "})]
    :ScienceKeywords [(umm-cmn/map->ScienceKeywordType
-                      {:Category "EARTH SCIENCE SERVICES"
-                       :Topic "DATA ANALYSIS AND VISUALIZATION"
-                       :Term "GEOGRAPHIC INFORMATION SYSTEMS"})]
+                       {:Category "EARTH SCIENCE"
+                        :Topic "ATMOSPHERE"
+                        :Term "AIR QUALITY",
+                        :VariableLevel1 "CARBON MONOXIDE"})]
    :SpatialExtent (umm-c/map->SpatialExtentType {:GranuleSpatialRepresentation "NO_SPATIAL"})
    :ShortName "short"
    :Version "V1"

--- a/system-int-test/test/cmr/system_int_test/ingest/provider/provider_cmr_only_client_id_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider/provider_cmr_only_client_id_test.clj
@@ -19,7 +19,9 @@
   "Executes the given function with the concept and client-id and make sure the status code
   is correct. It will print out the executed function name when test fails."
   [func-var concept client-id]
-  (let [{:keys [status errors]} ((var-get func-var) concept {:client-id client-id})]
+  (let [{:keys [status errors]} ((var-get func-var) concept {:client-id client-id})
+        _ (println "Status returned = " status)
+        _ (println "Errors returned = " errors)]
     (is (#{200 201} status) (format "Failed in %s. with errors: %s" func-var errors))))
 
 (deftest collection-cmr-only-client-id-test
@@ -33,6 +35,7 @@
           concept (dissoc (d/item->concept coll1) :revision-id)]
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "any"))))
+  ;; TODO this test fails too sometimes
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client Echo"
     (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
           concept (dissoc (d/item->concept coll1) :revision-id)]
@@ -43,6 +46,7 @@
       (ingest/clear-caches)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "ECHO"))))
+  ;; TODO this is the problem test
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client other than Echo"
     (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
           concept (dissoc (d/item->concept coll1) :revision-id)]

--- a/system-int-test/test/cmr/system_int_test/ingest/provider/provider_cmr_only_client_id_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/provider/provider_cmr_only_client_id_test.clj
@@ -19,60 +19,58 @@
   "Executes the given function with the concept and client-id and make sure the status code
   is correct. It will print out the executed function name when test fails."
   [func-var concept client-id]
-  (let [{:keys [status errors]} ((var-get func-var) concept {:client-id client-id})
-        _ (println "Status returned = " status)
-        _ (println "Errors returned = " errors)]
+  (let [{:keys [status errors]} ((var-get func-var) concept {:client-id client-id})]
     (is (#{200 201} status) (format "Failed in %s. with errors: %s" func-var errors))))
 
 (deftest collection-cmr-only-client-id-test
   (testing "ingest operations on CMR-ONLY provider can be submitted by client Echo"
-    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (dissoc (d/item->concept coll1) :revision-id)]
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "ECHO"))))
   (testing "ingest operations on CMR-ONLY provider can be submitted by client other than Echo"
-    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (dissoc (d/item->concept coll1) :revision-id)]
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "any"))))
-  ;; TODO this test fails too sometimes
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client Echo"
-    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (dissoc (d/item->concept coll1) :revision-id)]
       (ingest/update-ingest-provider {:provider-id "PROV1"
                                       :short-name "PROV1"
                                       :cmr-only false
                                       :small false})
       (ingest/clear-caches)
+      (Thread/sleep 3000)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "ECHO"))))
-  ;; TODO this is the problem test
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client other than Echo"
-    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [coll1 (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (dissoc (d/item->concept coll1) :revision-id)]
       (ingest/update-ingest-provider {:provider-id "PROV1"
                                       :short-name "PROV1"
                                       :cmr-only false
                                       :small false})
       (ingest/clear-caches)
+      (Thread/sleep 3000)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "any")))))
 
 (deftest granule-cmr-only-client-id-test
   (testing "ingest operations on CMR-ONLY provider can be submitted by client Echo"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (d/item->concept (dg/granule-with-umm-spec-collection collection "C1-PROV1"))]
       (ingest/ingest-concept concept)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "ECHO"))))
   (testing "ingest operations on CMR-ONLY provider can be submitted by client other than Echo"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (d/item->concept (dg/granule-with-umm-spec-collection collection "C1-PROV1"))]
       (ingest/ingest-concept concept)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "any"))))
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client Echo"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (d/item->concept (dg/granule-with-umm-spec-collection collection "C1-PROV1"))]
       (ingest/ingest-concept concept)
       (ingest/update-ingest-provider {:provider-id "PROV1"
@@ -80,10 +78,11 @@
                                       :cmr-only false
                                       :small false})
       (ingest/clear-caches)
+      (Thread/sleep 3000)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "ECHO"))))
   (testing "ingest operations on non CMR-ONLY provider can be submitted by client other than Echo"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           concept (d/item->concept (dg/granule-with-umm-spec-collection collection "C1-PROV1"))]
       (ingest/ingest-concept concept)
       (ingest/update-ingest-provider {:provider-id "PROV1"
@@ -91,12 +90,13 @@
                                       :cmr-only false
                                       :small false})
       (ingest/clear-caches)
+      (Thread/sleep 3000)
       (doseq [func ingest-functions-to-test]
         (assert-ingest-success func concept "any")))))
 
 (deftest granule-virtual-product-service-ingest-test
   (testing "ingest with Virtual-Product-Service as client-id should succeed for cmr-only provider"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           granule (dg/granule-with-umm-spec-collection collection "C1-PROV1")
           concept (d/item->concept granule)]
       (assert-ingest-success #'ingest/validate-concept concept "Virtual-Product-Service")
@@ -109,7 +109,7 @@
       (is (= 0 (:hits (search/find-refs :granule {:granule-ur (:granule-ur granule)
                                                   :page-size 50}))))))
   (testing "ingest with Virtual-Product-Service as client-id should succeed for non cmr-only provider"
-    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}) {:validate-keywords false})
+    (let [collection (d/ingest-umm-spec-collection "PROV1" (data-umm-c/collection {:EntryTitle "ET1"}))
           granule (dg/granule-with-umm-spec-collection collection "C1-PROV1")
           concept (d/item->concept granule)]
       (ingest/update-ingest-provider {:provider-id "PROV1"
@@ -117,6 +117,7 @@
                                       :cmr-only false
                                       :small false})
       (ingest/clear-caches)
+      (Thread/sleep 3000)
       (assert-ingest-success #'ingest/validate-concept concept "Virtual-Product-Service")
       (assert-ingest-success #'ingest/ingest-concept concept "Virtual-Product-Service")
       (index/wait-until-indexed)


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Int test periodically failing

### What is the Solution?

Caches needed to be refreshed and tests did not wait long enough sometimes for it to complete in the backend. Increased time to wait to give caches enough time to fully refresh

### What areas of the application does this impact?

Int tests

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
