### PR TITLE
CMR-10310: Allow the subscription endpoint to take an https URL in the EndPoint element

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1157,7 +1157,7 @@ For NRT Notification subscriptions to be used there are three new fields that ar
 <ul>
     <li>Type: [required] Must be set to "granule" because NRT Notification subscriptions are only for granules.</li>
     <li>CollectionConceptId: [required] Because type must be "granule", we must set "CollectionConceptId" as well, as indicated in Data Fields section</li>
-    <li>EndPoint: [required] describes where notifications get sent. At this time only AWS SQS ARN's are allowed. NRT Notification subscriptions that do not use an AWS SQS ARN will fail. If Batch Notification subscriptions are desired, do not use this field.</li>
+    <li>EndPoint: [required] describes where notifications get sent. At this time, only AWS SQS ARN's and HTTP/S URLs are allowed. HTTP/s URLs must be in the following full URL name format: https://www.websitename.com/123. If Batch Notification subscriptions are desired, do not use this field.</li>
     <li>Mode: [required] describes whether the notification is for New (ingested for the first time into the CMR) granules, Updated granules, or Deleted granules. </li>
     <ul>
         <li>Valid values: "New", "Update", "Delete". Any combination of these values are valid and they are set using a json array. </li>
@@ -1181,7 +1181,7 @@ curl  --request POST '%CMR-ENDPOINT%/ingest/subscriptions/my-native-id-of-my-sub
     "SubscriberId": "My_sub_id",
     "EmailAddress": "myemail@email.com",
     "CollectionConceptId": "MyCollectionID",
-    "EndPoint": "MyAWSSQSARN",
+    "EndPoint": "MySQSARN",
     "Mode": ["New","Update"],
     "Method":"ingest",
     "MetadataSpecification": {

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -84,7 +84,7 @@
   [subscription-concept]
   (let [method (:Method subscription-concept)
         endpoint (:EndPoint subscription-concept)
-        default-url-validator (UrlValidator.)]
+        default-url-validator (UrlValidator. UrlValidator/ALLOW_LOCAL_URLS)]
 
     (if (= method "ingest")
       (if-not (or (some? (re-matches #"arn:aws:sqs:.*" endpoint)) (.isValid default-url-validator endpoint))

--- a/ingest-app/src/cmr/ingest/api/subscriptions.clj
+++ b/ingest-app/src/cmr/ingest/api/subscriptions.clj
@@ -20,7 +20,9 @@
    [cmr.transmit.search :as search]
    [cmr.transmit.urs :as urs])
   (:import
-   [java.util UUID]))
+   [java.util UUID])
+  (:import
+    (org.apache.commons.validator.routines UrlValidator)))
 
 (def ^:private CMR_PROVIDER
   "CMR provider-id, used by collection subscription."
@@ -76,6 +78,20 @@
                        {:token (config/echo-system-token)}
                        query-params)]
     (search-concept-refs-with-sub-params context search-params subscription-type)))
+
+(defn- validate-subscription-endpoint
+  "Validates the subscription endpoint for purposes of validation. Throws error if not valid."
+  [subscription-concept]
+  (let [method (:Method subscription-concept)
+        endpoint (:EndPoint subscription-concept)
+        default-url-validator (UrlValidator.)]
+
+    (if (= method "ingest")
+      (if-not (or (some? (re-matches #"arn:aws:sqs:.*" endpoint)) (.isValid default-url-validator endpoint))
+        (errors/throw-service-error
+          :bad-request
+          "Subscription creation failed - Method was ingest, but the endpoint given was not valid SQS ARN or HTTP/S URL.
+          If it is a URL, make sure to give the full URL path like so: https://www.google.com.")))))
 
 (defn- check-subscription-limit
   "Given the configuration for subscription limit, this valdiates that the user has no more than
@@ -272,7 +288,7 @@
 
 (defn- body->subscription
   "Returns the subscription concept for the given request body, etc.
-  This is the raw subscritpion that is ready for metadata validation,
+  This is the raw subscription that is ready for metadata validation,
   but still needs some sanitization to be saved to database."
   [native-id body content-type headers]
   (let [sub-concept (api-core/body->concept!
@@ -319,6 +335,7 @@
       (api-core/verify-provider-exists context provider-id))
     (validate-user-id context subscriber-id)
     (validate-query context parsed)
+    (validate-subscription-endpoint parsed)
     (let [parsed-metadata (assoc parsed :SubscriberId subscriber-id)]
       {:concept (assoc sub-concept
                        :metadata (json/generate-string parsed-metadata)

--- a/ingest-app/test/cmr/ingest/api/subscriptions_test.clj
+++ b/ingest-app/test/cmr/ingest/api/subscriptions_test.clj
@@ -1,8 +1,9 @@
 (ns cmr.ingest.api.subscriptions-test
   (:require
-   [clojure.string :as string]
-   [clojure.test :refer :all]
-   [cmr.ingest.api.subscriptions :as subscriptions]))
+    [clojure.string :as string]
+    [clojure.test :refer :all]
+    [cmr.common.util :as util]
+    [cmr.ingest.api.subscriptions :as subscriptions]))
 
 (deftest generate-native-id-test
   (let [parsed {:Name "the_beginning"
@@ -14,3 +15,32 @@
 
     (testing "name is used as the prefix"
       (is (string/starts-with? native-id "the_beginning")))))
+
+(deftest validate-subscription-endpoint-test
+  (testing "validate subscription endpoint str -- expected valid"
+    (util/are3 [subscription-concept]
+               (let [fun #'cmr.ingest.api.subscriptions/validate-subscription-endpoint]
+                 (is (= nil (fun subscription-concept))))
+
+               "given method is search -- endpoint ignored"
+               {:EndPoint "blahblah", :Method "search"}
+
+               "given method is search and endpoint not given -- endpoint ignored"
+               {:EndPoint "blahblah", :Method "search"}
+
+               "given method is ingest and sqs arn is valid"
+               {:EndPoint "arn:aws:sqs:us-east-1:000000000:Test-Queue", :Method "ingest"}
+
+               "given method is ingest and url is valid"
+               {:EndPoint "https://testwebsite.com", :Method "ingest"}))
+
+  (testing "validate subscription endpoint str -- expected invalid"
+    (util/are3 [subscription-concept]
+               (let [fun #'cmr.ingest.api.subscriptions/validate-subscription-endpoint]
+                 (is (thrown? Exception (fun subscription-concept))))
+
+               "given method is ingest and sqs arn is invalid"
+               {:EndPoint "iaminvalidendpoint", :Method "ingest"}
+
+               "given method is ingest and endpoint is empty is invalid"
+               {:Endpoint "", :Method "ingest"})))

--- a/message-queue-lib/src/cmr/message_queue/queue/aws_queue.clj
+++ b/message-queue-lib/src/cmr/message_queue/queue/aws_queue.clj
@@ -33,7 +33,7 @@
        (.build))))
 
 (defn create-queue
-  "Create an instance of a an AWS queue in either AWS or elasticMQ."
+  "Create an instance of an AWS queue in either AWS or elasticMQ."
   [sqs-client queue-name]
   (try
     (let [sqs-request (-> (CreateQueueRequest/builder)

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -2,7 +2,6 @@
   "Buisness logic for subscription processing."
   (:require
    [cheshire.core :as json]
-   [clojure.string :as str]
    [clj-http.client :as client]
    [cmr.common.log :refer [debug info]]
    [cmr.common.services.errors :as errors]

--- a/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/subscriptions.clj
@@ -122,7 +122,7 @@
 (defn- is-valid-subscription-endpoint-url
   "Checks if subscription endpoint destination is a valid url. Returns true or false."
   [endpoint]
-  (let [default-validator (UrlValidator.)]
+  (let [default-validator (UrlValidator. UrlValidator/ALLOW_LOCAL_URLS)]
     (.isValid default-validator endpoint)))
 
 (defn- send-sub-to-url-dest

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
@@ -682,3 +682,56 @@
                (is (= "G12345-PROV1" (:concept-id real-message)))
                (is (= '(:concept-id :granule-ur :producer-granule-id :location) (keys real-message)))
                (is (some? (queue/delete-messages sqs-client internal-queue-url messages))))))))))
+
+(deftest is-sqs-arn-test
+  (testing "sqs endpoint validation"
+    (are3 [expected endpoint]
+          (let [fun #'cmr.metadata-db.services.subscriptions/is-valid-sqs-arn]
+            (is (= expected (fun endpoint))))
+
+          "valid sqs endpoint"
+          true
+          "arn:aws:sqs:us-west-1:123456789:Test-Queue"
+
+          "valid sqs endpoint with any string after sqs: "
+          true
+          "arn:aws:sqs:anything after this is valid"
+
+          "invalid sqs endpoint"
+          false
+          "some string"
+
+          "invalid sqs endpoint - because partial"
+          false
+          "arn:aws:sns:blah blah")))
+
+(deftest is-valid-url-test
+  (testing "url string validation"
+    (are3 [expected endpoint]
+          (let [fun #'cmr.metadata-db.services.subscriptions/is-valid-subscription-endpoint-url]
+            (is (= expected (fun endpoint))))
+
+          "valid url -- with https prefix"
+          true
+          "https://www.google.com"
+
+          "invalid url - no https prefix"
+          false
+          "www.google.com"
+
+          "invalid url -- no www prefix"
+          false
+          "google.com"
+
+          "valid url -- with http prefix"
+          true
+          "http://www.google.com"
+
+          "invalid url - non-existent domain"
+          false
+          "hello.blach"
+
+          "invalid url - some string"
+          false
+          "this is just some string"
+          )))

--- a/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
+++ b/metadata-db-app/test/cmr/metadata_db/test/services/subscriptions_test.clj
@@ -711,6 +711,14 @@
           (let [fun #'cmr.metadata-db.services.subscriptions/is-valid-subscription-endpoint-url]
             (is (= expected (fun endpoint))))
 
+          "valid local url -- with http prefix"
+          true
+          "http://localhost:9324/000000000000"
+
+          "valid local url -- with https prefix"
+          true
+          "https://localhost:9324/000000000000"
+
           "valid url -- with https prefix"
           true
           "https://www.google.com"


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Ingest subscription could only take in SQS ARN as endpoint to send sub messages to

### What is the Solution?

Add the ability to send sub message to any HTTP/S endpoint

### What areas of the application does this impact?

Ingest

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
