### PR TITLE
CMR-10452: adds KEYWORD_MANAGEMENT_SYSTEM acl

### DIFF
--- a/access-control-app/docs/acl-schema.md
+++ b/access-control-app/docs/acl-schema.md
@@ -83,6 +83,7 @@ This element must be one of the following enum values:
 * `USER_CONTEXT`
 * `USER`
 * `GROUP`
+* `KEYWORD_MANAGEMENT_SYSTEM`
 * `ANY_ACL`
 * `EVENT_NOTIFICATION`
 * `EXTENDED_SERVICE`

--- a/access-control-app/docs/api.md
+++ b/access-control-app/docs/api.md
@@ -180,6 +180,7 @@ For system, provider, and single instance identities, the grantable permissions 
 | `USER_CONTEXT`                         | read                         |
 | `USER`                                 | read, update, delete         |
 | `GROUP`                                | create, read                 |
+| `KEYWORD_MANAGEMENT_SYSTEM`            | create, read, update, delete |
 | `ANY_ACL`                              | create, read, update, delete |
 | `EVENT_NOTIFICATION`                   | delete                       |
 | `EXTENDED_SERVICE`                     | delete                       |

--- a/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/permission_check_test.clj
@@ -192,7 +192,7 @@
                                "\"METRIC_DATA_POINT_SAMPLE\" \"SYSTEM_INITIALIZER\" \"ARCHIVE_RECORD\" "
                                "\"ERROR_MESSAGE\" \"TOKEN\" \"TOKEN_REVOCATION\" \"EXTENDED_SERVICE_ACTIVATION\" "
                                "\"ORDER_AND_ORDER_ITEMS\" \"PROVIDER\" \"TAG_GROUP\" \"TAXONOMY\" "
-                               "\"TAXONOMY_ENTRY\" \"USER_CONTEXT\" \"USER\" \"GROUP\" \"ANY_ACL\" "
+                               "\"TAXONOMY_ENTRY\" \"USER_CONTEXT\" \"USER\" \"GROUP\" \"KEYWORD_MANAGEMENT_SYSTEM\" \"ANY_ACL\" "
                                "\"EVENT_NOTIFICATION\" \"EXTENDED_SERVICE\" \"SYSTEM_OPTION_DEFINITION\" "
                                "\"SYSTEM_OPTION_DEFINITION_DEPRECATION\" \"INGEST_MANAGEMENT_ACL\" \"SYSTEM_CALENDAR_EVENT\" "
                                "\"DASHBOARD_ADMIN\" \"DASHBOARD_ARC_CURATOR\" \"DASHBOARD_MDQ_CURATOR\"]")

--- a/access-control-app/src/cmr/access_control/data/acl_schema.clj
+++ b/access-control-app/src/cmr/access_control/data/acl_schema.clj
@@ -32,6 +32,7 @@
    "USER_CONTEXT"
    "USER"
    "GROUP"
+   "KEYWORD_MANAGEMENT_SYSTEM"
    system-any-acl-target
    "EVENT_NOTIFICATION"
    "EXTENDED_SERVICE"

--- a/access-control-app/src/cmr/access_control/services/acl_validation.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_validation.clj
@@ -63,6 +63,7 @@
                               "USER_CONTEXT"                    [r]
                               "USER"                            [r u d]
                               "GROUP"                           [c r]
+                              "KEYWORD_MANAGEMENT_SYSTEM"       [c r u d]
                               "ANY_ACL"                         [c r u d]
                               "EVENT_NOTIFICATION"              [d]
                               "EXTENDED_SERVICE"                [d]


### PR DESCRIPTION
# Overview

### What is the feature/fix?

We are adding a new acl target for system acls for utilization in MMT.  This acl is for controlling keyword crud.

### What is the Solution?

Added the target string to the acl schema, then added the crud configuration to the acl validation namespace.

### What areas of the application does this impact?

cmr-access-control

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
