### PR TITLE
CMR-10099: When deleting a collection and its granules are in their own index, delete the index.

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
@@ -81,6 +81,12 @@
                                                 :ignore_unavailable))
                :body {:query query}})))
 
+(defn delete-index
+  "Deletes an index from the elastic store"
+  [conn index]
+  (rest/delete conn
+             (rest/url-with-path conn index)))
+
 (defn ^:private bulk-with-url
   "Construct the bulk URL and form body to specification provided by:
   https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -229,6 +229,11 @@
   [elastic-store index-name type-name query]
   (es-helper/delete-by-query (:conn elastic-store) index-name type-name query))
 
+(defn delete-index
+  "Delete index"
+  [elastic-store index-name]
+  (es-helper/delete-index elastic-store index-name))
+
 (defn create-index-alias
   "Creates the alias for the index."
   [conn index alias-name]

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -161,6 +161,24 @@
         (info "Existing index set:" (pr-str existing-index-set))
         (info "New index set:" (pr-str expected-index-set))))))
 
+(defn delete-index
+  "Delete an elastic index by name"
+  [context index]
+  (let [existing-index-set (index-set-es/get-index-set context idx-set/index-set-id)
+        expected-extra-granule-indexes (idx-set/index-set->reduced-extra-granule-indexes existing-index-set index)
+        expected-index-set (idx-set/index-set expected-extra-granule-indexes)
+        ])
+  (if (requires-update? existing-index-set expected-index-set)
+    (do
+      (info "Removing index to produce index set " (pr-str expected-index-set))
+      (index-set-svc/update-index-set context expected-index-set)
+      (info "Deleting collection index.")
+      (esi/delete-index (context->conn context) index))
+    (do
+      (info "Ignoring delete index request because index set is unchanged.")
+      (info "Existing index set: " (pr-str existing-index-set))
+      (info "Requested index deletion: " (pr-str index)))))
+
 (defn reset-es-store
   "Delete elasticsearch indexes and re-create them via index-set app. A nuclear option just for the development team."
   [context]

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -375,7 +375,7 @@
                                                      :client-id t-config/cmr-client-id}
                                            :throw-exceptions false}))
            status (:status response)]
-       (if-not (some #{200 404} [status])
+       (when-not (some #{200 404} [status])
          (if (= 409 status)
            (if ignore-conflict?
              (info (str "Ignore conflict: " (str response)))

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -167,7 +167,7 @@
   (let [existing-index-set (index-set-es/get-index-set context idx-set/index-set-id)
         expected-extra-granule-indexes (idx-set/index-set->reduced-extra-granule-indexes existing-index-set index)
         expected-index-set (idx-set/index-set expected-extra-granule-indexes)
-        ])
+        ]
   (if (requires-update? existing-index-set expected-index-set)
     (do
       (info "Removing index to produce index set " (pr-str expected-index-set))
@@ -177,7 +177,7 @@
     (do
       (info "Ignoring delete index request because index set is unchanged.")
       (info "Existing index set: " (pr-str existing-index-set))
-      (info "Requested index deletion: " (pr-str index)))))
+      (info "Requested index deletion: " (pr-str index))))))
 
 (defn reset-es-store
   "Delete elasticsearch indexes and re-create them via index-set app. A nuclear option just for the development team."

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -984,6 +984,12 @@
        (map :name)
        (remove #(= % "small_collections"))))
 
+(defn index-set->reduced-extra-granule-indexes
+  "Takes an index set and a collection concept id and returns the extra granule indexes
+   minus the provided collection"
+  [index-set collection-concept-id]
+  (remove #(= % collection-concept-id) (index-set->extra-granule-indexes index-set)))
+
 (defn fetch-concept-type-index-names
   "Fetch a map containing index names for each concept type from index-set app along with the list
    of rebalancing collections"

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -1156,7 +1156,7 @@
          (get-granule-index-names-for-collection context coll-concept-id target-index-key))
 
        ;; Default
-       (if (some? (concept-type (common-generic/latest-approved-documents)))
+       (when (some? (concept-type (common-generic/latest-approved-documents)))
          ;; Generics are a bunch of document types, find out which one to work with
          ;; and return the index name for those
          (if all-revisions-index?

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -663,20 +663,21 @@
   "Performs the cascade actions of collection deletion,
   i.e. propagate collection deletion to granules and variables"
   [context concept-mapping-types concept-id revision-id]
-  (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)
-          small-collections-index-name (:small_collections (:granule (:index-names (idx-set/get-concept-type-index-names context))))]
-    (if (= index small-collections-index-name)
-      (let [resp (es/delete-by-query
-                   context
-                   index
-                   (concept-mapping-types :granule)
-                   {:term {(query-field->elastic-field :collection-concept-id :granule)
-                           concept-id}})]
-         (when (not= (get resp :status) 200)
-           (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response. Elastic delete by query resp = %s" concept-id revision-id resp))))
-      (let [resp (es/delete-index context index)]
-        (when (not= (get resp :status) 200)
-          (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
+  (let [small-collections-index-name (:small_collections (:granule (:index-names (idx-set/get-concept-type-index-names context))))]
+    (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)]
+      (if (= index small-collections-index-name)
+        (let [resp (es/delete-by-query
+                    context
+                    index
+                    (concept-mapping-types :granule)
+                    {:term {(query-field->elastic-field :collection-concept-id :granule)
+                            concept-id}})]
+          (when (not= (get resp :status) 200)
+            (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response. Elastic delete by query resp = %s" concept-id revision-id resp))))
+        (let [resp (es/delete-index context index)]
+          (when (not= (get resp :status) 200)
+            (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp)))))))
+
   ;; reindex variables associated with the collection
   (reindex-associated-variables context concept-id revision-id))
 

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -663,15 +663,20 @@
   "Performs the cascade actions of collection deletion,
   i.e. propagate collection deletion to granules and variables"
   [context concept-mapping-types concept-id revision-id]
-  (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)]
-    (let [resp (es/delete-by-query
-                context
-                index
-                (concept-mapping-types :granule)
-                {:term {(query-field->elastic-field :collection-concept-id :granule)
-                        concept-id}})]
-      (when (not= (get resp :status) 200)
-        (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response. Elastic delete by query resp = %s" concept-id revision-id resp)))))
+  (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)
+          small-collections-index-name (:small_collections (:granule (:index-names (idx-set/get-concept-type-index-names context))))]
+    (if (= index small-collections-index-name)
+      (let [resp (es/delete-by-query
+                   context
+                   index
+                   (concept-mapping-types :granule)
+                   {:term {(query-field->elastic-field :collection-concept-id :granule)
+                           concept-id}})]
+         (when (not= (get resp :status) 200)
+           (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response. Elastic delete by query resp = %s" concept-id revision-id resp))))
+      (let [resp (es/delete-index context index)]
+        (when (not= (get resp :status) 200)
+          (warn (format "cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
   ;; reindex variables associated with the collection
   (reindex-associated-variables context concept-id revision-id))
 

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -706,7 +706,7 @@
 (defn- delete-concept-default-helper
   "A private func that deletes concept indexes in elastic"
   [context concept concept-id revision-id options]
-  (if (nil? concept)
+  (when (nil? concept)
     (errors/throw-service-error
       :not-found
       (str "Failed to retrieve concept " concept-id "/" revision-id " from metadata-db.")))

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -171,3 +171,12 @@
                  {:connection-manager (s/conn-mgr)
                   :body (query-for-granules-by-collection coll)
                   :content-type "application/json"}))
+
+(defn check-index-exists
+  "Helpper to check if elasticsearch index exists."
+  [coll]
+  (let [index-name (string/replace (format "1_%s" (string/lower-case (:concept-id coll)))
+                                   #"-" "_")]
+    (client/head (format "%s/%s" (url/elastic-root) index-name)
+                 {:connection-manager (s/conn-mgr)
+                  :throw-exceptions false})))

--- a/system-int-test/src/cmr/system_int_test/utils/index_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/index_util.clj
@@ -5,11 +5,9 @@
    [clj-http.client :as client]
    [clojure.string :as string]
    [clojure.test :refer [is]]
-   [cmr.common.log :as log :refer (debug info warn error)]
-   [cmr.indexer.config :as config]
+   [cmr.common.log :as log :refer (warn)]
    [cmr.message-queue.test.queue-broker-side-api :as qb-side-api]
    [cmr.system-int-test.system :as s]
-   [cmr.system-int-test.utils.queue :as queue]
    [cmr.system-int-test.utils.url-helper :as url]
    [cmr.transmit.config :as transmit-config]))
 

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
@@ -1,0 +1,28 @@
+(ns cmr.system-int-test.ingest.misc.deleted-collection-index-test
+  "When a rebalanced collection is deleted, the index associated should be removed
+   this namespace tests that functionality."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.system-int-test.data2.core :as data-core]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
+   [cmr.system-int-test.utils.ingest-util :as ingest]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(deftest deleted-collection-test-index
+  (testing "Ingest granule, rebalance collection, delete collection"
+    (let [collection (data-core/ingest-umm-spec-collection "PROV1"
+                                                      (data-umm-c/collection {})
+                                                      {:validate-keywords false})]
+      (bootstrap/start-rebalance-collection (:concept-id collection))
+      (index/wait-until-indexed)
+      (bootstrap/finalize-rebalance-collection (:concept-id collection))
+      (index/wait-until-indexed)
+      (let [index-exists-before-delete-response (index/check-index-exists collection)
+            _ (ingest/delete-concept (data-core/umm-c-collection->concept collection :echo10) {})
+            _ (index/wait-until-indexed)
+            index-exists-after-delete-response (index/check-index-exists collection)]
+        (is (= 200 (:status index-exists-before-delete-response)))
+        (is (= 404 (:status index-exists-after-delete-response)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
@@ -2,7 +2,7 @@
   "When a rebalanced collection is deleted, the index associated should be removed
    this namespace tests that functionality."
   (:require
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [cmr.system-int-test.data2.core :as data-core]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.utils.index-util :as index]

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_collection_index_test.clj
@@ -9,7 +9,7 @@
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
    [cmr.system-int-test.utils.ingest-util :as ingest]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+(use-fixtures :once (ingest/reset-fixture {"provguid1" "PROV1"}))
 
 (deftest deleted-collection-test-index
   (testing "Ingest granule, rebalance collection, delete collection"


### PR DESCRIPTION
# Overview
Deleting granule indices in ES when the collection is deleted
### What is the feature/fix?

When a collection is deleted and has a granule collection associated with it, the index is deleted straight out of elastic instead of deleting the granule documents

### What is the Solution?

In cascade collection delete in indexer, if the index being deleted from is NOT small collections, it just deletes the elasticsearch index and updates the index set. Otherwise does the same current action (deletes documents within the small collections index)

### What areas of the application does this impact?

indexer

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
