### PR TITLE
CMR-10945: Address Selmer vulnerability.

### DIFF
--- a/other/cmr-exchange/http-kit-support/project.clj
+++ b/other/cmr-exchange/http-kit-support/project.clj
@@ -30,7 +30,7 @@
                  [org.clojure/clojure "1.11.2"]
                  [org.clojure/data.xml "0.2.0-alpha5"]
                  [ring/ring-defaults "0.3.4"]
-                 [selmer "1.12.5"]
+                 [selmer "1.12.65"]
                  [tolitius/xml-in "0.1.0"]
                  [commons-fileupload "1.6.0"]
                  [commons-io "2.20.0"]]

--- a/other/cmr-exchange/service-bridge/project.clj
+++ b/other/cmr-exchange/service-bridge/project.clj
@@ -57,7 +57,7 @@
                  [ring/ring-core "1.14.2"]
                  [ring/ring-codec "1.3.0"]
                  [ring/ring-defaults "0.3.4"]
-                 [selmer "1.12.12"]
+                 [selmer "1.12.65"]
                  [tolitius/xml-in "0.1.0"]]
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
              "-Xms2g"


### PR DESCRIPTION
# Overview

### What is the objective?

This PR will make service-bridge free of vulnerabilities according to our Snyk reporting.

### What are the changes?

Address Selmer security vulnerability in service-bridge

### What areas of the application does this impact?

service bridge

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library dependencies to their latest stable versions across supported modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->