### PR TITLE
CMR-9708: Moving the has-granules-or-opensearch to event bridge and bootstrap. 

### DIFF
--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -151,6 +151,9 @@
               (= keyword-cache-name has-granules-or-cwic-results-feature/has-granules-or-cwic-cache-key)
               (has-granules-or-cwic-results-feature/refresh-has-granules-or-cwic-map request-context)
 
+              (= keyword-cache-name has-granules-or-cwic-results-feature/has-granules-or-opensearch-cache-key)
+              (has-granules-or-cwic-results-feature/refresh-has-granules-or-opensearch-map request-context)
+
               (= keyword-cache-name :granule-counts)
               (info "The granule-counts cache is currently being developed.")
 

--- a/bootstrap-app/src/cmr/bootstrap/system.clj
+++ b/bootstrap-app/src/cmr/bootstrap/system.clj
@@ -82,7 +82,10 @@
    (humanizer-report-service/create-humanizer-report-cache-client)
 
    has-gran-or-cwic-results-feature/has-granules-or-cwic-cache-key
-   (has-gran-or-cwic-results-feature/create-has-granules-or-cwic-map-cache)})
+   (has-gran-or-cwic-results-feature/create-has-granules-or-cwic-map-cache)
+
+   has-gran-or-cwic-results-feature/has-granules-or-opensearch-cache-key
+   (has-gran-or-cwic-results-feature/create-has-granules-or-opensearch-map-cache)})
 
 (def jobs-to-schedule
   "Create all the schedules to be added to the sys latter."
@@ -107,10 +110,7 @@
      "bootstrap-humanizer-alias-cache-refresh")
 
     (humanizer-report-service/refresh-humanizer-report-cache-job
-     "bootstrap-humanizer-report-cache-refresh")
-
-    (has-gran-or-cwic-results-feature/refresh-has-granules-or-cwic-map-job
-     "bootstrap-has-granules-or-cwic-map-cache-refresh")]))
+     "bootstrap-humanizer-report-cache-refresh")]))
 
 (defn- attach-startup-tasks
   "Attach processes that need to run after the web service starts up if it has been configured to

--- a/job-utilities/job-details.json
+++ b/job-utilities/job-details.json
@@ -37,5 +37,43 @@
                 "year" : "*"
             }
         }
+    },
+    "RefreshHasGranulesOrCwicMap": {
+        "target" : {
+            "endpoint" : "caches/refresh/has-granules-or-cwic-map",
+            "service" : "bootstrap",
+            "single-target" : true,
+            "request-type" : "POST"
+        },
+        "scheduling" : {
+            "type" : "interval",
+            "timing" : {
+                "minutes" : 10,
+                "hours" : 1,
+                "day-of-month" : "*",
+                "month" : "*",
+                "day-of-week" : "?",
+                "year" : "*"
+            }
+        }
+    },
+    "RefreshHasGranulesOrOpensearchMap": {
+        "target" : {
+            "endpoint" : "caches/refresh/has-granules-or-opensearch-map",
+            "service" : "bootstrap",
+            "single-target" : true,
+            "request-type" : "POST"
+        },
+        "scheduling" : {
+            "type" : "interval",
+            "timing" : {
+                "minutes" : 10,
+                "hours" : 1,
+                "day-of-month" : "*",
+                "month" : "*",
+                "day-of-week" : "?",
+                "year" : "*"
+            }
+        }
     }
 }

--- a/job-utilities/job-details.json
+++ b/job-utilities/job-details.json
@@ -46,13 +46,13 @@
             "request-type" : "POST"
         },
         "scheduling" : {
-            "type" : "interval",
+            "type" : "cron",
             "timing" : {
                 "minutes" : 10,
-                "hours" : 1,
-                "day-of-month" : "*",
+                "hours" : "*",
+                "day-of-month" : "?",
                 "month" : "*",
-                "day-of-week" : "?",
+                "day-of-week" : "*",
                 "year" : "*"
             }
         }
@@ -65,13 +65,13 @@
             "request-type" : "POST"
         },
         "scheduling" : {
-            "type" : "interval",
+            "type" : "cron",
             "timing" : {
                 "minutes" : 10,
-                "hours" : 1,
-                "day-of-month" : "*",
+                "hours" : "*",
+                "day-of-month" : "?",
                 "month" : "*",
-                "day-of-week" : "?",
+                "day-of-week" : "*",
                 "year" : "*"
             }
         }

--- a/job-utilities/test/test_eventbridge_schedule/test_deploy_schedule.py
+++ b/job-utilities/test/test_eventbridge_schedule/test_deploy_schedule.py
@@ -95,7 +95,7 @@ class TestDeploySchedule(unittest.TestCase):
         with self.assertRaises(SystemExit):
             deploy_schedule.get_environment()
 
-    @patch('boto3.client')
+    @patch('eventbridge_schedule.deploy_schedule.boto3')
     @patch('builtins.open', new_callable=mock_open, read_data=json.dumps(test_job_data))
     @patch.dict(os.environ, {"CMR_ENVIRONMENT": "test"})
     def test_get_function_client_error(self, _mock_file, mock_client):
@@ -105,7 +105,7 @@ class TestDeploySchedule(unittest.TestCase):
         get_function_mock = Mock()
         get_function_mock.get_function.side_effect = ClientError(test_error_response, "get_function")
 
-        mock_client.return_value = get_function_mock
+        mock_client.client.return_value = get_function_mock
 
         deploy_schedule.environment = "test"
 

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -33,7 +33,7 @@
                                    :primary-connection (redis-config/redis-conn-opts)}))
 
 (defn get-cwic-collections
-  "Returns any CWIC collections and sets the the granule count to 1 so that these collections
+  "Returns any CWIC collections and sets the granule count to 1 so that these collections
   are included with the query."
   [context]
   (let [condition (qm/string-conditions :consortiums ["CWIC"])
@@ -47,7 +47,7 @@
             [coll-id 1]))))
 
 (defn get-opensearch-collections
-  "Returns any Opensearch collections and sets the the granule count to 1 so that these collections
+  "Returns any Opensearch collections and sets the granule count to 1 so that these collections
   are included with the query."
   [context]
   (let [condition (gc/or-conds (map #(qm/string-conditions :consortiums [%])

--- a/search-app/src/cmr/search/system.clj
+++ b/search-app/src/cmr/search/system.clj
@@ -119,7 +119,7 @@
                       context-augmenter/token-user-id-cache-name (context-augmenter/create-token-user-id-cache)
                       :has-granules-map (hgrf/create-has-granules-map-cache)
                       hgocrf/has-granules-or-cwic-cache-key (hgocrf/create-has-granules-or-cwic-map-cache)
-                      :has-granules-or-opensearch-map (hgocrf/create-has-granules-or-opensearch-map-cache)
+                      hgocrf/has-granules-or-opensearch-cache-key (hgocrf/create-has-granules-or-opensearch-map-cache)
                       metadata-transformer/xsl-transformer-cache-name (mem-cache/create-in-memory-cache)
                       acl/token-imp-cache-key (acl/create-token-imp-cache)
                       acl/token-pc-cache-key (acl/create-token-pc-cache)
@@ -146,7 +146,6 @@
                          `system-holder
                          [(af/refresh-acl-cache-job "search-acl-cache-refresh")
                           hgrf/refresh-has-granules-map-job
-                          hgocrf/refresh-has-granules-or-opensearch-map-job
                           (metadata-cache/refresh-collections-metadata-cache-job)
                           (metadata-cache/update-collections-metadata-cache-job)
                           (cache-info/create-log-cache-info-job "search")

--- a/search-app/test/cmr/search/test/unit/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/test/cmr/search/test/unit/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -1,0 +1,71 @@
+(ns cmr.search.test.unit.services.query-execution.has-granules-or-cwic-results-feature 
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cmr.common.util :refer [are3]]
+   [cmr.search.services.query-execution.has-granules-or-cwic-results-feature :as hgocrf]))
+
+ (deftest create-granules-or-cwic-map-test
+   (let [context nil]
+      (are3 [expected get-collection-granule-counts-fn get-cwic-collections-fn]
+            (is (= expected (hgocrf/create-has-granules-or-cwic-map
+                             context
+                             get-collection-granule-counts-fn
+                             get-cwic-collections-fn)))
+
+            "No collection granules counts and no cwic collections"
+            {}
+            (fn [_context] {})
+            (fn [_context] {})
+
+            "with collection granule count and no cwic collections"
+            {"C1234-PROV1" true "C1235-PROV2" true}
+            (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+            (fn [_context] {})
+
+            "with collection granule count and with cwic collections"
+            {"C1234-PROV1" true "C1235-PROV2" true "C1236-PROV1" true "C1237-PROV2" true}
+            (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+            (fn [_context] {"C1236-PROV1" 10 "C1237-PROV2" 20})
+
+            "no collection granule count and with cwic collections"
+            {"C1236-PROV1" true "C1237-PROV2" true}
+            (fn [_context] {})
+            (fn [_context] {"C1236-PROV1" 10 "C1237-PROV2" 20})
+
+            "with collection granule count and with cwic collections with same values"
+            {"C1234-PROV1" true "C1235-PROV2" true}
+            (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+            (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20}))))
+
+(deftest create-granules-or-opensearch-map-test
+  (let [context nil]
+    (are3 [expected get-collection-granule-counts-fn get-opensearch-collections-fn]
+          (is (= expected (hgocrf/create-has-granules-or-opensearch-map
+                           context
+                           get-collection-granule-counts-fn
+                           get-opensearch-collections-fn)))
+
+          "No collection granules counts and no opensearch collections"
+          {}
+          (fn [_context] {})
+          (fn [_context] {})
+
+          "with collection granule count and no opensearch collections"
+          {"C1234-PROV1" true "C1235-PROV2" true}
+          (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+          (fn [_context] {})
+
+          "with collection granule count and with opensearch collections"
+          {"C1234-PROV1" true "C1235-PROV2" true "C1236-PROV1" true "C1237-PROV2" true}
+          (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+          (fn [_context] {"C1236-PROV1" 10 "C1237-PROV2" 20})
+
+          "no collection granule count and with opensearch collections"
+          {"C1236-PROV1" true "C1237-PROV2" true}
+          (fn [_context] {})
+          (fn [_context] {"C1236-PROV1" 10 "C1237-PROV2" 20})
+
+          "with collection granule count and with opensearch collections with same values"
+          {"C1234-PROV1" true "C1235-PROV2" true}
+          (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20})
+          (fn [_context] {"C1234-PROV1" 10 "C1235-PROV2" 20}))))

--- a/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
+++ b/system-int-test/test/cmr/system_int_test/admin/cache_api_test.clj
@@ -196,31 +196,33 @@
            (let [response (list-cache-keys (url/bootstrap-read-caches-url) "token-imp" admin-read-token)]
              (is (every? (set response)
                          [["ABC-1" "read"]
-                          ["ABC-2" "read"]])))))) (testing "normal user cannot retrieve cache values"
-                                                    (are [url]
-                                                         (let [response (client/request {:url url
-                                                                                         :method :get
-                                                                                         :query-params {:token normal-user-token}
-                                                                                         :connection-manager (s/conn-mgr)
-                                                                                         :throw-exceptions false})
-                                                               errors (:errors (json/decode (:body response) true))]
-                                                           (is (= 401 (:status response)))
-                                                           (is (= ["You do not have permission to perform that action."] errors)))
-                                                      (str (url/indexer-read-caches-url) "/acls/acls")
-                                                      (str (url/mdb-read-caches-url) "/acls/acls")
-                                                      (str (url/access-control-read-caches-url) "/acls/acls")
-                                                      (str (url/ingest-read-caches-url) "/acls/acls")
-                                                      (str (url/search-read-caches-url) "/acls/acls"))
-                                                    (s/only-with-real-database
-                                                     (testing "normal user cannot retrieve cache values for bootstrap"
-                                                       (let [response (client/request {:url (url/bootstrap-read-caches-url)
-                                                                                       :method :get
-                                                                                       :query-params {:token normal-user-token}
-                                                                                       :connection-manager (s/conn-mgr)
-                                                                                       :throw-exceptions false})
-                                                             errors (:errors (json/decode (:body response) true))]
-                                                         (is (= 401 (:status response)))
-                                                         (is (= ["You do not have permission to perform that action."] errors))))))
+                          ["ABC-2" "read"]]))))))
+
+    (testing "normal user cannot retrieve cache values"
+      (are [url]
+            (let [response (client/request {:url url
+                                            :method :get
+                                            :query-params {:token normal-user-token}
+                                            :connection-manager (s/conn-mgr)
+                                            :throw-exceptions false})
+                  errors (:errors (json/decode (:body response) true))]
+              (is (= 401 (:status response)))
+              (is (= ["You do not have permission to perform that action."] errors)))
+         (str (url/indexer-read-caches-url) "/acls/acls")
+         (str (url/mdb-read-caches-url) "/acls/acls")
+         (str (url/access-control-read-caches-url) "/acls/acls")
+         (str (url/ingest-read-caches-url) "/acls/acls")
+         (str (url/search-read-caches-url) "/acls/acls"))
+       (s/only-with-real-database
+        (testing "normal user cannot retrieve cache values for bootstrap"
+          (let [response (client/request {:url (url/bootstrap-read-caches-url)
+                                          :method :get
+                                          :query-params {:token normal-user-token}
+                                          :connection-manager (s/conn-mgr)
+                                          :throw-exceptions false})
+                errors (:errors (json/decode (:body response) true))]
+            (is (= 401 (:status response)))
+            (is (= ["You do not have permission to perform that action."] errors))))))
 
     (testing "retrieval of value for non-existent key results in a 404"
       (let [response (client/request {:url (str (url/indexer-read-caches-url)

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_counts_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_counts_search_test.clj
@@ -1,20 +1,16 @@
 (ns cmr.system-int-test.search.granule.granule-counts-search-test
   "This tests the granule counts search feature which allows retrieving counts of granules per collection."
   (:require
-   [clojure.test :refer :all]
+   [clojure.test :refer [are deftest is testing use-fixtures]]
    [cmr.common.util :as util :refer [are3]]
-   [cmr.common-app.config :as common-config]
    [cmr.spatial.codec :as codec]
    [cmr.spatial.mbr :as m]
    [cmr.spatial.point :as p]
    [cmr.spatial.polygon :as poly]
    [cmr.system-int-test.data2.collection :as dc]
-   [cmr.mock-echo.client.echo-util :as e]
-   [cmr.system-int-test.system :as s]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
    [cmr.system-int-test.data2.granule-counts :as gran-counts]
-   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]


### PR DESCRIPTION
# Overview

### What is the objective?

Move the has-granules-or-opensearch cache from search to AWS eventbridge and bootstrap so that only 1 process refreshes the cache and it offloads the search app from having to do it.

### What are the changes?

Move the has-granules-or-opensearch cache from search to AWS eventbridge and bootstrap so that only 1 process refreshes the cache and it offloads the search app from having to do it.

### What areas of the application does this impact?

Search, Bootstrap, and Job_Utilities

# Required Checklist

- [X] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Cache refresh endpoint now supports the "has granules or OpenSearch" cache key.

- Refactor
  - Has-granules maps moved to a Redis-backed, on-demand creation approach; legacy periodic refresh jobs removed.

- Chores
  - Added scheduled refresh tasks for CWIC and OpenSearch maps; scheduler registrations updated/trimmed across systems.

- Tests
  - Added unit tests for map-creation logic and updated integration/mocking around caching and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->