### PR TITLE
CMR-10874: Update granule timeline search API doc and make the validation error message match the API doc parameters.

### DIFF
--- a/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
+++ b/metadata-db-app/src/cmr/metadata_db/data/oracle/concepts.clj
@@ -653,7 +653,6 @@
     :else
     (let [table (tables/get-table-name provider :granule)
           ;; Oracle caps IN clause at 1000, so chunk the IDs
-          ;; This is only theoretical, it is unlikely we will get close to even 100.
           batches (partition-all 900 granule-concept-ids)]
       (->> batches
            (mapcat

--- a/search-app/docs/api.md
+++ b/search-app/docs/api.md
@@ -2966,10 +2966,11 @@ It supports all normal granule parameters. It requires the following parameters.
   * **Collection identifier** - One of the following parameters must be provided to specify which collection(s) to search:
     * `concept_id` - Collection concept id.
     * `collection_concept_id` - Collection concept id.
+    * `echo_collection_id` - Collection concept id.
     * `entry_id` - Collection entry id (concatenation of short_name and version).
     * `entry_title` - Collection entry title.
     * `short_name` and `version` - Both parameters must be provided together to identify a specific collection.
-  
+
   It is recommended that the timeline search be limited to a few collections for good performance.
 
 The response format is in JSON. Intervals are returned as tuples containing three numbers like `[949363200,965088000,4]`. The two numbers are the start and stop date of the interval represented by the number of seconds since the epoch. The third number is the number of granules within that interval.

--- a/search-app/src/cmr/search/services/parameters/parameter_validation.clj
+++ b/search-app/src/cmr/search/services/parameters/parameter_validation.clj
@@ -795,7 +795,7 @@
                 (:entry-title params)
                 (:echo-collection-id params)
                 (and (:short-name params) (:version params)))
-    ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]))
+    ["Timeline searches must include a collection identifier parameter (concept_id, collection_concept_id, echo_collection_id, entry_id, entry_title, or both short_name and version) to limit the search scope."]))
 
 (defn- timeline-start-date-validation
   "Validates the timeline start date parameter"

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_timeline_test.clj
@@ -92,14 +92,14 @@
 
         (testing "missing collection identifier"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept_id, collection_concept_id, echo_collection_id, entry_id, entry_title, or both short_name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year}))))
 
         (testing "short-name without version"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept_id, collection_concept_id, echo_collection_id, entry_id, entry_title, or both short_name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year
@@ -107,7 +107,7 @@
 
         (testing "version without short-name"
           (is (= {:status 400
-                  :errors ["Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."]}
+                  :errors ["Timeline searches must include a collection identifier parameter (concept_id, collection_concept_id, echo_collection_id, entry_id, entry_title, or both short_name and version) to limit the search scope."]}
                  (search/get-granule-timeline {:start-date "2000-01-01T00:00:00Z"
                                                :end-date "2001-01-01T00:00:00Z"
                                                :interval :year
@@ -154,7 +154,7 @@
 
         (testing "missing parameters with post"
           (is (= {:status 400 :errors ["Parameter [foo] was not recognized."
-                                       "Timeline searches must include a collection identifier parameter (concept-id, collection-concept-id, echo-collection-id, entry-id, entry-title, or both short-name and version) to limit the search scope."
+                                       "Timeline searches must include a collection identifier parameter (concept_id, collection_concept_id, echo_collection_id, entry_id, entry_title, or both short_name and version) to limit the search scope."
                                        "start_date is a required parameter for timeline searches"
                                        "end_date is a required parameter for timeline searches"
                                        "interval is a required parameter for timeline searches"]}
@@ -355,7 +355,7 @@
           :start-date "1992-01-01T00:00:00Z"
           :end-date "2002-02-01T00:00:00Z"
           :interval :month}))
-      
+
       (testing "correct headers are returned"
         (let [response (search/get-granule-timeline {:concept-id (:concept-id coll1)
                                                      :start-date "2000-01-01T00:00:00Z"


### PR DESCRIPTION
# Overview

### What is the objective?

The all granule search issue documented in the ticket is fixed by part of the code changes added in CMR-10871. The core issue is now OBE. This PR just updated the api doc for granule timeline search parameter validation and error message to make them match.

### What are the changes?

CMR search api doc is updated to add echo_collection_id and the validation error message is updated to match API doc.

### What areas of the application does this impact?

CMR search. Some of the tests can be run locally to verify the fix:
With granule time-line-test data, 
verify regular timeline search works:
curl -i "http://localhost:3003/granules/timeline?dataset_id=Dataset1&start_date=2000-01-01T00:00:00Z&end_date=2002-02-01T00:00:00.000Z&interval=month"

verify granule search is skipped when granule timeline search found no matching collection using collection identifiers:
curl -i "http://localhost:3003/granules/timeline?dataset_id=Data1&start_date=2000-01-01T00:00:00Z&end_date=2002-02-01T00:00:00.000Z&interval=month" 
The logs has message: `This is a granule search with MatchNone condition, skip querying ES.`.

Verify granule timeline search parameter validation error message match parameter name in API doc:
curl -i "http://localhost:3003/granules/timeline?datasetid=Dataset1&start_date=2000-01-01T00:00:00Z&end_date=2002-02-01T00:00:00.000Z&interval=month"

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
