### PR TITLE
CMR-10764: Update sys-tests to work with split cluster

### DIFF
--- a/indexer-app/int-test/cmr/indexer/test/utility.clj
+++ b/indexer-app/int-test/cmr/indexer/test/utility.clj
@@ -87,6 +87,50 @@
                                   :properties {:concept-id {:type "keyword" :norms false :index_options "docs"},
                                                :collection-concept-id {:type "keyword" :norms false :index_options "docs"}}}}}})
 
+(def sample-index-set-updated
+  {:index-set
+   {:name "cmr-base-index-set-updated"
+    :id sample-index-set-id
+    :create-reason "updated index set from sample index"
+    :random {:indexes
+             [{:name "RAND1-PROV0"
+               :settings {:index {:number_of_shards 1,
+                                  :number_of_replicas 0,
+                                  :refresh_interval "20s"}}}]
+             :mapping {:dynamic "strict",
+                       :_source {:enabled true},
+                       :properties {:concept-id  {:type "keyword" :norms false :index_options "docs"},
+                                    :entry-title {:type "keyword" :norms false :index_options "docs"}}}}
+    :collection {:indexes
+                 [{:name "COLL2-PROV1"
+                   :settings {:index {:number_of_shards 1,
+                                      :number_of_replicas 0,
+                                      :refresh_interval "20s"}}}]
+                 :mapping {:dynamic "strict",
+                           :_source {:enabled true},
+                           :properties {:concept-id  {:type "keyword" :norms false :index_options "docs"},
+                                        :entry-title {:type "keyword" :norms false :index_options "docs"}}}}
+    :granule {:indexes
+              [{:name "small_collections"
+                :settings {:index {:number_of_shards 1,
+                                   :number_of_replicas 0,
+                                   :refresh_interval "10s"}}}
+               {:name "GRAN5-PROV3"
+                :settings {:index {:number_of_shards 1,
+                                   :number_of_replicas 0,
+                                   :refresh_interval "10s"}}}
+               {:name "GRAN6-PROV4"
+                :settings {:index {:number_of_shards 1,
+                                   :number_of_replicas 0,
+                                   :refresh_interval "10s"}}}]
+              :individual-index-settings {:index {:number_of_shards 1,
+                                                  :number_of_replicas 0,
+                                                  :refresh_interval "10s"}}
+              :mapping {:dynamic "strict",
+                        :_source {:enabled true},
+                        :properties {:concept-id {:type "keyword" :norms false :index_options "docs"},
+                                     :collection-concept-id {:type "keyword" :norms false :index_options "docs"}}}}}})
+
 (def invalid-sample-index-set
   {:index-set
    {:name "cmr-base-index-set"
@@ -171,6 +215,21 @@
                    :headers {transmit-config/token-header (transmit-config/echo-system-token)}
                    :accept :json
                    :throw-exceptions false})
+        status (:status response)
+        body (cheshire/decode (:body response) true)]
+    {:status status :errors (:errors body) :response (assoc response :body body)}))
+
+(defn update-index-set
+  "submit a request to index-set app to create indices"
+  [idx-set id]
+  (let [response (client/request
+                   {:method :put
+                    :url (index-set-url id)
+                    :body (cheshire.core/generate-string idx-set)
+                    :content-type :json
+                    :headers {transmit-config/token-header (transmit-config/echo-system-token)}
+                    :accept :json
+                    :throw-exceptions false})
         status (:status response)
         body (cheshire/decode (:body response) true)]
     {:status status :errors (:errors body) :response (assoc response :body body)}))

--- a/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
+++ b/indexer-app/int-test/cmr/indexer/test/valid_data_crud_tests.clj
@@ -106,6 +106,29 @@
         (is (esi/exists? @util/gran-elastic-connection es-idx-name)))
       (is (= expected-idx-cnt (count actual-es-indices))))))
 
+;; Verify that you can update an index set multiple times and get the correct indices created and deleted
+(deftest update-index-sets-test
+  (testing "update index sets"
+    (let [;; create index set
+          index-set util/sample-index-set
+          _ (util/create-index-set index-set)
+          ;; create updated index set input
+          updated-index-set util/sample-index-set-updated
+          updated-index-set-id (get-in updated-index-set [:index-set :id]) ;; should be the same as the original sample-index-set
+          ;; update index set
+          updated-resp (util/update-index-set updated-index-set updated-index-set-id)
+          found-index-set (-> (util/get-index-set updated-index-set-id) :response :body)]
+
+      (is (= (:status updated-resp) 200))
+
+      (is (= (get-in updated-index-set [:index-set :name]) (get-in found-index-set [:index-set :name])))
+      (is (= (get-in updated-index-set [:index-set :create-reason]) (get-in found-index-set [:index-set :create-reason])))
+      (is (= (get-in updated-index-set [:index-set :collection]) (get-in found-index-set [:index-set :collection])))
+      (is (= (get-in updated-index-set [:index-set :granule]) (get-in found-index-set [:index-set :granule])))
+      (is (= (get-in updated-index-set [:index-set :random]) (get-in found-index-set [:index-set :random])))
+      (is (= {:COLL2-PROV1 "3_coll2_prov1"} (get-in found-index-set [:index-set :concepts :collection])))
+      (is (= {:small_collections "3_small_collections", :GRAN5-PROV3 "3_gran5_prov3", :GRAN6-PROV4 "3_gran6_prov4"}
+             (get-in found-index-set [:index-set :concepts :granule]))))))
 
 ;; manual reset
 (comment


### PR DESCRIPTION
# Overview

### What is the objective?

Check all sys tests work and added new test to make sure indexer update changes are tested

### What are the changes?

added new test to make sure indexer update changes are tested

### What areas of the application does this impact?

All

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
