### PR TITLE
CMR-10430: CMR should honor permissions in the autocomplete responses

### DIFF
--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -170,15 +170,18 @@
   [context collections]
   (let [results (map (fn [collection]
                       (try
-                        [(cp/parse-concept context collection) nil]
+                        {:success (cp/parse-concept context collection)
+                         :concept-id (:concept-id collection)}
                         (catch Exception e
-                          (error (format "An error occurred while parsing collection for autocomplete with concept-id [%s]: %s"
-                                        (:concept-id collection)
-                                        (.getMessage e)))
-                          [nil (:concept-id collection)])))
-                    collections)
-        parsed-collections (keep first results)
-        failed-concept-ids (keep second results)]
+                          (error (format 
+                                  "An error occurred while parsing collection for autocomplete with concept-id [%s]: %s"
+                                  (:concept-id collection)
+                                  (.getMessage e)))
+                          {:failed true
+                           :concept-id (:concept-id collection)})))
+                     collections)
+        parsed-collections (map :success (remove :failed results))
+        failed-concept-ids (map :concept-id (filter :failed results))]
     [parsed-collections failed-concept-ids]))
 
 (defn- get-humanized-collections

--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -186,15 +186,15 @@
   (let [{:keys [index-names]} (idx-set/get-concept-type-index-names context)
         index (get-in index-names [:autocomplete :autocomplete])
         humanized-fields-fn (partial get-humanized-collections context)
-        parsed-concepts (->> collections
-                             (remove :deleted)
+        existing-collections (remove :deleted collections)
+        parsed-concepts (->> existing-collections
                              (map #(parse-collection context %))
                              (remove nil?))
         collection-permissions (map (fn [collection]
                                       (let [permissions (collection-util/get-coll-permitted-group-ids context provider-id collection)]
                                         {:id (:concept-id collection)
                                          :permissions permissions}))
-                                    collections)
+                                    existing-collections)
         humanized-fields (map humanized-fields-fn parsed-concepts)
         humanized-fields-with-permissions (map merge collection-permissions humanized-fields)]
     (->> humanized-fields-with-permissions

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
@@ -173,16 +173,18 @@
                                      "q=RESTRICTED-ORG" 
                                      {:headers {:authorization unauthorized-token}}))]
 
-          ;; Should now contain the previously restricted organization for guest users, but not the other restricted organizations
-          ;; nor the public organization that had its permissions revoked
+          ;; Should now contain the previously restricted organization for guest users, 
+          ;; but not the other restricted organizations, nor the public organization that
+          ;; had its permissions revoked
           (is (= #{"RESTRICTED-ORG"}
               (->> guest-results
                    (map :value)
                    set)))
 
-          ;; Because :contains-public-collections is true, unauthorized users should still see the restricted organization
-          ;; that is now public even without permmissions specific to registered users or this users group, 
-          ;; the other restricted organizations and the public organization should not be visible
+          ;; Because :contains-public-collections is true, unauthorized users should still
+          ;; see the restricted organization that is now public even without permmissions
+          ;; specific to registered users or this users group, the other restricted
+          ;; organizations and the public organization should not be visible
           (is (= #{"RESTRICTED-ORG"}
               (->> unauthorized-results
                    (map :value)

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
@@ -141,18 +141,30 @@
 
     (let [unauthorized-token (e/login (s/context) "authorized-user" [authorized-group-id])]
       (testing "After revoking all permissions, user should not see suggestions for restricted collections"
-        (let [unauthorized-results (extract-autocomplete-entries 
-                                    (search/get-autocomplete-json 
-                                     "q=RESTRICTED-ORG" 
-                                     {:headers {:authorization unauthorized-token}}))]
-          (is (empty? unauthorized-results))))
-      
-        (let [unauthorized-results (extract-autocomplete-entries 
-                                    (search/get-autocomplete-json 
-                                     "q=PUBLIC-ORG" 
+        ;; Guests should not see any suggestions
+        (let [unauthorized-results (extract-autocomplete-entries
+                                    (search/get-autocomplete-json
+                                     "q=RESTRICTED-ORG"))]
+          (is (empty? unauthorized-results)))
+
+        (let [unauthorized-results (extract-autocomplete-entries
+                                    (search/get-autocomplete-json
+                                     "q=PUBLIC-ORG"))]
+          (is (empty? unauthorized-results)))
+
+        ;; Authorized users should not see any suggestions
+        (let [unauthorized-results (extract-autocomplete-entries
+                                    (search/get-autocomplete-json
+                                     "q=RESTRICTED-ORG"
                                      {:headers {:authorization unauthorized-token}}))]
           (is (empty? unauthorized-results)))
 
+        (let [unauthorized-results (extract-autocomplete-entries
+                                    (search/get-autocomplete-json
+                                     "q=PUBLIC-ORG"
+                                     {:headers {:authorization unauthorized-token}}))]
+          (is (empty? unauthorized-results))))
+          
       ;; Now grant guest permission to the restricted collection
       (e/grant-guest (s/context) 
                      (e/coll-catalog-item-id "PROV1" (e/coll-id ["Restricted Collection"])))
@@ -177,15 +189,15 @@
           ;; but not the other restricted organizations, nor the public organization that
           ;; had its permissions revoked
           (is (= #{"RESTRICTED-ORG"}
-              (->> guest-results
-                   (map :value)
-                   set)))
+                 (->> guest-results
+                      (map :value)
+                      set)))
 
           ;; Because :contains-public-collections is true, unauthorized users should still
           ;; see the restricted organization that is now public even without permmissions
           ;; specific to registered users or this users group, the other restricted
           ;; organizations and the public organization should not be visible
           (is (= #{"RESTRICTED-ORG"}
-              (->> unauthorized-results
-                   (map :value)
-                   set)))))))))
+                 (->> unauthorized-results
+                      (map :value)
+                      set)))))))))

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
@@ -1,0 +1,188 @@
+(ns cmr.system-int-test.search.autocomplete.suggestion-permissions-test
+ "Tests permissions for autocomplete suggestions "
+ (:require
+   [clojure.test :refer :all]
+   [cmr.mock-echo.client.echo-util :as e]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-spec]
+   [cmr.system-int-test.system :as s]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.transmit.config :as transmit-config]))
+
+(defn extract-autocomplete-entries
+ "Helper to extract entries from autocomplete response"
+ [response]
+ (get-in response [:feed :entry]))
+
+(use-fixtures :each (join-fixtures
+                     [(ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}
+                                            {:grant-all-search? false})]))
+
+(deftest suggestion-permissions-test
+ (testing "Suggestions respect collection access permissions"
+  ;; Create groups for our test
+  (let [authorized-group-id (e/get-or-create-group (s/context) "authorized-group")
+         
+        ;; Create restricted collection with specific data center to test for suggestions
+        _ (d/ingest-umm-spec-collection
+           "PROV1"
+           (data-umm-spec/collection
+           {:EntryTitle "Restricted Collection"
+            :ShortName "RESTRICTED"
+            :DataCenters [(data-umm-spec/data-center 
+                           {:Roles ["ARCHIVER"] 
+                            :ShortName "RESTRICTED-ORG"})]})
+           {:format :umm-json
+            :validate-keywords false})
+
+        ;; Create another restricted collection with different data center, this one will will delete later
+        second-restricted-collection (d/ingest-umm-spec-collection
+                          "PROV1"
+                          (data-umm-spec/collection
+                          {:EntryTitle "Second Restricted Collection"
+                            :ShortName "SECOND RESTRICTED COLLECTION"
+                            :DataCenters [(data-umm-spec/data-center 
+                                          {:Roles ["ARCHIVER"] 
+                                           :ShortName "RESTRICTED-ORG2"})]})
+                          {:format :umm-json
+                            :validate-keywords false})
+
+        ;; Create another restricted collection with different data center
+        _ (d/ingest-umm-spec-collection
+           "PROV1"
+           (data-umm-spec/collection
+           {:EntryTitle "Third Restricted Collection"
+            :ShortName "THIRD RESTRICTED COLLECTION"
+            :DataCenters [(data-umm-spec/data-center 
+                           {:Roles ["ARCHIVER"] 
+                            :ShortName "RESTRICTED-ORG3"})]})
+           {:format :umm-json
+            :validate-keywords false})
+
+        ;; Create public collection with different data center
+        _ (d/ingest-umm-spec-collection
+           "PROV1"
+           (data-umm-spec/collection
+           {:EntryTitle "Public Collection"
+           :ShortName "PUBLIC"
+           :DataCenters [(data-umm-spec/data-center 
+                         {:Roles ["ARCHIVER"] 
+                         :ShortName "PUBLIC-ORG"})]})
+           {:format :umm-json
+           :validate-keywords false})       
+         
+        ;; Grant explicit permission to only the authorized group for restricted collections
+        _ (e/grant-group (s/context) 
+                         authorized-group-id 
+                         (e/coll-catalog-item-id "PROV1" (e/coll-id ["Restricted Collection"])))
+
+        _ (e/grant-group (s/context) 
+                         authorized-group-id 
+                         (e/coll-catalog-item-id "PROV1" (e/coll-id ["Second Restricted Collection"])))
+
+        _ (e/grant-group (s/context) 
+                         authorized-group-id 
+                         (e/coll-catalog-item-id "PROV1" (e/coll-id ["Third Restricted Collection"])))
+         
+        ;; Grant guest permission to the public collection
+        _ (e/grant-guest (s/context) 
+                         (e/coll-catalog-item-id "PROV1" (e/coll-id ["Public Collection"])))
+
+        ;; Grant registered users permission to the public collection
+        _ (e/grant-registered-users 
+           (s/context) 
+           (e/coll-catalog-item-id "PROV1" (e/coll-id ["Public Collection"])))
+
+        ;; Create tokens for testing different access scenarios
+        authorized-token (e/login (s/context) "authorized-user" [authorized-group-id])]
+
+    ;; Delete second restricted collection collection, testing CMR-10362 solution 
+    (ingest/delete-concept (d/item->concept second-restricted-collection :echo10))
+
+    ;; Index the collections and suggestions
+    (index/wait-until-indexed)
+    (ingest/reindex-collection-permitted-groups transmit-config/mock-echo-system-token)
+    (index/wait-until-indexed)
+    (index/reindex-suggestions)
+    (index/wait-until-indexed)
+    (search/clear-caches)
+
+    (testing "Guest user should not see suggestions for restricted collection but should see for public collection"
+      (let [guest-results (extract-autocomplete-entries 
+                           (search/get-autocomplete-json "q=ORG"))]
+        ;; Should contain only the public organization
+        (is (= #{"PUBLIC-ORG"}
+                (->> guest-results
+                     (map :value)
+                     set)))))
+     
+    (testing "Authorized user should see suggestions for all collections"
+      (let [authorized-results (extract-autocomplete-entries 
+                                (search/get-autocomplete-json "q=ORG" 
+                                                             {:headers {:authorization authorized-token}}))]
+        ;; Should find all organizations in the results except the deleted collection's organization
+        (is (= #{"RESTRICTED-ORG" "PUBLIC-ORG" "RESTRICTED-ORG3"}
+                (->> authorized-results
+                     (map :value)
+                     set)))))
+
+    ;; Ungrant the authorized group        
+    (e/ungrant-by-search (s/context) {:identity-type "catalog_item"})
+
+    ;; Re-index the collections and suggestions
+    (index/wait-until-indexed)
+    (ingest/reindex-collection-permitted-groups transmit-config/mock-echo-system-token)
+    (index/wait-until-indexed)
+    (index/reindex-suggestions)
+    (index/wait-until-indexed)
+    (search/clear-caches)
+
+    (let [unauthorized-token (e/login (s/context) "authorized-user" [authorized-group-id])]
+      (testing "After revoking all permissions, user should not see suggestions for restricted collections"
+        (let [unauthorized-results (extract-autocomplete-entries 
+                                    (search/get-autocomplete-json 
+                                     "q=RESTRICTED-ORG" 
+                                     {:headers {:authorization unauthorized-token}}))]
+          (is (empty? unauthorized-results))))
+      
+        (let [unauthorized-results (extract-autocomplete-entries 
+                                    (search/get-autocomplete-json 
+                                     "q=PUBLIC-ORG" 
+                                     {:headers {:authorization unauthorized-token}}))]
+          (is (empty? unauthorized-results)))
+
+      ;; Now grant guest permission to the restricted collection
+      (e/grant-guest (s/context) 
+                     (e/coll-catalog-item-id "PROV1" (e/coll-id ["Restricted Collection"])))
+      
+      ;; Re-index and clear caches
+      (index/wait-until-indexed)
+      (ingest/reindex-collection-permitted-groups transmit-config/mock-echo-system-token)
+      (index/wait-until-indexed)
+      (index/reindex-suggestions)
+      (index/wait-until-indexed)
+      (search/clear-caches)
+      
+      (testing "After granting guest permission, users should see suggestions for previously restricted collection"
+        (let [guest-results (extract-autocomplete-entries 
+                             (search/get-autocomplete-json "q=RESTRICTED-ORG"))
+              unauthorized-results (extract-autocomplete-entries 
+                                    (search/get-autocomplete-json 
+                                     "q=RESTRICTED-ORG" 
+                                     {:headers {:authorization unauthorized-token}}))]
+
+          ;; Should now contain the previously restricted organization for guest users, but not the other restricted organizations
+          ;; nor the public organization that had its permissions revoked
+          (is (= #{"RESTRICTED-ORG"}
+              (->> guest-results
+                   (map :value)
+                   set)))
+
+          ;; Because :contains-public-collections is true, unauthorized users should still see the restricted organization
+          ;; that is now public, the other restricted organizations and the public organization should not be visible
+          (is (= #{"RESTRICTED-ORG"}
+              (->> unauthorized-results
+                   (map :value)
+                   set)))))))))

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_permissions_test.clj
@@ -42,8 +42,8 @@
                           "PROV1"
                           (data-umm-spec/collection
                           {:EntryTitle "Second Restricted Collection"
-                            :ShortName "SECOND RESTRICTED COLLECTION"
-                            :DataCenters [(data-umm-spec/data-center 
+                           :ShortName "SECOND RESTRICTED COLLECTION"
+                           :DataCenters [(data-umm-spec/data-center 
                                           {:Roles ["ARCHIVER"] 
                                            :ShortName "RESTRICTED-ORG2"})]})
                           {:format :umm-json
@@ -66,12 +66,12 @@
            "PROV1"
            (data-umm-spec/collection
            {:EntryTitle "Public Collection"
-           :ShortName "PUBLIC"
-           :DataCenters [(data-umm-spec/data-center 
-                         {:Roles ["ARCHIVER"] 
-                         :ShortName "PUBLIC-ORG"})]})
-           {:format :umm-json
-           :validate-keywords false})       
+            :ShortName "PUBLIC"
+            :DataCenters [(data-umm-spec/data-center 
+                          {:Roles ["ARCHIVER"] 
+                           :ShortName "PUBLIC-ORG"})]})
+            {:format :umm-json
+             :validate-keywords false})       
          
         ;; Grant explicit permission to only the authorized group for restricted collections
         _ (e/grant-group (s/context) 


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Autocomplete suggestions were not honoring collection permissions properly, returning in some cases autocomplete suggestions for collections that are not public to guest user.

### What is the Solution?

The issue had two potential causes:

- The (map merge) call was combining two lists of hash maps (humanized fields and collection permissions) without properly accounting for deleted collections in both lists. When only one list removed deleted collections, the permissions became misaligned with the incorrect fields, causing unpredictable permission results whenever a batch included deleted collections.
- Additionally, the (remove nil?) operation after (map #(parse-collection context %)) could also be contributing to the problem. This is harder to verify since the nils represent collections that failed to parse, making direct testing difficult.

Example of the problem:

```
user=> (def coll-perms [{:id "C1200000007-PROV1", :permissions ["AG1200000007-CMR"]} 
  #_=>                  {:id "C1200000009-PROV1", :permissions ["guest" "registered"]} 
  #_=>                  {:id "C1200000008-PROV1", :permissions ["AG1200000008-CMR"]}])
#'user/coll-perms
user=> (def h-fields [{:a 1} {:b 2} {:c 3}])
#'user/h-fields
user=> (map merge coll-perms h-fields)
({:id "C1200000007-PROV1", :permissions ["AG1200000007-CMR"], :a 1} {:id "C1200000009-PROV1", :permissions ["guest" "registered"], :b 2} {:id "C1200000008-PROV1", :permissions ["AG1200000008-CMR"], :c 3})
user=> (def h-fields [{:a 1} {:c 3}])
#'user/h-fields
user=> (map merge coll-perms h-fields)
({:id "C1200000007-PROV1", :permissions ["AG1200000007-CMR"], :a 1} {:id "C1200000009-PROV1", :permissions ["guest" "registered"], :c 3})
```

The solution is ensuring both lists maintain alignment by properly filtering out both deleted collections and those that fail to parse before the merge operation.

### What areas of the application does this impact?

Autocomplete suggestions

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
