### PR TITLE
CMR-10371: Evaluate and Address Breaking Changes for Migration to 8.x

### DIFF
--- a/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
@@ -28,12 +28,12 @@
                    {:date_histogram
                     {:field (q2e/query-field->elastic-field :start-date :granule)
                      :min_doc_count 1
-                     :interval interval-granularity}}
+                     :calendar_interval interval-granularity}}
                    :end-date-intervals
                     {:date_histogram
                      {:field (q2e/query-field->elastic-field :end-date :granule)
                       :min_doc_count 1
-                      :interval interval-granularity}}}}})
+                      :calendar_interval interval-granularity}}}}})
 
 (defmethod query-execution/pre-process-query-result-feature :timeline
   [context query feature]

--- a/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
+++ b/search-app/src/cmr/search/results_handlers/timeline_results_handler.clj
@@ -36,7 +36,7 @@
                       :calendar_interval interval-granularity}}}}})
 
 (defmethod query-execution/pre-process-query-result-feature :timeline
-  [context query feature]
+  [_context query _feature]
   (let [{:keys [interval]} query
         temporal-cond (query/map->TemporalCondition (select-keys query [:start-date :end-date]))]
     (-> query
@@ -47,7 +47,7 @@
 
 
 (defmethod elastic-search-index/concept-type+result-format->fields [:granule :timeline]
-  [concept-type query]
+  [_concept-type _query]
   ;; Timeline results are aggregation results so we select no fields
   [])
 
@@ -220,9 +220,9 @@
                      (map (partial constrain-interval-to-user-range start-date end-date)))}))
 
 (defmethod elastic-results/elastic-results->query-results [:granule :timeline]
-  [context query elastic-results]
+  [_context query elastic-results]
   (let [{:keys [start-date end-date interval]} query
-        items (map (partial collection-bucket->intervals (:interval query) start-date end-date)
+        items (map (partial collection-bucket->intervals interval start-date end-date)
                    (get-in elastic-results [:aggregations :by-collection :buckets]))]
     (r-model/map->Results {:items items
                      :timed-out (:timed_out elastic-results)
@@ -245,7 +245,7 @@
   (update-in coll-result [:intervals] (partial map (partial interval->response-tuple query))))
 
 (defmethod qs/search-results->response [:granule :timeline]
-  [context query results]
+  [_context query results]
   (let [{:keys [items]} results
         response (map (partial collection-result->response-result query) items)]
     (json/generate-string response)))

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -4,23 +4,23 @@
 (defmulti parse-date
   "Returns the value from the date string that matches the provided interval.
   Example: (parse-date \"2017-01-01T00:00:00+0000\" :year) returns 2017."
-  (fn [datetime interval]
+  (fn [_datetime interval]
     interval))
 
 (defmethod parse-date :year
-  [datetime interval]
+  [datetime _interval]
   (second (re-find #"^(\d{4})-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*Z$" datetime)))
 
 (defmethod parse-date :month
-  [datetime interval]
+  [datetime _interval]
   (second (re-find #"^\d{4}-(\d{2})-\d{2}T\d{2}:\d{2}:\d{2}.*Z$" datetime)))
 
 (defmethod parse-date :day
-  [datetime interval]
+  [datetime _interval]
   (second (re-find #"^\d{4}-\d{2}-(\d{2})T\d{2}:\d{2}:\d{2}.*Z$" datetime)))
 
 (defmethod parse-date :hour
-  [datetime interval]
+  [datetime _interval]
   (second (re-find #"^\d{4}-\d{2}-\d{2}T(\d{2}):\d{2}:\d{2}.*Z$" datetime)))
 
 (defn- time-intervals->next-interval
@@ -42,7 +42,7 @@
   "Returns the time interval to request in temporal facets based on the query parameters."
   [query-params]
   (let [field-reg-ex (re-pattern "temporal_facet.*")
-        temporal-facet-params (keep (fn [[k v]]
+        temporal-facet-params (keep (fn [[k _v]]
                                       (when (re-matches field-reg-ex k) k))
                                     query-params)]
     (time-intervals->next-interval (map keyword (get-subfields temporal-facet-params)))))

--- a/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
+++ b/search-app/src/cmr/search/services/query_execution/facets/temporal_facets.clj
@@ -54,4 +54,4 @@
     {:date_histogram
      {:field :start-date-doc-values
       :min_doc_count 1
-      :interval interval-granularity}}))
+      :calendar_interval interval-granularity}}))


### PR DESCRIPTION
# Overview
Addressing a breaking change for elasticsearch 8.x
### What is the feature/fix?

Fixing the usage of interval in date_histogram

### What is the Solution?

Replaced interval with calendar_interval

### What areas of the application does this impact?

granule timelines

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
