### PR TITLE
CMR-10672: Search in Citations Schema returns zero results for requested RelationshipType (CMR Bug)

### DIFF
--- a/indexer-app/test/cmr/indexer/test/data/concepts/generic.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/generic.clj
@@ -1,0 +1,144 @@
+(ns cmr.indexer.test.data.concepts.generic
+  (:require
+   [clojure.test :refer :all]
+   [cmr.indexer.data.concepts.generic :as generic]))
+
+(def sample-citation-data
+  {:RelatedIdentifiers [{:RelationshipType "Cites"
+                         :RelatedIdentifier "10.5067/MODIS/MOD08_M3.061"
+                         :RelatedIdentifierType "DOI"}
+                        {:RelationshipType "Describes"
+                         :RelatedIdentifier "ark:/13030/tf1p17542"
+                         :RelatedIdentifierType "ARK"}]
+   :CitationMetadata {:Title "Global Climate Study"
+                      :Year 2021
+                      :Author [{:Given "John" :Family "Smith" :ORCID "0000-0002-1825-0097"}]}})
+
+(def sample-single-object-data
+  {:CitationMetadata {:Title "Climate Research"
+                      :Year 2020}})
+
+(def empty-data {})
+
+(defn assert-collections-equal-unordered
+  "Asserts two collections contain the same elements, ignoring order"
+  [expected actual]
+  (is (= (set expected) (set actual))))
+
+(deftest field->index-complex-field-test
+  (testing "Complex field indexer with field names in format"
+    (let [settings {:Field ".CitationMetadata"
+                    :Name "Citation-Info"
+                    :Configuration {:sub-fields ["Title" "Year"]
+                                    :format "%s=%s"}}
+          result (generic/field->index-complex-field settings sample-single-object-data)]
+      (is (= {:citation-info "Title=Climate Research, Year=2020"
+              :citation-info-lowercase "title=climate research, year=2020"}
+             result))))
+
+  (testing "Complex field with missing data"
+    (let [settings {:Field ".NonExistentField"
+                    :Name "Missing-Field"
+                    :Configuration {:sub-fields ["Title" "Year"]
+                                    :format "%s=%s"}}
+          result (generic/field->index-complex-field settings sample-single-object-data)]
+      (is (= {:missing-field "Title=null, Year=null"
+              :missing-field-lowercase "title=null, year=null"}
+             result)))))
+
+(deftest field->index-complex-field-with-values-only-test
+  (testing "Complex field with values only, single object"
+    (let [settings {:Field ".CitationMetadata"
+                    :Name "Citation-Values"
+                    :Configuration {:sub-fields ["Title" "Year"]
+                                    :format "%s:%s"}}
+          result (generic/field->index-complex-field-with-values-only settings sample-single-object-data)]
+      (is (= {:citation-values "Climate Research:2020"
+              :citation-values-lowercase "climate research:2020"}
+             result))))
+
+  (testing "Complex field with values only, array data"
+    (let [settings {:Field ".RelatedIdentifiers"
+                    :Name "Related-Identifier-With-Type"
+                    :Configuration {:sub-fields ["RelationshipType" "RelatedIdentifier"]
+                                    :format "%s:%s"}}
+          result (generic/field->index-complex-field-with-values-only settings sample-citation-data)]
+      (is (= {:related-identifier-with-type ["Cites:10.5067/MODIS/MOD08_M3.061"
+                                             "Describes:ark:/13030/tf1p17542"]
+              :related-identifier-with-type-lowercase ["cites:10.5067/modis/mod08_m3.061"
+                                                       "describes:ark:/13030/tf1p17542"]}
+             result))))
+
+  (testing "Complex field with empty array"
+    (let [settings {:Field ".EmptyArray"
+                    :Name "Empty-Field"
+                    :Configuration {:sub-fields ["Title" "Year"]
+                                    :format "%s:%s"}}
+          result (generic/field->index-complex-field-with-values-only settings {:EmptyArray []})]
+      (is (= {:empty-field []
+              :empty-field-lowercase []}
+             result)))))
+
+(deftest field->index-simple-array-field-test
+  (testing "Simple array field extracts values from array elements"
+    (let [settings {:Field ".RelatedIdentifiers"
+                     :Name "Related-Identifier"
+                     :Configuration {:sub-fields ["RelatedIdentifier"]}}
+           result (generic/field->index-simple-array-field settings sample-citation-data)]
+       (assert-collections-equal-unordered
+        ["10.5067/MODIS/MOD08_M3.061" "ark:/13030/tf1p17542"]
+        (:related-identifier result))
+       (assert-collections-equal-unordered
+        ["10.5067/modis/mod08_m3.061" "ark:/13030/tf1p17542"]
+        (:related-identifier-lowercase result))))
+
+  (testing "Simple array field with multiple sub-fields"
+    (let [settings {:Field ".RelatedIdentifiers"
+                    :Name "Relationship-Info"
+                    :Configuration {:sub-fields ["RelationshipType" "RelatedIdentifier"]}}
+          result (generic/field->index-simple-array-field settings sample-citation-data)]
+      (assert-collections-equal-unordered
+       #{"Cites" "10.5067/MODIS/MOD08_M3.061" "Describes" "ark:/13030/tf1p17542"}
+       (set (:relationship-info result)))))
+
+  (testing "Simple array field with nested data"
+    (let [settings {:Field ".CitationMetadata.Author"
+                    :Name "Author-Info"
+                    :Configuration {:sub-fields ["Given" "Family"]}}
+          result (generic/field->index-simple-array-field settings sample-citation-data)]
+      (assert-collections-equal-unordered ["John" "Smith"] (:author-info result))
+      (assert-collections-equal-unordered ["john" "smith"] (:author-info-lowercase result))))
+
+  (testing "Simple array field with empty data"
+    (let [settings {:Field ".NonExistent"
+                    :Name "Missing-Array"
+                    :Configuration {:sub-fields ["Field1"]}}
+          result (generic/field->index-simple-array-field settings empty-data)]
+      (is (= {:missing-array []
+              :missing-array-lowercase []}
+             result))))
+
+(deftest field->index-default-field-test
+  (testing "Default field indexer for simple values"
+    (let [settings {:Field ".CitationMetadata.Title"
+                    :Name "Title"}
+          result (generic/field->index-default-field settings sample-citation-data)]
+      (is (= {:title "Global Climate Study"
+              :title-lowercase "global climate study"}
+             result))))
+
+  (testing "Default field indexer with nested path"
+    (let [settings {:Field ".CitationMetadata.Author.0.Given"
+                    :Name "First-Author-Given"}
+          result (generic/field->index-default-field settings sample-citation-data)]
+      (is (= {:first-author-given "John"
+              :first-author-given-lowercase "john"}
+             result))))
+
+  (testing "Default field indexer with missing field"
+    (let [settings {:Field ".NonExistent.Field"
+                    :Name "Missing-Field"}
+          result (generic/field->index-default-field settings empty-data)]
+      (is (= {:missing-field nil
+              :missing-field-lowercase nil}
+             result))))))

--- a/schemas/resources/schemas/citation/v1.0.0/config.json
+++ b/schemas/resources/schemas/citation/v1.0.0/config.json
@@ -48,12 +48,6 @@
       "Mapping": "string"
     },
     {
-      "Description": "The nature of the relationship between the cited resource and the collection",
-      "Field": ".RelationshipType",
-      "Name": "Relationship-Type",
-      "Mapping": "string"
-    },
-    {
       "Description": "Science Keywords in keywords",
       "Field": ".ScienceKeywords",
       "Name": "keyword",
@@ -68,6 +62,17 @@
       "Mapping": "string",
       "Indexer": "simple-array-field",
       "Configuration": {"sub-fields": ["RelatedIdentifier"]}
+    },
+    {
+      "Description": "Related Identifiers with Relationship Types", 
+      "Field": ".RelatedIdentifiers",
+      "Name": "Related-Identifier-With-Type",
+      "Mapping": "string", 
+      "Indexer": "complex-fields-only",
+      "Configuration": {
+        "sub-fields": ["RelationshipType", "RelatedIdentifier"],
+        "format": "%s:%s"
+      }
     },
     {
       "Description": "Citation Title",

--- a/schemas/resources/schemas/citation/v1.0.0/search.md
+++ b/schemas/resources/schemas/citation/v1.0.0/search.md
@@ -35,6 +35,7 @@ The following parameters can be used to search citations:
 * `identifier-type` - Search by identifier type
 * `relationship-type` - Search by relationship type
 * `related-identifier` - Search by related identifier
+* `related-identifier-with-type` - Search for specific relationship-identifier pairs using format `RelationshipType:RelatedIdentifier` (e.g., `Cites:10.5067/SAMPLE/DATA`, `Describes:ark:/13030/tf1p17542`)
 * `title` - Search by title
 * `year` - Search by publication year (integer)
 * `type` - Search by citation type
@@ -216,6 +217,23 @@ __Sample response__
             </reference>
         </references>
     </results>
+```
+
+#### Related Identifier Searching
+
+The `related-identifier-with-type` parameter enables searches for citations with specific relationship types to specific identifiers. 
+
+__Examples__
+
+```
+    # Find citations that cite a specific DOI
+    curl "%CMR-ENDPOINT%/citations?related-identifier-with-type=Cites:10.5067/MODIS/MOD08_M3.061"
+
+    # Case-insensitive search
+    curl "%CMR-ENDPOINT%/citations?related-identifier-with-type-lowercase=cites:10.5067/modis/mod08_m3.061"
+
+    # Find all citations that cite something using wildcard option
+    curl "%CMR-ENDPOINT%/citations?related-identifier-with-type=Cites*&options%5Brelated-identifier-with-type%5D%5Bpattern%5D=true"
 ```
 
 #### <a name="sorting-citation-results"></a> Sorting Citation Results

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -219,6 +219,7 @@
    :identifier-type :string
    :relationship-type :string
    :related-identifier :string
+   :related-identifier-with-type :string
    :title :string
    :year :int
    :type :string


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Currently, its difficult to search for citations by what the citation is related to via the related identifiers.  This commit will add a new search parameter to facilitate these types of searches.

### What is the Solution?

related-identifier-with-type search parameter was introduced.  Also, a new indexer mapping type was introduced complex-fields-only that allows for formatting via fields of the mapping alone, without field names which is what the other indexer mapping type was doing.

### What areas of the application does this impact?

searching and indexing generics, specifically citations, but adds some configuration functionality for generics in general

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
