### PR TITLE
CMR-11007: Fix Reshard to work with Generic and All Generic indexes

### DIFF
--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -221,6 +221,13 @@
       (is (= {:name "collection_index" :number_of_shards 3}
              (#'svc/get-index-config index-set :collection "collection_index")))))
 
+  (testing "returns index config when found resharded index"
+    (let [index-set {:index-set
+                     {:collection
+                      {:indexes [{:name "collection_index" :number_of_shards 3}]}}}]
+      (is (= {:name "collection_index" :number_of_shards 3}
+             (#'svc/get-index-config index-set :collection "collection_index_2_shards")))))
+
   (testing "returns nil when index name not found"
     (let [index-set {:index-set
                      {:granule


### PR DESCRIPTION
# Overview

### What is the objective?

Add support to reshard generic concepts.

### What are the changes?

Fix get-canonical-key-name to handle all concept types including generic concepts.
Preserve the settings other than num_shards of the original index in the resharded index.

### What areas of the application does this impact?

CMR indexer

### Test locally
1. Create some generic concepts locally, e.g.
(ltest/run-test #'cmr.system-int-test.search.misc.generic-association-test/test-collection-and-generic-association)
Use kibana to verify the default `1_all_generic_grid_revisions` index exists and it has 5 shards and 1 document indexed.
Verify the `1_all_generic_grid_revisions_alias` is pointing to `1_all_generic_grid_revisions` index.

2. Verify resharding the generic index run successfully
curl -i -XPOST -H "Authorization: mock-echo-system-token" "http://localhost:3006/reshard/1_all_generic_grid_revisions/start?num_shards=2"

3. Check generic index resharding status is successful
curl -i -H "Authorization: mock-echo-system-token" "http://localhost:3006/reshard/1_all_generic_grid_revisions/status"

4. Verify finalize generic index resharding run successfully
curl -i -XPOST -H "Authorization: mock-echo-system-token" "http://localhost:3006/reshard/1_all_generic_grid_revisions/finalize"
Use kibana to verify the default `1_all_generic_grid_revisions` index does not exist. It is being replaced by `1_all_generic_grid_revisions_2_shards` which has 2 shards and 1 document indexed.

Verify the `1_all_generic_grid_revisions_alias` is pointing to `1_all_generic_grid_revisions_2_shards` index.
Feel free to retrieve the index-set and verify all the settings and mapping on the `1_all_generic_grid_revisions_2_shards` index is correct.

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced index naming normalization with improved pattern recognition for special index types
  * Improved index configuration selection logic for better accuracy
  * Optimized resharding process with enhanced state management and metadata tracking

* **Tests**
  * Added test coverage for canonical naming validation scenarios
  * Added test cases for resharded index configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->