### PR TITLE
CMR-11289: Bumped up the netty lib to the latest

### DIFF
--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -8,6 +8,4 @@ RUN apt-get update \
       netbase \
       unzip \
       zip \
-      ca-certificates \
- && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -8,4 +8,6 @@ RUN apt-get update \
       netbase \
       unzip \
       zip \
+      ca-certificates \
+ && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -6,6 +6,10 @@
   "The java aws sdk version to use."
   "2.33.4") ;; latest as of 2025-09-05
 
+(def netty-version
+  "The netty version to use."
+  "4.1.133.Final") ;; latest as of 2025-09-05
+
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/message-queue-lib"
@@ -15,9 +19,9 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "2.3.0"] ;;behind other cmr projects
                  [clj-time]
-                 [io.netty/netty-handler "4.1.132.Final"]
-                 [io.netty/netty-codec-http "4.1.132.Final"]
-                 [io.netty/netty-codec-http2 "4.1.132.Final"]
+                 [io.netty/netty-handler ~netty-version]
+                 [io.netty/netty-codec-http ~netty-version]
+                 [io.netty/netty-codec-http2 ~netty-version]
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -22,6 +22,7 @@
                  [io.netty/netty-handler ~netty-version]
                  [io.netty/netty-codec-http ~netty-version]
                  [io.netty/netty-codec-http2 ~netty-version]
+                 [io.netty/netty-codec ~netty-version]
                  [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]


### PR DESCRIPTION
Bumping up the version of Netty in the message-queue-lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Netty-related HTTP handler and codec dependencies to version 4.1.133 and consolidated them to use a single shared Netty version.
  * Java builder image now installs CA certificates and updates the system certificate store during build.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasa/Common-Metadata-Repository/pull/2426)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->