### PR TITLE
CMR-10671: updates drift and commons-lang

### DIFF
--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -8,7 +8,7 @@
                  [commons-io "2.18.0"]
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
-                 [io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+                 [org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
                  [nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"]
@@ -29,7 +29,7 @@
                  [ring/ring-jetty-adapter "1.14.2"]
                  [ring/ring-codec "1.3.0"]
                  [ring/ring-json "0.5.1"]]
-  :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+  :plugins [[org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
             [lein-exec "0.3.7"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -74,7 +74,7 @@
                                            :properties-file "resources/security/dependencycheck.properties"}}
              :dev-dependencies {:dependencies [[criterium "0.4.4"]
                                                [debugger "0.2.0"]
-                                               [io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+                                               [org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
                                                [org.clojars.gjahad/debug-repl "0.3.3"]
                                                [org.clojure/tools.namespace "0.2.11"]
                                                [org.clojure/tools.nrepl "0.2.13"]

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -8,12 +8,16 @@
                  [clojurewerkz/elastisch "5.0.0-beta1"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.18.0"]
+                 ;; commons-compress does not currently use commons-lang3 3.18.0, for now
+                 ;; we will force it to use the latest version
+                 [org.apache.commons/commons-lang3 "3.18.0"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [org.apache.logging.log4j/log4j-api "2.15.0"]
                  [org.clojure/clojure "1.11.2"]
                  [org.elasticsearch/elasticsearch ~elastic-version]
-                 [org.apache.commons/commons-compress "1.26.0"]
+                 [org.apache.commons/commons-compress "1.26.0"
+                  :exclusions [org.apache.commons/commons-lang3]]
                  [org.testcontainers/testcontainers "1.19.7"]
                  [org.yaml/snakeyaml "1.31"]
                  [potemkin "0.4.5"]]

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -10,7 +10,7 @@
                  [commons-io "2.18.0"]
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
-                 [io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+                 [org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
                  [instaparse "1.4.10"]
                  [inflections "0.13.0"]
@@ -41,7 +41,7 @@
                  [ring/ring-core "1.14.2"]
                  [ring/ring-jetty-adapter "1.14.2"]
                  [ring/ring-json "0.5.1"]]
-  :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+  :plugins [[org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
             [lein-exec "0.3.7"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -8,7 +8,7 @@
                  [commons-io "2.18.0"] ;; used by migration
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
-                 [io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+                 [org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
                  [inflections "0.13.0"]
                  [nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
@@ -29,7 +29,7 @@
                  [ring/ring-core "1.14.2"]
                  [ring/ring-jetty-adapter "1.14.2"] ;; used by migration
                  [ring/ring-json "0.5.1"]]
-  :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+  :plugins [[org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
             [lein-exec "0.3.7"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -12,7 +12,11 @@
   :dependencies [[com.taoensso/carmine "3.0.1"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [org.clojure/clojure "1.11.2"]
-                 [org.apache.commons/commons-compress "1.26.0"]
+                 ;; commons-compress does not currently use commons-lang3 3.18.0, for now
+                 ;; we will force it to use the latest version
+                 [org.apache.commons/commons-lang3 "3.18.0"]
+                 [org.apache.commons/commons-compress "1.26.0"
+                  :exclusions [org.apache.commons/commons-lang3]]
                  [org.testcontainers/testcontainers "1.19.7"]]
   :plugins [[lein-exec "0.3.7"]
             [lein-shell "0.5.0"]]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -53,7 +53,7 @@
                                            :suppression-file "resources/security/suppression.xml"
                                            :properties-file "resources/security/dependencycheck.properties"}}
              :dev {:dependencies [[criterium "0.4.4"]
-                                  [io.github.jaybarra/drift "1.5.4.2-SNAPSHOT"]
+                                  [org.clojars.daniel-zamora/drift "1.5.6-SNAPSHOT"]
                                   [org.clojars.gjahad/debug-repl "0.3.3"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [org.clojure/tools.nrepl "0.2.13"]


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Updates common-lang3 library in multiple apps and pulls in new drift version with sub dependency clojure-tools update to common-lang3 version 3.18.

### What is the Solution?

Updates common-lang3 library in multiple apps and pulls in new drift version with sub dependency clojure-tools update to common-lang3 version 3.18.

### What areas of the application does this impact?

bootstap, dev-system, elastic-utils-lib, ingest, metadata-db, redis-utils, search

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
