### PR TITLE
CMR-10766: Create aliases for all CMR indices in Elasticsearch at dev-start.

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
@@ -60,6 +60,16 @@
              {:content-type :json
               :body {:actions actions}}))
 
+;; We have to roll our own get-aliases function because Elasticsearch route on GET alias
+;; for an index has changed and clojurewerkz is outdated
+(defn get-aliases
+  "get index aliases"
+  [conn index-name]
+  (let [aliases-url (rest/url-with-path conn index-name "_alias")
+        resp (rest/get conn aliases-url)
+        aliases (keys (get-in resp [(keyword index-name) :aliases]))]
+    (mapv name aliases)))
+
 (defn create-index-template
   "create an index template in elasticsearch"
   [conn template-name opts]

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -127,6 +127,11 @@
               :dynamic "strict"
               :properties ~properties}))))
 
+(defn create-index-alias
+  "Creates the alias for the index."
+  [conn index alias-name]
+  (esi-helper/update-aliases conn [{:add {:index index :alias alias-name}}]))
+
 (defn create-index-or-update-mappings
   "Creates the index needed in Elasticsearch for data storage or updates it. Parameters are as
    follows:
@@ -148,6 +153,7 @@
       (do
         (info (format "Creating %s index" index-name))
         (esi-helper/create conn index-name {:settings {:index index-settings} :mappings mappings})
+        (create-index-alias conn index-name (str index-name "_alias"))
         (esc/wait-for-healthy-elastic elastic-store)))
     (esi-helper/refresh conn index-name)))
 
@@ -228,8 +234,3 @@
   "Delete index"
   [elastic-store index-name]
   (es-helper/delete-index elastic-store index-name))
-
-(defn create-index-alias
-  "Creates the alias for the index."
-  [conn index alias-name]
-  (esi-helper/update-aliases conn [{:add {:index index :alias alias-name}}]))

--- a/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
+++ b/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
@@ -4,14 +4,15 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [clojurewerkz.elastisch.rest.index :as esi]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.indexer.services.index-set-service :as svc]
    [cmr.indexer.test.utility :as util]))
 
 (use-fixtures :each util/reset-fixture)
 
 ;; Verify index-set creation is successful.
-;; use elastisch to verify all indices of index-set exist and the index-set doc has been indexed
-;; in elastic
+;; use elastisch to verify all indices and aliases of index-set exist
+;; and the index-set doc has been indexed in elastic
 (deftest create-index-set-test
   (testing "create index-set"
     (let [index-set util/sample-index-set
@@ -19,10 +20,10 @@
       (is (= 201 status))))
   (testing "indices existence"
     (let [index-set util/sample-index-set
-          index-set-id (get-in index-set [:index-set :id])
           index-names (svc/get-index-names index-set)]
-      (for [idx-name index-names]
-        (is (esi/exists? @util/elastic-connection idx-name)))))
+      (doseq [idx-name index-names]
+        (is (esi/exists? @util/elastic-connection idx-name))
+        (is (= [(str idx-name "_alias")] (esi-helper/get-aliases @util/elastic-connection idx-name))))))
   (testing "index-set doc existence"
     (let [index-set util/sample-index-set
           index-set-id (get-in index-set [:index-set :id])

--- a/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
@@ -8,6 +8,7 @@
    [cmr.common.util :as util]
    [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.elastic-utils.es-index-helper :as esi-helper]
+   [cmr.elastic-utils.index-util :as esi]
    [cmr.indexer.config :as config]
    [cmr.indexer.services.messages :as m]
    [cmr.transmit.config :as t-config]))
@@ -37,6 +38,23 @@
             (error (format "error creating %s elastic index, elastic reported error: %s"
                           index-name error-message))
             (throw e)))))))
+
+(defn create-index-and-alias
+  "Create elastic index and its alias"
+  [es-store idx-w-config]
+  (let [{:keys [conn]} es-store
+        {:keys [index-name]} idx-w-config
+        alias (str index-name "_alias")]
+    (create-index es-store idx-w-config)
+    (try
+      (info "Now creating Elastic alias:" alias)
+      (esi/create-index-alias conn index-name alias)
+      (catch clojure.lang.ExceptionInfo e
+        (let [body (cheshire/decode (get-in (ex-data e) [:body]) true)
+              error-message (:error body)]
+          (error (format "error creating %s elastic index alias, elastic reported error: %s"
+                          alias error-message))
+          (throw e))))))
 
 (defn update-index
   "Update elastic index"

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -179,7 +179,7 @@
       (info "This instance of CMR will publish Elasticsearch indices for the following generic document types:" generic-docs))
     ;; rollback index-set creation if index creation fails
     (try
-      (dorun (map #(es/create-index es-store %) indices-w-config))
+      (dorun (map #(es/create-index-and-alias es-store %) indices-w-config))
       (catch ExceptionInfo e
         ;; TODO: Generic work: why does this fail to roll back with bad generics?
         (println "failed to create index, roll back, this does not always work")


### PR DESCRIPTION
# Overview

### What is the feature/fix?

This PR sets up the infrastructure to switch to search by aliases rather than index names directly by creating aliases for all CMR ES indices in dev-system.

### What is the Solution?

Create aliases for all CMR ES indices in dev-system.

### What areas of the application does this impact?

access-control and search applications where ES indices are created.

# Checklist

- [x] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors corrected
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
