### PR TITLE
CMR-10313: Using environment variable to set http subscription test lambda bucket name.

### DIFF
--- a/subscription/url-endpoint-test-lambda/src/url-endpoint-test-lambda.py
+++ b/subscription/url-endpoint-test-lambda/src/url-endpoint-test-lambda.py
@@ -1,4 +1,5 @@
 import json
+import os
 import boto3
 from botocore.exceptions import ClientError
 from sys import stdout
@@ -11,7 +12,7 @@ from sys import stdout
 # that you used in your tunnel.
 
 s3 = boto3.client('s3')
-BUCKET_NAME = 'cmr-notification-http-tester-bucket'
+BUCKET_NAME = os.getenv("BUCKET_NAME")
 FILE_NAME = 'notification-message.json'
 
 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

 Using environment variable to set http subscription test lambda bucket name.

### What is the Solution?

 Using environment variable to set http subscription test lambda bucket name.

### What areas of the application does this impact?

 Using environment variable to set http subscription test lambda bucket name.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
