### PR TITLE
CMR-10867: Fix querying by related identifier by allowing users to search for specific values

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -209,7 +209,10 @@
       ;; provider's consortiums contains EOSDIS indicates the colleciton is an EOSDIS record.
       (distinct (conj consortiums "GEOSS"))
       consortiums)))
-
+(comment 
+  (println (:OtherIdentifiers collection))
+  (map :Identifier (:OtherIdentifiers collection))
+  )
 (defn- get-elastic-doc-for-full-collection
   "Get all the fields for a normal collection index operation."
   [context concept collection]
@@ -350,7 +353,12 @@
                                               :HorizontalSpatialDomain
                                               :ResolutionAndCoordinateSystem
                                               :HorizontalDataResolution]))
-        concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))]
+        concept-seq-id (:sequence-number (concepts/parse-concept-id concept-id))
+        identifier (map :Identifier (:OtherIdentifiers collection))
+        identifier-lowercase (map util/safe-lowercase identifier)
+        _ (println "Identifier:" identifier)
+        _ (def collection collection)
+        _ (def concept concept)]
     (merge {:concept-id concept-id
             :doi-stored doi
             :doi-lowercase doi-lowercase
@@ -503,7 +511,9 @@
                                        (sort-by :Date)
                                        first
                                        :Date))
-                                (index-util/date->elastic c))}
+                                (index-util/date->elastic c))
+            :identifier identifier
+            :identifier-lowercase identifier-lowercase}
            (variable-service-tool-associations->elastic-docs
             context variable-associations service-associations tool-associations)
            (collection-temporal-elastic context concept-id collection)

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/keyword.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/keyword.clj
@@ -51,6 +51,7 @@
                      :CollectionPlatforms
                      :ProcessingLevel
                      :Projects
+                     :OtherIdentifiers
                      :RelatedUrls
                      :ScienceKeywords
                      :ShortName

--- a/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/keyword_util.clj
@@ -260,6 +260,7 @@
    :DirectoryNames #(mapcat names->keywords (:DirectoryNames %))
    :LocationKeywords #(lk/location-keywords->spatial-keywords-for-indexing (:LocationKeywords %))
    :Projects #(mapcat names->keywords (:Projects %))
+   :OtherIdentifiers #(map :Identifier (:OtherIdentifiers %))
    :RelatedUrls #(mapcat related-url->keywords (:RelatedUrls %))
    :TilingIdentificationSystems #(map :TilingIdentificationSystemName (:TilingIdentificationSystems %))
    :ArchiveAndDistributionInformation #(archive-distribution-data-formats %)

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -574,7 +574,9 @@
           :horizontal-data-resolutions float-prioritized-mapping
 
           ;; Direct Distribution Information
-          :s3-bucket-and-object-prefix-names m/string-field-mapping}
+          :s3-bucket-and-object-prefix-names m/string-field-mapping
+          :identifier           m/string-field-mapping
+          :identifier-lowercase m/string-field-mapping}
          spatial-coverage-fields))
 
 (declare deleted-granule-mapping)

--- a/schemas/resources/schemas/citation/v1.0.0/config.json
+++ b/schemas/resources/schemas/citation/v1.0.0/config.json
@@ -60,8 +60,9 @@
       "Field": ".RelatedIdentifiers",
       "Name": "Related-Identifier",
       "Mapping": "string",
-      "Indexer": "simple-array-field",
-      "Configuration": {"sub-fields": ["RelatedIdentifier"]}
+      "Indexer": "complex-fields-only",
+      "Configuration": {"sub-fields": ["RelatedIdentifier"],
+                        "format": "%s"}
     },
     {
       "Description": "Related Identifiers with Relationship Types", 

--- a/search-app/src/cmr/search/services/json_parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/json_parameters/conversion.clj
@@ -82,6 +82,7 @@
    :additional-attribute-value :additional-attribute
    :additional-attribute-range :additional-attribute
    :tag :nested-condition
+   :identifier :string
 
    ;; query constructs
    :or :or

--- a/search-app/src/cmr/search/services/parameters/conversion.clj
+++ b/search-app/src/cmr/search/services/parameters/conversion.clj
@@ -81,6 +81,7 @@
    :facets-size :string
    :shapefile :shapefile
    :simplify-shapefile :boolean
+   :identifier :string
 
    ;; Tag parameters
    :tag-data :tag-query

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -44,7 +44,7 @@
                       :processing-level-id-h :sensor :data-center-h :measurement :variable-name
                       :variable-concept-id :variable-native-id :author :service-name :service-type
                       :service-concept-id :tool-name :tool-type :tool-concept-id :granule-data-format
-                      :granule-data-format-h :horizontal-data-resolution-range :latency}
+                      :granule-data-format-h :horizontal-data-resolution-range :latency :identifier}
     :always-case-sensitive #{:echo-collection-id}
     :disallow-pattern #{:echo-collection-id}}))
 
@@ -163,6 +163,7 @@
    :granule-data-format-h cpv/string-plus-and-options
    :grid cpv/string-param-options
    :highlights highlights-option
+   :identifier cpv/string-plus-and-options
    :instrument cpv/string-plus-and-options
    :instrument-h cpv/string-plus-and-options
    :keyword cpv/pattern-option


### PR DESCRIPTION
# Overview

### What is the objective?

Changed how the data is indexed into a specific field so that users can search for a value when multiple values are entered.

### What are the changes?

Changed how the data is indexed into a specific field so that users can search for a value when multiple values are entered.

### What areas of the application does this impact?

Indexing of citation metadata.

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Search collections by identifier (supports multiple values and AND/OR options).
  - Collection records now index identifier and lowercase variants to improve matching and filtering.
  - Other Identifiers are included in keyword extraction for richer discoverability.
  - Related Identifier indexing updated to support complex sub-fields, improving search accuracy and preserving formatting in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->