### PR TITLE
CMR-10891: Add wildcard type fields support for search behind feature flag

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/config.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/config.clj
@@ -103,6 +103,15 @@
   {:type Boolean
    :default false})
 
+(declare enable-wildcard-field-searches)
+(defconfig enable-wildcard-field-searches
+  "When true, pattern searches (wildcards) will use dedicated Elasticsearch
+   wildcard-type fields for improved performance. When false, pattern searches
+   will use the standard keyword fields. This should be enabled only after all
+   indices have been reindexed to populate the wildcard fields."
+  {:default false
+   :type Boolean})
+
 (defn gran-elastic-config
   "Returns the elastic config as a map"
   []

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_query_to_elastic.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_query_to_elastic.clj
@@ -57,8 +57,8 @@
   [query-str]
   (fix-double-escapes
    (string/replace query-str
-                query-string-reserved-characters-regex
-                "\\\\$1")))
+                   query-string-reserved-characters-regex
+                   "\\\\$1")))
 
 (defprotocol ConditionToElastic
   "Defines a function to map from a query to elastic search query"
@@ -145,6 +145,40 @@
   (get (field->lowercase-field-mappings concept-type) (keyword field)
        (str (name field) "-lowercase")))
 
+(defmulti field->wildcard-field-mappings
+  "Mapping of query model field names to Elasticsearch wildcard field names."
+  (fn [concept-type]
+    concept-type))
+
+(defmethod field->wildcard-field-mappings :default
+  [_]
+  ;; No field mappings specified by default
+  {})
+
+(defn field->wildcard-field
+  "Maps a field name to the name of the wildcard field to use within elastic.
+  If a mapping is not present it defaults to the regular elastic field."
+  [concept-type field]
+  (get (field->wildcard-field-mappings concept-type) (keyword field)
+       (query-field->elastic-field field concept-type)))
+
+(defmulti field->lowercase-wildcard-field-mappings
+  "Mapping of query model field names to Elasticsearch lowercase wildcard field names."
+  (fn [concept-type]
+    concept-type))
+
+(defmethod field->lowercase-wildcard-field-mappings :default
+  [_]
+  ;; No field mappings specified by default
+  {})
+
+(defn field->lowercase-wildcard-field
+  "Maps a field name to the name of the lowercase wildcard field to use within elastic.
+  If a mapping is not present it defaults to the lowercase field for the field."
+  [concept-type field]
+  (get (field->lowercase-wildcard-field-mappings concept-type) (keyword field)
+       (field->lowercase-field concept-type field)))
+
 (defn- range-condition->elastic
   "Convert a range condition to an elastic search condition. Execution
   should either by 'fielddata' or 'index'."
@@ -206,9 +240,15 @@
   cmr.common.services.search.query_model.StringCondition
   (condition->elastic
     [{:keys [field value case-sensitive? pattern?]} concept-type]
-    (let [field (if case-sensitive?
-                  (query-field->elastic-field field concept-type)
-                  (field->lowercase-field concept-type field))
+    (let [field (if (and pattern? (config/enable-wildcard-field-searches))
+                  ;; New behavior: use dedicated wildcard fields for pattern searches
+                  (if case-sensitive?
+                    (field->wildcard-field concept-type field)
+                    (field->lowercase-wildcard-field concept-type field))
+                  ;; Original behavior: use standard fields
+                  (if case-sensitive?
+                    (query-field->elastic-field field concept-type)
+                    (field->lowercase-field concept-type field)))
           value (if case-sensitive? value (string/lower-case value))]
       (if pattern?
         {:wildcard {field value}}

--- a/search-app/src/cmr/search/data/query_to_elastic.clj
+++ b/search-app/src/cmr/search/data/query_to_elastic.clj
@@ -306,6 +306,19 @@
       (merge default-mappings query-field->lowercase-granule-doc-values-fields-map)
       default-mappings)))
 
+(defmethod q2e/field->wildcard-field-mappings :granule
+  [_]
+  {:granule-ur :granule-ur-wildcard
+   ;; Both aliases below are needed because pre-existing granule queries use both names.
+   :producer-gran-id :producer-granule-id-wildcard
+   :producer-granule-id :producer-granule-id-wildcard})
+
+(defmethod q2e/field->lowercase-wildcard-field-mappings :granule
+  [_]
+  {:granule-ur "granule-ur-lowercase-wildcard"
+   :producer-gran-id "producer-granule-id-lowercase-wildcard"
+   :producer-granule-id "producer-granule-id-lowercase-wildcard"})
+
 (defn- keywords-in-query
   "Returns a list of keywords if the query contains a keyword condition or nil if not.
   Used to set sort and use function score for keyword queries."
@@ -396,7 +409,7 @@
                                       (string/replace #"^\"" "* ")
                                       (string/replace #"\"$" " *")
                                       (string/replace #"\\\"" "\""))
-                       :field :keyword-phrase)
+             :field :keyword-phrase)
       (if (and query-str
                (string/includes? trimmed-query-str "\\\""))
         (assoc condition :query-str (string/replace trimmed-query-str #"\\\"" "\""))
@@ -412,21 +425,21 @@
     ;;Need the original query here because when the query-str is quoted, it's processed differently.
     (let [keywords (keywords-in-query query)]
       (if-let [all-keywords (seq (concat (:keywords keywords) (:field-keywords keywords)))]
-       (do
-        (validate-keyword-wildcards all-keywords)
+        (do
+          (validate-keyword-wildcards all-keywords)
         ;; Forces score to be returned even if not sorting by score.
-        {:track_scores true
+          {:track_scores true
          ;; function_score query allows us to compute a custom relevance score for each document
          ;; matched by the primary query. The final document relevance is given by multiplying
          ;; a boosting term for each matching filter in a set of filters.
-         :query {:function_score {:score_mode :multiply
-                                  :functions (k2e/keywords->boosted-elastic-filters keywords boosts)
-                                  :query {:bool {:must (eq/match-all)
-                                                 :filter core-query}}}}})
-       (if boosts
-         (errors/throw-service-errors :bad-request ["Relevance boosting is only supported for keyword queries"])
-         {:query {:bool {:must (eq/match-all)
-                         :filter core-query}}})))))
+           :query {:function_score {:score_mode :multiply
+                                    :functions (k2e/keywords->boosted-elastic-filters keywords boosts)
+                                    :query {:bool {:must (eq/match-all)
+                                                   :filter core-query}}}}})
+        (if boosts
+          (errors/throw-service-errors :bad-request ["Relevance boosting is only supported for keyword queries"])
+          {:query {:bool {:must (eq/match-all)
+                          :filter core-query}}})))))
 
 ;; this only needs to map overrides, defaults to one-to-one mappings
 (defmethod q2e/concept-type->sort-key-map :collection

--- a/search-app/test/cmr/search/test/unit/data/query_to_elastic_converters/granule_wildcard_fields.clj
+++ b/search-app/test/cmr/search/test/unit/data/query_to_elastic_converters/granule_wildcard_fields.clj
@@ -1,0 +1,88 @@
+(ns cmr.search.test.unit.data.query-to-elastic-converters.granule-wildcard-fields
+  "Tests wildcard field selection for granule string searches."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.common.services.search.query-model :as qm]
+   [cmr.elastic-utils.config :as elastic-config]
+   [cmr.elastic-utils.search.es-params-converter :as params]
+   [cmr.elastic-utils.search.es-query-to-elastic :as q2e]
+   ;; Require namespaces for their multimethod registrations used by the converters under test.
+   [cmr.search.data.query-to-elastic]
+   ;; Require parameter conversion methods so parameter->condition dispatch is available in this test.
+   [cmr.search.services.parameters.conversion]))
+
+(deftest granule-string-condition-field-selection-test
+  (with-redefs [elastic-config/enable-wildcard-field-searches (constantly true)]
+    (testing "granule-ur exact search uses lowercase keyword field"
+      (is (= {:term {"granule-ur-lowercase" "granule1"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Granule1" false false)
+              :granule))))
+    (testing "granule-ur wildcard search uses wildcard field"
+      (is (= {:wildcard {"granule-ur-lowercase-wildcard" "gran*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Gran*" false true)
+              :granule))))
+    (testing "producer-granule-id exact search uses lowercase keyword field"
+      (is (= {:term {"producer-gran-id-lowercase" "producer1"}}
+             (q2e/condition->elastic
+              (qm/string-condition :producer-granule-id "Producer1" false false)
+              :granule))))
+    (testing "producer-granule-id wildcard search uses wildcard field"
+      (is (= {:wildcard {"producer-granule-id-lowercase-wildcard" "prod*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :producer-granule-id "Prod*" false true)
+              :granule))))
+    (testing "case-sensitive wildcard search uses the case-sensitive wildcard field"
+      (is (= {:wildcard {:producer-granule-id-wildcard "Prod*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :producer-granule-id "Prod*" true true)
+              :granule))))))
+
+(deftest readable-granule-name-wildcard-field-selection-test
+  (with-redefs [elastic-config/enable-wildcard-field-searches (constantly true)]
+    (let [condition (params/parameter->condition
+                     nil
+                     :granule
+                     :readable-granule-name
+                     "Gran*"
+                     {:readable-granule-name {:pattern "true"}})]
+      (is (= {:bool {:should [{:wildcard {"granule-ur-lowercase-wildcard" "gran*"}}
+                              {:wildcard {"producer-granule-id-lowercase-wildcard" "gran*"}}]
+                     :minimum_should_match 1}}
+             (q2e/condition->elastic condition :granule))))))
+
+(deftest wildcard-field-feature-toggle-test
+  (testing "when feature toggle is enabled, wildcard searches use wildcard fields"
+    (with-redefs [elastic-config/enable-wildcard-field-searches (constantly true)]
+      (is (= {:wildcard {"granule-ur-lowercase-wildcard" "gran*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Gran*" false true)
+              :granule)))
+      (is (= {:wildcard {:producer-granule-id-wildcard "Prod*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :producer-granule-id "Prod*" true true)
+              :granule)))))
+
+  (testing "when feature toggle is disabled, wildcard searches use standard fields"
+    (with-redefs [elastic-config/enable-wildcard-field-searches (constantly false)]
+      (is (= {:wildcard {"granule-ur-lowercase" "gran*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Gran*" false true)
+              :granule)))
+      (is (= {:wildcard {:granule-ur "Gran*"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Gran*" true true)
+              :granule)))))
+
+  (testing "exact (non-pattern) searches are not affected by the toggle"
+    (with-redefs [elastic-config/enable-wildcard-field-searches (constantly true)]
+      (is (= {:term {"granule-ur-lowercase" "granule1"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Granule1" false false)
+              :granule))))
+    (with-redefs [elastic-config/enable-wildcard-field-searches (constantly false)]
+      (is (= {:term {"granule-ur-lowercase" "granule1"}}
+             (q2e/condition->elastic
+              (qm/string-condition :granule-ur "Granule1" false false)
+              :granule))))))


### PR DESCRIPTION
# Overview

### What is the objective?

Adds support for using Elasticsearch wildcard-type fields for granule wildcard searches, gated behind a feature flag so the behavior can be enabled only after the relevant indices are reindexed.

### What are the changes?

* Add feature flag defconfig `enable-wildcard-field-searches` -- when enabled, granule pattern searches now target dedicated wildcard fields for granule-ur and producer-granule-id, with separate case-sensitive and lowercase mappings. When the flag is disabled, wildcard searches continue using the existing standard fields, preserving prior behavior. Exact non-pattern searches are unchanged.

* Adds wildcard-field mapping helpers in elastic-utils-lib, granule-specific wildcard mappings in search-app, and unit coverage for enabled and disabled toggle behavior, including readable granule name handling.

### What areas of the application does this impact?

search-app, elastic-utils-lib

# Required Checklist

- [x ] New and existing unit and int tests pass locally and remotely
- [x ] clj-kondo has been run locally and all errors in changed files are corrected
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option (disabled by default) to use dedicated wildcard fields for pattern searches, improving wildcard-search behavior.
  * Granule searches can now target these wildcard-specific field variants when the option is enabled.

* **Tests**
  * Added unit tests verifying correct field selection for pattern vs exact granule searches and toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->