### PR TITLE
CMR-10853: Skip granule query when no collections are found using the collection identifiers in granule search params.

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/search/query_execution.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/query_execution.clj
@@ -2,7 +2,7 @@
   "Defines a bunch of defmulti functions and their defaults to handle different stats of the
    query-execution. These will be extended by other files."
   (:require
-   [cmr.common.log :as log :refer [debug]]
+   [cmr.common.log :as log :refer [info]]
    [cmr.elastic-utils.search.es-index :as idx]
    [cmr.elastic-utils.search.es-results-to-query-results :as rc]
    [cmr.elastic-utils.search.query-transform :as c2s]
@@ -124,7 +124,7 @@
   (let [[context processed-query] (concept-type-specific-query-processing context query)
         elastic-results (if (granule-no-coll-match? context)
                           (do
-                            (debug "No collection matched by collection identifying parameters in granule search, skip querying ES.")
+                            (info "No collection matched by collection identifying parameters in granule search, skip querying ES.")
                             empty-es-results)
                           (run-elasticsearch-query context processed-query))
         query-results (rc/elastic-results->query-results context processed-query elastic-results)]

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/query_execution.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/query_execution.clj
@@ -2,6 +2,7 @@
   "Defines a bunch of defmulti functions and their defaults to handle different stats of the
    query-execution. These will be extended by other files."
   (:require
+   [cmr.common.log :as log :refer [debug]]
    [cmr.elastic-utils.search.es-index :as idx]
    [cmr.elastic-utils.search.es-results-to-query-results :as rc]
    [cmr.elastic-utils.search.query-transform :as c2s]
@@ -93,16 +94,38 @@
   (fn [_context query]
     (query->execution-strategy query)))
 
+(def empty-es-results
+  "An empty result returned by Elasticsearch when no match is found."
+  {:took 0, :timed_out false, :_shards {:total 0, :successful 0, :skipped 0, :failed 0}, :hits {:total {:value 0}, :max_score nil, :hits ()}})
+
+(defn- granule-no-coll-match?
+  "Returns true if this is a granule query with a collection identifier
+   but no matching collection IDs, meaning we should skip querying ES."
+  [{:keys [query-concept-type has-coll-identifier query-collection-ids]}]
+  (and (= query-concept-type :granule)
+       has-coll-identifier
+       (empty? query-collection-ids)))
+
+(defn- run-elasticsearch-query
+  "Runs the Elasticsearch query pipeline: preprocess, apply ACLs (if needed),
+   reduce, and execute."
+  [context processed-query]
+  (let [processed-query (pre-process-query-result-features context processed-query)]
+    (->> processed-query
+         (#(if (or (tc/echo-system-token? context) (:skip-acls? %))
+             %
+             (add-acl-conditions-to-query context %)))
+         (c2s/reduce-query context)
+         (idx/execute-query context))))
+
+
 (defmethod execute-query :elasticsearch
   [context query]
-  (let [[context processed-query] (concept-type-specific-query-processing
-                                   context query)
-        processed-query (pre-process-query-result-features context processed-query)
-        elastic-results (->> processed-query
-                             (#(if (or (tc/echo-system-token? context) (:skip-acls? %))
-                                 %
-                                 (add-acl-conditions-to-query context %)))
-                             (c2s/reduce-query context)
-                             (idx/execute-query context))
+  (let [[context processed-query] (concept-type-specific-query-processing context query)
+        elastic-results (if (granule-no-coll-match? context)
+                          (do
+                            (debug "No collection matched by collection identifying parameters in granule search, skip querying ES.")
+                            empty-es-results)
+                          (run-elasticsearch-query context processed-query))
         query-results (rc/elastic-results->query-results context processed-query elastic-results)]
     (post-process-query-result-features context query elastic-results query-results)))

--- a/search-app/test/cmr/search/test/unit/services/parameter_validation.clj
+++ b/search-app/test/cmr/search/test/unit/services/parameter_validation.clj
@@ -302,12 +302,12 @@
            (pv/validate-parameters :service {:type "Harmony"}))))
   (testing "Service failed invalid parameters."
     (try
-      (pv/validate-parameters :service {:foo "Harmony"}))
+      (pv/validate-parameters :service {:foo "Harmony"})
       (is false "An error should have been thrown.")
       (catch clojure.lang.ExceptionInfo e
         (is (= {:type :bad-request
                 :errors #{"Parameter [foo] was not recognized."}}
-               (update-in (ex-data e) [:errors] set))))))
+               (update-in (ex-data e) [:errors] set)))))))
 
 (deftest exclude-validation-test
   (testing "concept-id is a valid key to exclude"

--- a/system-int-test/test/cmr/system_int_test/search/granule/all_granule_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/all_granule_search_test.clj
@@ -2,141 +2,158 @@
   (:require
    [clojure.test :refer :all]
    [cmr.common-app.test.side-api :as side]
+   [cmr.common.util :as util :refer [are3]]
    [cmr.search.api.concepts-search :as concepts-search]
    [cmr.system-int-test.utils.search-util :as search]))
 
 ;; Tests all granule search when allow-all-granule-params-flag is false
 ;; Existing tests should cover the case when the flag is set to true.
 (deftest allow-all-granule-params-flag-false-search-test
-  (let [saved-flag-value (concepts-search/allow-all-granule-params-flag)
-        saved-header-value (concepts-search/allow-all-gran-header)
-        _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! false))
-        _ (side/eval-form `(concepts-search/set-allow-all-gran-header! "ALL_GRANS_2172"))
-        header1 {"client-id" "testing", "ALL_GRANS_2172" true}
-        header1-insensitive {"client-id" "testing", "alL_GrAnS_2172" true}
-        header2 {"client-id" "testing", "ALL_GRANS_2172" false}
-        header3 {"client-id" "testing"}
-        header4 {"ALL_GRANS_2172" true}
-        header5 {"ALL_GRANS_2172" false}
-        header6 {}
-        params1 {:provider "PROV1"}
-        params2 {:provider_id "PROV1"}
-        params3 {:concept_id "G1234-PROV1"}
-        params3-alias {:echo_granule_id "G1234-PROV1"}
-        params3-collection {:concept_id "C1234-PROV1"}
-        params3-service {:concept_id "S1234-PROV1"}
-        params3-variable {:concept_id "V1234-PROV1"}
-        params3-empty-array {:concept_id ["" ""]}
-        params3-array-with-service {:concept_id ["" "S1234-PROV1"]}
-        params3-empty {:concept_id ""}
-        params3-number {:concept_id 1}
-        params4 {:collection_concept_id "C1234-PROV1"}
-        params4-alias {:echo_collection_id "C1234-PROV1"}
-        params5 {:short_name "short name"}
-        params5-alias {:shortName "short name"}
-        params6 {:version "1.0"}
-        params7 {:entry_title "testing"}
-        params7-alias {:dataset_id "testing"}
-        params8 {:bounding-box "-10,-5,10,5"}
-        params9 {"temporal[]" "2010-12-12T12:00:00Z,"}
-        params10 {"page_num" 2 "page_size" 5}
-        ;; With allow-all-granule-params-flag being set to false, all granule query is allowed
-        ;; only when client-id is present and allow-all-gran header is set to true.
-        result1 (search/find-refs :granule {} {:headers header1})
-        ;; allow-all-gran header is case insensitive
-        result1-insensitive (search/find-refs :granule {} {:headers header1-insensitive})
+  (let [saved-flag-value   (concepts-search/allow-all-granule-params-flag)
+        saved-header-value (concepts-search/allow-all-gran-header)]
+    (try
+      ;; set state for the test
+      (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! false))
+      (side/eval-form `(concepts-search/set-allow-all-gran-header! "ALL_GRANS_2172"))
 
-        ;; Without the proper headers and collection constriants, these should be rejected
-        result2 (search/find-refs :granule {} {:headers header2})
-        result3 (search/find-refs :granule {} {:headers header3})
-        result4 (search/find-refs :granule {} {:headers header4})
-        result5 (search/find-refs :granule {} {:headers header5})
-        result6 (search/find-refs :granule {} {:headers header6})
-        ;; Search with collection constraints should be allowed.
-        result7 (search/find-refs :granule params1)
-        result8 (search/find-refs :granule params2)
-        result9 (search/find-refs :granule params3)
-        result9-alias (search/find-refs :granule params3-alias)
-        result9-collection (search/find-refs :granule params3-collection)
-        ;; except for when service/variable concept ids are passed in.
-        ;; we only support granule and collection concept ids for the granule search.
-        result9-service (search/find-refs :granule params3-service)
-        result9-variable (search/find-refs :granule params3-variable)
-        result9-empty-array (search/find-refs :granule params3-empty-array)
-        result9-array-with-service (search/find-refs :granule params3-array-with-service)
-        result9-empty (search/find-refs :granule params3-empty)
-        result9-number (search/find-refs :granule params3-number)
-        result10 (search/find-refs :granule params4)
-        result10-alias (search/find-refs :granule params4-alias)
-        result11 (search/find-refs :granule params5)
-        result11-alias (search/find-refs :granule params5-alias)
-        result12 (search/find-refs :granule params6)
-        result13 (search/find-refs :granule params7)
-        result13-alias (search/find-refs :granule params7-alias)
-        ;; Search without collection constraints, but with other spatial, temporal page_num, page_size are rejected.
-        result14 (search/find-refs :granule params8)
-        result15 (search/find-refs :granule params9)
-        result16 (search/find-refs :granule params10)
-        err-msg "The CMR does not allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title. For any questions please contact cmr-support@nasa.gov."
-        err-msg-illegal-service-id "Invalid concept_id [S1234-PROV1]. For granule queries concept_id must be either a granule or collection concept ID."
-        err-msg-illegal-variable-id "Invalid concept_id [V1234-PROV1]. For granule queries concept_id must be either a granule or collection concept ID."
-        err-msg-illegal-service-id-in-array "Invalid concept_id [[\"\" \"S1234-PROV1\"]]. For granule queries concept_id must be either a granule or collection concept ID."
-        err-msg-illegal-number-id "Invalid concept_id [1]. For granule queries concept_id must be either a granule or collection concept ID."
-        _ (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! ~saved-flag-value))
-        _ (side/eval-form `(concepts-search/set-allow-all-gran-header! ~saved-header-value))]
-    (is (= nil
-           (:errors result1)))
-    (is (= nil
-           (:errors result1-insensitive)))
-    (is (= [err-msg]
-           (:errors result2)))
-    (is (= [err-msg]
-           (:errors result3)))
-    (is (= [err-msg]
-           (:errors result4)))
-    (is (= [err-msg]
-           (:errors result5)))
-    (is (= [err-msg]
-           (:errors result6)))
-    (is (= nil
-           (:errors result7)))
-    (is (= nil
-           (:errors result8)))
-    (is (= nil
-           (:errors result9)))
-    (is (= nil
-           (:errors result9-alias)))
-    (is (= nil
-           (:errors result9-collection)))
-    (is (= [err-msg-illegal-service-id]
-           (:errors result9-service)))
-    (is (= [err-msg-illegal-variable-id]
-           (:errors result9-variable)))
-    (is (= [err-msg]
-           (:errors result9-empty-array)))
-    (is (= [err-msg-illegal-service-id-in-array]
-           (:errors result9-array-with-service)))
-    (is (= [err-msg]
-           (:errors result9-empty)))
-    (is (= [err-msg-illegal-number-id]
-           (:errors result9-number)))
-    (is (= nil
-           (:errors result10)))
-    (is (= nil
-           (:errors result10-alias)))
-    (is (= nil
-           (:errors result11)))
-    (is (= nil
-           (:errors result11-alias)))
-    (is (= nil
-           (:errors result12)))
-    (is (= nil
-           (:errors result13)))
-    (is (= nil
-           (:errors result13-alias)))
-    (is (= [err-msg]
-           (:errors result14)))
-    (is (= [err-msg]
-           (:errors result15)))
-    (is (= [err-msg]
-           (:errors result16)))))
+      (let [err-msg "The CMR does not allow querying across granules in all collections. To help optimize your search, you should limit your query using conditions that identify one or more collections, such as provider, provider_id, concept_id, collection_concept_id, short_name, version or entry_title. For any questions please contact cmr-support@nasa.gov."
+            invalid-concept-id-err-msg "Invalid concept_id [S1234-PROV1]. For granule queries concept_id must be either a granule or collection concept ID."
+            invalid-concept-id-err-msg-in-array "Invalid concept_id [[\"\" \"S1234-PROV1\"]]. For granule queries concept_id must be either a granule or collection concept ID."
+            invalid-number-id-err-msg "Invalid concept_id [1]. For granule queries concept_id must be either a granule or collection concept ID."]
+
+        ;; -----------------
+        ;; Header-based tests
+        ;; -----------------
+        (are3 [expected header]
+              (is (= expected
+                     (:errors (search/find-refs :granule {} {:headers header}))))
+
+              "headers good"
+              nil
+              {"client-id" "testing", "ALL_GRANS_2172" true}
+
+              "headers good case-insensitive"
+              nil
+              {"client-id" "testing", "alL_GrAnS_2172" true}
+
+              "header wrong flag"
+              [err-msg]
+              {"client-id" "testing", "ALL_GRANS_2172" false}
+
+              "header missing flag"
+              [err-msg]
+              {"client-id" "testing"}
+
+              "header missing client-id"
+              [err-msg]
+              {"ALL_GRANS_2172" true}
+
+              "header wrong flag no client-id"
+              [err-msg]
+              {"ALL_GRANS_2172" false}
+
+              "header missing all"
+              [err-msg]
+              {})
+
+        ;; -----------------
+        ;; Param-based tests
+        ;; -----------------
+        (are3 [expected params]
+              (is (= expected
+                     (:errors (search/find-refs :granule params))))
+
+              "provider constraint"
+              nil
+              {:provider "PROV1"}
+
+              "provider_id constraint"
+              nil
+              {:provider_id "PROV1"}
+
+              "collection concept_id"
+              nil
+              {:concept_id "C1234-PROV1"}
+
+              "granule concept_id"
+              nil
+              {:concept_id "G1234-PROV1"}
+
+              "granule concept_id alias"
+              nil
+              {:echo_granule_id "G1234-PROV1"}
+
+              "collection_concept_id"
+              nil {:collection_concept_id "C1234-PROV1"}
+
+              "collection_concept_id alias"
+              nil
+              {:echo_collection_id "C1234-PROV1"}
+
+              "empty array"
+              [err-msg]
+              {:concept_id ["" ""]}
+
+              "array with service id"
+              [invalid-concept-id-err-msg-in-array]
+              {:concept_id ["" "S1234-PROV1"]}
+
+              "empty concept_id"
+              [err-msg]
+              {:concept_id ""}
+
+              "number concept_id"
+              [invalid-number-id-err-msg]
+              {:concept_id 1}
+
+              "invalid concept_id"
+              [invalid-concept-id-err-msg]
+              {:concept_id "S1234-PROV1"}
+
+              "invalid collection_concept_id"
+              [invalid-concept-id-err-msg]
+              {:collection_concept_id "S1234-PROV1"}
+
+              "invalid collection_concept_id alias"
+              [invalid-concept-id-err-msg]
+              {:echo_collection_id "S1234-PROV1"}
+
+              "invalid granule concept_id alias"
+              [invalid-concept-id-err-msg]
+              {:echo_granule_id "S1234-PROV1"}
+
+              "short_name"
+              nil
+              {:short_name "short name"}
+
+              "shortName alias"
+              nil
+              {:shortName "short name"}
+
+              "version"
+              nil
+              {:version "1.0"}
+
+              "entry_title"
+              nil
+              {:entry_title "testing"}
+
+              "dataset_id alias"
+              nil
+              {:dataset_id "testing"}
+
+              "bounding-box without collection"
+              [err-msg]
+              {:bounding-box "-10,-5,10,5"}
+
+              "temporal without collection"
+              [err-msg]
+              {"temporal[]" "2010-12-12T12:00:00Z,"}
+
+              "page num/size without collection"
+              [err-msg]
+              {"page_num" 2 "page_size" 5}))
+      (finally
+        ;; always restore original state
+        (side/eval-form `(concepts-search/set-allow-all-granule-params-flag! ~saved-flag-value))
+        (side/eval-form `(concepts-search/set-allow-all-gran-header! ~saved-header-value))))))

--- a/system-int-test/test/cmr/system_int_test/search/misc/search_after_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/misc/search_after_search_test.clj
@@ -51,31 +51,31 @@
 
     (testing "UMM-JSON search-after"
       (are3 [concept-type accept extension all-refs]
-        (let [params {:page-size 1
-                      :provider "PROV1"}
-              response (search/find-concepts-umm-json
-                        concept-type
-                        params
-                        {:url-extension extension
-                         :accept accept})
-              [num-scrolls all-concepts] (scroll-all-umm-json-with-search-after
-                                          concept-type params response)]
-          (is (not (nil? (:search-after response))))
-          (is (= (count all-refs) num-scrolls))
-          (is (= (set (map :concept-id all-refs))
-                 (set (map #(get-in % [:meta :concept-id]) all-concepts)))))
+            (let [params {:page-size 1
+                          :provider "PROV1"}
+                  response (search/find-concepts-umm-json
+                            concept-type
+                            params
+                            {:url-extension extension
+                             :accept accept})
+                  [num-scrolls all-concepts] (scroll-all-umm-json-with-search-after
+                                              concept-type params response)]
+              (is (not (nil? (:search-after response))))
+              (is (= (count all-refs) num-scrolls))
+              (is (= (set (map :concept-id all-refs))
+                     (set (map #(get-in % [:meta :concept-id]) all-concepts)))))
 
-        "Collection UMM-JSON via extension"
-        :collection nil "umm_json" colls
+            "Collection UMM-JSON via extension"
+            :collection nil "umm_json" colls
 
-        "Collection UMM-JSON via accept"
-        :collection mime-types/umm-json nil colls
+            "Collection UMM-JSON via accept"
+            :collection mime-types/umm-json nil colls
 
-        "Granule UMM-JSON via extension"
-        :granule nil "umm_json" grans
+            "Granule UMM-JSON via extension"
+            :granule nil "umm_json" grans
 
-        "Granule UMM-JSON via accept"
-        :granule mime-types/umm-json nil grans))
+            "Granule UMM-JSON via accept"
+            :granule mime-types/umm-json nil grans))
 
     (testing "search after with JSON query"
       (let [[coll1 coll2 coll3 coll4 coll5] colls
@@ -122,7 +122,6 @@
 
 (deftest granule-search-after
   (let [admin-read-group-concept-id (e/get-or-create-group (s/context) "admin-read-group")
-        admin-read-token (e/login (s/context) "admin" [admin-read-group-concept-id])
         _ (e/grant-group-admin (s/context) admin-read-group-concept-id :read)
         coll1 (data2-core/ingest-umm-spec-collection "PROV1"
                                                      (data-umm-c/collection {:EntryTitle "E1"
@@ -203,57 +202,56 @@
                         search-after-3 (:search-after result)]
                     (is (= (count all-grans) (:hits result)))
                     (is (nil? search-after-3))
-                    (is (data2-core/refs-match? [] result))))))))))))
+                    (is (data2-core/refs-match? [] result))))))))))
 
-(deftest search-after-invalid-parameters
-  (testing "invalid parameters"
-    (are3 [query expected-status err-msg]
-      (let [{:keys [status errors]} (search/find-refs :granule
-                                                      query
-                                                      {:allow-failure? true
-                                                       :headers {routes/SEARCH_AFTER_HEADER "[0]"}})]
-        (is (= expected-status status))
-        (is (= [err-msg] errors)))
+    (testing "invalid parameters"
+      (are3 [query expected-status err-msg]
+            (let [{:keys [status errors]} (search/find-refs :granule
+                                                            query
+                                                            {:allow-failure? true
+                                                             :headers {routes/SEARCH_AFTER_HEADER "[0]"}})]
+              (is (= expected-status status))
+              (is (= [err-msg] errors)))
 
-      "Search After queries cannot be all-granule queries"
-      {}
-      400
-      (str "The CMR does not allow querying across granules in all collections when using search-after."
-           " You should limit your query using conditions that identify one or more collections "
-           "such as provider, concept_id, short_name, or entry_title.")
+            "Search After queries cannot be all-granule queries"
+            {}
+            400
+            (str "The CMR does not allow querying across granules in all collections when using search-after."
+                 " You should limit your query using conditions that identify one or more collections "
+                 "such as provider, concept_id, short_name, or entry_title.")
 
-      "page_num is not allowed with search-after"
-      {:provider "PROV1" :page-num 2}
-      400
-      "page_num is not allowed with search-after"
+            "page_num is not allowed with search-after"
+            {:provider "PROV1" :page-num 2}
+            400
+            "page_num is not allowed with search-after"
 
-      "offset is not allowed with search-after"
-      {:provider "PROV1" :offset 2}
-      400
-      "offset is not allowed with search-after"
+            "offset is not allowed with search-after"
+            {:provider "PROV1" :offset 2}
+            400
+            "offset is not allowed with search-after"
 
-      "scroll is not allowed with search-after"
-      {:scroll true}
-      400
-      "scroll is not allowed with search-after"))
+            "scroll is not allowed with search-after"
+            {:scroll true}
+            400
+            "scroll is not allowed with search-after"))
 
-  (testing "invalid search-after header value"
-    (are3 [value err-msg]
-          (let [{:keys [status errors]} (search/find-refs :granule
-                                                          {:provider "PROV1"}
-                                                          {:allow-failure? true
-                                                           :headers {routes/SEARCH_AFTER_HEADER value}})]
-            (is (= 400 status))
-            (is (= [err-msg] errors)))
+    (testing "invalid search-after header value"
+      (are3 [value err-msg]
+            (let [{:keys [status errors]} (search/find-refs :granule
+                                                            {:provider "PROV1"}
+                                                            {:allow-failure? true
+                                                             :headers {routes/SEARCH_AFTER_HEADER value}})]
+              (is (= 400 status))
+              (is (= [err-msg] errors)))
 
-      "invaid search-after value, string"
-      12345
-      "search-after header value is invalid, must be in the form of a JSON array."
+            "invaid search-after value, string"
+            12345
+            "search-after header value is invalid, must be in the form of a JSON array."
 
-      "invaid search-after value, string with quotes"
-      "\"abc \""
-      "The search failed with error: [{:type \"parsing_exception\", :reason \"Unknown key for a VALUE_STRING in [search_after].\", :line 1, :col 17}]. Please double check your search_after header."
+            "invaid search-after value, string with quotes"
+            "\"abc \""
+            "The search failed with error: [{:type \"parsing_exception\", :reason \"Unknown key for a VALUE_STRING in [search_after].\", :line 1, :col 17}]. Please double check your search_after header."
 
-      "invaid search-after value, missing comma"
-      "[0 \"abc\"]"
-      "search-after header value is invalid, must be in the form of a JSON array.")))
+            "invaid search-after value, missing comma"
+            "[0 \"abc\"]"
+            "search-after header value is invalid, must be in the form of a JSON array."))))


### PR DESCRIPTION
# Overview

### What is the objective?

Fixed an issue where all granules query is performed when granule search parameters with collection identifiers returned no matching collections.

### What are the changes?

Add checks to make sure we skip granule query to ES when no collections are found using the collection identifiers (e.g. concept_id, collection_concept_id, echo_collection_id, short_name, version, entry_title, entry_id, etc.) in granule search parameters. 

Also fix concept-id format validation when searching granules with `collection-concept-id` which is not in the objective of this ticket.

### What areas of the application does this impact?

CMR search app.

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
