### PR TITLE
CMR-10533: Reinstate elastic

### DIFF
--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -1,4 +1,4 @@
-(def elastic-version "7.17.25")
+(def elastic-version "7.17.14")
 
 (defproject nasa-cmr/cmr-elastic-utils-lib "0.1.0-SNAPSHOT"
   :description "A library containing utilities for dealing with Elasticsearch."

--- a/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/embedded_elastic_server.clj
@@ -11,14 +11,12 @@
    (org.testcontainers.images.builder ImageFromDockerfile)))
 
 (def ^:private elasticsearch-official-docker-image
-  "Official docker image documented at
-   https://www.docker.elastic.co/r/elasticsearch/elasticsearch:7.17.25"
-  "docker.elastic.co/elasticsearch/elasticsearch:7.17.25")
+  "Official docker image."
+  "docker.elastic.co/elasticsearch/elasticsearch:7.17.14")
 
 (def ^:private kibana-official-docker-image
-  "Official kibana docker image documented at
-   https://www.docker.elastic.co/r/kibana/kibana:7.17.25"
-  "docker.elastic.co/kibana/kibana:7.17.25")
+  "Official kibana docker image."
+  "docker.elastic.co/kibana/kibana:7.17.14")
 
 (defn- build-kibana
   "Build kibana in an embedded docker."

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -23,8 +23,6 @@
 (def es-deps-target-path
   "es-deps")
 
-(def elastic-version "7.17.25")
-
 (defproject nasa-cmr/cmr-es-spatial-plugin "0.1.0-SNAPSHOT"
   :description "A Elastic Search plugin that enables spatial search entirely within elastic."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/es-spatial-plugin"
@@ -44,7 +42,7 @@
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                                      [com.fasterxml.jackson.dataformat/jackson-dataformat-yaml]]]
-                                       [org.elasticsearch/elasticsearch ~elastic-version]
+                                       [org.elasticsearch/elasticsearch "7.17.14"]
                                        [org.clojure/tools.reader "1.3.2"]
                                        [org.yaml/snakeyaml "1.31"]]}
              :es-deps {:dependencies [[nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"
@@ -79,7 +77,7 @@
                                   [org.clojure/tools.reader "1.3.2"]
                                   [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                                   [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
-                                  [org.elasticsearch/elasticsearch ~elastic-version]
+                                  [org.elasticsearch/elasticsearch "7.17.14"]
                                   [org.clojars.gjahad/debug-repl "0.3.3"]
                                   [org.clojure/tools.nrepl "0.2.13"]
                                   [org.clojure/tools.namespace "0.2.11"]


### PR DESCRIPTION
Removing the commit which bumped elastic library up to 7.17.14 instead of 7.17.25. We are going to handle this problem another way.