### PR TITLE
CMR-10404: Snyk Fix: Update nokogiri from 1.16.5 to 1.18.3

### DIFF
--- a/system-validation-test/Gemfile
+++ b/system-validation-test/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'cucumber'
   gem 'httparty'
   gem 'jsonpath'
-  gem 'nokogiri', ">= 1.13.10"
+  gem 'nokogiri', "= 1.18.3"
   gem 'rspec'
 end

--- a/system-validation-test/Gemfile.lock
+++ b/system-validation-test/Gemfile.lock
@@ -43,16 +43,16 @@ GEM
     multi_json (1.15.0)
     multi_test (1.1.0)
     multi_xml (0.6.0)
-    nokogiri (1.16.5-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-java)
+    nokogiri (1.18.3-java)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    racc (1.8.0)
-    racc (1.8.0-java)
+    racc (1.8.1)
+    racc (1.8.1-java)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -71,6 +71,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   universal-java-17
   x86_64-darwin-22
   x86_64-linux
@@ -79,7 +80,7 @@ DEPENDENCIES
   cucumber
   httparty
   jsonpath
-  nokogiri (>= 1.13.10)
+  nokogiri (= 1.18.3)
   rspec
 
 BUNDLED WITH


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Snyk Vuln step in GIT PR failed due to vulnerability in system-validation-test/Gemfile.lock

### What is the Solution?

Update Nokogiri from 1.16.5 to 1.18.3

### What areas of the application does this impact?

system validation test

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
