### PR TITLE
CMR-10799 -  try a newer version of the java aws api

### DIFF
--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -10,18 +10,13 @@
                  [clojurewerkz/elastisch "5.0.0-beta1"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.18.0"]
-                 ;; commons-compress does not currently use commons-lang3 3.18.0, for now
-                 ;; we will force it to use the latest version
-                 ;[org.apache.commons/commons-lang3 "3.18.0"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [org.apache.logging.log4j/log4j-api "2.15.0"]
                  [org.clojure/clojure]
                  [org.elasticsearch/elasticsearch ~elastic-version]
-                 ;[org.apache.commons/commons-compress "1.26.0"
-                 ; :exclusions [org.apache.commons/commons-lang3]]
-
-                 ;; Test containers requires a patch to common-compress
+                 ;; testcontainers needs a newer version of commons-compress, for now
+                 ;; we will force it to use the latest version
                  [org.apache.commons/commons-compress]
                  [org.testcontainers/testcontainers]
 

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -1,10 +1,10 @@
 (def aws-java-sdk-version
   "The java aws sdk version to use."
-  "1.12.788")
+  "1.12.788") ;; latest as of 2025-09-05
 
 (def aws-java-sdk2-version
   "The java aws sdk version to use."
-  "2.33.4")
+  "2.33.4") ;; latest as of 2025-09-05
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."
@@ -12,7 +12,7 @@
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
   :dependencies [[cheshire]
-                 [clj-http "2.3.0"] ;;behind other projects
+                 [clj-http "2.3.0"] ;;behind other cmr projects
                  [clj-time]
                  [io.netty/netty-handler "4.1.125.Final"]
                  [io.netty/netty-codec-http "4.1.125.Final"]
@@ -39,8 +39,8 @@
                  [org.apache.httpcomponents/httpcore "4.4.10"]
                  [org.clojure/clojure]
                  [org.clojure/tools.reader "1.3.2"]
-
-                 ;; Fix testcontainers use of commons-compress
+                 ;; testcontainers needs a newer version of commons-compress, for now
+                 ;; we will force it to use the latest version
                  [org.apache.commons/commons-compress]
                  [org.testcontainers/testcontainers]
 

--- a/project.clj
+++ b/project.clj
@@ -17,12 +17,12 @@
   :plugins [[lein-modules "0.3.11"]
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
-   :managed-dependencies [[cheshire "5.12.0"] ;; lattest is 6.1.0
-                          [clj-http "3.11.0"] ;; lattest is 3.13.1
-                          [clj-time "0.15.1"] ;; lattest is 0.15.2
-                          [org.clojure/clojure "1.11.2"] ;; lattest is 1.11.4
+   :managed-dependencies [[cheshire "5.12.0"] ;; latest is 6.1.0
+                          [clj-http "3.11.0"] ;; latest is 3.13.1
+                          [clj-time "0.15.1"] ;; latest is 0.15.2
+                          [org.clojure/clojure "1.11.2"] ;; lattest is 1.11.4 or 1.12.2
                           [org.apache.commons/commons-compress "1.28.0"] ;; see testcontainers
-                          [org.testcontainers/testcontainers "1.21.3"
+                          [org.testcontainers/testcontainers "1.21.3" ;; latest
                            :exclusions [[org.apache.commons/commons-compress]]]]
   :profiles {:uberjar {:modules {:dirs ["access-control-app"
                                         "bootstrap-app"

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -14,12 +14,8 @@
   :dependencies [[com.taoensso/carmine "3.0.1"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [org.clojure/clojure]
-                 ;; commons-compress does not currently use commons-lang3 3.18.0, for now
+                 ;; testcontainers needs a newer version of commons-compress, for now
                  ;; we will force it to use the latest version
-                 ;[org.apache.commons/commons-lang3 "3.18.0"]
-                 ;[org.apache.commons/commons-compress "1.26.0"
-                 ; :exclusions [org.apache.commons/commons-lang3]]
-                 ;; Test containers requires a patch
                  [org.apache.commons/commons-compress]
                  [org.testcontainers/testcontainers]]
   :plugins [[lein-exec "0.3.7"]


### PR DESCRIPTION
# Overview

Getting the latest version of software.amazon.awssdk/sqs and ins to run in CMR. but swap out the Netty libraries for the latest in our number series, 4.1.125.Final, so that Snyk will be quiet:
https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-12485149

Also bringing testcontainers up to the latest version and swapping out org.apache.commons/commons-compress to a version to resolve a snyk issue as well:
https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296

NOTE: I may recreate this pull request, I don't know why older changes are showing up in the log, created to illustrate changes.

### What is the objective?

Snyk

### What are the changes?

Update libraries and forcing sub libraries to use newer versions.

### What areas of the application does this impact?

message-queue-lib

List impacted applications
* metadata-db
* indexer-app
* virtual-product
* message-queue-lib (source of change)
* ingest-app
* search-app

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
