### PR TITLE
CMR-10213 new jetty - Attempt 2

### DIFF
--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -19,6 +19,19 @@
   ring jetty adapter default of 8."
   8)
 
+(declare use-web-compression?)
+(defconfig use-web-compression?
+  "Indicates whether the servers will use gzip compression. Disable this to
+  make tcpmon usable"
+  {:default true
+   :type Boolean})
+
+(declare use-access-log)
+(defconfig use-access-log
+  "Indicates whether the servers will use the access log."
+  {:default true
+   :type Boolean})
+
 (declare MAX_THREADS)
 (defconfig MAX_THREADS
   "The maximum number of threads for Jetty to use to process requests. This was originally set to
@@ -137,17 +150,48 @@
                    all-buffers
                    current-buffer)))))))
 
+(comment
+  ;; TODO: remove this
+  ;(defn create-access-log-handler-old
+  ;  "Setup access logging for each application. Access log entries will go to stdout similar to
+  ;application logging. As a result the access log entries will be in the same log as the
+  ;application log."
+  ;  [existing-handler]
+  ;  (doto (RequestLogHandler.)
+  ;    (.setHandler existing-handler)
+  ;    (.setRequestLog
+  ;     (doto (CustomRequestLog. (Slf4jRequestLogWriter.) CustomRequestLog/EXTENDED_NCSA_FORMAT)
+  ;       (.setLogLatency true)
+  ;       (.setLogDateFormat "yyyy-MM-dd HH:mm:ss.SSS")))))
+  )
+
+;(defn create-access-log-handler
+;  "Setup access logging for each application. Access log entries will go to stdout similar to
+;  application logging. As a result the access log entries will be in the same log as the
+;  application log."
+;  [existing-handler]
+;  (let [log-writer (doto (Slf4jRequestLogWriter.)
+;                     (.setDateFormat "yyyy-MM-dd HH:mm:ss.SSS"))]
+;    (doto (RequestLogHandler.)
+;      (.setHandler existing-handler)
+;      (.setRequestLog
+;        (doto (CustomRequestLog. log-writer CustomRequestLog/EXTENDED_NCSA_FORMAT))))))
+
+
 (defn create-access-log-handler
   "Setup access logging for each application. Access log entries will go to stdout similar to
   application logging. As a result the access log entries will be in the same log as the
   application log."
   [existing-handler]
-  (doto (RequestLogHandler.)
-    (.setHandler existing-handler)
-    (.setRequestLog
-      (doto (CustomRequestLog. (Slf4jRequestLogWriter.) CustomRequestLog/EXTENDED_NCSA_FORMAT)
-        (.setLogLatency true)
-        (.setLogDateFormat "yyyy-MM-dd HH:mm:ss.SSS")))))
+  (let [log-writer (Slf4jRequestLogWriter.)
+        date-format "yyyy-MM-dd HH:mm:ss.SSS"
+        log-format (str CustomRequestLog/EXTENDED_NCSA_FORMAT " %{yyyy-MM-dd HH:mm:ss.SSS}t")]
+    (doto (RequestLogHandler.)
+      (.setHandler existing-handler)
+      (.setRequestLog
+        (CustomRequestLog. log-writer log-format)))))
+
+
 
 (defn- create-gzip-handler
   "Setup gzip compression for responses.  Compression will be used for any response larger than
@@ -225,9 +269,10 @@
   "Creates a new web server. Accepts argument of port and a routes function that should accept
   system argument and return compojure routes to use."
   ([port routes-fn]
-   (create-web-server port routes-fn true true))
-  ([port routes-fn use-compression use-access-log]
+   (create-web-server port routes-fn use-web-compression? use-access-log))
+  ([port routes-fn use-compression use-access-log-opt]
+   (printf "Here in web server %s %s\n" (if use-compression "t" "f") (if use-access-log-opt "t" "f"))
    (map->WebServer {:port port
                     :use-compression? use-compression
-                    :use-access-log? use-access-log
+                    :use-access-log? use-access-log-opt
                     :routes-fn routes-fn})))

--- a/common-lib/src/cmr/common/api/web_server.clj
+++ b/common-lib/src/cmr/common/api/web_server.clj
@@ -150,48 +150,17 @@
                    all-buffers
                    current-buffer)))))))
 
-(comment
-  ;; TODO: remove this
-  ;(defn create-access-log-handler-old
-  ;  "Setup access logging for each application. Access log entries will go to stdout similar to
-  ;application logging. As a result the access log entries will be in the same log as the
-  ;application log."
-  ;  [existing-handler]
-  ;  (doto (RequestLogHandler.)
-  ;    (.setHandler existing-handler)
-  ;    (.setRequestLog
-  ;     (doto (CustomRequestLog. (Slf4jRequestLogWriter.) CustomRequestLog/EXTENDED_NCSA_FORMAT)
-  ;       (.setLogLatency true)
-  ;       (.setLogDateFormat "yyyy-MM-dd HH:mm:ss.SSS")))))
-  )
-
-;(defn create-access-log-handler
-;  "Setup access logging for each application. Access log entries will go to stdout similar to
-;  application logging. As a result the access log entries will be in the same log as the
-;  application log."
-;  [existing-handler]
-;  (let [log-writer (doto (Slf4jRequestLogWriter.)
-;                     (.setDateFormat "yyyy-MM-dd HH:mm:ss.SSS"))]
-;    (doto (RequestLogHandler.)
-;      (.setHandler existing-handler)
-;      (.setRequestLog
-;        (doto (CustomRequestLog. log-writer CustomRequestLog/EXTENDED_NCSA_FORMAT))))))
-
-
 (defn create-access-log-handler
   "Setup access logging for each application. Access log entries will go to stdout similar to
   application logging. As a result the access log entries will be in the same log as the
   application log."
   [existing-handler]
   (let [log-writer (Slf4jRequestLogWriter.)
-        date-format "yyyy-MM-dd HH:mm:ss.SSS"
         log-format (str CustomRequestLog/EXTENDED_NCSA_FORMAT " %{yyyy-MM-dd HH:mm:ss.SSS}t")]
     (doto (RequestLogHandler.)
       (.setHandler existing-handler)
       (.setRequestLog
         (CustomRequestLog. log-writer log-format)))))
-
-
 
 (defn- create-gzip-handler
   "Setup gzip compression for responses.  Compression will be used for any response larger than
@@ -271,7 +240,6 @@
   ([port routes-fn]
    (create-web-server port routes-fn use-web-compression? use-access-log))
   ([port routes-fn use-compression use-access-log-opt]
-   (printf "Here in web server %s %s\n" (if use-compression "t" "f") (if use-access-log-opt "t" "f"))
    (map->WebServer {:port port
                     :use-compression? use-compression
                     :use-access-log? use-access-log-opt

--- a/dev-system/src/cmr/dev_system/config.clj
+++ b/dev-system/src/cmr/dev_system/config.clj
@@ -29,16 +29,19 @@
   {:default 5601
    :type Long})
 
-(defconfig use-web-compression?
-  "Indicates whether the servers will use gzip compression. Disable this to
-  make tcpmon usable"
-  {:default true
-   :type Boolean})
+(comment
+  ;; TODO: Remove these or keep them
 
-(defconfig use-access-log
-  "Indicates whether the servers will use the access log."
- {:default false
-  :type Boolean})
+  (defconfig _use-web-compression?
+    "Indicates whether the servers will use gzip compression. Disable this to
+  make tcpmon usable"
+    {:default true
+     :type Boolean})
+
+  (defconfig _use-access-log
+    "Indicates whether the servers will use the access log."
+    {:default false
+     :type Boolean}))
 
 (defconfig dev-system-echo-type
   "Specifies whether dev system should run an in-memory mock ECHO or use an

--- a/dev-system/src/cmr/dev_system/config.clj
+++ b/dev-system/src/cmr/dev_system/config.clj
@@ -29,20 +29,6 @@
   {:default 5601
    :type Long})
 
-(comment
-  ;; TODO: Remove these or keep them
-
-  (defconfig _use-web-compression?
-    "Indicates whether the servers will use gzip compression. Disable this to
-  make tcpmon usable"
-    {:default true
-     :type Boolean})
-
-  (defconfig _use-access-log
-    "Indicates whether the servers will use the access log."
-    {:default false
-     :type Boolean}))
-
 (defconfig dev-system-echo-type
   "Specifies whether dev system should run an in-memory mock ECHO or use an
   external ECHO."

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -4,6 +4,7 @@
    [cmr.access-control.system :as access-control-system]
    [cmr.bootstrap.config :as bootstrap-config]
    [cmr.bootstrap.system :as bootstrap-system]
+   [cmr.common.api.web-server :as web-serv]
    [cmr.common.jobs :as jobs]
    [cmr.common.lifecycle :as lifecycle]
    [cmr.common.log :refer [info warn error]]
@@ -78,8 +79,8 @@
   "Update the web configuration options for the passed app system."
   [app-system]
   (-> app-system
-      (assoc-in [:web :use-compression?] (cmr.common.api.web-server/use-web-compression?))
-      (assoc-in [:web :use-access-log?] (cmr.common.api.web-server/use-access-log))))
+      (assoc-in [:web :use-compression?] (web-serv/use-web-compression?))
+      (assoc-in [:web :use-access-log?] (web-serv/use-access-log))))
 
 (defn- set-web-server-options
   "Modifies an app server instance to configure web server options, returning a

--- a/dev-system/src/cmr/dev_system/system.clj
+++ b/dev-system/src/cmr/dev_system/system.clj
@@ -78,8 +78,8 @@
   "Update the web configuration options for the passed app system."
   [app-system]
   (-> app-system
-      (assoc-in [:web :use-compression?] (dev-config/use-web-compression?))
-      (assoc-in [:web :use-access-log?] (dev-config/use-access-log))))
+      (assoc-in [:web :use-compression?] (cmr.common.api.web-server/use-web-compression?))
+      (assoc-in [:web :use-access-log?] (cmr.common.api.web-server/use-access-log))))
 
 (defn- set-web-server-options
   "Modifies an app server instance to configure web server options, returning a


### PR DESCRIPTION
# Overview

The first attempt at pushing out the Jetty change failed in SIT as that environment ran the code in a different way (using different settings) which exposed an error. This version removes the use of libraries which caused the problem. 

It seams that the web_server.clj file was not always being compiled unless you called `cmr setup dev` between changes. After doing this I was able to get runtime errors.

NOTE: this pull request is into the first branch so that I can show just what was changed here. I will then merge that branch (which was approved already) into master.

### What is the feature/fix?

1. Removed library calls which no longer exist.
2. Exposed dev-system configurations globally so that all apps can choose to run without compression and logs instead of assuming.

### What areas of the application does this impact?

1. All web servers now have two new options (which should not be needed for deployment).
2. Dev-system will use logs now conforming to the global default.

# Checklist

- [-] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [-] New and existing unit and int tests pass locally and remotely
- [-] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
