### PR TITLE
CMR-10455: Update subscription doc on subscription edge case limit

### DIFF
--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1169,9 +1169,10 @@ For NRT Notification subscriptions to be used there are three new fields that ar
         </ul>
 </ul>
 
-**IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
-Currently, if User1 creates a subscription to Coll1 and then User2 creates a different subscription to the same Coll1 for the same queue, it will overwrite the first subscription for that specific queue.
-So please have each of your queues to have only one agreed upon subscription.
+IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
+Currently, if <User 1> creates a subscription to <Collection 1> and then <User 2> creates a different subscription 
+to the same <Collection 1> for the same queue, it will overwrite the first subscription for that specific queue.
+So please, have each queue have only one agreed upon subscription.
 
 ##### NRT Notification Subscription POST Request
 
@@ -1232,9 +1233,10 @@ If a native-id is provided in a POST, and a subscription already exists for that
 
 PUT requests should be used for updating subscriptions. Creating subscriptions with PUT may be deprecated in the future. All PUT requests require a native-id to be part of the request URL.
 
-**IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
-Currently, if User1 creates a subscription to Coll1 and then User2 creates a different subscription to the same Coll1 for the same queue, it will overwrite the first subscription for that specific queue.
-So please have each of your queues to have only one agreed upon subscription.
+IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
+Currently, if <User 1> creates a subscription to <Collection 1> and then <User 2> creates a different subscription
+to the same <Collection 1> for the same queue, it will overwrite the first subscription for that specific queue.
+So please, have each queue have only one agreed upon subscription.
 
 ##### Create Batch Notification subscription with %CMR-ENDPOINT%/subscriptions/<native-id> URL
 ```

--- a/ingest-app/docs/api.md
+++ b/ingest-app/docs/api.md
@@ -1169,6 +1169,10 @@ For NRT Notification subscriptions to be used there are three new fields that ar
         </ul>
 </ul>
 
+**IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
+Currently, if User1 creates a subscription to Coll1 and then User2 creates a different subscription to the same Coll1 for the same queue, it will overwrite the first subscription for that specific queue.
+So please have each of your queues to have only one agreed upon subscription.
+
 ##### NRT Notification Subscription POST Request
 
 ```
@@ -1227,6 +1231,10 @@ The response will include the [concept id](#concept-id) ,the [revision id](#revi
 If a native-id is provided in a POST, and a subscription already exists for that provider with the given native-id, the request will be rejected.
 
 PUT requests should be used for updating subscriptions. Creating subscriptions with PUT may be deprecated in the future. All PUT requests require a native-id to be part of the request URL.
+
+**IMPORTANT: There is limit to creating and updating subscriptions related to the specific scenario highlighted below:
+Currently, if User1 creates a subscription to Coll1 and then User2 creates a different subscription to the same Coll1 for the same queue, it will overwrite the first subscription for that specific queue.
+So please have each of your queues to have only one agreed upon subscription.
 
 ##### Create Batch Notification subscription with %CMR-ENDPOINT%/subscriptions/<native-id> URL
 ```


### PR DESCRIPTION
# Overview

### What is the feature/fix?

To update doc on limitation of subscription queue create and update.
Currently, the ingest (NRT) subscriptions has a situation where if User1 creates a subscription to Coll1 and then User2 creates a different subscription to the same Coll1 for the same queue, it will overwrite the first subscription in the backend SNS subscription filter for that queue.

### What is the Solution?

Add the limit to the CMR Ingest documentation page so that users understand what to expect

### What areas of the application does this impact?

Ingest Doc

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
