### PR TITLE
CMR-10424: Update the "NASA Official" footers on all CMR pages to be Doug Newman

### DIFF
--- a/site-templates/resources/templates/base.html
+++ b/site-templates/resources/templates/base.html
@@ -22,7 +22,7 @@
 {% block footer %}
 <nav role="navigation">
   <ul class="footer-links">
-      <li>NASA Official: Stephen Berrick</li>
+      <li>NASA Official: Doug Newman</li>
       <li><a href="https://www.nasa.gov/FOIA/index.html">FOIA</a></li>
       <li><a href="https://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
       <li><a href="https://www.usa.gov/">USA.gov</a></li>


### PR DESCRIPTION
# Overview

### What is the feature/fix?

NASA Official name was outdated

### What is the Solution?

Update NASA Official footers to Doug Newman

### What areas of the application does this impact?

Serach and Ingest App webpages

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
