### PR TITLE
CMR-10801: As a metadata steward, I should not get a CMR validation error for a keyword long name when it’s not provided and not required

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/collection/collection_keyword_validation_test.clj
@@ -474,6 +474,60 @@
           "Case Insensitive"
           "Atm" "aIRBORNE Topographic Mapper"))
 
+  (testing "Blank and 'Not provided' long names should not cause validation errors"
+    (testing "Platform with 'Not provided' long name should be valid"
+      (assert-valid-keywords
+        {:Platforms [(data-umm-cmn/platform {:ShortName "CESSNA 188"
+                                             :LongName "Not provided"
+                                             :Type "Propeller"})]}))
+
+    (testing "Instrument with 'Not provided' long name should be valid"
+      (assert-valid-keywords
+        {:Platforms
+         [(data-umm-cmn/platform
+            {:ShortName "A340-600"
+             :LongName "Airbus A340-600"
+             :Type "Jet"
+             :Instruments [(data-umm-cmn/instrument {:ShortName "ACOUSTIC SOUNDERS"
+                                                     :LongName "Not provided"})]})]}))
+
+    (testing "Project with 'Not provided' long name should be valid"
+      (assert-valid-keywords
+        {:Projects [(assoc (data-umm-cmn/project "EUCREX-94" "") :LongName "Not provided")]}))
+
+    (testing "Invalid long names with valid short names should still fail validation"
+      (testing "Platform with invalid long name should fail"
+        (assert-invalid-keywords
+          {:Platforms [(data-umm-cmn/platform {:ShortName "CESSNA 188"
+                                               :LongName "Invalid Long Name"
+                                               :Type "Propeller"})]}
+          ["Platforms" 0]
+          [(format (str "Platform short name [%s], long name [%s], and type [%s]"
+                        " was not a valid keyword combination.")
+                   "CESSNA 188" "Invalid Long Name" "Propeller")]))
+
+      (testing "Instrument with invalid long name should fail"
+        (assert-invalid-keywords
+          {:Platforms
+           [(data-umm-cmn/platform
+              {:ShortName "A340-600"
+               :LongName "Airbus A340-600"
+               :Type "Jet"
+               :Instruments [(data-umm-cmn/instrument {:ShortName "ACOUSTIC SOUNDERS"
+                                                       :LongName "Invalid Long Name"})]})]}
+          ["Platforms" 0 "Instruments" 0]
+          [(format (str "Instrument short name [%s] and long name [%s]"
+                        " was not a valid keyword combination.")
+                   "ACOUSTIC SOUNDERS" "Invalid Long Name")]))
+
+      (testing "Project with invalid long name should fail"
+        (assert-invalid-keywords
+          {:Projects [(assoc (data-umm-cmn/project "EUCREX-94" "") :LongName "Invalid Long Name")]}
+          ["Projects" 0]
+          [(format (str "Project short name [%s] and long name [%s]"
+                        " was not a valid keyword combination.")
+                   "EUCREX-94" "Invalid Long Name")]))))
+
   (testing "Science Keyword validation"
     (are [attribs]
          (let [sk (data-umm-cmn/science-keyword attribs)]


### PR DESCRIPTION
# Overview

### What is the objective?

Fix KMS keyword validation to properly handle "Not provided" as a valid long-name value for Platforms, Instruments, and Projects. Previously, only nil long-names were handled correctly - any non-nil value (including "Not provided") would fail validation if the KMS entry lacked a long-name field.

### What are the changes?

- Added skip-long-name-validation? helper function that treats nil, empty strings, and "Not provided" (case-insensitive, with trimming) as equivalent
- Refactored long-name validation logic into a new lookup-by-umm-c-keyword-with-long-name function that:
    - Removes long-name from comparison when it should be skipped
    - Removes long-name from KMS index keys during lookup to enable matching on remaining fields
    - Supports optional transform functions for keyword-specific transformations
- Added dedicated lookup functions for Instruments and Projects (previously used default path)
- Updated Platforms lookup to use the new shared helper function

### What areas of the application does this impact?

common-app-lib: KMS keyword lookup service and validation logic)

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyword lookup support for instruments and projects in collection metadata.

* **Bug Fixes**
  * Improved handling to skip or ignore missing, blank, or "Not provided" long-name values for platforms, instruments, and projects so matching and validation behave correctly.

* **Tests**
  * Expanded test coverage for long-name scenarios (nil, blank, "Not provided", invalid) to ensure correct matching and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->