### PR TITLE
CMR-10525: removes associatedDois from doi search on collections

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -232,8 +232,7 @@
         parsed-version-id (collection-util/parse-version-id version-id)
         s3-bucket-and-object-prefix-names (get-in collection [:DirectDistributionInformation :S3BucketAndObjectPrefixNames])
         doi (get-in collection [:DOI :DOI])
-        doi-lowercase (into [(util/safe-lowercase doi)]
-                            (mapv #(util/safe-lowercase (:DOI %)) (get collection :AssociatedDOIs)))
+        doi-lowercase (util/safe-lowercase doi)
         processing-level-id (get-in collection [:ProcessingLevel :Id])
         spatial-keywords (lk/location-keywords->spatial-keywords-for-indexing
                           (:LocationKeywords collection))

--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_doi_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_doi_search_test.clj
@@ -106,22 +106,4 @@
             "Search for collections with DOIs that aren't provided or missing"
             [coll3 no-doi]
             {:or [{:not {:doi {:value "*" :pattern true}}} {:doi "Not provided"}]}))))
-
-(deftest search-by-associated-doi
-  (let [coll1 (d/ingest-umm-spec-collection
-               "PROV1"
-               (-> exp-conv/curr-ingest-ver-example-collection-record
-                   (assoc :ShortName "CMR3674SN1")
-                   (assoc :EntryTitle "CMR3674ET1"))
-               {:format :umm-json
-                :accept-format :json
-                :validate-keywords false})]
-    (index/wait-until-indexed)
-    (testing "search collections by associated doi"
-      (are3 [items doi options]
-        (let [params (merge {:doi doi}
-                            (when options
-                              {"options[doi]" options}))]
-          (d/refs-match? items (search/find-refs :collection params)))
-       "search collections with doi1"
-       [coll1] "10.4567/DOI1" {}))))
+            


### PR DESCRIPTION
# Overview

### What is the feature/fix?

DOI search now only returns collections where the DOI of the collection matches, and not the associatedDOI's field

### What is the Solution?

Modified the collection document indexing to not include associated dois in the doi field, so that the search parameter doi will only search on a collection's doi, not also associated dois.

### What areas of the application does this impact?

cmr indexer and search app

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
