### PR TITLE
CMR-10276: Unhandled Search Exception: No matching clause: [nil nil]

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
+++ b/metadata-db-app/src/cmr/metadata_db/services/concept_service.clj
@@ -565,7 +565,7 @@
         (info (format "Found [%d] concepts in [%d] ms" (count concepts) millis))
         (keep concepts-by-tuple concept-id-revision-id-tuples))
       ;; some concepts weren't found in the database
-      (keep #(if (concepts-by-tuple %) (concepts-by-tuple %) {:metadata nil}) concept-id-revision-id-tuples)))) 
+      (keep #(when (concepts-by-tuple %) (concepts-by-tuple %)) concept-id-revision-id-tuples)))) 
 
 (defn get-latest-concepts
   "Get the latest version of concepts by specifiying a list of concept-ids. Results are


### PR DESCRIPTION
# Overview

### What is the feature/fix?

When a concept search has a mismatch from elasticsearch vs metadata-db, and a transform was called on what is returned by get-concepts, without an allow-missing flag. `{:metadata nil}` was what was being returned, this could not be processed properly by parse-metadata.

### What is the Solution?

Return nil inside the anon function, inside the keep, so only concepts that exist in the db will be processed by parse-metadata farther down the stack.

### What areas of the application does this impact?

cmr-search-app metadata transformation code.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
