### PR TITLE
CMR-10784: Create aliases for indices created during migration and rebalancing.

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_index_helper.clj
@@ -36,7 +36,7 @@
                :throw-exceptions true})))
 
 (defn refresh
- "refresh an index"
+ "Refresh an index"
   [conn index-name]
   (-> (rest/index-refresh-url conn (join-names index-name))
       (client/post (merge (.http-opts conn)
@@ -48,12 +48,12 @@
       (rest/parse-safely)))
 
 (defn delete
-  "delete an index"
+  "Delete an index"
   [conn index-name]
   (esi/delete conn index-name))
 
 (defn update-aliases
-  "update index aliases"
+  "Update index aliases"
   [conn actions]
   (rest/post conn
              (rest/index-aliases-batch-url conn)
@@ -63,15 +63,20 @@
 ;; We have to roll our own get-aliases function because Elasticsearch route on GET alias
 ;; for an index has changed and clojurewerkz is outdated
 (defn get-aliases
-  "get index aliases"
+  "Get index aliases"
   [conn index-name]
   (let [aliases-url (rest/url-with-path conn index-name "_alias")
         resp (rest/get conn aliases-url)
         aliases (keys (get-in resp [(keyword index-name) :aliases]))]
     (mapv name aliases)))
 
+(defn alias-exists?
+  "Return true if the given index has the default alias in the form of <index-name>_alias"
+  [conn index-name]
+  (boolean (some #{(str index-name "_alias")} (get-aliases conn index-name))))
+
 (defn create-index-template
-  "create an index template in elasticsearch"
+  "Create an index template in elasticsearch"
   [conn template-name opts]
   (let [{:keys [index-patterns settings mappings aliases]} opts
         template-url (rest/url-with-path conn "_index_template" template-name)

--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -153,8 +153,11 @@
       (do
         (info (format "Creating %s index" index-name))
         (esi-helper/create conn index-name {:settings {:index index-settings} :mappings mappings})
-        (create-index-alias conn index-name (str index-name "_alias"))
         (esc/wait-for-healthy-elastic elastic-store)))
+
+    ;; if the alias does not exist, add it
+    (when-not (esi-helper/alias-exists? conn index-name)
+      (create-index-alias conn index-name (str index-name "_alias")))
     (esi-helper/refresh conn index-name)))
 
 (defmacro try-elastic-operation

--- a/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
+++ b/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
@@ -112,7 +112,8 @@
      (doseq [collection expected-coll-indexes
              :let [collection-index-part (-> collection (string/replace "-" "_") string/lower-case)
                    elastic-index-name (str util/sample-index-set-id "_" collection-index-part)]]
-       (is (esi/exists? @util/elastic-connection elastic-index-name))))))
+       (is (esi/exists? @util/elastic-connection elastic-index-name))
+       (is (esi-helper/alias-exists? @util/elastic-connection elastic-index-name))))))
 
 ;; Tests adding a collection that is rebalancing its granules from small_collections to a separate
 ;; granule index


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Create aliases for indices created during migration and rebalancing.

### What is the Solution?

Create default aliases (in the form of <index-name>_alias) for CMR indices in the index-set during access-control and indexer application's db-migrate operations. If there are new indices that need to be added, the new indices and their default aliases with also be created as a result of db-migrate.

New granule indices created as a result of rebalancing will also have their default aliases created automatically.

Note: Separate granule indices moved back to small_collections index during rebalancing will not have their aliases removed because the finalize operation in rebalancing will not delete the separate granule index automatically  (to avoid issue with search cache refreshing). As a result, we will rely on the cascading deletion of aliases when the separate granule index gets deleted eventually.

I have tested locally and in WL4 to verify:
1) New index added to index-set will be created together with its default alias as a result of db-migrate during deployment for both the Access-Control and Indexer apps.
2) Aliases for existing index in Access-Control app (acls, groups) will be added automatically as a result of db-migrate during deployment.
3) Aliases for existing index in Indexer app will NOT be added automatically (if the rest of the indices stay the same) as a result of db-migrate during deployment. We can manually create them by invoking the `db-migrate` endpoint on Indexer app with `force=true` parameter.

### What areas of the application does this impact?

Access-control app and Indexer app db-migrate endpoints.

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
