### PR TITLE
CMR-10768: As a CMR operator, I want to CMR to use aliases when searching against Elasticsearch so that we can switch between underlying ES indices

### DIFF
--- a/access-control-app/src/cmr/access_control/services/acl_service.clj
+++ b/access-control-app/src/cmr/access_control/services/acl_service.clj
@@ -20,6 +20,7 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.services.search.query-model :as qm]
    [cmr.common.util :as util :refer [defn-timed]]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.elastic-utils.search.es-group-query-conditions :as gc]
    [cmr.elastic-utils.search.es-index :as common-esi]
    [cmr.elastic-utils.search.es-params-converter :as cp]
@@ -470,7 +471,7 @@
   ;; Search is not a dependency of access-control and this must be
   ;; defined for collection search to work
   {:index-name (if (:all-revisions? query)
-                 "1_all_collection_revisions"
+                 (esi-helper/index-alias "1_all_collection_revisions")
                  "collection_search_alias")
    :type-name "collection"})
 

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/ac_elasticsearch.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/ac_elasticsearch.clj
@@ -41,7 +41,7 @@
     (let [{:keys [concept-id revision-id]} concept
           type (concept->type concept)
           elastic-version revision-id
-          index-name (access-control-index/concept-type->index-name type)
+          index-alias (access-control-index/concept-type->index-alias type)
           elastic-doc (parsed-concept->elastic-doc context concept concept)
           ;; "only index the document if the given version is equal or higher than
           ;; the version of the stored document."
@@ -50,7 +50,7 @@
                              {:_id concept-id
                               :version elastic-version
                               :version_type version-type})]
-      (assoc elastic-doc :_index index-name))
+      (assoc elastic-doc :_index index-alias))
 
     (catch Throwable e
       (error e (str "Skipping failed catalog item. Exception trying to convert "

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/access_control_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/access_control_index.clj
@@ -8,6 +8,7 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.util :as util :refer [defn-timed]]
    [cmr.elastic-utils.es-helper :as es-helper]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.elastic-utils.index-util :as m :refer [defmapping defnestedmapping]]
    [cmr.elastic-utils.search.es-index :as esi]
    [cmr.elastic-utils.search.es-query-to-elastic :as q2e]
@@ -132,7 +133,7 @@
 
 (defmethod esi/concept-type->index-info :access-group
   [_context _ _]
-  {:index-name group-index-name
+  {:index-name (esi-helper/index-alias group-index-name)
    :type-name group-type-name})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -415,7 +416,7 @@
 
 (defmethod esi/concept-type->index-info :acl
   [_context _ _]
-  {:index-name acl-index-name
+  {:index-name (esi-helper/index-alias acl-index-name)
    :type-name acl-type-name})
 
 (defmethod q2e/concept-type->field-mappings :acl
@@ -454,6 +455,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Support for bulk indexing
 
-(def concept-type->index-name
-  {:acl acl-index-name
-   :access-group group-index-name})
+(def concept-type->index-alias
+  {:acl (esi-helper/index-alias acl-index-name)
+   :access-group (esi-helper/index-alias group-index-name)})

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -12,6 +12,7 @@
    [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.connect :as es]
    [cmr.elastic-utils.es-helper :as es-helper]
+   [cmr.elastic-utils.es-index-helper :as esi-helper]
    [cmr.elastic-utils.search.es-query-to-elastic :as q2e]
    [cmr.transmit.connection :as transmit-conn])
   (:import
@@ -28,7 +29,7 @@
 (defmethod concept-type->index-info :collection
   [_context _ query]
   {:index-name (if (:all-revisions? query)
-                 "1_all_collection_revisions"
+                 (esi-helper/index-alias "1_all_collection_revisions")
                  (es-config/collections-index-alias))
    :type-name "collection"})
 
@@ -310,7 +311,7 @@
         (if (or (nil? search-after-values)
                 (>= (count accumulated-hits) total-hits))
           ;; We've got all results
-          (do 
+          (do
             (debug "Returning all results with total hits:" total-hits
                    "and took time:" took-total
                    "timed out:" timed-out)
@@ -322,7 +323,7 @@
 
           (let [next-response (send-query-to-elastic
                                context
-                               (assoc query-with-sort 
+                               (assoc query-with-sort
                                       :page-size batch-size
                                       :search-after search-after-values))
                 new-hits (get-in next-response [:hits :hits])]

--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -104,7 +104,7 @@
    concept id to collection information. The collection will only be in the map if it has granules."
   [context]
   (-> (es-helper/search (indexer-util/context->conn context)
-                        "1_small_collections,1_c*" ;; Searching all granule indexes
+                        "1_small_collections_alias,1_c*_alias" ;; Searching all granule indexes
                         ["granule"] ;; With the granule type.
                         {:query (esq/match-all)
                          :size 0
@@ -119,7 +119,7 @@
   (let [revision-date (t/minus (tk/now) (t/seconds granules-updated-in-last-n))
         revision-date-str (datetime-helper/utc-time->elastic-time revision-date)]
     (-> (es-helper/search (indexer-util/context->conn context)
-                          "1_small_collections,1_c*" ;; Searching all granule indexes
+                          "1_small_collections_alias,1_c*_alias" ;; Searching all granule indexes
                           ["granule"] ;; With the granule type.
                           {:query {:bool {:must (esq/match-all)
                                           :filter {:range {:revision-date-doc-values

--- a/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
@@ -3,9 +3,9 @@
   (:require
    [cmr.indexer.data.elasticsearch :as es]))
 
-(def deleted-granule-index-name
-  "The name of the index in elastic search."
-  "1_deleted_granules")
+(def deleted-granules-index-alias
+  "The alias of the deleted granules index in elastic search."
+  "1_deleted_granules_alias")
 
 (def deleted-granule-type-name
   "The name of the mapping type within the cubby elasticsearch index."
@@ -16,7 +16,7 @@
   [context concept-id revision-id options]
   (let [elastic-options (select-keys options [:ignore-conflict?])]
     (es/delete-document
-      context [deleted-granule-index-name] deleted-granule-type-name
+      context [deleted-granules-index-alias] deleted-granule-type-name
       concept-id revision-id nil elastic-options)))
 
 (defn deleted-granule->elastic-doc
@@ -35,5 +35,5 @@
   [context concept concept-id revision-id elastic-version elastic-options]
   (let [es-doc (deleted-granule->elastic-doc concept)]
     (es/save-document-in-elastic
-      context [deleted-granule-index-name] deleted-granule-type-name
+      context [deleted-granules-index-alias] deleted-granule-type-name
       es-doc concept-id revision-id elastic-version elastic-options)))

--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -246,8 +246,7 @@
                       (update :tool-associations #(parse-non-tombstone-associations context %)))
           elastic-id (get-elastic-id concept-id revision-id all-revisions-index?)
           index-names (idx-set/get-concept-index-names
-                       context concept-id revision-id options
-                       concept)
+                       context concept-id revision-id options concept)
           elastic-doc (if (:deleted concept)
                         ;; The concept is a tombstone
                         (parsed-concept->elastic-doc context concept concept)

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -76,12 +76,12 @@
         rebalancing-indexes (map granule-index-names (map keyword rebalancing-collections))
         ;; Exclude all the rebalancing collection indexes.
         excluded-collections-str (if (seq rebalancing-indexes)
-                                   (str "," (string/join "," (map #(str "-" (esi-helper/index-alias %)) rebalancing-indexes)))
+                                   (str "," (string/join "," (map #(str "-" % "*") rebalancing-indexes)))
                                    "")]
     (format "%d_c*_alias,%d_small_collections_alias,-%d_collections*%s"
             index-set-id index-set-id index-set-id excluded-collections-str)))
 
-(defn- get-granule-indexes
+(defn- get-granule-index-aliases
   "Returns the granule index aliases that should be searched based on the input query"
   [context query]
   (let [coll-concept-ids (seq (cex/extract-collection-concept-ids query))
@@ -100,7 +100,7 @@
 
 (defmethod common-esi/concept-type->index-info :granule
   [context _ query]
-  {:index-name (get-granule-indexes context query)
+  {:index-name (get-granule-index-aliases context query)
    :type-name "granule"})
 
 (defmethod common-esi/concept-type->index-info :collection

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -107,9 +107,9 @@
   (-> (select-keys params (filter keyword? (keys params)))
       common-params/sanitize-params))
 
-(def deleted-granule-index-name
-  "The name of the index in elastic search. Duplicated from indexer app."
-  "1_deleted_granules")
+(def deleted-granules-index-alias
+  "The alias of the deleted granules index in elastic search. Duplicated from indexer app."
+  "1_deleted_granules_alias")
 
 (def deleted-granule-type-name
   "The name of the mapping type within the cubby elasticsearch index. Duplicated from indexer app."
@@ -517,7 +517,7 @@
         _ (pv/validate-deleted-granules-params params)
         query (make-deleted-granules-query params)
         results (es-helper/search (common-idx/context->conn context)
-                                  deleted-granule-index-name
+                                  deleted-granules-index-alias
                                   deleted-granule-type-name
                                   query)
         result-format (:result-format params)

--- a/search-app/test/cmr/search/test/unit/data/elastic_search_index_test.clj
+++ b/search-app/test/cmr/search/test/unit/data/elastic_search_index_test.clj
@@ -51,16 +51,16 @@
       (let [query (qm/query {:concept-type :granule
                              :condition (qm/string-conditions :concept-id ["C1200000001-PROV1"] true)
                              :page-size 1})]
-        (is (= "1_small_collections,1_c*_prov1" (#'search-index/get-granule-indexes context query)))))
+        (is (= "1_small_collections_alias,1_c*_prov1_alias" (#'search-index/get-granule-index-aliases context query)))))
 
     (testing "provider id to index name"
       (let [query (qm/query {:concept-type :granule
                              :condition (qm/string-conditions :provider ["PROV1"] true)
                              :page-size 2})]
-        (is (= "1_small_collections,1_c*_prov1" (#'search-index/get-granule-indexes context query)))))
+        (is (= "1_small_collections_alias,1_c*_prov1_alias" (#'search-index/get-granule-index-aliases context query)))))
 
     (testing "all granule to index name"
       (let [query (qm/query {:concept-type :granule
                               :condition (qm/string-conditions :provider-id ["PROV1"] true)
                               :page-size 3})]
-         (is (= "1_c*,1_small_collections,-1_collections*" (#'search-index/get-granule-indexes context query)))))))
+         (is (= "1_c*_alias,1_small_collections_alias,-1_collections*" (#'search-index/get-granule-index-aliases context query)))))))

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granules_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granules_index_test.clj
@@ -23,7 +23,7 @@
   "Check elastic search deleted-granules index from related deleted granule entry,
    Returns true if document exists, false if it does not."
   [concept-id]
-  (index/doc-present? deleted-granule/deleted-granule-index-name
+  (index/doc-present? deleted-granule/deleted-granules-index-alias
                       deleted-granule/deleted-granule-type-name
                       concept-id))
 


### PR DESCRIPTION
# Overview

### What is the objective?

As a CMR operator, I want to CMR to use aliases when searching against Elasticsearch so that we can switch between underlying ES indices

### What are the changes?

Switch CMR to use aliases when searching against Elasticsearch so that we can switch between underlying ES indices

### What areas of the application does this impact?

access-control, indexer and bootstrap apps.

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
