### PR TITLE
CMR-10762: Update Search App to work with split-cluster (locally)

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_debug.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_debug.clj
@@ -11,9 +11,10 @@
 (defn- context->conn
   "Pulls out the context from the search index"
   [context es-cluster-name]
-  (case es-cluster-name
-    es-config/elastic-name (get-in context [:system :search-index :conn])
-    es-config/gran-elastic-name (get-in context [:system :gran-search-index :conn])))
+  (cond
+    (= es-cluster-name es-config/elastic-name) (get-in context [:system :search-index :conn])
+    (= es-cluster-name es-config/gran-elastic-name) (get-in context [:system :gran-search-index :conn])
+    :else (throw (Exception. (es-config/invalid-elastic-cluster-name-msg es-cluster-name)))))
 
 (defn get-collection-permitted-groups
   "NOTE: Use for debugging only. Gets collections along with their currently permitted groups. This

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -7,6 +7,7 @@
    [cmr.common.hash-cache :as hcache]
    [cmr.common.services.errors :as e]
    [cmr.common.services.search.query-model :as qm]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.search.es-index :as common-esi]
    [cmr.elastic-utils.search.es-index-name-cache :as index-names-cache]
    [cmr.elastic-utils.search.es-query-to-elastic :as q2e]
@@ -154,8 +155,10 @@
      :type-name (name concept-type)}))
 
 (defn- context->conn
-  [context]
-  (get-in context [:system :search-index :conn]))
+  [context es-cluster-name]
+  (case es-cluster-name
+    es-config/elastic-name (get-in context [:system :search-index :conn])
+    es-config/gran-elastic-name (get-in context [:system :gran-search-index :conn])))
 
 (comment defn- get-collection-permitted-groups
   "NOTE: Use for debugging only. Gets collections along with their currently permitted groups. This

--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -156,9 +156,10 @@
 
 (defn- context->conn
   [context es-cluster-name]
-  (case es-cluster-name
-    es-config/elastic-name (get-in context [:system :search-index :conn])
-    es-config/gran-elastic-name (get-in context [:system :gran-search-index :conn])))
+  (cond
+    (= es-cluster-name es-config/elastic-name) (get-in context [:system :search-index :conn])
+    (= es-cluster-name es-config/gran-elastic-name) (get-in context [:system :gran-search-index :conn])
+    :else (throw (Exception. (es-config/invalid-elastic-cluster-name-msg es-cluster-name)))))
 
 (comment defn- get-collection-permitted-groups
   "NOTE: Use for debugging only. Gets collections along with their currently permitted groups. This

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -14,6 +14,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.set :as set]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.search.es-wrapper :as esq]
    [cmr.common-app.services.search :as common-search]
    [cmr.common.concepts :as cc]
@@ -516,7 +517,7 @@
         params (dissoc (common-params/sanitize-params params) :sort-key)
         _ (pv/validate-deleted-granules-params params)
         query (make-deleted-granules-query params)
-        results (es-helper/search (common-idx/context->conn context)
+        results (es-helper/search (common-idx/context->conn context es-config/gran-elastic-name)
                                   deleted-granule-index-name
                                   deleted-granule-type-name
                                   query)
@@ -560,4 +561,5 @@
 (defn clear-scroll
   "Clear the scroll context for the given scroll id"
   [context scroll-id]
-  (es-helper/clear-scroll (common-idx/context->conn context) scroll-id))
+  (es-helper/clear-scroll (common-idx/context->conn context es-config/gran-elastic-name) scroll-id)
+  (es-helper/clear-scroll (common-idx/context->conn context es-config/elastic-name) scroll-id))

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -19,6 +19,7 @@
    [cmr.common.log :as log]
    [cmr.common.nrepl :as nrepl]
    [cmr.common.system :as common-sys]
+   [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.search.es-index :as common-idx]
    [cmr.elastic-utils.search.es-index-name-cache :as elastic-search-index-names-cache]
    [cmr.metadata-db.system :as mdb-system]
@@ -89,6 +90,7 @@
   [:log
    :caches
    orbits-runtime/system-key
+   :gran-search-index
    :search-index
    :scheduler
    :web
@@ -108,7 +110,8 @@
              ;; An embedded version of the metadata db app to allow quick retrieval of data
              ;; from oracle.
              :embedded-systems {:metadata-db metadata-db}
-             :search-index (common-idx/create-elastic-search-index)
+             :gran-search-index (common-idx/create-elastic-search-index es-config/gran-elastic-name)
+             :search-index (common-idx/create-elastic-search-index es-config/elastic-name)
              :web (web-server/create-web-server (transmit-config/search-port) routes/handlers)
              :nrepl (nrepl/create-nrepl-if-configured (search-nrepl-port))
              ;; Caches added to this list must be explicitly cleared in query-service/clear-cache


### PR DESCRIPTION
# Overview

### What is the objective?

To update search app to work with split cluster

### What are the changes?

Added the two clusters as settings

### What areas of the application does this impact?

- Search App

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
