### PR TITLE
CMR-11270: reshard preserves _version

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/es_helper.clj
@@ -127,7 +127,8 @@
   "Copies the contents of one index into another. Used for resharding."
   [conn source-index target-index]
   (let [body {"source" {:index source-index}
-              "dest" {:index target-index}}
+              "dest" {:index target-index
+                      :version_type "external_gte"}}
         url (str (rest/url-with-path conn "_reindex") "?wait_for_completion=false")]
     (rest/post-string conn url
                       {:body (json/encode body)

--- a/elastic-utils-lib/test/cmr/elastic_utils/test/elastic_results_to_query_results.clj
+++ b/elastic-utils-lib/test/cmr/elastic_utils/test/elastic_results_to_query_results.clj
@@ -1,0 +1,16 @@
+(ns cmr.elastic-utils.test.elastic-results-to-query-results
+  (:require
+   [clojure.test :refer :all]
+   [cmr.elastic-utils.search.es-results-to-query-results :as es-results]
+   ;; Load multimethod implementations for concept-type-specific revision-id extraction.
+   [cmr.elastic-utils.search.elastic-results-to-query-results]))
+
+(deftest granule-revision-id-defaults-to-elastic-version
+  (let [elastic-result {:_version 1
+                        :_source {:revision-id 2}}]
+    (is (= 1 (es-results/get-revision-id-from-elastic-result :granule elastic-result)))))
+
+(deftest collection-revision-id-comes-from-stored-source-field
+  (let [elastic-result {:_version 1
+                        :_source {:revision-id 3}}]
+    (is (= 3 (es-results/get-revision-id-from-elastic-result :collection elastic-result)))))

--- a/system-int-test/test/cmr/system_int_test/search/citation/citation_reshard_revision_lookup_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/citation/citation_reshard_revision_lookup_test.clj
@@ -1,82 +1,109 @@
-(ns cmr.system-int-test.search.collection.collection-reshard-revision-lookup-test
-  "Verifies collection search behavior after resharding when an older DB revision has been removed."
+(ns cmr.system-int-test.search.citation.citation-reshard-revision-lookup-test
+  "Verifies citation search behavior after resharding when an older DB revision has been removed."
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
-   [cmr.system-int-test.data2.core :as d]
-   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
    [cmr.system-int-test.utils.elastic-util :as es-util]
-   [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.metadata-db-util :as mdb]
    [cmr.system-int-test.utils.search-util :as search]))
 
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
 
-(deftest ^:oracle collection-umm-json-search-after-reshard-with-missing-old-db-revision
-  (let [collections-index-name "1_collections_v2"
-        resharded-index-name (str collections-index-name "_2_shards")
-        entry-title "reshard-collection"
-        collection-r1 (d/ingest-umm-spec-collection
-                       "PROV1"
-                       (data-umm-c/collection
-                        {:ShortName "RESHARD"
-                         :Version "1"
-                         :EntryTitle entry-title}))
-        collection-r2 (d/ingest-umm-spec-collection
-                       "PROV1"
-                       (data-umm-c/collection
-                        {:ShortName "RESHARD"
-                         :Version "1"
-                         :EntryTitle entry-title
-                         :Abstract "updated"}))
-        concept-id (:concept-id collection-r2)]
+(defn- create-citation-document
+  [provider-id native-id name identifier identifier-type & [optional-fields]]
+  (let [doc (merge
+             {:Name name
+              :Identifier identifier
+              :IdentifierType identifier-type
+              :ResolutionAuthority "https://doi.org"
+              :MetadataSpecification
+              {:URL "https://cdn.earthdata.nasa.gov/generics/citation/v1.0.0"
+               :Name "Citation"
+               :Version "1.0.0"}}
+             optional-fields)]
+    (ingest/ingest-concept
+     {:provider-id provider-id
+      :concept-type :citation
+      :native-id native-id
+      :format "application/json"
+      :metadata (json/generate-string doc)})))
+
+(deftest ^:oracle citation-umm-json-search-after-reshard-with-missing-old-db-revision
+  (let [citation-index-name "1_generic_citation"
+        resharded-index-name (str citation-index-name "_2_shards")
+        native-id "reshard-citation"
+        identifier "10.5067/RESHARD-CITATION"
+        citation-r1 (create-citation-document
+                     "PROV1"
+                     native-id
+                     "Reshard Citation"
+                     identifier
+                     "DOI"
+                     {:CitationMetadata
+                      {:Title "Reshard Citation"
+                       :Year 2024
+                       :Type "journal-article"}})
+        concept-id (:concept-id citation-r1)
+        citation-r2 (create-citation-document
+                     "PROV1"
+                     native-id
+                     "Reshard Citation Updated"
+                     identifier
+                     "DOI"
+                     {:CitationMetadata
+                      {:Title "Reshard Citation Updated"
+                       :Year 2025
+                       :Type "journal-article"}})]
     (index/wait-until-indexed)
 
     (testing "sanity check before removing the old DB revision"
-      (let [json-response (search/find-concepts-json :collection {:concept-id concept-id})
-            umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})]
+      (let [json-response (search/find-concepts-json :citation {:concept-id concept-id})
+            umm-json-response (search/find-concepts-umm-json :citation {:concept-id concept-id})]
         (is (= 1 (:hits json-response)) (pr-str json-response))
         (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
         (is (= 1 (count (get-in umm-json-response [:results :items]))))
         (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
 
-    ;; This simulates the post-cleanup production state where the collection's superseded
+    ;; This simulates the post-cleanup production state where the citation's superseded
     ;; revision is gone from metadata-db, but the latest revision still exists.
-    (is (= 200 (:status (mdb/force-delete-concept concept-id (:revision-id collection-r1)))))
-    (is (nil? (mdb/get-concept concept-id (:revision-id collection-r1))))
-    (is (= 2 (:revision-id (mdb/get-concept concept-id (:revision-id collection-r2)))))
+    (is (= 200 (:status (mdb/force-delete-concept concept-id (:revision-id citation-r1)))))
+    (is (nil? (mdb/get-concept concept-id (:revision-id citation-r1))))
+    (is (= 2 (:revision-id (mdb/get-concept concept-id (:revision-id citation-r2)))))
 
     (testing "sanity check before resharding"
-      (let [json-response (search/find-concepts-json :collection {:concept-id concept-id})
-            umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})]
+      (let [json-response (search/find-concepts-json :citation {:concept-id concept-id})
+            umm-json-response (search/find-concepts-umm-json :citation {:concept-id concept-id})]
         (is (= 1 (:hits json-response)) (pr-str json-response))
         (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
         (is (= 1 (count (get-in umm-json-response [:results :items]))))
         (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
 
-    (let [original-doc (es-util/get-doc collections-index-name concept-id "elastic")
+    (let [original-doc (es-util/get-doc citation-index-name concept-id "elastic")
           start-reshard-response (bootstrap/start-reshard-index
-                                  collections-index-name
+                                  citation-index-name
                                   {:synchronous true
                                    :num-shards 2
                                    :elastic-name "elastic"})
           task-id (:task-id start-reshard-response)
           _ (bootstrap/wait-for-reshard-complete
-             collections-index-name
+             citation-index-name
              "elastic"
              task-id
              {})
           finalize-reshard-response (bootstrap/finalize-reshard-index
-                                     collections-index-name
+                                     citation-index-name
                                      {:synchronous true
                                       :elastic-name "elastic"})
           resharded-doc (es-util/get-doc resharded-index-name concept-id "elastic")
-          json-response (search/find-concepts-json :collection {:concept-id concept-id})
-          umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})
+          json-response (search/find-concepts-json :citation {:concept-id concept-id})
+          umm-json-response (search/find-concepts-umm-json :citation {:concept-id concept-id})
           umm-json-items (get-in umm-json-response [:results :items])]
       (is (= 200 (:status start-reshard-response)) (pr-str start-reshard-response))
       (is (= 2 (get-in original-doc [:_source :revision-id])) (pr-str original-doc))
+      (is (= 2 (:_version original-doc)) (pr-str original-doc))
       (is (= (:_version original-doc) (:_version resharded-doc))
           (pr-str {:original-es-version (:_version original-doc)
                    :resharded-es-version (:_version resharded-doc)
@@ -84,8 +111,8 @@
       (is (= 200 (:status finalize-reshard-response)) (pr-str finalize-reshard-response))
       (is (= 2 (get-in resharded-doc [:_source :revision-id])) (pr-str resharded-doc))
 
-      ;; Collections look up revision-id from the stored source field, but
-      ;; resharding should still preserve the elastic version consistently.
+      ;; Citations use the generic UMM JSON handler, which reads revision-id from
+      ;; the elastic result to fetch the latest metadata-db revision.
       (is (= 1 (:hits json-response)) (pr-str json-response))
       (is (= 200 (:status umm-json-response))
           (pr-str {:umm-json-response umm-json-response

--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_reshard_revision_lookup_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_reshard_revision_lookup_test.clj
@@ -1,0 +1,105 @@
+(ns cmr.system-int-test.search.collection.collection-reshard-revision-lookup-test
+  "Verifies collection search behavior after resharding when an older DB revision has been removed."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
+   [cmr.system-int-test.utils.elastic-util :as es-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(deftest ^:oracle collection-umm-json-search-after-reshard-with-missing-old-db-revision
+  (let [collections-index-name "1_collections_v2"
+        resharded-index-name (str collections-index-name "_2_shards")
+        entry-title "reshard-collection"
+        collection-r1 (d/ingest-umm-spec-collection
+                       "PROV1"
+                       (data-umm-c/collection
+                        {:ShortName "RESHARD"
+                         :Version "1"
+                         :EntryTitle entry-title}))
+        collection-r2 (d/ingest-umm-spec-collection
+                       "PROV1"
+                       (data-umm-c/collection
+                        {:ShortName "RESHARD"
+                         :Version "1"
+                         :EntryTitle entry-title
+                         :Abstract "updated"}))
+        concept-id (:concept-id collection-r2)]
+    (index/wait-until-indexed)
+
+    (testing "sanity check before removing the old DB revision"
+      (let [json-response (search/find-concepts-json :collection {:concept-id concept-id})
+            umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})]
+        (is (= 1 (:hits json-response)) (pr-str json-response))
+        (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
+        (is (= 1 (count (get-in umm-json-response [:results :items]))))
+        (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
+
+    ;; This simulates the post-cleanup production state where the collection's superseded
+    ;; revision is gone from metadata-db, but the latest revision still exists.
+    (is (= 200 (:status (mdb/force-delete-concept concept-id (:revision-id collection-r1)))))
+    (is (nil? (mdb/get-concept concept-id (:revision-id collection-r1))))
+    (is (= 2 (:revision-id (mdb/get-concept concept-id (:revision-id collection-r2)))))
+
+    (testing "sanity check before resharding"
+      (let [json-response (search/find-concepts-json :collection {:concept-id concept-id})
+            umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})]
+        (is (= 1 (:hits json-response)) (pr-str json-response))
+        (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
+        (is (= 1 (count (get-in umm-json-response [:results :items]))))
+        (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
+
+    (let [original-doc (es-util/get-doc collections-index-name concept-id "elastic")
+          start-reshard-response (bootstrap/start-reshard-index
+                                  collections-index-name
+                                  {:synchronous true
+                                   :num-shards 2
+                                   :elastic-name "elastic"})
+          task-id (:task-id start-reshard-response)
+          resharded-doc (es-util/get-doc resharded-index-name concept-id "elastic")
+          _ (bootstrap/wait-for-reshard-complete
+             collections-index-name
+             "elastic"
+             task-id
+             {})
+          finalize-reshard-response (bootstrap/finalize-reshard-index
+                                     collections-index-name
+                                     {:synchronous true
+                                      :elastic-name "elastic"})
+          json-response (search/find-concepts-json :collection {:concept-id concept-id})
+          umm-json-response (search/find-concepts-umm-json :collection {:concept-id concept-id})
+          umm-json-items (get-in umm-json-response [:results :items])]
+      (is (= 200 (:status start-reshard-response)) (pr-str start-reshard-response))
+      (is (= 2 (get-in original-doc [:_source :revision-id])) (pr-str original-doc))
+      (is (= 2 (get-in resharded-doc [:_source :revision-id])) (pr-str resharded-doc))
+      (is (= (:_version original-doc) (:_version resharded-doc))
+          (pr-str {:original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 200 (:status finalize-reshard-response)) (pr-str finalize-reshard-response))
+
+      ;; Collections look up revision-id from the stored source field, but
+      ;; resharding should still preserve the elastic version consistently.
+      (is (= 1 (:hits json-response)) (pr-str json-response))
+      (is (= 200 (:status umm-json-response))
+          (pr-str {:umm-json-response umm-json-response
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 1 (count umm-json-items))
+          (pr-str {:umm-json-response umm-json-response
+                   :json-response json-response
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 2 (get-in umm-json-items [0 :meta :revision-id]))
+          (pr-str {:umm-json-items umm-json-items
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])})))))

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_reshard_revision_lookup_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_reshard_revision_lookup_test.clj
@@ -62,7 +62,6 @@
                                    :num-shards 2
                                    :elastic-name "gran-elastic"})
           task-id (:task-id start-reshard-response)
-          resharded-doc (es-util/get-doc resharded-index-name concept-id "gran-elastic")
           _ (bootstrap/wait-for-reshard-complete
              small-collections-index-name
              "gran-elastic"
@@ -72,18 +71,19 @@
                                      small-collections-index-name
                                      {:synchronous true
                                       :elastic-name "gran-elastic"})
+          resharded-doc (es-util/get-doc resharded-index-name concept-id "gran-elastic")
           json-response (search/find-concepts-json :granule {:granule-ur granule-ur})
           umm-json-response (search/find-concepts-umm-json :granule {:granule-ur granule-ur})
           umm-json-items (get-in umm-json-response [:results :items])]
       (is (= 200 (:status start-reshard-response)) (pr-str start-reshard-response))
       (is (= 2 (get-in original-doc [:_source :revision-id])) (pr-str original-doc))
       (is (= 2 (:_version original-doc)) (pr-str original-doc))
-      (is (= 2 (get-in resharded-doc [:_source :revision-id])) (pr-str resharded-doc))
       (is (= (:_version original-doc) (:_version resharded-doc))
           (pr-str {:original-es-version (:_version original-doc)
                    :resharded-es-version (:_version resharded-doc)
                    :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
       (is (= 200 (:status finalize-reshard-response)) (pr-str finalize-reshard-response))
+      (is (= 2 (get-in resharded-doc [:_source :revision-id])) (pr-str resharded-doc))
 
       ;; The reshard path should preserve the elastic version so granule DB-backed
       ;; formats continue to look up the latest revision after finalize.

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_reshard_revision_lookup_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_reshard_revision_lookup_test.clj
@@ -1,0 +1,106 @@
+(ns cmr.system-int-test.search.granule.granule-reshard-revision-lookup-test
+  "Reproduces granule search behavior after resharding when an older DB revision has been removed."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.system-int-test.data2.core :as d]
+   [cmr.system-int-test.data2.granule :as dg]
+   [cmr.system-int-test.data2.umm-spec-collection :as data-umm-c]
+   [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
+   [cmr.system-int-test.utils.elastic-util :as es-util]
+   [cmr.system-int-test.utils.index-util :as index]
+   [cmr.system-int-test.utils.ingest-util :as ingest]
+   [cmr.system-int-test.utils.metadata-db-util :as mdb]
+   [cmr.system-int-test.utils.search-util :as search]))
+
+(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"}))
+
+(deftest ^:oracle granule-umm-json-search-after-reshard-with-missing-old-db-revision
+  (let [small-collections-index-name "1_small_collections"
+        resharded-index-name (str small-collections-index-name "_2_shards")
+        granule-ur "reshard-granule"
+        collection (d/ingest-umm-spec-collection
+                    "PROV1"
+                    (data-umm-c/collection
+                     {:ShortName "RESHARD"
+                      :Version "1"
+                      :EntryTitle "reshard-collection"}))
+        granule (dg/granule-with-umm-spec-collection
+                 collection
+                 (:concept-id collection)
+                 {:granule-ur granule-ur})
+        granule-r1 (d/ingest "PROV1" granule {:format :umm-json})
+        granule-r2 (d/ingest "PROV1" granule {:format :umm-json})
+        concept-id (:concept-id granule-r2)]
+    (index/wait-until-indexed)
+
+    (testing "sanity check before removing the old DB revision"
+      (let [json-response (search/find-concepts-json :granule {:granule-ur granule-ur})
+            umm-json-response (search/find-concepts-umm-json :granule {:granule-ur granule-ur})]
+        (is (= 1 (:hits json-response)) (pr-str json-response))
+        (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
+        (is (= 1 (count (get-in umm-json-response [:results :items]))))
+        (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
+
+    ;; This simulates the post-cleanup production state where the granule's superseded
+    ;; revision is gone from metadata-db, but the latest revision still exists.
+    (is (= 200 (:status (mdb/force-delete-concept concept-id (:revision-id granule-r1)))))
+    (is (nil? (mdb/get-concept concept-id (:revision-id granule-r1))))
+    (is (= 2 (:revision-id (mdb/get-concept concept-id (:revision-id granule-r2)))))
+
+    (testing "sanity check before resharding"
+      (let [json-response (search/find-concepts-json :granule {:granule-ur granule-ur})
+            umm-json-response (search/find-concepts-umm-json :granule {:granule-ur granule-ur})]
+        (is (= 1 (:hits json-response)) (pr-str json-response))
+        (is (= 200 (:status umm-json-response)) (pr-str umm-json-response))
+        (is (= 1 (count (get-in umm-json-response [:results :items]))))
+        (is (= 2 (get-in umm-json-response [:results :items 0 :meta :revision-id])))))
+
+    (let [original-doc (es-util/get-doc small-collections-index-name concept-id "gran-elastic")
+          start-reshard-response (bootstrap/start-reshard-index
+                                  small-collections-index-name
+                                  {:synchronous true
+                                   :num-shards 2
+                                   :elastic-name "gran-elastic"})
+          task-id (:task-id start-reshard-response)
+          resharded-doc (es-util/get-doc resharded-index-name concept-id "gran-elastic")
+          _ (bootstrap/wait-for-reshard-complete
+             small-collections-index-name
+             "gran-elastic"
+             task-id
+             {})
+          finalize-reshard-response (bootstrap/finalize-reshard-index
+                                     small-collections-index-name
+                                     {:synchronous true
+                                      :elastic-name "gran-elastic"})
+          json-response (search/find-concepts-json :granule {:granule-ur granule-ur})
+          umm-json-response (search/find-concepts-umm-json :granule {:granule-ur granule-ur})
+          umm-json-items (get-in umm-json-response [:results :items])]
+      (is (= 200 (:status start-reshard-response)) (pr-str start-reshard-response))
+      (is (= 2 (get-in original-doc [:_source :revision-id])) (pr-str original-doc))
+      (is (= 2 (:_version original-doc)) (pr-str original-doc))
+      (is (= 2 (get-in resharded-doc [:_source :revision-id])) (pr-str resharded-doc))
+      (is (= (:_version original-doc) (:_version resharded-doc))
+          (pr-str {:original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 200 (:status finalize-reshard-response)) (pr-str finalize-reshard-response))
+
+      ;; The reshard path should preserve the elastic version so granule DB-backed
+      ;; formats continue to look up the latest revision after finalize.
+      (is (= 1 (:hits json-response)) (pr-str json-response))
+      (is (= 200 (:status umm-json-response))
+          (pr-str {:umm-json-response umm-json-response
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 1 (count umm-json-items))
+          (pr-str {:umm-json-response umm-json-response
+                   :json-response json-response
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])}))
+      (is (= 2 (get-in umm-json-items [0 :meta :revision-id]))
+          (pr-str {:umm-json-items umm-json-items
+                   :original-es-version (:_version original-doc)
+                   :resharded-es-version (:_version resharded-doc)
+                   :resharded-source-revision (get-in resharded-doc [:_source :revision-id])})))))


### PR DESCRIPTION
# Overview

### What is the objective?

Ensure that resharding preserves Elasticsearch documents' `_version` (which should match revision ID) instead of resetting _version to 1. This matches behavior of bulk-index and fixes granule search bug.

### What are the changes?

* Add clause `:version_type "external_gte"` to reshard logic to tell Elasticsearch not to reset _version

* New system integration tests both ensure that _version and revision ID match, and also cover the observed search bug wherein a granule that had _version reset to 1 and whose old revisions were already gone from DB then failed to show up in search results for DB-dependent formats such as umm_json. 

### What areas of the application does this impact?

elastic-utils-lib

# Required Checklist

- [ x] New and existing unit and int tests pass locally and remotely
- [ x] clj-kondo has been run locally and all errors in changed files are corrected
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document version handling during index resharding operations to correctly preserve and apply revision information.

* **Tests**
  * Added integration tests validating search results accurately return revision IDs after resharding, including scenarios with deleted older revisions across citations, collections, and granules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->