### PR TITLE
CMR-11300: Add missing uuid lookups for the keyword schemes: providers and spatial-keywords

### DIFF
--- a/indexer-app/src/cmr/indexer/data/concepts/collection.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection.clj
@@ -472,7 +472,8 @@
                                                 :kms-uuids (let [concept-uuids (keep :uuid (map #(kms-util/concept->elastic-doc context %) (:DirectoryNames collection)))
                                                                  granule-data-format-uuids (keep :uuid (map #(kms-util/granule-data-format->elastic-doc context %) granule-data-format))
                                                                  iso-topic-uuids (keep :uuid (map #(kms-util/iso-topic-category->elastic-doc context %) (:ISOTopicCategories collection)))
-                                                                 location-uuids (keep :uuid (map #(clk/location-keyword->elastic-doc context %) (:LocationKeywords collection)))
+                                                                 ;; Location and spatial-keywords are used somewhat interchangably in the system
+                                                                 location-uuids (keep :uuid (map #(kms-util/spatial-keyword-by-map->elastic-doc context %) (:LocationKeywords collection)))
                                                                  ;; The mimetypes being validated are from the `GETDATA` field
                                                                  mime-type-uuids (keep :uuid (map #(kms-util/mime-type->elastic-doc context %) (keep :MimeType (keep :GetData related-urls))))
                                                                  processing-level-uuid (:uuid (kms-util/processing-level-id->elastic-doc context processing-level-id))
@@ -481,8 +482,9 @@
                                                                  temporal-uuids (keep :uuid (map #(kms-util/temporal-keyword->elastic-doc context %) temporal-keywords))
                                                                  science-keyword-uuids (keep :uuid (map #(kms-util/science-keyword->elastic-doc context %) (:ScienceKeywords collection)))
                                                                  platform-uuids (keep :uuid (map #(kms-util/platform->elastic-doc context %) platform-short-names))
+                                                                 provider-uuids (keep :uuid (map #(kms-util/provider->elastic-doc context %) data-center-names))
                                                                  instrument-uuids (keep :uuid (map #(kms-util/instrument->elastic-doc context %) instrument-short-names))
-                                                                 uuids (distinct (concat concept-uuids granule-data-format-uuids iso-topic-uuids location-uuids mime-type-uuids project-uuids related-url-uuids temporal-uuids science-keyword-uuids platform-uuids instrument-uuids))]
+                                                                 uuids (distinct (concat concept-uuids granule-data-format-uuids iso-topic-uuids location-uuids mime-type-uuids project-uuids related-url-uuids temporal-uuids science-keyword-uuids platform-uuids instrument-uuids provider-uuids))]
                                                              ;; Uniquely this can only be a single value
                                                              (if processing-level-uuid
                                                                (conj uuids processing-level-uuid)

--- a/indexer-app/src/cmr/indexer/data/concepts/collection/kms_util.clj
+++ b/indexer-app/src/cmr/indexer/data/concepts/collection/kms_util.clj
@@ -100,3 +100,18 @@
     (when uuid
       {:uuid uuid})))
 
+(defn provider->elastic-doc
+  "Converts a provider into an elastic document with the uuid
+  for that provider from the GCMD KMS keywords."
+  [context provider]
+  (let [uuid (kms-lookup/lookup-provider-by-short-name context provider)]
+    (when uuid
+      {:uuid uuid})))
+
+(defn spatial-keyword-by-map->elastic-doc
+  "Converts a spatial keyword into an elastic document with the uuid
+  for that provider from the GCMD KMS keywords."
+  [context spatial-keywords]
+  (let [uuid (kms-lookup/lookup-spatial-keyword-by-map context spatial-keywords)]
+    (when uuid
+      {:uuid uuid})))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/kms_util.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/kms_util.clj
@@ -14,7 +14,9 @@
    :iso-topic-categories [{:iso-topic-category "ISO-1" :uuid "uuid-iso-1"}]
    :related-urls [{:url-content-type "Type" :type "Type1" :subtype "SubType1" :uuid "uuid-ru-1"}]
    :granule-data-format [{:short-name "GDF-1" :uuid "uuid-gdf-1"}]
-   :mime-type [{:mime-type "MIME-1" :uuid "uuid-mime-1"}]})
+   :mime-type [{:mime-type "MIME-1" :uuid "uuid-mime-1"}]
+   :provider [{:short-name "NSIDC" :uuid "uuid-provider-1"}]
+   :spatial-keywords [{:category "OCEAN" :type "ATLANTIC OCEAN" :subregion-1 "NORTH ATLANTIC OCEAN" :uuid "uuid-spatial-1"}]})
 
 (defn- mock-cache
   [mock-fn]
@@ -89,7 +91,21 @@
      (mock-cache
       (fn [keyword-scheme]
         (case keyword-scheme
-          nil)))}}})
+          nil)))
+     :kms-providers-index
+     (mock-cache
+      (fn [field]
+        (let [items (:provider sample-map)
+              item (first (filter #(= field (string/lower-case (:short-name %))) items))]
+          (:uuid item))))
+     :kms-spatial-keywords-index
+     (mock-cache
+      (fn [field]
+        (let [items (:spatial-keywords sample-map)
+              item (first (filter #(= field {:category (string/lower-case (:category %))
+                                             :type (string/lower-case (:type %))
+                                             :subregion-1 (string/lower-case (:subregion-1 %))}) items))]
+          (:uuid item))))}}})
 
 (deftest project-short-name->elastic-doc-test
   (testing "Project found in KMS"
@@ -162,3 +178,21 @@
   (testing "Mime type not found in KMS"
     (is (nil?
          (kms-util/mime-type->elastic-doc test-context "NOT-IN-KMS")))))
+
+(deftest provider->elastic-doc-test
+  (testing "Provider found in KMS"
+    (is (= {:uuid "uuid-provider-1"}
+           (kms-util/provider->elastic-doc test-context "NSIDC"))))
+
+  (testing "Provider type not found in KMS"
+    (is (nil?
+         (kms-util/provider->elastic-doc test-context "NOT-IN-KMS")))))
+
+(deftest spatial-keyword-by-map->elastic-doc-test
+  (testing "Spatial keyword found in KMS"
+    (is (= {:uuid "uuid-spatial-1"}
+           (kms-util/spatial-keyword-by-map->elastic-doc test-context {:category "Ocean" :type "Atlantic Ocean" :subregion-1 "North Atlantic Ocean"}))))
+
+  (testing "Spatial keyword not found in KMS"
+    (is (nil?
+         (kms-util/spatial-keyword-by-map->elastic-doc test-context {:category "NOT-IN-KMS"})))))


### PR DESCRIPTION
# Overview

### What is the objective?

Adds the lookup for providers scheme. Fixes spatial keyword lookup to use the new cache though the results would be unchanged

### What are the changes?

Update `kms_util` index which looks over collection metadata and does a lookup against the keyword scheme corresponding to that scheme (providers and sptial-keywords)

### What areas of the application does this impact?

Collection indxing

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [NA] I have removed unnecessary/dead code and imports in files I have changed
- [NA] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
  
  Green build:
  https://ci.earthdata.nasa.gov/browse/CN2-CSN2970-3
