### PR TITLE
CMR-10549: updates system-validation-test cucumber version

### DIFF
--- a/system-validation-test/Gemfile
+++ b/system-validation-test/Gemfile
@@ -3,9 +3,10 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'cucumber'
+  gem 'cucumber', '~> 9.2.1' 
   gem 'httparty'
   gem 'jsonpath'
   gem 'nokogiri', "= 1.18.3"
   gem 'rspec'
+  gem 'ffi', '~> 1.16.3'
 end

--- a/system-validation-test/Gemfile.lock
+++ b/system-validation-test/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (3.1.8)
-    bigdecimal (3.1.8-java)
-    builder (3.2.4)
+    bigdecimal (3.1.9)
+    bigdecimal (3.1.9-java)
+    builder (3.3.0)
     csv (3.3.0)
-    cucumber (9.2.0)
+    cucumber (9.2.1)
       builder (~> 3.2)
       cucumber-ci-environment (> 9, < 11)
       cucumber-core (> 13, < 14)
@@ -18,7 +18,7 @@ GEM
       multi_test (~> 1.1)
       sys-uname (~> 1.2)
     cucumber-ci-environment (10.0.1)
-    cucumber-core (13.0.2)
+    cucumber-core (13.0.3)
       cucumber-gherkin (>= 27, < 28)
       cucumber-messages (>= 20, < 23)
       cucumber-tag-expressions (> 5, < 7)
@@ -26,10 +26,10 @@ GEM
       bigdecimal
     cucumber-gherkin (27.0.0)
       cucumber-messages (>= 19.1.4, < 23)
-    cucumber-html-formatter (21.3.1)
-      cucumber-messages (> 19, < 25)
+    cucumber-html-formatter (21.9.0)
+      cucumber-messages (> 19, < 28)
     cucumber-messages (22.0.0)
-    cucumber-tag-expressions (6.1.0)
+    cucumber-tag-expressions (6.1.2)
     diff-lcs (1.5.1)
     ffi (1.16.3)
     ffi (1.16.3-java)
@@ -66,7 +66,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    sys-uname (1.2.3)
+    sys-uname (1.3.1)
       ffi (~> 1.1)
 
 PLATFORMS
@@ -74,10 +74,12 @@ PLATFORMS
   arm64-darwin-23
   universal-java-17
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
-  cucumber
+  cucumber (~> 9.2.1)
+  ffi (~> 1.16.3)
   httparty
   jsonpath
   nokogiri (= 1.18.3)


### PR DESCRIPTION
# Overview

### What is the feature/fix?

system-validaiton-test build was failing.

### What is the Solution?

Updated the cucumber version to the one that will work with our current version of ruby, limited ffi to work with the current version of ruby

### What areas of the application does this impact?

system-validation-tests

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
