### PR TITLE
CMR-10398: Fix Synk vulnerability for netty

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -4,7 +4,7 @@
 
 (def aws-java-sdk2-version
   "The java aws sdk version to use."
-  "2.30.13")
+  "2.28.19")
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."
@@ -12,6 +12,7 @@
   :dependencies [[cheshire "5.12.0"]
                  [clj-http "2.3.0"]
                  [clj-time "0.15.1"]
+                 [netty-ring-adapter "4.1.118.Final"]
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -4,7 +4,7 @@
 
 (def aws-java-sdk2-version
   "The java aws sdk version to use."
-  "2.28.19")
+  "2.30.13")
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -12,7 +12,7 @@
   :dependencies [[cheshire "5.12.0"]
                  [clj-http "2.3.0"]
                  [clj-time "0.15.1"]
-                 [netty-ring-adapter "4.1.118.Final"]
+                 [io.netty/netty-handler "4.1.118.Final"]
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Snyk Vulnerability found and must be fixed for io.netty:netty-handler in cmr-message-queue-lib

### What is the Solution?

Forced the underlying vulnerable library netty-handler to version 4.1.112.Final

### What areas of the application does this impact?

Bootstrap, Access Control, Message Queue Lib

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
