### PR TITLE
DRAFT! CMR-10049: deprecated some group apis

### DIFF
--- a/access-control-app/src/cmr/access_control/api/routes.clj
+++ b/access-control-app/src/cmr/access_control/api/routes.clj
@@ -42,12 +42,12 @@
   [headers]
   (mt/extract-header-mime-type #{mt/json} headers "content-type" true))
 
-(defn- create-group-with-managing-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} create-group-with-managing-group
   "Helper function to invoke group service create-group function to pass in a managing group id."
   [ctx managing-group-id group]
   (group-service/create-group ctx group {:managing-group-id managing-group-id}))
 
-(defn- create-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} create-group
   "Processes a create group request."
   [ctx headers body managing-group-id]
   (validate-content-type headers)
@@ -58,14 +58,14 @@
        (util/map-keys->snake_case)
        api-response))
 
-(defn- get-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} get-group
   "Retrieves the group with the given concept-id."
   [ctx concept-id]
   (-> (group-service/get-group ctx concept-id)
       (util/map-keys->snake_case)
       api-response))
 
-(defn- update-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} update-group
   "Processes a request to update a group."
   [ctx headers body concept-id]
   (validate-content-type headers)
@@ -76,17 +76,17 @@
        (util/map-keys->snake_case)
        api-response))
 
-(defn- delete-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} delete-group
   "Deletes the group with the given concept-id."
   [ctx concept-id]
   (api-response (util/map-keys->snake_case (group-service/delete-group ctx concept-id))))
 
-(defn- get-members
+(defn- ^{:deprecated "No replacment, use EDL instead"} get-members
   "Handles a request to fetch group members"
   [ctx concept-id]
   (api-response (group-service/get-members ctx concept-id)))
 
-(defn- add-members
+(defn- ^{:deprecated "No replacment, use EDL instead"} add-members
   "Handles a request to add group members"
   [ctx headers body concept-id]
   (validate-content-type headers)
@@ -96,7 +96,7 @@
        (util/map-keys->snake_case)
        api-response))
 
-(defn- remove-members
+(defn- ^{:deprecated "No replacment, use EDL instead"} remove-members
   "Handles a request to remove group members"
   [ctx headers body concept-id]
   (validate-content-type headers)
@@ -106,7 +106,7 @@
        (util/map-keys->snake_case)
        api-response))
 
-(defn- search-for-groups
+(defn- ^{:deprecated "No replacment, use EDL instead"} search-for-groups
   [ctx headers params]
   (mt/extract-header-mime-type #{mt/json mt/any} headers "accept" true)
   (-> (group-service/search-for-groups ctx (dissoc params :token))

--- a/access-control-app/src/cmr/access_control/services/auth_util.clj
+++ b/access-control-app/src/cmr/access_control/services/auth_util.clj
@@ -135,7 +135,7 @@
   ;; Note: temporarily use :create permission for CMR-2585
   (verify-group-permission context "delete" :create group))
 
-(defn verify-can-update-group
+(defn ^{:deprecated "No replacment, use EDL instead"} verify-can-update-group
   "Throws service error if context user does not have permission to delete group map."
   [context group]
   ;; Note: temporarily use :create permission for CMR-2585

--- a/access-control-app/src/cmr/access_control/services/group_service.clj
+++ b/access-control-app/src/cmr/access_control/services/group_service.clj
@@ -225,7 +225,7 @@
                                                           :target "GROUP_MANAGEMENT"}}))
        result))))
 
-(defn get-group-by-concept-id
+(defn- get-group-by-concept-id
   "Retrieves a group with the given concept id, returns its parsed metadata."
   [context concept-id]
   (edn/read-string (:metadata (fetch-group-concept context concept-id))))

--- a/access-control-app/src/cmr/access_control/services/group_service.clj
+++ b/access-control-app/src/cmr/access_control/services/group_service.clj
@@ -82,7 +82,7 @@
       concept)
     (errors/throw-service-error :not-found (g-msg/group-does-not-exist concept-id))))
 
-(defn- save-updated-group-concept
+(defn- ^{:deprecated "No replacment, use EDL instead"} save-updated-group-concept
   "Saves an updated group concept"
   [context existing-concept updated-group]
   (let [updated-concept (-> existing-concept
@@ -184,7 +184,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Service level functions
 
-(defn create-group
+;; NOTE: this is also used by bootstrap.clj
+(defn ^{:deprecated "No replacment, use EDL instead"} create-group
   "Creates the group by saving it to Metadata DB. Returns a map of the concept id and revision id of
   the created group."
   ([context group]
@@ -229,7 +230,7 @@
   [context concept-id]
   (edn/read-string (:metadata (fetch-group-concept context concept-id))))
 
-(defn get-group
+(defn ^{:deprecated "No replacment, use EDL instead"} get-group
   "Retrieves a group with the given concept id."
   [context concept-id]
   (let [group (get-group-by-concept-id context concept-id)]
@@ -239,7 +240,7 @@
         (assoc :num-members (count (:members group)))
         (dissoc :members))))
 
-(defn delete-group
+(defn ^{:deprecated "No replacment, use EDL instead"} delete-group
   "Deletes a group with the given concept id"
   [context concept-id]
   (common-enabled/validate-write-enabled context "access control")
@@ -248,7 +249,8 @@
     (auth/verify-can-delete-group context (assoc group :concept-id concept-id))
     (save-deleted-group-concept context group-concept)))
 
-(defn update-group
+
+(defn ^{:deprecated "No replacment, use EDL"} update-group
   "Updates an existing group with the given concept id"
   [context concept-id updated-group]
   (common-enabled/validate-write-enabled context "access control")
@@ -303,7 +305,7 @@
    :concept-id cpv/string-param-options
    :member #{:pattern :and}})
 
-(defn validate-group-search-params
+(defn ^{:deprecated "No replacment, use EDL instead"} validate-group-search-params
   "Validates the parameters for a group search. Returns the parameters or throws an error if invalid."
   [_context params]
   (let [[safe-params type-errors] (cpv/apply-type-validations
@@ -353,7 +355,7 @@
             (when (= (:include-members params) "true")
               {:result-features [:include-members]}))]))
 
-(defn search-for-groups
+(defn ^{:deprecated "No replacment, use EDL instead"} search-for-groups
   [context params]
   (let [[query-creation-time query] (u/time-execution
                                      (->> params
@@ -380,7 +382,8 @@
           (fn [existing-members]
             (vec (distinct (concat existing-members members))))))
 
-(defn add-members
+;; Note this function is also used by bootstrap.clj
+(defn ^{:deprecated "No replacment, use EDL instead"} add-members
   "Adds members to the group identified by the concept id persisting it to Metadata DB. Returns
   the new concept id and revision id."
   ([context concept-id members]
@@ -395,7 +398,7 @@
        (auth/verify-can-update-group context (assoc existing-group :concept-id concept-id)))
      (save-updated-group-concept context existing-concept updated-group))))
 
-(defn- remove-members-from-group
+(defn- ^{:deprecated "No replacment, use EDL instead"} remove-members-from-group
   "Removes the members from the group."
   [group members]
   (update group
@@ -403,7 +406,7 @@
           (fn [existing-members]
             (vec (remove (set members) existing-members)))))
 
-(defn remove-members
+(defn ^{:deprecated "No replacment, use EDL instead"} remove-members
   "Removes members from the group identified by the concept id persisting it to Metadata DB. Returns
   the new concept id and revision id."
   [context concept-id members]
@@ -413,7 +416,7 @@
     (auth/verify-can-update-group context (assoc existing-group :concept-id concept-id))
     (save-updated-group-concept context existing-concept updated-group)))
 
-(defn get-members
+(defn ^{:deprecated "No replacment, use EDL instead"} get-members
   "Gets the members in the group."
   [context concept-id]
   (let [concept (fetch-group-concept context concept-id)


### PR DESCRIPTION
NOTE, I have not decided if I want to go forward with this as of now, I will decide before the sprint ends.

# Overview
While doing some investigations into APIs that use ACL and groups I marked several APIs as deprecated to visually confirm that some functions were not being used. I want to contribute these to CMR to ensure that everyone knows what will need to be removed. I'm wanting to start marking more functions as deprecated going forward to make it easy to remove these latter.

### What is the feature/fix?

I added deprecated to functions and in one case made a function private.

### What is the Solution?

to use ^{:deprecated "No replacment, use EDL instead"} on functions

### What areas of the application does this impact?

This should only impact group functions which are behind a feature toggle, so no impact should be seen on a normal installation of CMR

# Checklist
TBD:

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
