### PR TITLE
CMR-11243: Update netty codec http and http2

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -15,8 +15,9 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "2.3.0"] ;;behind other cmr projects
                  [clj-time]
-                 [io.netty/netty-handler "4.1.125.Final"]
-                 [io.netty/netty-codec-http "4.1.125.Final"]
+                 [io.netty/netty-handler "4.1.132.Final"]
+                 [io.netty/netty-codec-http "4.1.132.Final"]
+                 [io.netty/netty-codec-http2 "4.1.132.Final"]
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]


### PR DESCRIPTION
# Overview

### What is the objective?

Update netty deps

### What are the changes?

Update netty deps

### What areas of the application does this impact?

All

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network communication library dependencies to the latest stable version.
  * Added HTTP/2 codec support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->