### PR TITLE
Revert "CMR-10969: Cache failed LP token validation"

### DIFF
--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -137,11 +137,6 @@
    a locally generated EDL test jwk and is used in token unit tests"
   {:default "\n    {\n      \"kty\": \"RSA\",\n      \"n\": \"xSxiOkM8m8oCyWn-sNNZxBVTUcPAlhXRjKpLTYIM21epMC9rqEnrgL7iuntmp3UcffOIKtFHOtCG-jWUkyzxZHPPMo0kYZVHKRjGj-AVAy3FA-d2AtUc1dPlrQ0TpdDoTzew_6-48BcbdFEQI3161wcMoy40unYYYfzo3KuUeNcCY3cmHzSkYn4iQHaBy5zTAzKTIcYCTpaBGDk4_IyuysvaYmgwdeNO26hNV9dmPx_rWgYZYlashXZ_kRLirDaGpnJJHyPrYaEJpMIWuIfsh_UoMjsyuoQGe4XU6pG8uNnUd31mHa4VU78cghGZGrCz_YkPydfFlaX65LBp9aLdCyKkA66pDdnCkm8odVMgsH2x_kGM7sNlQ6ELTsT-dtJoiEDI_z3fSZehLw469QpTGQjfsfXUCYm8QrGckJF4bJc935TfGU86qr2Ik2YoipP_L4K_oqUf8i6bwO0iomo_C7Ukr4l-dh4D5O7szAb9Ga804OZusFk3JENlc1-RlB20S--dWrrO-v_L8WI2d72gizOKky0Xwzd8sseEqfMWdktyeKoaW0ANkBJHib4E0QxgedeTca0DH_o0ykMjOZLihOFtvDuCsbHG3fv41OQr4qRoX97QO2Hj1y3EBYtUEypan46g-fUyLCt-sYP66RkBYzCJkikCbzF_ECBDgX314_0\",\n      \"e\": \"AQAB\",\n      \"kid\": \"edljwtpubkey_development\"\n}"})
 
-(declare invalid-token-timeout)
-(defconfig invalid-token-timeout
-  "Number of minutes to keep invalid tokens in the cache."
-  {:default 5})
-
 (defn mins->ms
   "Returns the number of minutes in milliseconds"
   [mins]


### PR DESCRIPTION
Reverts nasa/Common-Metadata-Repository#2354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed invalid-token-timeout configuration option
  * Simplified token authentication and caching workflow for improved performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->