### PR TITLE
CMR-10751: Add Indexer index-set and rebalance API changes

### DIFF
--- a/common-lib/src/cmr/common/util.clj
+++ b/common-lib/src/cmr/common/util.clj
@@ -1171,3 +1171,16 @@
         (as-> $ (string/join "&" $))
         string/trim
         digest/md5)))
+
+(defn deep-merge
+  "Recursively merges two maps.
+   If a key exists in both and its value is also a map,
+   it recursively merges those inner maps. Otherwise,
+   it prefers the value from the second map."
+  [m1 m2]
+  (merge-with
+    (fn [v1 v2]
+      (cond
+        (and (map? v1) (map? v2)) (deep-merge v1 v2)
+        :else v2))
+    m1 m2))

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -3,7 +3,6 @@
   (:require
    [cheshire.core :as json]
    [clojure.set :as set]
-   [clojure.string :as string]
    [clojurewerkz.elastisch.rest.index :as esri]
    [cmr.common.concepts :as concepts]
    [cmr.common.lifecycle :as lifecycle]

--- a/indexer-app/int-test/cmr/indexer/test/utility.clj
+++ b/indexer-app/int-test/cmr/indexer/test/utility.clj
@@ -144,6 +144,10 @@
 ;;; utility methods
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn gran-elastic-root
+  []
+  (format "http://%s:%s" (es-config/gran-elastic-host) (es-config/gran-elastic-port)))
+
 (defn elastic-root
   []
   (format "http://%s:%s" (es-config/elastic-host) (es-config/elastic-port)))
@@ -270,10 +274,12 @@
            (vals (get-in idx-set [:concepts concept])))))
 
 
+(def gran-elastic-connection (atom nil))
 (def elastic-connection (atom nil))
 
 (defn reset-fixture [f]
   (reset)
+  (reset! gran-elastic-connection (esr/connect (gran-elastic-root)))
   (reset! elastic-connection (esr/connect (elastic-root)))
   (f)
   (reset))

--- a/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
+++ b/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
@@ -4,15 +4,15 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [clojurewerkz.elastisch.rest.index :as esi]
-   [cmr.elastic-utils.es-index-helper :as esi-helper]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.indexer.services.index-set-service :as svc]
    [cmr.indexer.test.utility :as util]))
 
 (use-fixtures :each util/reset-fixture)
 
 ;; Verify index-set creation is successful.
-;; use elastisch to verify all indices and aliases of index-set exist
-;; and the index-set doc has been indexed in elastic
+;; use elastisch to verify all indices of index-set exist and the index-set doc has been indexed
+;; in elastic
 (deftest create-index-set-test
   (testing "create index-set"
     (let [index-set util/sample-index-set
@@ -20,10 +20,12 @@
       (is (= 201 status))))
   (testing "indices existence"
     (let [index-set util/sample-index-set
-          index-names (svc/get-index-names index-set)]
-      (doseq [idx-name index-names]
-        (is (esi/exists? @util/elastic-connection idx-name))
-        (is (= [(str idx-name "_alias")] (esi-helper/get-aliases @util/elastic-connection idx-name))))))
+          index-names-from-gran-cluster (svc/get-index-names index-set es-config/gran-elastic-name)
+          index-names-from-non-gran-cluster (svc/get-index-names index-set es-config/elastic-name)]
+      (for [idx-name index-names-from-gran-cluster]
+        (is (esi/exists? @util/gran-elastic-connection idx-name)))
+      (for [idx-name index-names-from-non-gran-cluster]
+        (is (esi/exists? @util/elastic-connection idx-name)))))
   (testing "index-set doc existence"
     (let [index-set util/sample-index-set
           index-set-id (get-in index-set [:index-set :id])
@@ -38,12 +40,17 @@
     (let [index-set util/sample-index-set
           suffix-idx-name "C4-PROV2"
           index-set-id (get-in index-set [:index-set :id])
-          expected-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
+          expected-coll-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
           {:keys [status]} (util/create-index-set index-set)
           fetched-index-set (-> (util/get-index-set index-set-id) :response :body)
-          actual-idx-name (get-in fetched-index-set [:index-set :concepts :collection (keyword suffix-idx-name)])]
+          actual-coll-idx-name (get-in fetched-index-set [:index-set :concepts :collection (keyword suffix-idx-name)])]
       (is (= 201 status))
-      (is (= expected-idx-name actual-idx-name)))))
+      (is (= expected-coll-idx-name actual-coll-idx-name))
+      (is (= (get-in index-set [:index-set :collection]) (get-in fetched-index-set [:index-set :collection])))
+      (is (= (get-in index-set [:index-set :granule]) (get-in fetched-index-set [:index-set :granule])))
+      (is (= {:C4-PROV2 "3_c4_prov2", :C6-PROV3 "3_c6_prov3"} (get-in fetched-index-set [:index-set :concepts :collection])))
+      (is (= {:small_collections "3_small_collections", :C4-PROV3 "3_c4_prov3", :C5-PROV5 "3_c5_prov5"}
+             (get-in fetched-index-set [:index-set :concepts :granule]))))))
 
 ;; Verify index-set delete is successful.
 ;; First create a index-set, verify a specified index in index-set is created, delete index-set
@@ -51,20 +58,29 @@
 (deftest delete-index-set-test
   (testing "create index-set"
     (let [index-set util/sample-index-set
-          suffix-idx-name "C4-PROV2"
           index-set-id (get-in index-set [:index-set :id])
-          expected-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
+          expected-coll-idx-name (svc/gen-valid-index-name index-set-id "C4-PROV2")
+          expected-gran-idx-name (svc/gen-valid-index-name index-set-id "C5-PROV5")
           {:keys [status]} (util/create-index-set index-set)]
       (is (= 201 status))
-      (is (esi/exists? @util/elastic-connection expected-idx-name))))
+      ;; this is creating a collection index, so we need to check the non-gran elastic cluster
+      (is (esi/exists? @util/elastic-connection expected-coll-idx-name))
+      (is (esi/exists? @util/gran-elastic-connection expected-gran-idx-name))
+
+      ;; check that coll index does not exist in gran cluster
+      (is (not (esi/exists? @util/gran-elastic-connection expected-coll-idx-name)))
+
+      ;; check that gran index does not exist in non-gran cluster
+      (is (not (esi/exists? @util/elastic-connection expected-gran-idx-name)))))
   (testing "delete index-set"
     (let [index-set util/sample-index-set
           index-set-id (get-in index-set [:index-set :id])
-          suffix-idx-name "C99-Collections"
-          expected-idx-name (svc/gen-valid-index-name index-set-id suffix-idx-name)
+          expected-coll-idx-name (svc/gen-valid-index-name index-set-id "C4-PROV2")
+          expected-gran-idx-name (svc/gen-valid-index-name index-set-id "C5-PROV5")
           {:keys [status]} (util/delete-index-set index-set-id)]
       (is (= 204 status))
-      (is (not (esi/exists? @util/elastic-connection expected-idx-name))))))
+      (is (not (esi/exists? @util/gran-elastic-connection expected-gran-idx-name)))
+      (is (not (esi/exists? @util/elastic-connection expected-coll-idx-name))))))
 
 ;; Verify get index-sets fetches all index-sets in elastic.
 ;; Create 2 index-sets with different ids but with same number of concepts and indices associated
@@ -84,7 +100,7 @@
           body (-> (util/get-index-sets) :response :body)
           actual-es-indices (util/list-es-indices body)]
       (for [es-idx-name actual-es-indices]
-        (is (esi/exists? @util/elastic-connection es-idx-name)))
+        (is (esi/exists? @util/gran-elastic-connection es-idx-name)))
       (is (= expected-idx-cnt (count actual-es-indices))))))
 
 
@@ -112,7 +128,7 @@
      (doseq [collection expected-coll-indexes
              :let [collection-index-part (-> collection (string/replace "-" "_") string/lower-case)
                    elastic-index-name (str util/sample-index-set-id "_" collection-index-part)]]
-       (is (esi/exists? @util/elastic-connection elastic-index-name))))))
+       (is (esi/exists? @util/gran-elastic-connection elastic-index-name))))))
 
 ;; Tests adding a collection that is rebalancing its granules from small_collections to a separate
 ;; granule index

--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -9,9 +9,11 @@
    [cmr.common.api.context :as context]
    [cmr.common.api.errors :as errors]
    [cmr.common.cache :as cache]
+   [cmr.common.util :as c-util]
    [cmr.common-app.api.health :as common-health]
    [cmr.common-app.api.request-logger :as req-log]
    [cmr.common-app.api.routes :as common-routes]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.indexer.data.concepts.collection]
    [cmr.indexer.data.concepts.granule]
    [cmr.indexer.data.concepts.subscription]
@@ -32,14 +34,21 @@
   "Routes providing index-set operations"
   (context "/index-sets" []
     (POST "/" {body :body request-context :request-context}
-      (let [index-set (walk/keywordize-keys body)]
-        (acl/verify-ingest-management-permission request-context :update)
-        (r/created (index-set-svc/create-index-set request-context index-set))))
+      "Given a combined/full index set, we will validate the index set and then separate out all gran indexes to go to gran cluster and the rest will be created in the non-gran cluster."
+      (let [index-set (walk/keywordize-keys body)
+            _ (acl/verify-ingest-management-permission request-context :update)
+            ;; both validations need to happen first before do any actions
+            _ (index-set-svc/validate-requested-index-set request-context es-config/gran-elastic-name index-set false)
+            _ (index-set-svc/validate-requested-index-set request-context es-config/elastic-name index-set false)
+            split-index-set-map (index-set-svc/split-index-set-by-cluster index-set)
+            index-set-resp (index-set-svc/create-indexes-and-index-set request-context split-index-set-map)]
+        (r/created index-set-resp)
+        ))
 
     ;; respond with index-sets in elastic
     (GET "/" {request-context :request-context}
       (acl/verify-ingest-management-permission request-context :read)
-      (r/response (index-set-svc/get-index-sets request-context)))
+      (r/response (index-set-svc/get-all-index-sets request-context)))
 
     (POST "/reset" {request-context :request-context}
       (acl/verify-ingest-management-permission request-context :update)
@@ -47,25 +56,47 @@
       (index-set-svc/reset request-context)
       {:status 204})
 
+    ;; TODO add sys tests for this new endpoint
+    (context "/elastic-name/:es-cluster-name" [es-cluster-name]
+      (GET "/" {request-context :request-context}
+        (acl/verify-ingest-management-permission request-context :read)
+        (r/response (index-set-svc/get-index-sets request-context es-cluster-name)))) ;; this is directly what is in elastic
+
+    ;; TODO add sys tests for this new endpoint
+    (context "/elastic-name/:es-cluster-name/:id" [es-cluster-name id]
+      (GET "/" {request-context :request-context}
+        (acl/verify-ingest-management-permission request-context :read)
+        (r/response (index-set-svc/get-index-set request-context es-cluster-name id))))
+
     (context "/:id" [id]
       (GET "/" {request-context :request-context}
         (acl/verify-ingest-management-permission request-context :read)
-        (r/response (index-set-svc/get-index-set request-context id)))
+        (let [gran-index-set (index-set-svc/get-index-set request-context es-config/gran-elastic-name id)
+              non-gran-index-set (index-set-svc/get-index-set request-context es-config/elastic-name id)
+              combined-index-set (c-util/deep-merge gran-index-set non-gran-index-set)]
+          (r/response combined-index-set)))
 
       (PUT "/" {request-context :request-context body :body}
-        (let [index-set (walk/keywordize-keys body)]
+        (let [index-set (walk/keywordize-keys body)
+              ;; Split the given index set into the proper sub-index-sets per cluster
+              split-index-set-map (index-set-svc/split-index-set-by-cluster index-set)]
           (acl/verify-ingest-management-permission request-context :update)
-          (index-set-svc/update-index-set request-context index-set)
+          ;; Validation for both index sets need to happen before we update anything
+          (index-set-svc/validate-requested-index-set request-context es-config/gran-elastic-name index-set true)
+          (index-set-svc/validate-requested-index-set request-context es-config/elastic-name index-set true)
+          ;; upsert indexes and index set based on the split index set
+          (index-set-svc/create-or-update-indexes-and-index-set request-context es-config/gran-elastic-name ((keyword es-config/gran-elastic-name) split-index-set-map))
+          (index-set-svc/create-or-update-indexes-and-index-set request-context es-config/elastic-name ((keyword es-config/elastic-name) split-index-set-map))
           {:status 200}))
 
       (DELETE "/" {request-context :request-context}
         (acl/verify-ingest-management-permission request-context :update)
-        (index-set-svc/delete-index-set request-context id)
+        (index-set-svc/delete-index-set request-context id es-config/gran-elastic-name)
+        (index-set-svc/delete-index-set request-context id es-config/elastic-name)
         {:status 204})
 
       (context "/rebalancing-collections/:concept-id" [concept-id]
-
-        ;; Marks the collection as rebalancing in the index set.
+        ;; Marks the collection as re-balancing in the index set.
         (POST "/start" {request-context :request-context params :params}
           (acl/verify-ingest-management-permission request-context :update)
           (index-set-svc/mark-collection-as-rebalancing request-context id concept-id (:target params))

--- a/indexer-app/src/cmr/indexer/config.clj
+++ b/indexer-app/src/cmr/indexer/config.clj
@@ -14,8 +14,9 @@
 ;; index name and config for storing index-set requests
 ;; index the request after creating all of the requested indices successfully
 ;; foot print of this index will remain small
-(def idx-cfg-for-index-sets
-  {:index-name "index-sets"
+(defn idx-cfg-for-index-sets
+  [es-cluster-name]
+  {:index-name (str es-cluster-name "-index-sets")
    :settings {"index" {"number_of_shards" 1
                        "number_of_replicas"  1
                        "refresh_interval" "30s"}}

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -7,7 +7,10 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util]
    [cmr.elastic-utils.connect :as es]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.es-helper :as es-helper]
+   [cmr.elastic-utils.search.es-index :as es-index]
+   [cmr.elastic-utils.search.es-messenger :as es-msg]
    [cmr.elastic-utils.index-util :as esi]
    [cmr.indexer.config :as config]
    [cmr.indexer.indexer-util :as indexer-util]
@@ -94,74 +97,127 @@
   (fn [_context concept _parsed-concept]
     (cs/concept-id->type (:concept-id concept))))
 
-(defn requires-update?
+(defn index-set-requires-update?
+  "Returns true if the existing index set does not match the expected index set and requires
+  update. Takes either the context which will be used to request index sets or the existing
+  and expected index sets.
+  This does not compare the :concepts values when determining update status."
+  [existing-index-set expected-index-set]
+  (let [updated-value (update-in existing-index-set [:index-set] dissoc :concepts)
+        result (not= updated-value expected-index-set)]
+    result))
+
+(defn cluster-requires-update?
   "Returns true if the existing index set does not match the expected index set and requires
   update. Takes either the context which will be used to request index sets or the existing
   and expected index sets."
-  ([context]
-   (let [existing-index-set (index-set-es/get-index-set context idx-set/index-set-id)
-         extra-granule-indexes (idx-set/index-set->extra-granule-indexes existing-index-set)
-         expected-index-set (idx-set/index-set extra-granule-indexes)]
-     (requires-update? existing-index-set expected-index-set)))
-  ([existing-index-set expected-index-set]
-   (not= (update-in existing-index-set [:index-set] dissoc :concepts)
-         expected-index-set)))
+  [context es-cluster-name]
+  (let [existing-index-set (index-set-es/get-index-set context es-cluster-name idx-set/index-set-id)
+        expected-index-set (cond
+                             (= es-cluster-name es-config/elastic-name) idx-set/non-gran-index-set
+                             (= es-cluster-name es-config/gran-elastic-name) idx-set/gran-index-set
+                             :else (throw (Exception. (es-msg/invalid-elastic-cluster-name-msg es-cluster-name))))]
+    (index-set-requires-update? existing-index-set expected-index-set)))
 
-(defn create-indexes
-  "Create elastic index for each index name"
+
+(defn create-default-indexes
+  "Create elastic indexes for each index name for both es clusters."
   [context]
-  (let [existing-index-set (index-set-es/get-index-set context idx-set/index-set-id)
-        extra-granule-indexes (idx-set/index-set->extra-granule-indexes existing-index-set)
-        expected-index-set (idx-set/index-set extra-granule-indexes)]
+  ;; create indexes for non-gran-cluster
+  (let [;; setup for non-gran-cluster
+        existing-non-gran-index-set (index-set-es/get-index-set context es-config/elastic-name idx-set/index-set-id)
+        expected-non-gran-index-set (idx-set/non-gran-index-set)
+
+        ;; setup for gran cluster
+        existing-gran-index-set (index-set-es/get-index-set context es-config/gran-elastic-name idx-set/index-set-id)
+        extra-granule-indexes (idx-set/index-set->extra-granule-indexes existing-gran-index-set)
+        expected-gran-index-set (idx-set/gran-index-set extra-granule-indexes)]
+
     (cond
-      (nil? existing-index-set)
+      ;; Check if exist and needs update
+      (index-set-requires-update? existing-non-gran-index-set expected-non-gran-index-set)
       (do
-        (info "Index set does not exist so creating it.")
-        (index-set-svc/create-index-set context expected-index-set)
-        (info "Creating collection index alias.")
-        (esi/create-index-alias (indexer-util/context->conn context)
+        (warn "Non-gran index set does not match. You may want to update it. This is separate manual call you'll need to make.")
+        (warn "Expected:" (pr-str expected-non-gran-index-set))
+        (warn "Actual:" (pr-str existing-non-gran-index-set)))
+
+      ;; Check if we need to create
+      (nil? existing-non-gran-index-set)
+      (do
+        (index-set-svc/create-or-update-indexes-and-index-set context es-config/elastic-name expected-non-gran-index-set)
+        (esi/create-index-alias (indexer-util/context->conn context es-config/elastic-name)
                                 (idx-set/collections-index)
                                 (idx-set/collections-index-alias)))
+      :else
+      (info "Non-gran index set exists and matches."))
 
 
-      ;; Compare them to see if they're the same
-      (requires-update? existing-index-set expected-index-set)
+    (cond
+      ;; Check if we need to update
+      (index-set-requires-update? existing-gran-index-set expected-gran-index-set)
       (do
-        (warn "Index set does not match you may want to update it.")
-        (warn "Expecting:" (pr-str expected-index-set))
-        (warn "Actual:" (pr-str existing-index-set)))
+        (warn "Gran index set does not match you may want to update it. This is separate manual call you'll need to make.")
+        (warn "Expecting:" (pr-str expected-gran-index-set))
+        (warn "Actual:" (pr-str existing-gran-index-set)))
+
+      ;; Check if we need to create
+      (nil? existing-gran-index-set)
+      (do
+        (warn "Gran index set does not exist so creating it.")
+        (index-set-svc/create-or-update-indexes-and-index-set context es-config/gran-elastic-name expected-gran-index-set))
 
       :else
-      (info "Index set exists and matches."))))
+      (info "Gran index set exists and matches."))
+    )
+  )
 
 (defn update-indexes
   "Updates the indexes to make sure they have the latest mappings"
   [context params]
-  (let [existing-index-set (index-set-es/get-index-set context idx-set/index-set-id)
-        extra-granule-indexes (idx-set/index-set->extra-granule-indexes existing-index-set)
-        ;; We use the extra granule indexes from the existing configured index set when determining
-        ;; the expected index set.
-        expected-index-set (idx-set/index-set extra-granule-indexes)]
+
+  ;(info "10636- Updating non-gran indexes.")
+  (let [existing-index-set (index-set-es/get-index-set context es-config/elastic-name idx-set/index-set-id)
+        expected-index-set (idx-set/non-gran-index-set)]
     (if (or (= "true" (:force params))
-            (requires-update? existing-index-set expected-index-set))
+            (index-set-requires-update? existing-index-set expected-index-set))
       (do
-        (info "Updating the index set to " (pr-str expected-index-set))
-        (index-set-svc/update-index-set context expected-index-set)
-        (info "Creating colleciton index alias.")
-        (esi/create-index-alias (indexer-util/context->conn context)
+        ;(info "10636- Updating the non-gran index set to " (pr-str expected-index-set))
+        (index-set-svc/validate-requested-index-set context es-config/elastic-name expected-index-set true)
+        (index-set-svc/create-or-update-indexes-and-index-set context es-config/elastic-name expected-index-set)
+        (info "Creating collection index alias.")
+        (esi/create-index-alias (indexer-util/context->conn context es-config/elastic-name)
                                 (idx-set/collections-index)
                                 (idx-set/collections-index-alias)))
       (do
-        (info "Ignoring upate indexes request because index set is unchanged.")
-        (info "Existing index set:" (pr-str existing-index-set))
-        (info "New index set:" (pr-str expected-index-set))))))
+        (info "10636-Ignoring update indexes request because non-gran index set is unchanged.")
+        (info "10636-Existing non-gran index set:" (pr-str existing-index-set))
+        (info "10636-New non-gran index set:" (pr-str expected-index-set)))))
+
+
+  ;(info "10636-Updating gran indexes.")
+  (let [existing-index-set (index-set-es/get-index-set context es-config/gran-elastic-name idx-set/index-set-id)
+        extra-granule-indexes (idx-set/index-set->extra-granule-indexes existing-index-set)
+        ;; We use the extra granule indexes from the existing configured index set when determining
+        ;; the expected index set.
+        expected-index-set (idx-set/gran-index-set extra-granule-indexes)]
+    (if (or (= "true" (:force params))
+            (index-set-requires-update? existing-index-set expected-index-set))
+      (do
+        (info "Updating the gran index set to " (pr-str expected-index-set))
+        (index-set-svc/validate-requested-index-set context es-config/gran-elastic-name expected-index-set true)
+        (index-set-svc/create-or-update-indexes-and-index-set context es-config/gran-elastic-name expected-index-set))
+      (do
+        (info "Ignoring update gran indexes request because gran index set is unchanged.")
+        (info "Existing gran index set:" (pr-str existing-index-set))
+        (info "New gran index set:" (pr-str expected-index-set)))))
+  )
 
 (defn delete-granule-index
   "Delete an elastic index by name"
   [context index]
   (info (format "Deleting granule index %s from elastic" index))
   (try
-    (esi/delete-index (indexer-util/context->conn context) index)
+    (esi/delete-index (indexer-util/context->conn context es-config/gran-elastic-name) index)
     (catch Throwable e
       (error e (str "Failed to delete granule index: "
                     (pr-str index))))))
@@ -170,14 +226,18 @@
   "Delete elasticsearch indexes and re-create them via index-set app. A nuclear option just for the development team."
   [context]
   (index-set-svc/reset context)
-  (create-indexes context))
+  (create-default-indexes context))
 
 (defrecord ESstore
   [;; configuration of host, port and admin-token for elasticsearch
    config
 
    ;; The connection to elasticsearch
-   conn]
+   conn
+
+   ;; name of this es store
+   ^String es-cluster-name
+   ]
 
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -187,7 +247,9 @@
     [this _system]
     (let [conn (es/try-connect (:config this))
           this (assoc this :conn conn)]
-      (index-set-es/create-index this config/idx-cfg-for-index-sets)
+      ;; this is creating the index set index with the list of indexes in Elastic... do we want them to be a different list in each cluster? Right now, the non-gran cluster has this index
+      ;; unless we want a copy of this index set in each cluster with it being accurate to that specific index, or it only goes to the non-gran cluster...let's try the non-gran cluster only and see what it does
+      (index-set-es/create-index this (config/idx-cfg-for-index-sets (:es-cluster-name this)))
       this))
 
   (stop [this _system]
@@ -195,8 +257,8 @@
 
 (defn create-elasticsearch-store
   "Creates the Elasticsearch store."
-  [config]
-  (->ESstore config nil))
+  [config es-cluster-name]
+  (->ESstore config nil es-cluster-name))
 
 (defn- try-elastic-operation
   "Attempt to perform the operation in Elasticsearch, handles exceptions.
@@ -218,8 +280,8 @@
 
 (defn- context->es-config
   "Returns the elastic config in the context"
-  [context]
-  (get-in context [:system :db :config]))
+  [context es-cluster-name]
+  (get-in context [:system (es-config/es-cluster-name-str->keyword es-cluster-name) :config]))
 
 (defn parse-non-tombstone-associations
   "Returns the parsed associations that are not tombstones"
@@ -301,26 +363,40 @@
   [context docs]
   (doseq [docs-batch (partition-all MAX_BULK_OPERATIONS_PER_REQUEST docs)]
     (let [bulk-operations (cmr-bulk/create-bulk-index-operations docs-batch)
-          conn (indexer-util/context->conn context)
+          conn (indexer-util/context->conn context es-config/elastic-name)
           response (es-helper/bulk conn bulk-operations)]
-      (handle-bulk-index-response response))))
+      (handle-bulk-index-response response)))
+  nil)
 
 (defn bulk-index-documents
   "Save a batch of documents in Elasticsearch."
-  ([context docs]
-   (bulk-index-documents context docs nil))
-  ([context docs {:keys [all-revisions-index?]}]
+  ([context docs es-cluster-name]
+   (bulk-index-documents context docs es-cluster-name nil))
+  ([context docs es-cluster-name {:keys [all-revisions-index?]}]
    (doseq [docs-batch (partition-all MAX_BULK_OPERATIONS_PER_REQUEST docs)]
      (let [bulk-operations (cmr-bulk/create-bulk-index-operations docs-batch all-revisions-index?)
-           conn (indexer-util/context->conn context)
+           conn (indexer-util/context->conn context es-cluster-name)
            response (es-helper/bulk conn bulk-operations)]
        (handle-bulk-index-response response)))))
+
+(defn get-es-cluster-conn
+  [context es-index]
+  ;; if es-index is granule type then get granule connection, else get the non-gran cluster connection
+  ;(info "10636- INSIDE get-es-cluster-conn, es-index = " es-index)
+  (let [cluster-name (if
+                       (and (not (= es-index "1_collections_v2"))
+                            (or (clojure.string/starts-with? es-index "1_c")
+                                (= es-index "1_small_collections")
+                                (= es-index "1_deleted_granules")))
+                       :gran-elastic
+                       :elastic)]
+    (indexer-util/context->conn context cluster-name)))
 
 (defn save-document-in-elastic
   "Save the document in Elasticsearch, raise error if failed."
   [context es-indexes es-type es-doc concept-id revision-id elastic-version options]
   (doseq [es-index es-indexes]
-    (let [conn (indexer-util/context->conn context)
+    (let [conn (get-es-cluster-conn context es-index)
           {:keys [ignore-conflict? all-revisions-index?]} options
           elastic-id (get-elastic-id concept-id revision-id all-revisions-index?)
           result (try-elastic-operation
@@ -338,7 +414,8 @@
 (defn get-document
   "Get the document from Elasticsearch, raise error if failed."
   [context es-index es-type elastic-id]
-  (es-helper/doc-get (indexer-util/context->conn context) es-index es-type elastic-id))
+  (let [es-cluster-name (es-index/get-es-cluster-name-from-concept-id elastic-id)]
+    (es-helper/doc-get (indexer-util/context->conn context es-cluster-name) es-index es-type elastic-id)))
 
 (defn delete-document
   "Delete the document from Elasticsearch, raise error if failed."
@@ -346,9 +423,10 @@
    (delete-document context es-indexes es-type concept-id revision-id elastic-version nil))
   ([context es-indexes _es-type concept-id revision-id elastic-version options]
    (doseq [es-index es-indexes]
-     ;; Cannot use elastisch for deletion as we require special headers on delete
-     (let [{:keys [admin-token]} (context->es-config context)
-           {:keys [uri http-opts]} (indexer-util/context->conn context)
+     ;; Cannot use elasticsearch for deletion as we require special headers on delete
+     (let [es-cluster-name (es-index/get-es-cluster-name-from-concept-id concept-id)
+           {:keys [admin-token]} (context->es-config context es-cluster-name)
+           {:keys [uri http-opts]} (indexer-util/context->conn context es-cluster-name)
            {:keys [ignore-conflict? all-revisions-index?]} options
            elastic-id (get-elastic-id concept-id revision-id all-revisions-index?)
            delete-url (if elastic-version

--- a/indexer-app/src/cmr/indexer/indexer_util.clj
+++ b/indexer-app/src/cmr/indexer/indexer_util.clj
@@ -1,12 +1,16 @@
 (ns cmr.indexer.indexer-util
-  "Provide util functions for indexer functionality")
+  "Provide util functions for indexer functionality"
+  (:require
+    [cmr.common.log :as log :refer [info warn error]]
+    [cmr.elastic-utils.config :as es-util-config]))
+
 
 (defn context->es-store
-  "Returns the elastic store object in the context"
-  [context]
-  (get-in context [:system :db]))
+  "Returns the elastic store object in the context."
+  [context es-cluster-name]
+  (get-in context [:system (es-util-config/es-cluster-name-str->keyword es-cluster-name)]))
 
 (defn context->conn
-  "Returns the elastisch connection in the context"
-  [context]
-  (get-in context [:system :db :conn]))
+  "Returns the elastisearch connection in the context"
+  [context es-cluster-name]
+  (get-in context [:system (es-util-config/es-cluster-name-str->keyword es-cluster-name) :conn]))

--- a/indexer-app/src/cmr/indexer/services/autocomplete.clj
+++ b/indexer-app/src/cmr/indexer/services/autocomplete.clj
@@ -7,6 +7,7 @@
    [cmr.common.config :refer [defconfig]]
    [cmr.common.log :as log :refer [info error]]
    [cmr.common.util :as util :refer [defn-timed]]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.indexer-util :as indexer-util]
    [cmr.indexer.data.concept-parser :as cp]
@@ -243,7 +244,7 @@
         mapping-type (concept-mapping-types :collection)
         document-age (format "now-%dh/h" (autocomplete-suggestion-age-limit))]
     (es-helper/delete-by-query
-     (indexer-util/context->conn context)
+     (indexer-util/context->conn context es-config/elastic-name)
      index
      mapping-type
      {:range {(service/query-field->elastic-field :modified :suggestion) {:lt document-age}}})))

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -1,35 +1,57 @@
 (ns cmr.indexer.services.index-set-service
   "Provide functions to store, retrieve, delete index-sets"
   (:require
-   [cheshire.core :as json]
-   [clojure.string :as string]
-   [cmr.common.config :as common-config]
-   [cmr.common.log :as log :refer [info]]
-   [cmr.common.rebalancing-collections :as rebalancing-collections]
-   [cmr.common.services.errors :as errors]
-   [cmr.common.util :as util]
-   [cmr.indexer.config :as config]
-   [cmr.indexer.data.index-set-elasticsearch :as es]
-   [cmr.indexer.services.messages :as m]
-   [cmr.indexer.indexer-util :as indexer-util])
+    [cheshire.core :as json]
+    [clojure.set :as set]
+    [clojure.string :as string]
+    [cmr.common.config :as common-config]
+    [cmr.common.log :as log :refer [info warn]]
+    [cmr.common.util :as util]
+    [cmr.common.rebalancing-collections :as rebalancing-collections]
+    [cmr.common.services.errors :as errors]
+    [cmr.common.util :as util]
+    [cmr.elastic-utils.config :as es-config]
+    [cmr.elastic-utils.search.es-messenger :as es-msg]
+    [cmr.indexer.config :as config]
+    [cmr.indexer.data.index-set :as index-set]
+    [cmr.indexer.data.index-set-elasticsearch :as es]
+    [cmr.indexer.services.messages :as m]
+    [cmr.indexer.indexer-util :as indexer-util])
   (:import
    (clojure.lang ExceptionInfo)))
 
 
-(defn- add-searchable-generic-types
+(defn add-searchable-generic-types
   "Add the list of supported generic document types to a list of fixed searchable
-   concept types presumable from searchable-concept-types"
-  [initial-list]
-  (reduce (fn [data, item] (conj data (keyword (str "generic-" (name item)))))
-          initial-list
-          (keys (common-config/approved-pipeline-documents))))
+   concept types presumable from searchable-concept-types.
+   Given a specific elastic cluster, we will or will not filter out granules from the searchable generic types."
+  [initial-list es-cluster-name]
+  (let [approved-pipeline-documents (common-config/approved-pipeline-documents)
+        filtered-pipeline-documents (cond
+                                      (= es-config/gran-elastic-name es-cluster-name)
+                                      (into {} (for [[k v] approved-pipeline-documents
+                                            :when (.startsWith (name k) "granule")]
+                                        [k v]))
 
-(def searchable-concept-types
+                                      (= es-config/elastic-name es-cluster-name)
+                                      (into {} (for [[k v] approved-pipeline-documents
+                                            :when (not (.startsWith (name k) "granule"))]
+                                        [k v]))
+
+                                      :else (throw (Exception. (es-msg/invalid-elastic-cluster-name-msg es-cluster-name [es-config/gran-elastic-name es-config/elastic-name]))))]
+    (reduce (fn [data, item] (conj data (keyword (str "generic-" (name item)))))
+            initial-list
+            (keys filtered-pipeline-documents))))
+
+(def searchable-gran-concept-types
+  "Defines the concept types that are indexed in elasticsearch and thus searchable."
+  [:deleted-granule
+   :granule])
+
+(def searchable-non-gran-concept-types
   "Defines the concept types that are indexed in elasticsearch and thus searchable."
   [:autocomplete
    :collection
-   :deleted-granule
-   :granule
    :service
    :subscription
    :tag
@@ -42,10 +64,17 @@
   (string/lower-case (string/replace (format "%s_%s" prefix-id suffix) #"-" "_")))
 
 (defn- build-indices-list-w-config
-  "Given an index-set, build list of indices with config."
-  [idx-set]
+  "Given an index-set, build list of indices that includes the given indices and the required concepts in our config."
+  [idx-set es-cluster-name]
   (let [prefix-id (get-in idx-set [:index-set :id])]
-    (for [concept-type (add-searchable-generic-types searchable-concept-types)
+    (for [concept-type (cond
+                         (= es-cluster-name es-config/gran-elastic-name)
+                         (add-searchable-generic-types searchable-gran-concept-types es-cluster-name)
+
+                         (= es-cluster-name es-config/elastic-name)
+                         (add-searchable-generic-types searchable-non-gran-concept-types es-cluster-name)
+
+                         :else (throw (Exception. (es-msg/invalid-elastic-cluster-name-msg es-cluster-name [es-config/gran-elastic-name es-config/elastic-name]))))
           idx (get-in idx-set [:index-set concept-type :indexes])]
       (let [mapping (get-in idx-set [:index-set concept-type :mapping])
             {idx-name :name settings :settings} idx]
@@ -54,54 +83,75 @@
          :mapping mapping}))))
 
 (defn get-index-names
-  "Given a index set build list of index names."
-  [idx-set]
+  "Given an index set build list of index names."
+  [idx-set es-cluster-name]
   (let [prefix-id (get-in idx-set [:index-set :id])]
-    (for [concept-type (add-searchable-generic-types searchable-concept-types)
+    (for [concept-type (cond
+                         (= es-cluster-name es-config/gran-elastic-name)
+                         (add-searchable-generic-types searchable-gran-concept-types es-cluster-name)
+
+                         (= es-cluster-name es-config/elastic-name)
+                         (add-searchable-generic-types searchable-non-gran-concept-types es-cluster-name)
+
+                         :else (throw (Exception. (es-msg/invalid-elastic-cluster-name-msg es-cluster-name [es-config/gran-elastic-name es-config/elastic-name]))))
           idx (get-in idx-set [:index-set concept-type :indexes])]
       (gen-valid-index-name prefix-id (:name idx)))))
-
-(defn given-index-names->es-index-names
-  "Map given names with generated elastic index names."
-  [index-names-array prefix-id]
-  (apply merge
-         (for [index-name index-names-array]
-           {(keyword index-name) (gen-valid-index-name prefix-id index-name)})))
 
 (defn prune-index-set
   "Returns the index set with only the id, name, and a map of concept types to
   the index name map."
-  [index-set]
-  (let [prefix (:id index-set)]
+  [index-set es-cluster-name]
+  (let [prefix (:id index-set)
+        generic-searchable-concept-types (cond
+                                           (= es-cluster-name es-config/gran-elastic-name)
+                                           ;; we will not add generics to the searchable gran concept types
+                                           (add-searchable-generic-types searchable-gran-concept-types es-cluster-name)
+
+                                           (= es-cluster-name es-config/elastic-name)
+                                           (add-searchable-generic-types searchable-non-gran-concept-types es-cluster-name)
+
+                                           :else (throw (Exception. (es-msg/invalid-elastic-cluster-name-msg es-cluster-name [es-config/gran-elastic-name es-config/elastic-name]))))
+        ]
     {:id (:id index-set)
      :name (:name index-set)
-     :concepts (into {} (for [concept-type (add-searchable-generic-types searchable-concept-types)]
+     :concepts (into {} (for [concept-type generic-searchable-concept-types]
                           [concept-type
                            (into {} (for [idx (get-in index-set [concept-type :indexes])]
                                       [(keyword (:name idx)) (gen-valid-index-name prefix (:name idx))]))]))}))
 
-(defn get-index-sets
-  "Fetch all index-sets in elastic."
+(defn get-all-index-sets
+  "Fetch all index-sets in elastic and combines it into one json."
   [context]
-  (let [{:keys [index-name mapping]} config/idx-cfg-for-index-sets
+  (let [{:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-config/elastic-name)
         idx-mapping-type (first (keys mapping))
-        index-sets (es/get-index-sets (indexer-util/context->es-store context) index-name idx-mapping-type)]
-    (map #(select-keys (:index-set %) [:id :name :concepts])
-         index-sets)))
+        non-gran-index-set-array (es/get-index-sets (indexer-util/context->es-store context es-config/elastic-name) index-name idx-mapping-type)
 
-(defn index-set-exists?
-  "Check index-set existsence"
-  [context index-set-id]
-  (let [{:keys [index-name mapping]} config/idx-cfg-for-index-sets
-        idx-mapping-type (first (keys mapping))]
-    (es/index-set-exists? (indexer-util/context->es-store context) index-name idx-mapping-type index-set-id)))
+        {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-config/gran-elastic-name)
+        idx-mapping-type (first (keys mapping))
+
+        gran-index-set-array (es/get-index-sets (indexer-util/context->es-store context es-config/gran-elastic-name) index-name idx-mapping-type)
+
+        all-index-set-array (map util/deep-merge gran-index-set-array non-gran-index-set-array)
+        result (map #(select-keys (:index-set %) [:id :name :concepts])
+                    all-index-set-array)]
+    result))
+
+(defn get-index-sets
+  [context es-cluster-name]
+  (let [{:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
+        idx-mapping-type (first (keys mapping))
+        index-set-array (es/get-index-sets (indexer-util/context->es-store context es-cluster-name) index-name idx-mapping-type)
+
+        result (map #(select-keys (:index-set %) [:id :name :concepts])
+                    index-set-array)]
+    result))
 
 (defn get-index-set
   "Fetch index-set associated with an index-set id."
-  [context index-set-id]
-  (or (es/get-index-set context index-set-id)
-      (errors/throw-service-error :not-found
-                                  (m/index-set-not-found-msg index-set-id))))
+  [context es-cluster-name index-set-id]
+  (or (es/get-index-set context es-cluster-name index-set-id)
+        (errors/throw-service-error :not-found
+                                    (m/index-set-not-found-msg index-set-id))))
 
 (defn index-set-id-validation
   "Verify id is a positive integer."
@@ -122,8 +172,8 @@
 
 (defn index-cfg-validation
   "Verify if required elements are present to create an elastic index."
-  [index-set]
-  (let [indices-w-config (build-indices-list-w-config index-set)
+  [index-set es-cluster-name]
+  (let [indices-w-config (build-indices-list-w-config index-set es-cluster-name)
         json-index-set-str (json/generate-string index-set)]
     (when-not (every? true? (map #(and (boolean (% :index-name))
                                        (boolean (% :settings)) (boolean (% :mapping))) indices-w-config))
@@ -131,31 +181,32 @@
 
 (defn index-set-existence-check
   "Check index-set existence"
-  [context index-set]
+  [context es-cluster-name index-set]
   (let [index-set-id (get-in index-set [:index-set :id])
-        {:keys [index-name mapping]} config/idx-cfg-for-index-sets
+        {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
         idx-mapping-type (first (keys mapping))]
-    (when (es/index-set-exists? (indexer-util/context->es-store context) index-name idx-mapping-type index-set-id)
+    (when (es/get-index-set-if-exists (indexer-util/context->es-store context es-cluster-name) index-name idx-mapping-type index-set-id)
       (m/index-set-exists-msg index-set-id))))
 
 (defn validate-requested-index-set
   "Verify input index-set is valid."
-  [context index-set allow-update?]
+  [context es-cluster-name index-set allow-update?]
   (when-not allow-update?
-    (when-let [error (index-set-existence-check context index-set)]
+    (when-let [error (index-set-existence-check context es-cluster-name index-set)]
       (errors/throw-service-error :conflict error))
     (when-let [error (id-name-existence-check index-set)]
       (errors/throw-service-error :invalid-data error)))
   (when-let [error (index-set-id-validation index-set)]
     (errors/throw-service-error :invalid-data error))
-  (when-let [error (index-cfg-validation index-set)]
+  (when-let [error (index-cfg-validation index-set es-cluster-name)]
     (errors/throw-service-error :invalid-data error)))
 
 (defn index-requested-index-set
   "Index requested index-set along with generated elastic index names"
-  [context index-set]
-  (let [index-set-w-es-index-names (assoc-in index-set [:index-set :concepts]
-                                             (:concepts (prune-index-set (:index-set index-set))))
+  [context index-set es-cluster-name]
+  (let [indexes-w-added-concepts (prune-index-set (:index-set index-set) es-cluster-name)
+        index-set-w-es-index-names (assoc-in index-set [:index-set :concepts]
+                                             (:concepts indexes-w-added-concepts))
         encoded-index-set-w-es-index-names (-> index-set-w-es-index-names
                                                json/generate-string
                                                util/string->gzip-base64)
@@ -163,56 +214,117 @@
                 :index-set-name (get-in index-set [:index-set :name])
                 :index-set-request encoded-index-set-w-es-index-names}
         doc-id (str (:index-set-id es-doc))
-        {:keys [index-name mapping]} config/idx-cfg-for-index-sets
+        {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
         idx-mapping-type (first (keys mapping))]
-    (es/save-document-in-elastic context index-name idx-mapping-type doc-id es-doc)))
+    (es/save-document-in-elastic context index-name idx-mapping-type doc-id es-doc es-cluster-name)))
 
-(defn create-index-set
-  "Create indices listed in index-set. Rollback occurs if indices creation or
-  index-set doc indexing fails."
-  [context index-set]
-  (validate-requested-index-set context index-set false)
-  (let [index-names (get-index-names index-set)
-        indices-w-config (build-indices-list-w-config index-set)
-        es-store (indexer-util/context->es-store context)]
+(defn split-index-set-by-cluster
+  "Given an index set with combined indexes from all clusters, we will split it based on cluster.
+  combined-index-set is a map structured like below:
+  {:index-set {:name cmr-index-set :id 1 :granule {} :collection {} :concepts {}...}}
+
+  and will return a map like the one below:
+  {
+  :gran-elastic {:index-set {:name cmr-index-set :id 1 :collection {} :concepts {}...}}
+  :elastic {:index-set {:name cmr-index-set :id 1 :granule {} :concepts {}}}
+  }
+  "
+  [combined-index-set]
+  (let [;; setup keys we need to extract from the combined index set
+        combined-concepts-map (get-in combined-index-set [:index-set :concepts])
+        inner-combined-index-set (:index-set combined-index-set)
+        gran-index-keys (keys (:index-set (index-set/gran-index-set nil)))
+
+        ;; re-build the outer map for gran index set
+        gran-outer-map-index-set (select-keys inner-combined-index-set gran-index-keys)
+        ;; rebuild the inner concepts map for the gran index set
+        gran-concepts-map-index-set (select-keys combined-concepts-map gran-index-keys)
+        ;; combine
+        gran-index-set (assoc gran-outer-map-index-set :concepts gran-concepts-map-index-set)
+
+        ;; all other indices given in the index set will go the non gran index set. This relies heavily on the gran index set template.
+        ;; TODO CMR-10636 do we want to restrict this to the collection index list only? If so, we have to update this code.
+        non-gran-index-keys-to-extract (set/difference (set (keys inner-combined-index-set)) (set gran-index-keys))
+        non-gran-outer-map-index-set (select-keys inner-combined-index-set non-gran-index-keys-to-extract)
+        non-gran-outer-map-index-set (-> non-gran-outer-map-index-set
+                                         (dissoc :concepts)
+                                         (assoc :name (:name inner-combined-index-set)
+                                                :id (:id inner-combined-index-set)
+                                                :create-reason (:create-reason inner-combined-index-set)))
+        non-gran-concepts-map-index-set (select-keys combined-concepts-map (set/difference (set (keys combined-concepts-map)) (set gran-index-keys)))
+        non-gran-index-set (assoc non-gran-outer-map-index-set :concepts non-gran-concepts-map-index-set)]
+
+    {(keyword es-config/gran-elastic-name) {:index-set gran-index-set}
+     (keyword es-config/elastic-name) {:index-set non-gran-index-set}}))
+
+(defn create-indexes-and-index-set
+  "Create indices listed in index-set for specific elastic cluster. Rollback occurs if indices creation or
+  index-set doc indexing fails.
+  We combine the work of both index sets here because if one fails to one cluster, we want to rollback all the indices to all clusters together.
+
+  We expect the split-index-map to have the following structure:
+  {
+  :gran-elastic {:index-set {:name cmr-index-set :id 1 :collection {} :concepts {}...}}
+  :elastic {:index-set {:name cmr-index-set :id 1 :granule {} :concepts {}}}
+  }
+  "
+  [context split-index-set-map]
+  (let [;; setup gran index set configs
+        gran-index-set ((keyword es-config/gran-elastic-name) split-index-set-map)
+        gran-index-names (get-index-names gran-index-set es-config/gran-elastic-name)
+        gran-indices-w-config (build-indices-list-w-config gran-index-set es-config/gran-elastic-name)
+        gran-es-store (indexer-util/context->es-store context es-config/gran-elastic-name)
+
+        ;; setup non-gran index set configs
+        non-gran-index-set ((keyword es-config/elastic-name) split-index-set-map)
+        non-gran-index-names (get-index-names non-gran-index-set es-config/elastic-name)
+        non-gran-indices-w-config (build-indices-list-w-config non-gran-index-set es-config/elastic-name)
+        non-gran-es-store (indexer-util/context->es-store context es-config/elastic-name)]
+
     (when-let [generic-docs (keys (common-config/approved-pipeline-documents))]
       (info "This instance of CMR will publish Elasticsearch indices for the following generic document types:" generic-docs))
-    ;; rollback index-set creation if index creation fails
+
+    ;; create indices and rollback if index creation fails
     (try
-      (dorun (map #(es/create-index-and-alias es-store %) indices-w-config))
+      (dorun (map #(es/create-index gran-es-store %) gran-indices-w-config))
+      (dorun (map #(es/create-index non-gran-es-store %) non-gran-indices-w-config))
       (catch ExceptionInfo e
         ;; TODO: Generic work: why does this fail to roll back with bad generics?
-        (println "failed to create index, roll back, this does not always work")
-        (dorun (map #(es/delete-index es-store %) index-names))
+        (warn "failed to create index, roll back, this does not always work")
+        (dorun (map #(es/delete-index gran-es-store %) gran-index-names))
+        (dorun (map #(es/delete-index non-gran-es-store %) non-gran-index-names))
         (m/handle-elastic-exception "attempt to create indices of index-set failed" e)))
+
+    ;; create index-sets and rollback if index-set creation fails
     (try
-      (index-requested-index-set context index-set)
+      (index-requested-index-set context gran-index-set es-config/gran-elastic-name)
+      (index-requested-index-set context non-gran-index-set es-config/elastic-name)
       (catch ExceptionInfo e
-        (dorun (map #(es/delete-index es-store %) index-names))
+        (warn "failed to create index sets, roll back, this does not always work")
+        (dorun (map #(es/delete-index gran-es-store %) gran-index-names))
         (m/handle-elastic-exception "attempt to index index-set doc failed"  e)))))
 
-(defn update-index-set
+(defn create-or-update-indexes-and-index-set
   "Updates indices in the index set"
-  [context index-set]
-  (info "Updating index-set" (pr-str index-set))
-  (validate-requested-index-set context index-set true)
-  (let [indices-w-config (build-indices-list-w-config index-set)
-        es-store (indexer-util/context->es-store context)]
+  [context es-cluster-name index-set]
+  ;(validate-requested-index-set context es-cluster-name index-set true)
+  (let [indices-w-config (build-indices-list-w-config index-set es-cluster-name)
+        es-store (indexer-util/context->es-store context es-cluster-name)]
 
     (doseq [idx indices-w-config]
-      (es/update-index es-store idx))
+      (es/create-or-update-index es-store idx))
 
-    (index-requested-index-set context index-set)))
+    (index-requested-index-set context index-set es-cluster-name)))
 
 (defn delete-index-set
-  "Delete all indices having 'id_' as the prefix in the elastic, followed by
+  "Delete all indices having 'id_' as the prefix in all the elastic clusters, followed by
   index-set doc delete"
-  [context index-set-id]
-  (let [index-names (get-index-names (get-index-set context index-set-id))
-        {:keys [index-name mapping]} config/idx-cfg-for-index-sets
-        idx-mapping-type (first (keys mapping))]
-    (dorun (map #(es/delete-index (indexer-util/context->es-store context) %) index-names))
-    (es/delete-document context index-name idx-mapping-type index-set-id)))
+  [context index-set-id es-cluster-name]
+    (let [index-names (get-index-names (get-index-set context es-cluster-name index-set-id) es-cluster-name)
+          {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
+          idx-mapping-type (first (keys mapping))]
+      (dorun (map #(es/delete-index (indexer-util/context->es-store context es-cluster-name) %) index-names))
+      (es/delete-document context index-name idx-mapping-type index-set-id es-cluster-name)))
 
 (defn- add-rebalancing-collection
   "Adds a new rebalancing collections to the set of rebalancing collections."
@@ -262,7 +374,7 @@
          "The collection [%s] does not have a separate granule index."
          collection-concept-id)))))
 
-(defn- add-new-granule-index
+(defn- add-new-granule-index-to-index-set
   "Adds a new granule index for the given collection. Validates the collection
   does not already have an index."
   [index-set collection-concept-id]
@@ -289,7 +401,7 @@
   (info (format "Starting to rebalance granules for collection [%s] to target [%s]."
                 concept-id target))
   (rebalancing-collections/validate-target target concept-id)
-  (let [index-set (as-> (get-index-set context index-set-id) index-set
+  (let [gran-index-set (as-> (get-index-set context es-config/gran-elastic-name index-set-id) index-set
                         (update-in
                           index-set
                           [:index-set :granule :rebalancing-collections]
@@ -306,19 +418,20 @@
                           (do
                              (validate-granule-index-exists index-set concept-id)
                              index-set)
-                          (add-new-granule-index index-set concept-id)))]
+                          (add-new-granule-index-to-index-set index-set concept-id)))]
     ;; Update the index set. This will create the new collection indexes as needed.
-    (update-index-set context index-set)))
+    (validate-requested-index-set context es-config/gran-elastic-name gran-index-set true)
+    (create-or-update-indexes-and-index-set context es-config/gran-elastic-name gran-index-set)))
 
 (defn finalize-collection-rebalancing
   "Removes the collection from the list of rebalancing collections"
   [context index-set-id concept-id]
-  (let [index-set (get-index-set context index-set-id)
-        target (get-in index-set [:index-set :granule :rebalancing-targets (keyword concept-id)])
+  (let [gran-index-set (get-index-set context es-config/gran-elastic-name index-set-id)
+        target (get-in gran-index-set [:index-set :granule :rebalancing-targets (keyword concept-id)])
         _ (info (format "Finalizing rebalancing granules for collection [%s] to target [%s]."
                         concept-id target))
         _ (rebalancing-collections/validate-target target concept-id)
-        index-set (as-> index-set index-set
+        index-set (as-> gran-index-set index-set
                         (update-in
                           index-set
                           [:index-set :granule :rebalancing-collections]
@@ -335,7 +448,8 @@
                           (remove-granule-index-from-index-set index-set concept-id)
                           index-set))]
     ;; Update the index set. This will create the new collection indexes as needed.
-    (update-index-set context index-set)))
+    (validate-requested-index-set context es-config/gran-elastic-name index-set true)
+    (create-or-update-indexes-and-index-set context es-config/gran-elastic-name index-set)))
 
 (defn update-collection-rebalancing-status
   "Update the collection rebalancing status."
@@ -343,29 +457,38 @@
   (rebalancing-collections/validate-status status)
   (info (format "Updating collection rebalancing status for collection [%s] to status [%s]."
                 concept-id status))
-  (let [index-set (get-index-set context index-set-id)]
+  (let [index-set (get-index-set context es-config/gran-elastic-name index-set-id)]
     (when-not (get-in index-set [:index-set :granule :rebalancing-status (keyword concept-id)])
       (errors/throw-service-error
        :bad-request
        (format
          "The index set does not contain the rebalancing collection [%s]"
          concept-id)))
-    (update-index-set
+    (validate-requested-index-set context es-config/gran-elastic-name index-set true)
+    (create-or-update-indexes-and-index-set
      context
+     es-config/gran-elastic-name
      (update-in
       index-set
       [:index-set :granule :rebalancing-status]
       assoc (keyword concept-id) status))))
 
 (defn reset
-  "Put elastic in a clean state after deleting indices associated with index-
-  sets and index-set docs."
+  "Put elastic in a clean state after deleting indices associated with index-sets and index-set docs."
   [context]
-  (let [{:keys [index-name]} config/idx-cfg-for-index-sets
-        index-set-ids (es/get-index-set-ids
-                       (indexer-util/context->es-store context)
-                       index-name
-                       "_doc")]
+  (let [{:keys [index-name]} (config/idx-cfg-for-index-sets es-config/gran-elastic-name)
+        gran-index-set-ids (es/get-index-set-ids
+                             (indexer-util/context->es-store context es-config/gran-elastic-name)
+                             index-name
+                             "_doc")
+        {:keys [index-name]} (config/idx-cfg-for-index-sets es-config/elastic-name)
+        non-gran-index-set-ids (es/get-index-set-ids
+                                 (indexer-util/context->es-store context es-config/elastic-name)
+                                 index-name
+                                 "_doc")]
     ;; delete indices assoc with index-set
-    (doseq [id index-set-ids]
-      (delete-index-set context (str id)))))
+    (doseq [id gran-index-set-ids]
+      (delete-index-set context (str id) es-config/gran-elastic-name))
+
+    (doseq [id non-gran-index-set-ids]
+      (delete-index-set context (str id) es-config/elastic-name))))

--- a/indexer-app/src/cmr/indexer/services/template_service.clj
+++ b/indexer-app/src/cmr/indexer/services/template_service.clj
@@ -1,6 +1,7 @@
 (ns cmr.indexer.services.template-service
   "Provide functions to create index templates"
   (:require
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.es-index-helper :as es-index]
    [cmr.indexer.data.index-set :as index-set]
    [cmr.indexer.indexer-util :as indexer-util]))
@@ -12,14 +13,15 @@
                             :index-patterns ["1_c*"]}})
 
 (defn- make-template
-  "Send individual template map to be ingested to elasticsearch"
-  [context index-template-key]
-  (es-index/create-index-template (indexer-util/context->conn context)
+  "Send individual template map to be ingested to a specific elasticsearch cluster"
+  [context index-template-key es-cluster-name]
+  (es-index/create-index-template (indexer-util/context->conn context es-cluster-name)
                                   (name index-template-key)
                                   (index-template-key index-templates)))
 
 (defn make-templates
-  "Send template maps to be ingested to elasticsearch"
+  "Send template maps to be ingested to both elasticsearch clusters"
   [context]
   (doseq [index-template (keys index-templates)]
-    (make-template context index-template)))
+    (make-template context index-template es-config/gran-elastic-name)
+    (make-template context index-template es-config/elastic-name)))

--- a/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
+++ b/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
@@ -8,7 +8,7 @@
 (def test-index-set
   "A real copy of an index set from UAT with the mappings replaced to be smaller and reduce churn"
   {:index-set
-   (merge 
+   (merge
     {:name "cmr-base-index-set",
      :id 1,
      :create-reason "indexer app requires this index set",
@@ -100,16 +100,17 @@
     (is (= ["C274209-USGS_EROS" "C274211-USGS_EROS"]
            (i/index-set->extra-granule-indexes test-index-set))))
   (testing "no extra indexes configured"
-    (is (empty? (i/index-set->extra-granule-indexes (i/index-set nil)))))
+    (is (empty? (i/index-set->extra-granule-indexes (i/gran-index-set nil)))))
   (testing "Nil index set"
     ;; A nil index set is possible if there is no existing index set.
     (is (empty? (i/index-set->extra-granule-indexes nil)))))
 
 (deftest requires-update-test
   (testing "No updates required"
-    (is (not (es/requires-update?
+    (is (not (es/index-set-requires-update?
               test-index-set
-              (i/index-set (i/index-set->extra-granule-indexes test-index-set))))))
+              (i/gran-index-set (i/index-set->extra-granule-indexes test-index-set))))))
   (testing "Updates required from individual index settings"
-    (is (es/requires-update? (update-in test-index-set [:index-set :granule] dissoc :individual-index-settings)
-                             (i/index-set (i/index-set->extra-granule-indexes test-index-set))))))
+    (is (es/index-set-requires-update?
+          (update-in test-index-set [:index-set :granule] dissoc :individual-index-settings)
+          (i/gran-index-set (i/index-set->extra-granule-indexes test-index-set))))))

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -1,7 +1,9 @@
 (ns cmr.indexer.test.services.index-set-service-test
   "unit tests for index-set app service functions"
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.indexer.data.index-set-generics :as index-set-gen]
    [cmr.indexer.services.index-set-service :as svc]
    [cmr.indexer.test.utility :as util]))
@@ -22,20 +24,72 @@
     (is (= expected-index-name3 actual-index-name3))))
 
 (deftest prune-index-set-test
-  (let [pruned-index-set {:id 3
-                          :name "cmr-base-index-set"
-                          :concepts (merge
-                                     {:collection  {:C6-PROV3 "3_c6_prov3"
-                                                    :C4-PROV2 "3_c4_prov2"}
-                                      :granule {:small_collections "3_small_collections"
-                                                :C4-PROV3 "3_c4_prov3"
-                                                :C5-PROV5 "3_c5_prov5"}
-                                      :tag {}
-                                      :variable {}
-                                      :service {}
-                                      :tool {}
-                                      :deleted-granule {}
-                                      :autocomplete {}
-                                      :subscription {}}
-                                     (zipmap (keys (index-set-gen/generic-mappings-generator)) (repeat {})))}]
-    (is (= pruned-index-set (svc/prune-index-set (:index-set util/sample-index-set))))))
+  (let [expected-pruned-gran-index-set {:id 3
+                                        :name "cmr-base-index-set"
+                                        :concepts (merge
+                                                    {:granule {:small_collections "3_small_collections"
+                                                               :C4-PROV3 "3_c4_prov3"
+                                                               :C5-PROV5 "3_c5_prov5"}
+                                                     :deleted-granule {}})}
+        expected-pruned-non-gran-index-set {:id 3
+                                            :name "cmr-base-index-set"
+                                            :concepts (merge
+                                                        {:collection  {:C6-PROV3 "3_c6_prov3"
+                                                                       :C4-PROV2 "3_c4_prov2"}
+                                                         :tag {}
+                                                         :variable {}
+                                                         :service {}
+                                                         :tool {}
+                                                         :autocomplete {}
+                                                         :subscription {}}
+                                                        (zipmap (keys (index-set-gen/generic-mappings-generator)) (repeat {})))}
+        actual-pruned-non-gran-index-set (svc/prune-index-set (:index-set util/sample-index-set) es-config/elastic-name)
+        actual-pruned-gran-index-set (svc/prune-index-set (:index-set util/sample-index-set) es-config/gran-elastic-name)]
+    (is (= expected-pruned-gran-index-set actual-pruned-gran-index-set))
+    (is (= expected-pruned-non-gran-index-set actual-pruned-non-gran-index-set))))
+
+(deftest split-index-set-by-cluster-test
+  (let [file-path (str (-> (clojure.java.io/file ".")
+                      .getAbsolutePath) "/test/cmr/indexer/test/services/test_files/combined-index-set.json")
+        combined-index-set-map (-> file-path
+                                   slurp
+                                   (json/parse-string true))
+        split-index-set-map (svc/split-index-set-by-cluster combined-index-set-map)
+
+        actual-gran-index-set (get split-index-set-map (keyword es-config/gran-elastic-name))
+        actual-non-gran-index-set (get split-index-set-map (keyword es-config/elastic-name))
+
+        expected-gran-index-set-file-path (str (-> (clojure.java.io/file ".")
+                                                   .getAbsolutePath) "/test/cmr/indexer/test/services/test_files/expected-gran-index-set.json")
+        expected-gran-index-set (-> expected-gran-index-set-file-path
+                                    slurp
+                                    (json/parse-string true))
+        expected-non-gran-index-set-file-path (str (-> (clojure.java.io/file ".")
+                                                       .getAbsolutePath) "/test/cmr/indexer/test/services/test_files/expected-non-gran-index-set.json")
+        expected-non-gran-index-set (-> expected-non-gran-index-set-file-path
+                                        slurp
+                                        (json/parse-string true))
+        ]
+    (is (= actual-gran-index-set expected-gran-index-set))
+    (is (= actual-non-gran-index-set expected-non-gran-index-set))))
+
+
+(deftest add-searchable-generic-types-test
+  (let [;; setup non-gran list
+        initial-non-gran-concept-list [:autocomplete
+                                       :collection
+                                       :service
+                                       :subscription
+                                       :tag
+                                       :tool
+                                       :variable]
+        updated-non-gran-list (svc/add-searchable-generic-types initial-non-gran-concept-list es-config/elastic-name)
+        expected-non-gran-list [:autocomplete :collection :service :subscription :tag :tool :variable :generic-order-option-draft :generic-grid-draft :generic-variable-draft :generic-grid :generic-data-quality-summary-draft :generic-citation :generic-visualization-draft :generic-tool-draft :generic-order-option :generic-visualization :generic-data-quality-summary :generic-citation-draft :generic-collection-draft :generic-service-draft]
+
+        ;; setup gran list
+        initial-gran-concept-list [:deleted-granule :granule]
+        updated-gran-list (svc/add-searchable-generic-types initial-gran-concept-list es-config/gran-elastic-name)
+        expected-gran-list [:deleted-granule :granule]]
+
+    (is (= updated-non-gran-list expected-non-gran-list))
+    (is (= updated-gran-list expected-gran-list))))

--- a/indexer-app/test/cmr/indexer/test/services/test_files/combined-index-set.json
+++ b/indexer-app/test/cmr/indexer/test/services/test_files/combined-index-set.json
@@ -1,0 +1,2554 @@
+{
+  "index-set":
+  {
+    "generic-order-option":
+    {
+      "indexes":
+      [
+        {
+          "name": "generic-order-option",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-generic-order-option-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "deleted":
+          {
+            "type": "boolean"
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "name":
+          {
+            "type": "keyword"
+          },
+          "keyword-lowercase":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "cmr-version":
+          {
+            "type": "keyword"
+          },
+          "generic-type":
+          {
+            "type": "keyword"
+          },
+          "user-id":
+          {
+            "type": "keyword"
+          },
+          "gen-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "gen-name":
+          {
+            "type": "keyword"
+          },
+          "keyword":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "id":
+          {
+            "type": "keyword"
+          },
+          "native-id":
+          {
+            "type": "keyword"
+          },
+          "gen-version":
+          {
+            "type": "keyword"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "revision-date":
+          {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "service":
+    {
+      "indexes":
+      [
+        {
+          "name": "services",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-service-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "revision-id":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "deleted":
+          {
+            "type": "boolean",
+            "doc_values": true
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-name":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "provider-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "long-name-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-name-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-type-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "user-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "keyword":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "native-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "long-name":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "name": "cmr-base-index-set",
+    "deleted-granule":
+    {
+      "indexes":
+      [
+        {
+          "name": "deleted_granules",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "concept-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "provider-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "granule-ur":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "parent-collection-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "granule":
+    {
+      "indexes":
+      [
+        {
+          "name": "small_collections",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 20,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "individual-index-settings":
+      {
+        "index":
+        {
+          "number_of_shards": 5,
+          "number_of_replicas": 1,
+          "max_result_window": 1000000,
+          "refresh_interval": "1s"
+        }
+      },
+      "mapping":
+      {
+        "properties":
+        {
+          "start-coordinate-1-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "cloud-cover":
+          {
+            "type": "float"
+          },
+          "crid-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-coordinate-1":
+          {
+            "type": "double"
+          },
+          "mbr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "granule-ur":
+          {
+            "type": "keyword"
+          },
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "orbit-end-clat-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "end-direction":
+          {
+            "type": "keyword"
+          },
+          "collection-concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "sensor-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "cycle":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "instrument-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-south":
+          {
+            "type": "float"
+          },
+          "mbr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "start-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "orbit-start-clat-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "ords-info":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "ords":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "provider-id-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platform-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-date":
+          {
+            "type": "date"
+          },
+          "end-coordinate-2":
+          {
+            "type": "double"
+          },
+          "size-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "collection-concept-id-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "short-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "collection-concept-id":
+          {
+            "type": "keyword"
+          },
+          "version-id-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "instrument-sn":
+          {
+            "type": "keyword"
+          },
+          "readable-granule-name-sort":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "entry-title-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "sensor-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "update-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "collection-concept-seq-id-doc-values":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "project-refs-lowercase":
+          {
+            "type": "keyword"
+          },
+          "downloadable":
+          {
+            "type": "boolean"
+          },
+          "native-id-stored":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "atom-links":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "two-d-coord-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "start-coordinate-1":
+          {
+            "type": "double"
+          },
+          "production-date":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "entry-title-lowercase":
+          {
+            "type": "keyword"
+          },
+          "orbit-asc-crossing-lon":
+          {
+            "type": "double"
+          },
+          "mbr-south":
+          {
+            "type": "float"
+          },
+          "feature-id":
+          {
+            "type": "keyword"
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "orbit-calculated-spatial-domains":
+          {
+            "properties":
+            {
+              "orbital-model-name":
+              {
+                "type": "keyword"
+              },
+              "orbit-number":
+              {
+                "type": "integer"
+              },
+              "start-orbit-number":
+              {
+                "type": "double"
+              },
+              "stop-orbit-number":
+              {
+                "type": "double"
+              },
+              "equator-crossing-longitude":
+              {
+                "type": "double"
+              },
+              "equator-crossing-date-time":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "start-coordinate-2":
+          {
+            "type": "double"
+          },
+          "platform-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "producer-gran-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north":
+          {
+            "type": "float"
+          },
+          "lr-east":
+          {
+            "type": "float"
+          },
+          "passes":
+          {
+            "properties":
+            {
+              "pass":
+              {
+                "type": "integer",
+                "doc_values": true
+              },
+              "tiles":
+              {
+                "type": "keyword",
+                "doc_values": true
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-west":
+          {
+            "type": "float"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "size":
+          {
+            "type": "double"
+          },
+          "orbit-end-clat":
+          {
+            "type": "double"
+          },
+          "project-refs":
+          {
+            "type": "keyword"
+          },
+          "mbr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "collection-concept-seq-id-long-doc-values":
+          {
+            "type": "unsigned_long",
+            "doc_values": true
+          },
+          "lr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "orbit-calculated-spatial-domains-json":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "end-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "collection-concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "start-lat":
+          {
+            "type": "double"
+          },
+          "sensor-sn":
+          {
+            "type": "keyword"
+          },
+          "provider-id-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "mbr-east":
+          {
+            "type": "float"
+          },
+          "lr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "end-coordinate-2-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "end-coordinate-1-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "producer-gran-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platform-sn":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id-doc-values":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "short-name-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-seq-id-long-doc-values":
+          {
+            "type": "unsigned_long",
+            "doc_values": true
+          },
+          "orbit-start-clat":
+          {
+            "type": "double"
+          },
+          "native-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "access-value-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "revision-date-stored-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "browsable":
+          {
+            "type": "boolean"
+          },
+          "granule-ur-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "day-night":
+          {
+            "type": "keyword"
+          },
+          "day-night-lowercase":
+          {
+            "type": "keyword"
+          },
+          "orbit-asc-crossing-lon-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "coordinate-system":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "mbr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "project-refs-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "feature-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "mbr-west":
+          {
+            "type": "float"
+          },
+          "start-coordinate-2-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "start-date":
+          {
+            "type": "date"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "attributes":
+          {
+            "properties":
+            {
+              "time-value":
+              {
+                "type": "date"
+              },
+              "float-value":
+              {
+                "type": "double"
+              },
+              "datetime-value":
+              {
+                "type": "date"
+              },
+              "group":
+              {
+                "type": "keyword"
+              },
+              "int-value":
+              {
+                "type": "integer"
+              },
+              "name":
+              {
+                "type": "keyword"
+              },
+              "date-value":
+              {
+                "type": "date"
+              },
+              "string-value":
+              {
+                "type": "keyword"
+              },
+              "group-lowercase":
+              {
+                "type": "keyword"
+              },
+              "string-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "created-at":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "lr-north":
+          {
+            "type": "float"
+          },
+          "entry-title":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "day-night-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date"
+          },
+          "lr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "start-direction":
+          {
+            "type": "keyword"
+          },
+          "two-d-coord-name":
+          {
+            "type": "keyword"
+          },
+          "cloud-cover-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "revision-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "access-value":
+          {
+            "type": "float"
+          },
+          "crid-id":
+          {
+            "type": "keyword"
+          },
+          "end-lat":
+          {
+            "type": "double"
+          },
+          "lr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "concepts":
+    {
+      "generic-order-option":
+      {
+        "generic-order-option": "1_generic_order_option",
+        "all-generic-order-option-revisions": "1_all_generic_order_option_revisions"
+      },
+      "service":
+      {
+        "services": "1_services",
+        "all-service-revisions": "1_all_service_revisions"
+      },
+      "deleted-granule":
+      {
+        "deleted_granules": "1_deleted_granules"
+      },
+      "granule":
+      {
+        "small_collections": "1_small_collections"
+      },
+      "collection":
+      {
+        "collections-v2": "1_collections_v2",
+        "all-collection-revisions": "1_all_collection_revisions"
+      }
+    },
+    "id": 3,
+    "collection":
+    {
+      "indexes":
+      [
+        {
+          "name": "collections-v2",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 10,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-collection-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "service-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-names-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "parsed-version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "inclination-angle":
+          {
+            "type": "double"
+          },
+          "category":
+          {
+            "type": "keyword"
+          },
+          "archive-center-lowercase":
+          {
+            "type": "keyword"
+          },
+          "standard-product":
+          {
+            "type": "boolean"
+          },
+          "mbr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "has-granules-or-cwic":
+          {
+            "type": "boolean"
+          },
+          "granule-start-date":
+          {
+            "type": "date"
+          },
+          "tags":
+          {
+            "properties":
+            {
+              "tag-key-lowercase":
+              {
+                "type": "keyword"
+              },
+              "originator-id-lowercase":
+              {
+                "type": "keyword"
+              },
+              "tag-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "variable-level-2":
+          {
+            "type": "keyword"
+          },
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "archive-center":
+          {
+            "type": "keyword"
+          },
+          "deleted":
+          {
+            "type": "boolean"
+          },
+          "short-name":
+          {
+            "type": "keyword"
+          },
+          "eula-identifiers":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "sensor-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "limit-to-granules-temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "usage-relevancy-score":
+          {
+            "type": "integer"
+          },
+          "s3-bucket-and-object-prefix-names":
+          {
+            "type": "keyword"
+          },
+          "lr-south":
+          {
+            "type": "float"
+          },
+          "sensor-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "mbr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "cloud-hosted":
+          {
+            "type": "boolean"
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "instrument-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "ords-info":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "ords":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "create-data-date":
+          {
+            "type": "date"
+          },
+          "latency-lowercase":
+          {
+            "type": "keyword"
+          },
+          "granule-data-format":
+          {
+            "type": "keyword"
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "platform-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-date":
+          {
+            "type": "date"
+          },
+          "location-keywords":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "detailed-location-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subregion-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-location":
+              {
+                "type": "keyword"
+              },
+              "subregion-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type":
+              {
+                "type": "keyword"
+              },
+              "subregion-1":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "subregion-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subregion-2":
+              {
+                "type": "keyword"
+              },
+              "subregion-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "long-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "service-names-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-types-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "has-combine":
+          {
+            "type": "boolean"
+          },
+          "has-granules-or-opensearch":
+          {
+            "type": "boolean"
+          },
+          "measurements":
+          {
+            "type": "keyword"
+          },
+          "temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "science-keywords-flat":
+          {
+            "type": "keyword"
+          },
+          "short-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "granule-data-format-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn":
+          {
+            "type": "keyword"
+          },
+          "associated-difs":
+          {
+            "type": "keyword"
+          },
+          "detailed-variable":
+          {
+            "type": "keyword"
+          },
+          "related-urls":
+          {
+            "type": "keyword"
+          },
+          "measurements-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-granules":
+          {
+            "type": "boolean"
+          },
+          "update-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "service-names":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "version-id":
+          {
+            "type": "keyword"
+          },
+          "downloadable":
+          {
+            "type": "boolean"
+          },
+          "atom-links":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "two-d-coord-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "ongoing":
+          {
+            "type": "date"
+          },
+          "entry-title-lowercase":
+          {
+            "type": "keyword"
+          },
+          "collection-data-type-lowercase":
+          {
+            "type": "keyword"
+          },
+          "mbr-south":
+          {
+            "type": "float"
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "variable-native-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "insert-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "granule-end-date":
+          {
+            "type": "date"
+          },
+          "authors-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "topic":
+          {
+            "type": "keyword"
+          },
+          "user-id":
+          {
+            "type": "keyword"
+          },
+          "doi-stored":
+          {
+            "type": "keyword"
+          },
+          "variable-native-ids-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "mbr-north":
+          {
+            "type": "float"
+          },
+          "has-formats":
+          {
+            "type": "boolean"
+          },
+          "variables":
+          {
+            "properties":
+            {
+              "measurement":
+              {
+                "type": "keyword"
+              },
+              "measurement-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable":
+              {
+                "type": "keyword"
+              },
+              "variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "originator-id-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "doi":
+          {
+            "type": "keyword"
+          },
+          "granule-end-date-stored":
+          {
+            "type": "date"
+          },
+          "lr-east":
+          {
+            "type": "float"
+          },
+          "lr-west":
+          {
+            "type": "float"
+          },
+          "project-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "project-sn":
+          {
+            "type": "keyword"
+          },
+          "instrument-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "temporal-keyword-lowercase":
+          {
+            "type": "keyword"
+          },
+          "instrument-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "processing-level-id-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "science-keywords-humanized":
+          {
+            "properties":
+            {
+              "topic-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable":
+              {
+                "type": "keyword"
+              },
+              "topic":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "project-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "term":
+          {
+            "type": "keyword"
+          },
+          "summary":
+          {
+            "type": "text",
+            "analyzer": "english",
+            "index": true
+          },
+          "mbr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "has-spatial-subsetting":
+          {
+            "type": "boolean"
+          },
+          "instruments":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "class-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type":
+              {
+                "type": "keyword"
+              },
+              "class":
+              {
+                "type": "keyword"
+              },
+              "subtype-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "type-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subtype":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "science-keywords":
+          {
+            "properties":
+            {
+              "topic-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable":
+              {
+                "type": "keyword"
+              },
+              "topic":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "collection-data-type":
+          {
+            "type": "keyword"
+          },
+          "contact-email":
+          {
+            "type": "keyword"
+          },
+          "start-circular-latitude":
+          {
+            "type": "double"
+          },
+          "spatial-keyword-lowercase":
+          {
+            "type": "keyword"
+          },
+          "data-center":
+          {
+            "type": "keyword"
+          },
+          "horizontal-data-resolutions":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "float"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "archive-centers":
+          {
+            "properties":
+            {
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-0-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-1":
+              {
+                "type": "keyword"
+              },
+              "level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url":
+              {
+                "type": "keyword"
+              },
+              "level-0":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "level-2":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "sensor-sn":
+          {
+            "type": "keyword"
+          },
+          "variable-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "temporal-ranges":
+          {
+            "type": "date"
+          },
+          "number-of-orbits":
+          {
+            "type": "double"
+          },
+          "mbr-east":
+          {
+            "type": "float"
+          },
+          "lr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "spatial-keyword":
+          {
+            "type": "keyword"
+          },
+          "tags-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "platform-sn":
+          {
+            "type": "keyword"
+          },
+          "personnel":
+          {
+            "type": "keyword"
+          },
+          "latency":
+          {
+            "type": "keyword"
+          },
+          "data-center-lowercase":
+          {
+            "type": "keyword"
+          },
+          "variable-names-lowercase":
+          {
+            "type": "keyword"
+          },
+          "consortiums-lowercase":
+          {
+            "type": "keyword"
+          },
+          "native-id":
+          {
+            "type": "keyword"
+          },
+          "platforms2-humanized":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "basis":
+              {
+                "type": "keyword"
+              },
+              "basis-lowercase":
+              {
+                "type": "keyword"
+              },
+              "sub-category":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "sub-category-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "index-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "associated-difs-lowercase":
+          {
+            "type": "keyword"
+          },
+          "entry-id":
+          {
+            "type": "keyword"
+          },
+          "granule-start-date-stored":
+          {
+            "type": "date"
+          },
+          "platform-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "browsable":
+          {
+            "type": "boolean"
+          },
+          "consortiums":
+          {
+            "type": "keyword"
+          },
+          "platform-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "keyword2":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "keyword",
+            "index_options": "offsets"
+          },
+          "doi-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-transforms":
+          {
+            "type": "boolean"
+          },
+          "variable-names":
+          {
+            "type": "keyword"
+          },
+          "processing-level-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-variables":
+          {
+            "type": "boolean"
+          },
+          "coordinate-system":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "period":
+          {
+            "type": "double"
+          },
+          "variable-level-1":
+          {
+            "type": "keyword"
+          },
+          "mbr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "entry-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "service-features-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "granule-data-format-lowercase":
+          {
+            "type": "keyword"
+          },
+          "swath-width":
+          {
+            "type": "double"
+          },
+          "processing-level-id-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "mbr-west":
+          {
+            "type": "float"
+          },
+          "start-date":
+          {
+            "type": "date"
+          },
+          "project-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "project-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "attributes":
+          {
+            "properties":
+            {
+              "time-value":
+              {
+                "type": "date"
+              },
+              "float-value":
+              {
+                "type": "double"
+              },
+              "datetime-value":
+              {
+                "type": "date"
+              },
+              "group":
+              {
+                "type": "keyword"
+              },
+              "int-value":
+              {
+                "type": "integer"
+              },
+              "name":
+              {
+                "type": "keyword"
+              },
+              "date-value":
+              {
+                "type": "date"
+              },
+              "string-value":
+              {
+                "type": "keyword"
+              },
+              "group-lowercase":
+              {
+                "type": "keyword"
+              },
+              "string-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "created-at":
+          {
+            "type": "date"
+          },
+          "authors":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platforms2":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "basis":
+              {
+                "type": "keyword"
+              },
+              "basis-lowercase":
+              {
+                "type": "keyword"
+              },
+              "sub-category":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "sub-category-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "publication-references":
+          {
+            "type": "keyword"
+          },
+          "organization-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "lr-north":
+          {
+            "type": "float"
+          },
+          "entry-title":
+          {
+            "type": "keyword"
+          },
+          "platform-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "collection-citations":
+          {
+            "type": "keyword"
+          },
+          "revision-date":
+          {
+            "type": "date"
+          },
+          "has-opendap-url":
+          {
+            "type": "boolean"
+          },
+          "platforms":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "series-entity-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "series-entity":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "service-types-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "variable-level-3":
+          {
+            "type": "keyword"
+          },
+          "permitted-group-ids":
+          {
+            "type": "keyword"
+          },
+          "tool-names":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "two-d-coord-name":
+          {
+            "type": "keyword"
+          },
+          "has-temporal-subsetting":
+          {
+            "type": "boolean"
+          },
+          "access-value":
+          {
+            "type": "float"
+          },
+          "processing-level-id":
+          {
+            "type": "keyword"
+          },
+          "data-centers":
+          {
+            "properties":
+            {
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-0-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-1":
+              {
+                "type": "keyword"
+              },
+              "level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url":
+              {
+                "type": "keyword"
+              },
+              "level-0":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "level-2":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "organization-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "create-reason": "indexer app requires this index set"
+  }
+}

--- a/indexer-app/test/cmr/indexer/test/services/test_files/expected-gran-index-set.json
+++ b/indexer-app/test/cmr/indexer/test/services/test_files/expected-gran-index-set.json
@@ -1,0 +1,736 @@
+{
+  "index-set":
+  {
+    "name": "cmr-base-index-set",
+    "deleted-granule":
+    {
+      "indexes":
+      [
+        {
+          "name": "deleted_granules",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "concept-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "provider-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "granule-ur":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "parent-collection-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "granule":
+    {
+      "indexes":
+      [
+        {
+          "name": "small_collections",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 20,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "individual-index-settings":
+      {
+        "index":
+        {
+          "number_of_shards": 5,
+          "number_of_replicas": 1,
+          "max_result_window": 1000000,
+          "refresh_interval": "1s"
+        }
+      },
+      "mapping":
+      {
+        "properties":
+        {
+          "start-coordinate-1-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "cloud-cover":
+          {
+            "type": "float"
+          },
+          "crid-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-coordinate-1":
+          {
+            "type": "double"
+          },
+          "mbr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "granule-ur":
+          {
+            "type": "keyword"
+          },
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "orbit-end-clat-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "end-direction":
+          {
+            "type": "keyword"
+          },
+          "collection-concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "sensor-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "cycle":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "instrument-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-south":
+          {
+            "type": "float"
+          },
+          "mbr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "start-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "orbit-start-clat-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "ords-info":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "ords":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "provider-id-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platform-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-date":
+          {
+            "type": "date"
+          },
+          "end-coordinate-2":
+          {
+            "type": "double"
+          },
+          "size-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "collection-concept-id-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "short-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "collection-concept-id":
+          {
+            "type": "keyword"
+          },
+          "version-id-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "instrument-sn":
+          {
+            "type": "keyword"
+          },
+          "readable-granule-name-sort":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "entry-title-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "sensor-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "update-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "collection-concept-seq-id-doc-values":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "project-refs-lowercase":
+          {
+            "type": "keyword"
+          },
+          "downloadable":
+          {
+            "type": "boolean"
+          },
+          "native-id-stored":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "atom-links":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "two-d-coord-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "start-coordinate-1":
+          {
+            "type": "double"
+          },
+          "production-date":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "entry-title-lowercase":
+          {
+            "type": "keyword"
+          },
+          "orbit-asc-crossing-lon":
+          {
+            "type": "double"
+          },
+          "mbr-south":
+          {
+            "type": "float"
+          },
+          "feature-id":
+          {
+            "type": "keyword"
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "orbit-calculated-spatial-domains":
+          {
+            "properties":
+            {
+              "orbital-model-name":
+              {
+                "type": "keyword"
+              },
+              "orbit-number":
+              {
+                "type": "integer"
+              },
+              "start-orbit-number":
+              {
+                "type": "double"
+              },
+              "stop-orbit-number":
+              {
+                "type": "double"
+              },
+              "equator-crossing-longitude":
+              {
+                "type": "double"
+              },
+              "equator-crossing-date-time":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "start-coordinate-2":
+          {
+            "type": "double"
+          },
+          "platform-sn-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "producer-gran-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north":
+          {
+            "type": "float"
+          },
+          "lr-east":
+          {
+            "type": "float"
+          },
+          "passes":
+          {
+            "properties":
+            {
+              "pass":
+              {
+                "type": "integer",
+                "doc_values": true
+              },
+              "tiles":
+              {
+                "type": "keyword",
+                "doc_values": true
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-west":
+          {
+            "type": "float"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "size":
+          {
+            "type": "double"
+          },
+          "orbit-end-clat":
+          {
+            "type": "double"
+          },
+          "project-refs":
+          {
+            "type": "keyword"
+          },
+          "mbr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "collection-concept-seq-id-long-doc-values":
+          {
+            "type": "unsigned_long",
+            "doc_values": true
+          },
+          "lr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "orbit-calculated-spatial-domains-json":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "end-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "collection-concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "start-lat":
+          {
+            "type": "double"
+          },
+          "sensor-sn":
+          {
+            "type": "keyword"
+          },
+          "provider-id-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "mbr-east":
+          {
+            "type": "float"
+          },
+          "lr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "end-coordinate-2-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "end-coordinate-1-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "producer-gran-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platform-sn":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id-doc-values":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "short-name-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-seq-id-long-doc-values":
+          {
+            "type": "unsigned_long",
+            "doc_values": true
+          },
+          "orbit-start-clat":
+          {
+            "type": "double"
+          },
+          "native-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "access-value-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "revision-date-stored-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "browsable":
+          {
+            "type": "boolean"
+          },
+          "granule-ur-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "day-night":
+          {
+            "type": "keyword"
+          },
+          "day-night-lowercase":
+          {
+            "type": "keyword"
+          },
+          "orbit-asc-crossing-lon-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "coordinate-system":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "mbr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "project-refs-lowercase-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "feature-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "mbr-west":
+          {
+            "type": "float"
+          },
+          "start-coordinate-2-doc-values":
+          {
+            "type": "double",
+            "doc_values": true
+          },
+          "start-date":
+          {
+            "type": "date"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "attributes":
+          {
+            "properties":
+            {
+              "time-value":
+              {
+                "type": "date"
+              },
+              "float-value":
+              {
+                "type": "double"
+              },
+              "datetime-value":
+              {
+                "type": "date"
+              },
+              "group":
+              {
+                "type": "keyword"
+              },
+              "int-value":
+              {
+                "type": "integer"
+              },
+              "name":
+              {
+                "type": "keyword"
+              },
+              "date-value":
+              {
+                "type": "date"
+              },
+              "string-value":
+              {
+                "type": "keyword"
+              },
+              "group-lowercase":
+              {
+                "type": "keyword"
+              },
+              "string-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "created-at":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "lr-north":
+          {
+            "type": "float"
+          },
+          "entry-title":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "day-night-doc-values":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date"
+          },
+          "lr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "start-direction":
+          {
+            "type": "keyword"
+          },
+          "two-d-coord-name":
+          {
+            "type": "keyword"
+          },
+          "cloud-cover-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "revision-date-doc-values":
+          {
+            "type": "date",
+            "doc_values": true
+          },
+          "access-value":
+          {
+            "type": "float"
+          },
+          "crid-id":
+          {
+            "type": "keyword"
+          },
+          "end-lat":
+          {
+            "type": "double"
+          },
+          "lr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "concepts":
+    {
+      "deleted-granule":
+      {
+        "deleted_granules": "1_deleted_granules"
+      },
+      "granule":
+      {
+        "small_collections": "1_small_collections"
+      }
+    },
+    "id": 3,
+    "create-reason": "indexer app requires this index set"
+  }
+}

--- a/indexer-app/test/cmr/indexer/test/services/test_files/expected-non-gran-index-set.json
+++ b/indexer-app/test/cmr/indexer/test/services/test_files/expected-non-gran-index-set.json
@@ -1,0 +1,1829 @@
+{
+  "index-set":
+  {
+    "generic-order-option":
+    {
+      "indexes":
+      [
+        {
+          "name": "generic-order-option",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-generic-order-option-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "deleted":
+          {
+            "type": "boolean"
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "name":
+          {
+            "type": "keyword"
+          },
+          "keyword-lowercase":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "cmr-version":
+          {
+            "type": "keyword"
+          },
+          "generic-type":
+          {
+            "type": "keyword"
+          },
+          "user-id":
+          {
+            "type": "keyword"
+          },
+          "gen-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "gen-name":
+          {
+            "type": "keyword"
+          },
+          "keyword":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "id":
+          {
+            "type": "keyword"
+          },
+          "native-id":
+          {
+            "type": "keyword"
+          },
+          "gen-version":
+          {
+            "type": "keyword"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "revision-date":
+          {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "service":
+    {
+      "indexes":
+      [
+        {
+          "name": "services",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-service-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "revision-id":
+          {
+            "type": "integer",
+            "doc_values": true
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "deleted":
+          {
+            "type": "boolean",
+            "doc_values": true
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-name":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "provider-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "long-name-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-name-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "service-type-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "user-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "keyword":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "whitespace",
+            "index_options": "docs"
+          },
+          "native-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "long-name":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "concept-id":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "revision-date":
+          {
+            "type": "date",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "name": "cmr-base-index-set",
+    "concepts":
+    {
+      "generic-order-option":
+      {
+        "generic-order-option": "1_generic_order_option",
+        "all-generic-order-option-revisions": "1_all_generic_order_option_revisions"
+      },
+      "service":
+      {
+        "services": "1_services",
+        "all-service-revisions": "1_all_service_revisions"
+      },
+      "collection":
+      {
+        "collections-v2": "1_collections_v2",
+        "all-collection-revisions": "1_all_collection_revisions"
+      }
+    },
+    "id": 3,
+    "collection":
+    {
+      "indexes":
+      [
+        {
+          "name": "collections-v2",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 10,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        },
+        {
+          "name": "all-collection-revisions",
+          "settings":
+          {
+            "index":
+            {
+              "number_of_shards": 5,
+              "number_of_replicas": 1,
+              "max_result_window": 1000000,
+              "refresh_interval": "1s"
+            }
+          }
+        }
+      ],
+      "mapping":
+      {
+        "properties":
+        {
+          "service-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-names-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "parsed-version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "inclination-angle":
+          {
+            "type": "double"
+          },
+          "category":
+          {
+            "type": "keyword"
+          },
+          "archive-center-lowercase":
+          {
+            "type": "keyword"
+          },
+          "standard-product":
+          {
+            "type": "boolean"
+          },
+          "mbr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "has-granules-or-cwic":
+          {
+            "type": "boolean"
+          },
+          "granule-start-date":
+          {
+            "type": "date"
+          },
+          "tags":
+          {
+            "properties":
+            {
+              "tag-key-lowercase":
+              {
+                "type": "keyword"
+              },
+              "originator-id-lowercase":
+              {
+                "type": "keyword"
+              },
+              "tag-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "variable-level-2":
+          {
+            "type": "keyword"
+          },
+          "revision-id":
+          {
+            "type": "integer"
+          },
+          "associations-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "archive-center":
+          {
+            "type": "keyword"
+          },
+          "deleted":
+          {
+            "type": "boolean"
+          },
+          "short-name":
+          {
+            "type": "keyword"
+          },
+          "eula-identifiers":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "sensor-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "limit-to-granules-temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "usage-relevancy-score":
+          {
+            "type": "integer"
+          },
+          "s3-bucket-and-object-prefix-names":
+          {
+            "type": "keyword"
+          },
+          "lr-south":
+          {
+            "type": "float"
+          },
+          "sensor-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "mbr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "cloud-hosted":
+          {
+            "type": "boolean"
+          },
+          "native-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "concept-seq-id":
+          {
+            "type": "integer"
+          },
+          "instrument-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "ords-info":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "ords":
+          {
+            "type": "integer",
+            "store": true,
+            "index": false
+          },
+          "create-data-date":
+          {
+            "type": "date"
+          },
+          "latency-lowercase":
+          {
+            "type": "keyword"
+          },
+          "granule-data-format":
+          {
+            "type": "keyword"
+          },
+          "provider-id":
+          {
+            "type": "keyword"
+          },
+          "mbr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "platform-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "end-date":
+          {
+            "type": "date"
+          },
+          "location-keywords":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "detailed-location-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subregion-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-location":
+              {
+                "type": "keyword"
+              },
+              "subregion-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type":
+              {
+                "type": "keyword"
+              },
+              "subregion-1":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "subregion-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subregion-2":
+              {
+                "type": "keyword"
+              },
+              "subregion-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "long-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "service-names-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-types-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-north-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "has-combine":
+          {
+            "type": "boolean"
+          },
+          "has-granules-or-opensearch":
+          {
+            "type": "boolean"
+          },
+          "measurements":
+          {
+            "type": "keyword"
+          },
+          "temporals":
+          {
+            "properties":
+            {
+              "start-date":
+              {
+                "type": "date"
+              },
+              "end-date":
+              {
+                "type": "date"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "science-keywords-flat":
+          {
+            "type": "keyword"
+          },
+          "short-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "granule-data-format-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn":
+          {
+            "type": "keyword"
+          },
+          "associated-difs":
+          {
+            "type": "keyword"
+          },
+          "detailed-variable":
+          {
+            "type": "keyword"
+          },
+          "related-urls":
+          {
+            "type": "keyword"
+          },
+          "measurements-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-granules":
+          {
+            "type": "boolean"
+          },
+          "update-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "service-names":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "version-id":
+          {
+            "type": "keyword"
+          },
+          "downloadable":
+          {
+            "type": "boolean"
+          },
+          "atom-links":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "two-d-coord-name-lowercase":
+          {
+            "type": "keyword"
+          },
+          "ongoing":
+          {
+            "type": "date"
+          },
+          "entry-title-lowercase":
+          {
+            "type": "keyword"
+          },
+          "collection-data-type-lowercase":
+          {
+            "type": "keyword"
+          },
+          "mbr-south":
+          {
+            "type": "float"
+          },
+          "metadata-format":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "version-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "variable-native-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "insert-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "granule-end-date":
+          {
+            "type": "date"
+          },
+          "authors-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "topic":
+          {
+            "type": "keyword"
+          },
+          "user-id":
+          {
+            "type": "keyword"
+          },
+          "doi-stored":
+          {
+            "type": "keyword"
+          },
+          "variable-native-ids-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "mbr-north":
+          {
+            "type": "float"
+          },
+          "has-formats":
+          {
+            "type": "boolean"
+          },
+          "variables":
+          {
+            "properties":
+            {
+              "measurement":
+              {
+                "type": "keyword"
+              },
+              "measurement-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable":
+              {
+                "type": "keyword"
+              },
+              "variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "originator-id-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "doi":
+          {
+            "type": "keyword"
+          },
+          "granule-end-date-stored":
+          {
+            "type": "date"
+          },
+          "lr-east":
+          {
+            "type": "float"
+          },
+          "lr-west":
+          {
+            "type": "float"
+          },
+          "project-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "provider-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "project-sn":
+          {
+            "type": "keyword"
+          },
+          "instrument-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "temporal-keyword-lowercase":
+          {
+            "type": "keyword"
+          },
+          "instrument-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "processing-level-id-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "science-keywords-humanized":
+          {
+            "properties":
+            {
+              "topic-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable":
+              {
+                "type": "keyword"
+              },
+              "topic":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "project-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "term":
+          {
+            "type": "keyword"
+          },
+          "summary":
+          {
+            "type": "text",
+            "analyzer": "english",
+            "index": true
+          },
+          "mbr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "has-spatial-subsetting":
+          {
+            "type": "boolean"
+          },
+          "instruments":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "class-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "type":
+              {
+                "type": "keyword"
+              },
+              "class":
+              {
+                "type": "keyword"
+              },
+              "subtype-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "type-lowercase":
+              {
+                "type": "keyword"
+              },
+              "subtype":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "science-keywords":
+          {
+            "properties":
+            {
+              "topic-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable":
+              {
+                "type": "keyword"
+              },
+              "topic":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term":
+              {
+                "type": "keyword"
+              },
+              "variable-level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "term-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "variable-level-1":
+              {
+                "type": "keyword"
+              },
+              "detailed-variable-lowercase":
+              {
+                "type": "keyword"
+              },
+              "variable-level-3":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-east-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "collection-data-type":
+          {
+            "type": "keyword"
+          },
+          "contact-email":
+          {
+            "type": "keyword"
+          },
+          "start-circular-latitude":
+          {
+            "type": "double"
+          },
+          "spatial-keyword-lowercase":
+          {
+            "type": "keyword"
+          },
+          "data-center":
+          {
+            "type": "keyword"
+          },
+          "horizontal-data-resolutions":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "float"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "archive-centers":
+          {
+            "properties":
+            {
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-0-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-1":
+              {
+                "type": "keyword"
+              },
+              "level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url":
+              {
+                "type": "keyword"
+              },
+              "level-0":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "level-2":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "sensor-sn":
+          {
+            "type": "keyword"
+          },
+          "variable-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "tool-concept-ids":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "temporal-ranges":
+          {
+            "type": "date"
+          },
+          "number-of-orbits":
+          {
+            "type": "double"
+          },
+          "mbr-east":
+          {
+            "type": "float"
+          },
+          "lr-crosses-antimeridian":
+          {
+            "type": "boolean"
+          },
+          "spatial-keyword":
+          {
+            "type": "keyword"
+          },
+          "tags-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "platform-sn":
+          {
+            "type": "keyword"
+          },
+          "personnel":
+          {
+            "type": "keyword"
+          },
+          "latency":
+          {
+            "type": "keyword"
+          },
+          "data-center-lowercase":
+          {
+            "type": "keyword"
+          },
+          "variable-names-lowercase":
+          {
+            "type": "keyword"
+          },
+          "consortiums-lowercase":
+          {
+            "type": "keyword"
+          },
+          "native-id":
+          {
+            "type": "keyword"
+          },
+          "platforms2-humanized":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "basis":
+              {
+                "type": "keyword"
+              },
+              "basis-lowercase":
+              {
+                "type": "keyword"
+              },
+              "sub-category":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "sub-category-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "index-time":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "associated-difs-lowercase":
+          {
+            "type": "keyword"
+          },
+          "entry-id":
+          {
+            "type": "keyword"
+          },
+          "granule-start-date-stored":
+          {
+            "type": "date"
+          },
+          "platform-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "browsable":
+          {
+            "type": "boolean"
+          },
+          "consortiums":
+          {
+            "type": "keyword"
+          },
+          "platform-ln-lowercase":
+          {
+            "type": "keyword"
+          },
+          "keyword2":
+          {
+            "type": "text",
+            "norms": false,
+            "analyzer": "keyword",
+            "index_options": "offsets"
+          },
+          "doi-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-transforms":
+          {
+            "type": "boolean"
+          },
+          "variable-names":
+          {
+            "type": "keyword"
+          },
+          "processing-level-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "has-variables":
+          {
+            "type": "boolean"
+          },
+          "coordinate-system":
+          {
+            "type": "keyword",
+            "index": false
+          },
+          "period":
+          {
+            "type": "double"
+          },
+          "variable-level-1":
+          {
+            "type": "keyword"
+          },
+          "mbr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "entry-id-lowercase":
+          {
+            "type": "keyword"
+          },
+          "service-features-gzip-b64":
+          {
+            "type": "binary"
+          },
+          "granule-data-format-lowercase":
+          {
+            "type": "keyword"
+          },
+          "swath-width":
+          {
+            "type": "double"
+          },
+          "processing-level-id-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "concept-seq-id-long":
+          {
+            "type": "unsigned_long"
+          },
+          "mbr-west":
+          {
+            "type": "float"
+          },
+          "start-date":
+          {
+            "type": "date"
+          },
+          "project-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "project-sn-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "concept-id":
+          {
+            "type": "keyword"
+          },
+          "attributes":
+          {
+            "properties":
+            {
+              "time-value":
+              {
+                "type": "date"
+              },
+              "float-value":
+              {
+                "type": "double"
+              },
+              "datetime-value":
+              {
+                "type": "date"
+              },
+              "group":
+              {
+                "type": "keyword"
+              },
+              "int-value":
+              {
+                "type": "integer"
+              },
+              "name":
+              {
+                "type": "keyword"
+              },
+              "date-value":
+              {
+                "type": "date"
+              },
+              "string-value":
+              {
+                "type": "keyword"
+              },
+              "group-lowercase":
+              {
+                "type": "keyword"
+              },
+              "string-value-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "instrument-sn-lowercase":
+          {
+            "type": "keyword"
+          },
+          "created-at":
+          {
+            "type": "date"
+          },
+          "authors":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "platforms2":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "basis":
+              {
+                "type": "keyword"
+              },
+              "basis-lowercase":
+              {
+                "type": "keyword"
+              },
+              "sub-category":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "sub-category-lowercase":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "publication-references":
+          {
+            "type": "keyword"
+          },
+          "organization-lowercase-humanized":
+          {
+            "type": "keyword"
+          },
+          "lr-north":
+          {
+            "type": "float"
+          },
+          "entry-title":
+          {
+            "type": "keyword"
+          },
+          "platform-sn-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "collection-citations":
+          {
+            "type": "keyword"
+          },
+          "revision-date":
+          {
+            "type": "date"
+          },
+          "has-opendap-url":
+          {
+            "type": "boolean"
+          },
+          "platforms":
+          {
+            "properties":
+            {
+              "category":
+              {
+                "type": "keyword"
+              },
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "category-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "series-entity-lowercase":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "series-entity":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "service-types-lowercase":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "lr-south-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          },
+          "variable-level-3":
+          {
+            "type": "keyword"
+          },
+          "permitted-group-ids":
+          {
+            "type": "keyword"
+          },
+          "tool-names":
+          {
+            "type": "keyword",
+            "doc_values": true
+          },
+          "two-d-coord-name":
+          {
+            "type": "keyword"
+          },
+          "has-temporal-subsetting":
+          {
+            "type": "boolean"
+          },
+          "access-value":
+          {
+            "type": "float"
+          },
+          "processing-level-id":
+          {
+            "type": "keyword"
+          },
+          "data-centers":
+          {
+            "properties":
+            {
+              "short-name":
+              {
+                "type": "keyword"
+              },
+              "level-1-lowercase":
+              {
+                "type": "keyword"
+              },
+              "uuid-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-3":
+              {
+                "type": "keyword"
+              },
+              "long-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "short-name-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-0-lowercase":
+              {
+                "type": "keyword"
+              },
+              "level-1":
+              {
+                "type": "keyword"
+              },
+              "level-2-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url-lowercase":
+              {
+                "type": "keyword"
+              },
+              "url":
+              {
+                "type": "keyword"
+              },
+              "level-0":
+              {
+                "type": "keyword"
+              },
+              "long-name":
+              {
+                "type": "keyword"
+              },
+              "uuid":
+              {
+                "type": "keyword"
+              },
+              "level-2":
+              {
+                "type": "keyword"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "organization-humanized":
+          {
+            "properties":
+            {
+              "value":
+              {
+                "type": "keyword"
+              },
+              "value-lowercase":
+              {
+                "type": "keyword"
+              },
+              "priority":
+              {
+                "type": "integer"
+              }
+            },
+            "type": "nested",
+            "dynamic": "strict"
+          },
+          "lr-west-doc-values":
+          {
+            "type": "float",
+            "doc_values": true
+          }
+        },
+        "dynamic": "strict",
+        "_source":
+        {
+          "enabled": true
+        }
+      }
+    },
+    "create-reason": "indexer app requires this index set"
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature/fix?

Indexer's index-set APIs and rebalance APIs needed to be updated to work with split cluster

### What is the Solution?

Update the APIs

### What areas of the application does this impact?

Indexer App
Elastic Utils lib

# Checklist

- [ ] I have updated/added unit and int tests that prove my fix is effective or that my feature works
- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors corrected
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - refactored to reduce number of system state resets by updating fixtures (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
