### PR TITLE
CMR-11289: Fixing the certs that are included in the builder image for cmr

### DIFF
--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -8,4 +8,6 @@ RUN apt-get update \
       netbase \
       unzip \
       zip \
+      ca-certificates \
+ && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adding a command in docker to update certs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java 17 builder Docker image to ensure proper SSL/TLS certificate validation, improving reliability for secure connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasa/Common-Metadata-Repository/pull/2427)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->