### PR TITLE
CMR-10969: Cache failed LP token validation

### DIFF
--- a/transmit-lib/src/cmr/transmit/config.clj
+++ b/transmit-lib/src/cmr/transmit/config.clj
@@ -137,6 +137,12 @@
    a locally generated EDL test jwk and is used in token unit tests"
   {:default "\n    {\n      \"kty\": \"RSA\",\n      \"n\": \"xSxiOkM8m8oCyWn-sNNZxBVTUcPAlhXRjKpLTYIM21epMC9rqEnrgL7iuntmp3UcffOIKtFHOtCG-jWUkyzxZHPPMo0kYZVHKRjGj-AVAy3FA-d2AtUc1dPlrQ0TpdDoTzew_6-48BcbdFEQI3161wcMoy40unYYYfzo3KuUeNcCY3cmHzSkYn4iQHaBy5zTAzKTIcYCTpaBGDk4_IyuysvaYmgwdeNO26hNV9dmPx_rWgYZYlashXZ_kRLirDaGpnJJHyPrYaEJpMIWuIfsh_UoMjsyuoQGe4XU6pG8uNnUd31mHa4VU78cghGZGrCz_YkPydfFlaX65LBp9aLdCyKkA66pDdnCkm8odVMgsH2x_kGM7sNlQ6ELTsT-dtJoiEDI_z3fSZehLw469QpTGQjfsfXUCYm8QrGckJF4bJc935TfGU86qr2Ik2YoipP_L4K_oqUf8i6bwO0iomo_C7Ukr4l-dh4D5O7szAb9Ga804OZusFk3JENlc1-RlB20S--dWrrO-v_L8WI2d72gizOKky0Xwzd8sseEqfMWdktyeKoaW0ANkBJHib4E0QxgedeTca0DH_o0ykMjOZLihOFtvDuCsbHG3fv41OQr4qRoX97QO2Hj1y3EBYtUEypan46g-fUyLCt-sYP66RkBYzCJkikCbzF_ECBDgX314_0\",\n      \"e\": \"AQAB\",\n      \"kid\": \"edljwtpubkey_development\"\n}"})
 
+(declare invalid-token-timeout)
+(defconfig invalid-token-timeout
+  "Number of minutes to keep invalid tokens in the cache."
+  {:type Long
+   :default 5})
+
 (defn mins->ms
   "Returns the number of minutes in milliseconds"
   [mins]

--- a/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
+++ b/transmit-lib/src/cmr/transmit/launchpad_user_cache.clj
@@ -9,6 +9,7 @@
    [cmr.common.services.errors :as errors]
    [cmr.common.time-keeper :as time-keeper]
    [cmr.common.util :as common-util]
+   [cmr.transmit.config :as transmit-config]
    [cmr.transmit.urs :as urs]))
 
 (def launchpad-user-cache-key
@@ -26,14 +27,22 @@
 
 (defn get-launchpad-user
   "Get the launchpad user from the cache, uses token as key on miss.
-  Expiration time is calculated via the response from EDL and saved in the cache."
+  Expiration time is calculated via the response from EDL and saved in the cache.
+  Failed validations are also cached to prevent repeated requests with bad tokens."
   [context token]
   (let [get-launchpad-user-fn (fn []
-                                (when-let [resp (urs/get-launchpad-user context token)]
-                                  (assoc resp :expiration-time (-> (or (:lp_token_expires_in resp)
-                                                                       (/ LAUNCHPAD_USER_CACHE_TIME 1000))
-                                                                   (t/seconds)
-                                                                   (t/from-now)))))]
+                                (try
+                                  (let [resp (urs/get-launchpad-user context token)]
+                                    (assoc resp
+                                           :expiration-time (-> (or (:lp_token_expires_in resp)
+                                                                    (/ LAUNCHPAD_USER_CACHE_TIME 1000))
+                                                                (t/seconds)
+                                                                (t/from-now))
+                                           :valid true))
+                                  (catch Exception e
+                                    {:valid false
+                                     :error-message (.getMessage e)
+                                     :expiration-time (t/plus (time-keeper/now) (t/minutes (transmit-config/invalid-token-timeout)))})))]
     (if-let [cache (cache/context->cache context launchpad-user-cache-key)]
       (let [token-info (cache/get-value cache (keyword (str (hash token))) get-launchpad-user-fn)]
         (if (t/before? (:expiration-time token-info) (time-keeper/now))
@@ -44,5 +53,18 @@
              :unauthorized
              (format "Launchpad token (partially redacted) [%s] has expired."
                      (common-util/scrub-token token))))
-          token-info))
-      (get-launchpad-user-fn))))
+          (if (:valid token-info)
+            token-info
+            (errors/throw-service-error
+             :unauthorized
+             (or (:error-message token-info)
+                 (format "Invalid Launchpad token (partially redacted) [%s]"
+                         (common-util/scrub-token token)))))))
+      (let [result (get-launchpad-user-fn)]
+        (if (:valid result)
+          result
+          (errors/throw-service-error
+           :unauthorized
+           (or (:error-message result)
+               (format "Invalid Launchpad token (partially redacted) [%s]"
+                       (common-util/scrub-token token)))))))))


### PR DESCRIPTION
(NOTE -- this is the second PR for this ticket whose previous merge was reverted. Additional change is Long type for defconfig which was messing up build.)

# Overview

### What is the objective?

Cache failed LP token validations, in addition to successful ones, in order to prevent sending additional requests for the same bad token to URS.

### What are the changes?

Now caches failed validations as well. Altered the structure saved in the LP token cache so that it has a top level key indicating valid/invalid. Expiration remains unchanged for valid tokens. For invalid tokens expiration is currently set to 5 min by default on a new defconfig.

### What areas of the application does this impact?

transmit lib

# Required Checklist

- [ x] New and existing unit and int tests pass locally and remotely
- [ x] clj-kondo has been run locally and all errors in changed files are corrected
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new configuration setting to control how long invalid tokens are retained in the cache (default: 5 minutes).

* **Bug Fixes**
  * Improved token validation and caching: failed validations are now cached briefly with an expiration, successful validations record expiry and validity, and subsequent requests consistently use stored validity and error messages to surface authorization outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->