### PR TITLE
CMR-X: Move deleted gran index def

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/deleted_granule.clj
@@ -1,11 +1,8 @@
 (ns cmr.indexer.data.concepts.deleted-granule
   "Contains functions to parse and convert deleted-granule index document"
   (:require
-   [cmr.indexer.data.elasticsearch :as es]))
-
-(def deleted-granules-index-alias
-  "The alias of the deleted granules index in elastic search."
-  "1_deleted_granules_alias")
+   [cmr.indexer.data.elasticsearch :as es]
+   [cmr.indexer.data.index-set :as idx-set]))
 
 (def deleted-granule-type-name
   "The name of the mapping type within the cubby elasticsearch index."
@@ -16,7 +13,7 @@
   [context concept-id revision-id options]
   (let [elastic-options (select-keys options [:ignore-conflict?])]
     (es/delete-document
-      context [deleted-granules-index-alias] deleted-granule-type-name
+      context [idx-set/deleted-granules-index-alias] deleted-granule-type-name
       concept-id revision-id nil elastic-options)))
 
 (defn deleted-granule->elastic-doc
@@ -35,5 +32,5 @@
   [context concept concept-id revision-id elastic-version elastic-options]
   (let [es-doc (deleted-granule->elastic-doc concept)]
     (es/save-document-in-elastic
-      context [deleted-granules-index-alias] deleted-granule-type-name
+      context [idx-set/deleted-granules-index-alias] deleted-granule-type-name
       es-doc concept-id revision-id elastic-version elastic-options)))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -65,6 +65,10 @@
   "The index to use for the latest collection revisions."
   {:default "1_collections_v2" :type String})
 
+(def deleted-granules-index-alias
+  "The alias of the deleted granules index in elastic search."
+  "1_deleted_granules_alias")
+
 (def ^:private MAX_RESULT_WINDOW
   "Number of max results can be returned in an Elasticsearch query."
   1000000)

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granules_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granules_index_test.clj
@@ -6,6 +6,7 @@
    [clj-time.core :as t]
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3] :as util]
+   [cmr.indexer.data.index-set :as idx-set]
    [cmr.indexer.data.concepts.deleted-granule :as deleted-granule]
    [cmr.metadata-db.services.concept-service :as concept-service]
    [cmr.system-int-test.data2.core :as d]
@@ -23,7 +24,7 @@
   "Check elastic search deleted-granules index from related deleted granule entry,
    Returns true if document exists, false if it does not."
   [concept-id]
-  (index/doc-present? deleted-granule/deleted-granules-index-alias
+  (index/doc-present? idx-set/deleted-granules-index-alias
                       deleted-granule/deleted-granule-type-name
                       concept-id))
 


### PR DESCRIPTION
# Overview

### What is the objective?

I would like to move the deleted-gran def from its current file to index-set file to consolidate where all the index names are AND to prevent consistent merge conflict issues with my feature branch CMR-10600-split-cluster-feature. This will need to move at some point because it creates cyclical dependency issues in the split cluster feature branch.

### What are the changes?

Move deleted-granule-index-alias def into index-set file

### What areas of the application does this impact?

All

No logic should change. This is only a func move change.

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
