### PR TITLE
CMR-10533: Bumping up elastic to a recomended point release

### DIFF
--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -1,4 +1,4 @@
-(def elastic-version "7.17.14")
+(def elastic-version "7.17.25")
 
 (defproject nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"
   :description "A library containing utilities for dealing with Elasticsearch."

--- a/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
@@ -11,12 +11,14 @@
    (org.testcontainers.images.builder ImageFromDockerfile)))
 
 (def ^:private elasticsearch-official-docker-image
-  "Official docker image."
-  "docker.elastic.co/elasticsearch/elasticsearch:7.17.14")
+  "Official docker image documented at
+   https://www.docker.elastic.co/r/elasticsearch/elasticsearch:7.17.25"
+  "docker.elastic.co/elasticsearch/elasticsearch:7.17.25")
 
 (def ^:private kibana-official-docker-image
-  "Official kibana docker image."
-  "docker.elastic.co/kibana/kibana:7.17.14")
+  "Official kibana docker image documented at
+   https://www.docker.elastic.co/r/kibana/kibana:7.17.25"
+  "docker.elastic.co/kibana/kibana:7.17.25")
 
 (defn- build-kibana
   "Build kibana in an embedded docker."

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -23,6 +23,8 @@
 (def es-deps-target-path
   "es-deps")
 
+(def elastic-version "7.17.25")
+
 (defproject nasa-cmr/cmr-es-spatial-plugin "0.1.0-SNAPSHOT"
   :description "A Elastic Search plugin that enables spatial search entirely within elastic."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/es-spatial-plugin"
@@ -42,7 +44,7 @@
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-yaml]]]
-                                       [org.elasticsearch/elasticsearch "7.17.14"]
+                                       [org.elasticsearch/elasticsearch ~elastic-version]
                                        [org.clojure/tools.reader "1.3.2"]
                                        [org.yaml/snakeyaml "1.31"]]}
              :es-deps {:dependencies [[nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"
@@ -77,7 +79,7 @@
                                   [org.clojure/tools.reader "1.3.2"]
                                   [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                                   [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-                                  [org.elasticsearch/elasticsearch "7.17.14"]
+                                  [org.elasticsearch/elasticsearch ~elastic-version]
                                   [org.clojars.gjahad/debug-repl "0.3.3"]
                                   [org.clojure/tools.nrepl "0.2.13"]
                                   [org.clojure/tools.namespace "0.2.11"]


### PR DESCRIPTION
# Overview

Update the def elastic version from "7.17.14" to "7.17.25"

### What is the Solution?

Updated the version number where ever it showed up.

Changed elastic lib and the docker images 

### What areas of the application does this impact?

elastic util lib, including the embedded docker images and the spatial plugin.

# Checklist

- [-] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [-] clj-kondo has been run locally and all errors corrected
- [-] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
