### PR TITLE
CMR-10867: Fixing being able to search for 1 item out of a list of se…

### DIFF
--- a/schemas/resources/schemas/citation/v1.0.0/config.json
+++ b/schemas/resources/schemas/citation/v1.0.0/config.json
@@ -60,8 +60,9 @@
       "Field": ".RelatedIdentifiers",
       "Name": "Related-Identifier",
       "Mapping": "string",
-      "Indexer": "simple-array-field",
-      "Configuration": {"sub-fields": ["RelatedIdentifier"]}
+      "Indexer": "complex-fields-only",
+      "Configuration": {"sub-fields": ["RelatedIdentifier"],
+                        "format": "%s"}
     },
     {
       "Description": "Related Identifiers with Relationship Types", 


### PR DESCRIPTION
…veral.

# Overview

### What is the objective?

Fixing being able to search for 1 item out of a list of many in 1 field.

### What are the changes?

Fixed how the values for the field are stored in the index.

### What areas of the application does this impact?

indexer citations.

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how Related Identifiers are indexed to improve parsing and representation.
  * Added standardized formatting for Related Identifiers to ensure consistent display.
  * Enabled richer handling of sub-fields within Related Identifiers.

* **User Impact**
  * More accurate and consistent Related Identifier values in search, filters, and record views.
  * Improved reliability when multiple Related Identifiers are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->