### PR TITLE
CMR-10560: Support "Space Stations/Crewed Spacecraft"  value for platform-type in conversion from umm to xml

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/umm_to_xml_mappings/dif10.clj
@@ -38,7 +38,7 @@
     "Models/Analyses"
     "Navigation Platforms"
     "Solar/Space Observation Satellites"
-    "Space Stations/Manned Spacecraft"})
+    "Space Stations/Crewed Spacecraft"})
 
 (def product-levels
   "The set of values that DIF 10 defines for Processing levels as enumerations in its schema"

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_to_xml_mappings/dif10.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_to_xml_mappings/dif10.clj
@@ -29,6 +29,17 @@
         diff-result (first (select result "/DIF/DirectDistributionInformation"))]
     (is (= diff-result nil))))
 
+;; Testing the dif10 platform translation from umm-c to dif10.
+(deftest dif10-platform-test
+  (let [result (dif10/umm-c-to-dif10-xml
+                {:Platforms [{:ShortName "ISS"
+                              :LongName "International Space Station"
+                              :Type "Space Stations/Crewed Spacecraft"}]})
+        platform (first (select result "/DIF/Platform"))]
+    (is (= "ISS" (value-of platform "Short_Name")))
+    (is (= "International Space Station" (value-of platform "Long_Name")))
+    (is (= "Space Stations/Crewed Spacecraft" (value-of platform "Type")))))
+
 ;; Testing the dif10 metadata dates translation from umm-c to dif10
 (deftest dif10-metadata-dates-test
   (let [result1 (dif10/umm-c-to-dif10-xml 


### PR DESCRIPTION
# Overview
Support "Space Stations/Crewed Spacecraft"  value for platform-type in conversion from umm to xml

### What is the objective?

When translating from UMM to DIF 10, we currently translate the platform type to "Space Stations/Manned Spacecraft", which is no longer valid and should be "Space Stations/Crewed Spacecraft"

### What are the changes?

* Updated the set of values defined for platform types. Specifically, modified the "Space Stations/Manned Spacecraft" value to "Space Stations/Crewed Spacecraft"
* Added a unit test to build a small UMM-C collection with a single platform with the platform type set to "Space Stations/Crewed Spacecraft", then call `dif10/umm-c-to-dif10-xml` to confirm the platform is converted as expected.

### What areas of the application does this impact?

* umm-spec-lib

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform type terminology from "Space Stations/Manned Spacecraft" to "Space Stations/Crewed Spacecraft" for improved consistency.

* **Tests**
  * Added test validation for platform mapping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->