### PR TITLE
Revert "CMR-10838: Find all references to get-collection-granule-counts and c…"

### DIFF
--- a/search-app/src/cmr/search/data/elastic_search_index.clj
+++ b/search-app/src/cmr/search/data/elastic_search_index.clj
@@ -179,3 +179,46 @@
            (into {} (for [hit (get-in results [:hits :hits])]
                       [(:_id hit) (get-in hit [:_source :permitted-group-ids])]))))
 
+(defn get-collection-granule-counts
+  "Returns the collection granule count by searching elasticsearch by aggregation"
+  [context provider-ids]
+  (let [condition (if (seq provider-ids)
+                    (qm/string-conditions :provider-id provider-ids true)
+                    qm/match-all)
+        query (qm/query {:concept-type :granule
+                         :condition condition
+                         :page-size 0
+                         :aggregations {:by-provider
+                                        {:terms {:field (q2e/query-field->elastic-field
+                                                         :provider-id :granule)
+                                                 :size 10000}
+                                         :aggs {:by-collection-id
+                                                {:terms {:field (q2e/query-field->elastic-field
+                                                                 :collection-concept-seq-id-long
+                                                                 :granule)
+                                                         :size 10000}}}}}})
+        results (common-esi/execute-query context query)
+        extra-provider-count (get-in results [:aggregations :by-provider :sum_other_doc_count])]
+    ;; It's possible that there are more providers with granules than we expected.
+    ;; :sum_other_doc_count will be greater than 0 in that case.
+    (when (> extra-provider-count 0)
+      (e/internal-error! "There were [%s] more providers with granules than we ever expected to see."))
+
+    (into {} (for [provider-bucket (get-in results [:aggregations :by-provider :buckets])
+                   :let [extra-collection-count (get-in provider-bucket [:by-collection-id :sum_other_doc_count])]
+                   coll-bucket (get-in provider-bucket [:by-collection-id :buckets])
+                   :let [provider-id (:key provider-bucket)
+                         coll-seq-id (:key coll-bucket)
+                         num-granules (:doc_count coll-bucket)]]
+               (do
+                 ;; It's possible that there are more collections in the provider than we expected.
+                 ;; :sum_other_doc_count will be greater than 0 in that case.
+                 (when (> extra-collection-count 0)
+                   (e/internal-error!
+                    (format "Provider %s has more collections ([%s]) with granules than we support"
+                            provider-id extra-collection-count)))
+
+                 [(concepts/build-concept-id {:sequence-number coll-seq-id
+                                              :provider-id provider-id
+                                              :concept-type :collection})
+                  num-granules])))))

--- a/search-app/src/cmr/search/data/granule_counts_cache.clj
+++ b/search-app/src/cmr/search/data/granule_counts_cache.clj
@@ -1,12 +1,12 @@
 (ns cmr.search.data.granule-counts-cache
   (:require
+   [cmr.common.log :as log]
    [cmr.common.cache :as cache]
    [cmr.common.concepts :as concepts]
-   [cmr.common.log :as log]
    [cmr.common.services.errors :as e]
    [cmr.common.services.search.query-model :as qm]
-   [cmr.elastic-utils.search.es-index :as common-esi]
    [cmr.elastic-utils.search.es-query-to-elastic :as q2e]
+   [cmr.elastic-utils.search.es-index :as common-esi]
    [cmr.redis-utils.config :as redis-config]
    [cmr.redis-utils.redis-cache :as redis-cache]))
 
@@ -88,13 +88,6 @@
   ([context provider-ids]
    (get-granule-counts context provider-ids get-collection-granule-counts))
   ([context provider-ids get-collection-granule-counts-fn]
-   (let [cache (cache/context->cache context granule-counts-cache-key)
-         all-counts (cache/get-value cache
-                                     granule-counts-cache-key
-                                     #(get-collection-granule-counts-fn context nil))]
-     (if (seq provider-ids)
-       (into {} (filter (fn [[k _]]
-                          (some #(= (concepts/concept-id->provider-id k) %) provider-ids))
-                        all-counts))
-       all-counts))))
-
+   (cache/get-value (cache/context->cache context granule-counts-cache-key)
+                    granule-counts-cache-key
+                    #(get-collection-granule-counts-fn context provider-ids))))

--- a/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
+++ b/search-app/src/cmr/search/services/query_execution/has_granules_or_cwic_results_feature.clj
@@ -10,7 +10,7 @@
    [cmr.elastic-utils.search.es-index :as common-esi]
    [cmr.redis-utils.config :as redis-config]
    [cmr.redis-utils.redis-cache :as redis-cache]
-   [cmr.search.data.granule-counts-cache :as granule-counts-cache]))
+   [cmr.search.data.elastic-search-index :as idx]))
 
 (def has-granules-or-cwic-cache-key
   :has-granules-or-cwic-map)
@@ -79,7 +79,7 @@
   "Gets the granule counts for all collections. This function exists so that this function
   can be replaced for testing purposes."
   [context]
-  (granule-counts-cache/get-granule-counts context))
+  (idx/get-collection-granule-counts context nil))
 
 (defn create-has-granules-or-cwic-map
   "Creates the has granules or cwic map by combining all collections

--- a/search-app/src/cmr/search/services/query_service.clj
+++ b/search-app/src/cmr/search/services/query_service.clj
@@ -28,7 +28,7 @@
    [cmr.elastic-utils.search.es-params-converter :as common-params]
    [cmr.elastic-utils.search.query-execution :as qe]
    [cmr.search.api.core :refer [log-search-result-metadata]]
-   [cmr.search.data.granule-counts-cache :as granule-counts-cache]
+   [cmr.search.data.elastic-search-index :as idx]
    [cmr.search.data.metadata-retrieval.metadata-cache :as metadata-cache]
    [cmr.search.results-handlers.provider-holdings :as ph]
    [cmr.search.services.aql.conversion :as a]
@@ -39,11 +39,12 @@
    [cmr.search.services.parameters.provider-short-name :as psn]
    [cmr.search.services.result-format-helper :as rfh]
    [cmr.spatial.codec :as spatial-codec]
-   [cmr.spatial.tile :as tile]
-   ;; These must be required here to make multimethod implementations available.
-   ;; XXX This is not a good pattern for large software systems; we need to
-   ;;     find a different way to accomplish this goal ... possibly use protocols
-   ;;     instead.
+   [cmr.spatial.tile :as tile])
+  ;; These must be required here to make multimethod implementations available.
+  ;; XXX This is not a good pattern for large software systems; we need to
+  ;;     find a different way to accomplish this goal ... possibly use protocols
+  ;;     instead.
+  (:require
    cmr.search.data.complex-to-simple-converters.attribute
    cmr.search.data.complex-to-simple-converters.has-granules
    cmr.search.data.complex-to-simple-converters.has-granules-or-cwic
@@ -391,7 +392,7 @@
         ;; get all collections limited by the list of providers in json format
         collections (get-collections-by-providers context provider-ids true)
         ;; get a mapping of collection to granule count
-        collection-granule-count (granule-counts-cache/get-granule-counts context provider-ids)
+        collection-granule-count (idx/get-collection-granule-counts context provider-ids)
         ;; combine the granule count into collections to form provider holdings
         provider-holdings (map
                            #(assoc % :granule-count (get

--- a/search-app/test/cmr/search/test/unit/data/granule_counts_cache_test.clj
+++ b/search-app/test/cmr/search/test/unit/data/granule_counts_cache_test.clj
@@ -7,68 +7,46 @@
 
 (use-fixtures :once test-util/embedded-redis-server-fixture)
 
-(def collection-granule-counts-mock-data
-  {"C1-PROV1" 10, "C2-PROV1" 20})
-
-(defn mock-get-collection-granule-counts
-  "This is a test mock function to mock getting granule counts from elastic search."
-  [& _]
-  collection-granule-counts-mock-data)
-
-(defn setup-test-cache
-  "Helper function to set up the test context and cache."
-  []
-  (let [cache-key granule-counts-cache/granule-counts-cache-key
-        test-context {:system {:caches {cache-key (granule-counts-cache/create-granule-counts-cache-client)}}}
-        granule-counts-cache (get-in test-context [:system :caches cache-key])]
-    (cache/reset granule-counts-cache)
-    {:test-context test-context
-     :cache granule-counts-cache
-     :cache-key cache-key}))
-
 (deftest create-cache-test
   (testing "Creation of granule counts cache"
     (let [gc-cache (granule-counts-cache/create-granule-counts-cache-client)]
       (is (some? gc-cache) "Cache should not be nil")
       (is (satisfies? cache/CmrCache gc-cache) "Cache should satisfy the CmrCache protocol"))))
 
-(deftest granule-count-retrieval-and-caching-test
-  (let [{:keys [test-context cache cache-key]} (setup-test-cache)]
-    (testing "Cache is empty initially"
-      (is (nil? (cache/get-value cache cache-key))))
+(def collection-granule-counts-mock-data
+  {"C1-PROV1" 10, "C2-PROV1" 20})
 
-    (testing "Granule count retrieval with provider filtering"
-      (granule-counts-cache/refresh-granule-counts-cache test-context mock-get-collection-granule-counts)
+(defn mock-get-collection-granule-counts
+  "This is a test mock function to mock getting granule counts from elastic search."
+  [_context _provider-ids]
+  collection-granule-counts-mock-data)
 
-      (testing "Retrieve all granule counts"
-        (let [result (granule-counts-cache/get-granule-counts test-context nil mock-get-collection-granule-counts)]
-          (is (= collection-granule-counts-mock-data result))))
-
-      (testing "Retrieve granule counts for specific provider"
-        (let [result (granule-counts-cache/get-granule-counts test-context ["PROV1"] mock-get-collection-granule-counts)]
-          (is (= {"C1-PROV1" 10, "C2-PROV1" 20} result))))
-
-      (testing "Retrieve granule counts for non-existent provider"
-        (let [result (granule-counts-cache/get-granule-counts test-context ["PROV3"] mock-get-collection-granule-counts)]
-          (is (= {} result)))))
-
-    (testing "Cache operations"
-      (testing "Add to the cache"
-        (let [granule-counts {"C1200000022-PROV1" 2, "C1200000066-PROV1" 1}]
-          (is (cache/set-value cache cache-key granule-counts))))
-
-      (testing "Retrieve granule counts from cache"
-        (is (= {"C1200000022-PROV1" 2, "C1200000066-PROV1" 1}
-               (cache/get-value cache cache-key))))
-
-      (testing "Clear the cache"
-        (cache/reset cache)
-        (is (nil? (cache/get-value cache cache-key)))))))
+(deftest next-cache-test
+  (testing "Granule count cache operations"
+   (let [cache-key granule-counts-cache/granule-counts-cache-key
+         test-context {:system {:caches {cache-key (granule-counts-cache/create-granule-counts-cache-client)}}}
+         granule-counts-cache (get-in test-context [:system :caches cache-key])]
+     (cache/reset granule-counts-cache)
+     (testing "Cache is empty initially"
+       (is (nil? (cache/get-value granule-counts-cache cache-key))))
+     (testing "Did cache reload using get-granule-counts"
+       (is (= collection-granule-counts-mock-data (granule-counts-cache/get-granule-counts test-context nil mock-get-collection-granule-counts))))
+     (testing "Add to the cache"
+       (let [granule-counts {"C1200000022-PROV1" 2, "C1200000066-PROV1" 1}]
+         (is (cache/set-value granule-counts-cache cache-key granule-counts))))
+     (testing "Retrieve granule counts from cache"
+       (is (= {"C1200000022-PROV1" 2, "C1200000066-PROV1" 1}
+              (cache/get-value granule-counts-cache cache-key))))
+     (testing "Clear the cache"
+       (cache/reset granule-counts-cache)
+       (is (nil? (cache/get-value granule-counts-cache cache-key)))))))
 
 (deftest refresh-test
-  (let [{:keys [test-context cache cache-key]} (setup-test-cache)]
-    (testing "Refreshing granule counts cache"
-      (granule-counts-cache/refresh-granule-counts-cache test-context mock-get-collection-granule-counts)
-      (let [cached-value (cache/get-value cache cache-key)]
+  (testing "Refreshing granule counts cache"
+    (let [cache-key granule-counts-cache/granule-counts-cache-key
+          test-context {:system {:caches {cache-key (granule-counts-cache/create-granule-counts-cache-client)}}}]
+      (granule-counts-cache/refresh-granule-counts-cache test-context #(mock-get-collection-granule-counts test-context nil))
+      (let [cache (get-in test-context [:system :caches cache-key])
+            cached-value (cache/get-value cache cache-key)]
         (is (= collection-granule-counts-mock-data cached-value)
             "Cache should be updated with mock granule counts after refresh")))))


### PR DESCRIPTION
Reverts nasa/Common-Metadata-Repository#2329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized granule count retrieval mechanism to use Elasticsearch aggregations directly, enabling more efficient provider-scoped and collection-specific queries.
  * Simplified cache retrieval logic by passing provider filters at query time rather than post-processing results.

* **Tests**
  * Updated test suite to align with new granule count retrieval path and cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->