### PR TITLE
CMR-10889: add wildcard type Elasticsearch field mappings for granules

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/index_util.clj
@@ -18,6 +18,9 @@
 (def string-field-mapping
   {:type "keyword"})
 
+(def wildcard-field-mapping
+  {:type "wildcard"})
+
 (def search-as-you-type-field-mapping
   {:type "search_as_you_type"})
 

--- a/indexer-app/src/cmr/indexer/data/concepts/granule.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/granule.clj
@@ -194,8 +194,13 @@
 
             :granule-ur granule-ur
             :granule-ur-lowercase (string/lower-case granule-ur)
+            :granule-ur-wildcard granule-ur
+            :granule-ur-lowercase-wildcard (string/lower-case granule-ur)
             :producer-gran-id producer-gran-id
             :producer-gran-id-lowercase (when producer-gran-id (string/lower-case producer-gran-id))
+            :producer-granule-id-wildcard producer-gran-id
+            :producer-granule-id-lowercase-wildcard (when producer-gran-id
+                                                      (string/lower-case producer-gran-id))
             :day-night day-night
             :day-night-doc-values day-night
             :day-night-lowercase (when day-night (string/lower-case day-night))

--- a/indexer-app/src/cmr/indexer/data/index_set.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set.clj
@@ -676,9 +676,13 @@
 
     :granule-ur m/string-field-mapping
     :granule-ur-lowercase (m/doc-values m/string-field-mapping)
+    :granule-ur-wildcard m/wildcard-field-mapping
+    :granule-ur-lowercase-wildcard m/wildcard-field-mapping
 
     :producer-gran-id m/string-field-mapping
     :producer-gran-id-lowercase (m/doc-values m/string-field-mapping)
+    :producer-granule-id-wildcard m/wildcard-field-mapping
+    :producer-granule-id-lowercase-wildcard m/wildcard-field-mapping
 
     :day-night m/string-field-mapping
     :day-night-doc-values (m/doc-values m/string-field-mapping)

--- a/system-int-test/resources/index_set_granule_mapping.clj
+++ b/system-int-test/resources/index_set_granule_mapping.clj
@@ -4,6 +4,7 @@
  :end-coordinate-1 {:type "double"}
  :mbr-crosses-antimeridian {:type "boolean"}
  :granule-ur {:type "keyword"}
+ :granule-ur-wildcard {:type "wildcard"}
  :revision-id {:type "integer"}
  :orbit-end-clat-doc-values {:type "double", :doc_values true}
  :end-direction {:type "keyword"}
@@ -55,6 +56,8 @@
  :production-date {:type "date", :doc_values true}
  :entry-title-lowercase {:type "keyword"}
  :producer-gran-id-lowercase {:type "keyword", :doc_values true}
+ :producer-granule-id-wildcard {:type "wildcard"}
+ :producer-granule-id-lowercase-wildcard {:type "wildcard"}
  :orbit-asc-crossing-lon {:type "double"}
  :mbr-south {:type "float"}
  :feature-id {:type "keyword"}
@@ -82,6 +85,7 @@
  :size {:type "double"}
  :orbit-end-clat {:type "double"}
  :granule-ur-lowercase {:type "keyword", :doc_values true}
+ :granule-ur-lowercase-wildcard {:type "wildcard"}
  :project-refs {:type "keyword"}
  :mbr-east-doc-values {:type "float", :doc_values true}
  :lr-east-doc-values {:type "float", :doc_values true}


### PR DESCRIPTION
# Overview

### What is the objective?

Adds new wildcard-type fields to granule index mappings

### What are the changes?

Adds new wildcard-type fields to granule index mappings:
- granule-ur-wildcard
- granule-ur-lowercase-wildcard
- producer-granule-id-wildcard
- producer-granule-id-lowercase-wildcard

These fields will be populated during indexing but not yet used by search. After this merges, granule indices must be reindexed before CMR-10891 (search changes) can merge.

### What areas of the application does this impact?

indexer-app

# Required Checklist

- [x ] New and existing unit and int tests pass locally and remotely
- [x ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wildcard pattern matching support for granule identifiers, enabling more flexible search queries on granule URIs and producer granule IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->