### PR TITLE
CMR-10872: Reject Granule Timeline searches that do not include concept_id

### DIFF
--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2963,7 +2963,14 @@ It supports all normal granule parameters. It requires the following parameters.
   * `start_date` - The start date of the timeline intervals to search from.
   * `end_date` - The end date of to search from.
   * `interval` - The interval granularity. This can be one of year, month, day, hour, minute, or second. At least one granule found within the interval time will be considered coverage for that interval.
-  * `concept_id` - Specifies a collection concept id to search for. It is recommended that the timeline search be limited to a few collections for good performance.
+  * **Collection identifier** - One of the following parameters must be provided to specify which collection(s) to search:
+    * `concept_id` - Collection concept id.
+    * `collection_concept_id` - Collection concept id.
+    * `entry_id` - Collection entry id (concatenation of short_name and version).
+    * `entry_title` - Collection entry title.
+    * `short_name` and `version` - Both parameters must be provided together to identify a specific collection.
+  
+  It is recommended that the timeline search be limited to a few collections for good performance.
 
 The response format is in JSON. Intervals are returned as tuples containing three numbers like `[949363200,965088000,4]`. The two numbers are the start and stop date of the interval represented by the number of seconds since the epoch. The third number is the number of granules within that interval.
 

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -793,8 +793,9 @@
                 (:concept-id params)
                 (:entry-id params)
                 (:entry-title params)
+                (:echo-collection-id params)
                 (and (:short-name params) (:version params)))
-    ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]))
+    ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]))
 
 (defn- timeline-start-date-validation
   "Validates the timeline start date parameter"

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -785,6 +785,17 @@
   (when-let [c-concept-ids (util/seqify (:collection-concept-id params))]
     (mapcat (partial cc/concept-id-validation :collection-concept-id) c-concept-ids)))
 
+(defn- timeline-collection-identifier-validation
+  "Validates that collection identifier parameters are present for timeline searches.
+   Accepts collection-concept-id, entry-id, entry-title, provider, or short-name + version combination."
+  [_concept-type params]
+  (when-not (or (:collection-concept-id params)
+                (:concept-id params)
+                (:entry-id params)
+                (:entry-title params)
+                (and (:short-name params) (:version params)))
+    ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]))
+
 (defn- timeline-start-date-validation
   "Validates the timeline start date parameter"
   [_concept-type params]
@@ -1057,6 +1068,7 @@
         regular-params (dissoc safe-params :interval :start-date :end-date)
         errors (concat type-errors
                        (mapcat #(% :granule regular-params) (parameter-validations :granule))
+                       (timeline-collection-identifier-validation :granule safe-params)
                        (mapcat #(% :granule timeline-params) timeline-parameter-validations))]
     (when (seq errors)
       (errors/throw-service-errors :bad-request errors)))

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
@@ -92,14 +92,14 @@
 
         (testing "missing collection identifier"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year}))))
 
         (testing "short-name without version"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year
@@ -107,7 +107,7 @@
 
         (testing "version without short-name"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year
@@ -154,7 +154,7 @@
 
         (testing "missing parameters with post"
           (is (= {:status 400 :errors ["Parameter [foo] was not recognized."
-                                       "Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."
+                                       "Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."
                                        "start_date is a required parameter for timeline searches"
                                        "end_date is a required parameter for timeline searches"
                                        "interval is a required parameter for timeline searches"]}
@@ -175,6 +175,15 @@
                 :results [{:concept-id (:concept-id coll1)
                            :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
                (search/get-granule-timeline {:collection-concept-id (:concept-id coll1)
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year}))))
+
+      (testing "timeline search with echo-collection-id"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:echo-collection-id (:concept-id coll1)
                                              :start-date "2000-01-01T00:00:00Z"
                                              :end-date "2002-01-01T00:00:00Z"
                                              :interval :year}))))

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
@@ -1,14 +1,16 @@
 (ns cmr.system-int-test.search.granule.granule-timeline-test
   "This tests the granule timeline feature of the search api."
   (:require
-   [clojure.test :refer [are deftest is testing use-fixtures]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [cmr.common.util :refer [are3]]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
    [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.data2.umm-spec-common :as data-umm-cmn]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
-   [cmr.system-int-test.utils.search-util :as search]))
+   [cmr.system-int-test.utils.search-util :as search]
+   [cmr.indexer.data.index-set :as i]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
@@ -328,19 +330,23 @@
                                             {:url-extension "json"}))))
 
       (testing "get and post matches"
-        (are [search-params]
-             (= (search/get-granule-timeline search-params)
-                (search/get-granule-timeline-with-post search-params))
+        (are3
+         [search-params]
+         (is (= (search/get-granule-timeline search-params)
+                (search/get-granule-timeline-with-post search-params)))
 
-          {:concept-id [(:concept-id coll1) (:concept-id coll2)]
-           :start-date "1992-01-01T00:00:00Z"
-           :end-date "2002-02-01T00:00:00Z"
-           :interval :year}
+         "concept-id"
+         {:concept-id [(:concept-id coll1) (:concept-id coll2)]
+          :start-date "1992-01-01T00:00:00Z"
+          :end-date "2002-02-01T00:00:00Z"
+          :interval :year}
 
-          {:entry-title ["Dataset1" "Dataset2"]
-           :start-date "1992-01-01T00:00:00Z"
-           :end-date "2002-02-01T00:00:00Z"
-           :interval :month}))
+         "entry-title"
+         {:entry-title ["Dataset1" "Dataset2"]
+          :start-date "1992-01-01T00:00:00Z"
+          :end-date "2002-02-01T00:00:00Z"
+          :interval :month}))
+      
       (testing "correct headers are returned"
         (let [response (search/get-granule-timeline {:concept-id (:concept-id coll1)
                                                      :start-date "2000-01-01T00:00:00Z"

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
@@ -37,16 +37,16 @@
                                        :ShortName "S1"
                                        :Version "V1"
                                        :TemporalExtents
-                                        [(data-umm-cmn/temporal-extent
-                                           {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
+                                       [(data-umm-cmn/temporal-extent
+                                         {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
         coll2 (d/ingest-umm-spec-collection
                "PROV1"
                (data-umm-c/collection {:EntryTitle "Dataset2"
                                        :ShortName "S2"
                                        :Version "V2"
                                        :TemporalExtents
-                                        [(data-umm-cmn/temporal-extent
-                                           {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
+                                       [(data-umm-cmn/temporal-extent
+                                         {:beginning-date-time "1970-01-01T00:00:00Z"})]}))
         ;; Coll1 granules
         ;; Date range granules
         gran1 (make-gran coll1 1 "2000-02-01T00:00:00Z" "2000-05-01T00:00:00Z")
@@ -80,19 +80,43 @@
     (testing "invalid cases"
       (let [interval-msg (str "Timeline interval is a required parameter for timeline search "
                               "and must be one of year, month, day, hour, minute, or second.")]
-        (testing "missing parameters"
+        (testing "missing timeline parameters"
           (is (= {:status 400
                   :errors ["Parameter [foo] was not recognized."
                            "start_date is a required parameter for timeline searches"
                            "end_date is a required parameter for timeline searches"
                            "interval is a required parameter for timeline searches"]}
-                 (search/get-granule-timeline {:foo 5}))))
+                 (search/get-granule-timeline {:foo 5 :concept-id coll-ids}))))
+
+        (testing "missing collection identifier"
+          (is (= {:status 400
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                 (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
+                                               :end-date "2001-01-01T00:00:00Z"
+                                               :interval :year}))))
+
+        (testing "short-name without version"
+          (is (= {:status 400
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                 (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
+                                               :end-date "2001-01-01T00:00:00Z"
+                                               :interval :year
+                                               :short-name "TEST_COLLECTION"}))))
+
+        (testing "version without short-name"
+          (is (= {:status 400
+                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                 (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
+                                               :end-date "2001-01-01T00:00:00Z"
+                                               :interval :year
+                                               :version "1"}))))
 
         (testing "query validation is run"
           (is (= {:status 400
                   :errors ["The shape contained duplicate points. Points 1 [lon=1 lat=2], 2 [lon=1 lat=2] and 3 [lon=1 lat=2] were considered equivalent or very close."]}
                  (search/get-granule-timeline {:start-date "1994-01-01T00:00:00Z"
                                                :end-date "2001-05-01T00:00:00Z"
+                                               :concept-id coll-ids
                                                :interval :year
                                                :provider "PROV1"
                                                :polygon "1,2,1,2,1,2,1,2"}))))
@@ -101,12 +125,14 @@
           (is (= {:status 400
                   :errors ["Timeline parameter start_date datetime is invalid: [foo] is not a valid datetime."]}
                  (search/get-granule-timeline {:start-date "foo"
+                                               :concept-id coll-ids
                                                :end-date "2000-01-01T00:00:00Z"
                                                :interval :month}))))
         (testing "invalid end-date"
           (is (= {:status 400
                   :errors ["Timeline parameter end_date datetime is invalid: [foo] is not a valid datetime."]}
                  (search/get-granule-timeline {:end-date "foo"
+                                               :concept-id coll-ids
                                                :start-date "2000-01-01T00:00:00Z"
                                                :interval :month}))))
         (testing "invalid interval"
@@ -114,29 +140,78 @@
                   :errors [interval-msg]}
                  (search/get-granule-timeline {:start-date "1999-01-01T00:00:00Z"
                                                :end-date "2000-01-01T00:00:00Z"
+                                               :concept-id coll-ids
                                                :interval :foo}))))
         (testing "start after end"
           (is (= {:status 400
                   :errors ["start_date [2000-01-01T00:00:00Z] must be before the end_date [1999-01-01T00:00:00Z]"]}
                  (search/get-granule-timeline {:end-date "1999-01-01T00:00:00Z"
                                                :start-date "2000-01-01T00:00:00Z"
+                                               :concept-id coll-ids
                                                :interval :month}))))
 
         (testing "missing parameters with post"
           (is (= {:status 400 :errors ["Parameter [foo] was not recognized."
+                                       "Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, entry-id, entry-title, or both short-name and version) to limit the search scope."
                                        "start_date is a required parameter for timeline searches"
                                        "end_date is a required parameter for timeline searches"
                                        "interval is a required parameter for timeline searches"]}
                  (search/get-granule-timeline-with-post {:foo 5}))))))
 
+    (testing "valid collection identifiers"
+      (testing "timeline search with concept-id"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:concept-id (:concept-id coll1)
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year}))))
 
+      (testing "timeline search with collection-concept-id"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:collection-concept-id (:concept-id coll1)
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year}))))
+
+      (testing "timeline search with entry-id"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:entry-id "S1_V1"
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year}))))
+
+      (testing "timeline search with entry-title"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:entry-title "Dataset1"
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year}))))
+
+      (testing "timeline search with short-name and version"
+        (is (= {:status 200
+                :results [{:concept-id (:concept-id coll1)
+                           :intervals [["2000-01-01T00:00:00.000Z" "2002-01-01T00:00:00.000Z" 11]]}]}
+               (search/get-granule-timeline {:short-name "S1"
+                                             :version "V1"
+                                             :start-date "2000-01-01T00:00:00Z"
+                                             :end-date "2002-01-01T00:00:00Z"
+                                             :interval :year})))))
     (testing "multiple collections"
       (is (= {:status 200
               :results [{:concept-id (:concept-id coll1)
                          :intervals [["2000-01-01T00:00:00.000Z" "2001-05-01T00:00:00.000Z" 8]]}
                         {:concept-id (:concept-id coll2)
                          :intervals [["1994-01-01T00:00:00.000Z" "1996-01-01T00:00:00.000Z" 6]]}]}
-             (search/get-granule-timeline {:start-date "1994-01-01T00:00:00Z"
+             (search/get-granule-timeline {:concept-id coll-ids
+                                           :start-date "1994-01-01T00:00:00Z"
                                            :end-date "2001-05-01T00:00:00Z"
                                            :interval :year}))))
 
@@ -257,15 +332,15 @@
              (= (search/get-granule-timeline search-params)
                 (search/get-granule-timeline-with-post search-params))
 
-             {:concept-id [(:concept-id coll1) (:concept-id coll2)]
-              :start-date "1992-01-01T00:00:00Z"
-              :end-date "2002-02-01T00:00:00Z"
-              :interval :year}
+          {:concept-id [(:concept-id coll1) (:concept-id coll2)]
+           :start-date "1992-01-01T00:00:00Z"
+           :end-date "2002-02-01T00:00:00Z"
+           :interval :year}
 
-             {:entry-title ["Dataset1" "Dataset2"]
-              :start-date "1992-01-01T00:00:00Z"
-              :end-date "2002-02-01T00:00:00Z"
-              :interval :month}))
+          {:entry-title ["Dataset1" "Dataset2"]
+           :start-date "1992-01-01T00:00:00Z"
+           :end-date "2002-02-01T00:00:00Z"
+           :interval :month}))
       (testing "correct headers are returned"
         (let [response (search/get-granule-timeline {:concept-id (:concept-id coll1)
                                                      :start-date "2000-01-01T00:00:00Z"


### PR DESCRIPTION
# Overview

### What is the objective?

Granule timeline searches can get expensive for elasticsearch if no collection identifier is supplied as a parameter

### What are the changes?

Added parameter validation for timeline searches which requires concept-id, collection-concept-id, entry-tile, entry-id, or the combination of short-name and version.  An error is returned explaining this when none is supplied.

### What areas of the application does this impact?

Granule timeline searches.

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Granule timeline API now accepts multiple collection identifiers: concept ID, collection concept ID, entry ID, entry title, or short name + version.
- Bug Fixes
  - Enforced validation for timeline searches: start date and a collection identifier are now required, with clearer error messages when missing.
- Documentation
  - API docs updated to detail all supported collection identifier options and clarified guidance on limiting searches to a few collections.
- Tests
  - Expanded coverage for new identifier options and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->