### PR TITLE
CMR-11089 - Implement /bulk_index/between_date_time to reduce indexing batch sizes

### DIFF
--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -254,6 +254,8 @@ Operator can use the `start_index` parameter to index concepts with sequence num
 
 The `/after_date_time` endpoint is retained for compatibility. New callers should use
 `/between_date_time`, which bounds the request and splits large ranges into smaller indexing chunks.
+Compatibility requests to `/after_date_time` are bounded from the supplied `date_time` to now and
+will be rejected if the implicit range is larger than the configured maximum window.
 
 For all providers and all system concepts:
 

--- a/bootstrap-app/README.md
+++ b/bootstrap-app/README.md
@@ -252,6 +252,9 @@ Operator can use the `start_index` parameter to index concepts with sequence num
 
 ### Bulk index concepts newer than a given date-time
 
+The `/after_date_time` endpoint is retained for compatibility. New callers should use
+`/between_date_time`, which bounds the request and splits large ranges into smaller indexing chunks.
+
 For all providers and all system concepts:
 
     curl -i \
@@ -267,6 +270,26 @@ For a given list of providers (use provider `CMR` to index all system concepts):
     	"http://localhost:3006/bulk_index/after_date_time?date_time=2015-02-02T10:00:00Z"
 
 Similar to the bulk index a provider endpoint, this reindexing of concepts newer than a given date-time will not reindex the concepts in the all revisions index. The workaround here is to use the indexer endpoint for reindexing collections and the concept specific bootstrap bulk indexing endpoint for variables, services, tools and subscriptions.
+
+### Bulk index concepts between two date-times
+
+For all providers and all system concepts:
+
+    curl -i \
+    	-X POST \
+    	"http://localhost:3006/bulk_index/between_date_time?start_date_time=2015-02-02T10:00:00Z&end_date_time=2015-02-02T12:00:00Z"
+
+For a given list of providers (use provider `CMR` to index all system concepts):
+
+    curl -i \
+    	-X POST \
+    	-H "Content-Type: application/json" \
+    	-d '{"provider_ids": ["PROV1", "PROV2", "CMR"]}' \
+    	"http://localhost:3006/bulk_index/between_date_time?start_date_time=2015-02-02T10:00:00Z&end_date_time=2015-02-02T12:00:00Z"
+
+The `start_date_time` parameter is required. Callers can provide either `end_date_time` or `hours`.
+If neither is provided, bootstrap uses the end of the start date's day. Internally, bootstrap enforces
+smaller chunks across the requested time range before publishing indexing work.
 
 ### Bulk index all system concepts (tags/acls/access-groups)
 

--- a/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
@@ -117,17 +117,17 @@
   [context body params]
   (let [dispatcher (api-util/get-dispatcher context params :index-data-between-date-time)
         provider-ids (get body "provider_ids")
-        date-time (:date_time params)]
-    (let [start-date-time (parse-date-time-param :date_time date-time)
-          end-date-time (time-keeper/now)]
-      (validate-date-time-range start-date-time end-date-time)
-      (validate-after-date-time-window start-date-time end-date-time)
-      {:status 202
-       :body {:message (msg/data-later-than-date-time
-                        params
-                        (service/index-data-between-date-time
-                         context dispatcher provider-ids start-date-time end-date-time)
-                        date-time)}})))
+        date-time (:date_time params)
+        start-date-time (parse-date-time-param :date_time date-time)
+        end-date-time (time-keeper/now)]
+    (validate-date-time-range start-date-time end-date-time)
+    (validate-after-date-time-window start-date-time end-date-time)
+    {:status 202
+     :body {:message (msg/data-later-than-date-time
+                      params
+                      (service/index-data-between-date-time
+                       context dispatcher provider-ids start-date-time end-date-time)
+                      date-time)}}))
 
 (defn data-between-date-time
   "Index all the data with revision-date between the given date-times."

--- a/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
@@ -1,11 +1,66 @@
 (ns cmr.bootstrap.api.bulk-index
   "Defines the bulk index functions for the bootstrap API."
   (:require
+   [clj-time.core :as time]
    [cmr.bootstrap.api.messages :as msg]
    [cmr.bootstrap.api.util :as api-util]
    [cmr.bootstrap.services.bootstrap-service :as service]
    [cmr.common.date-time-parser :as date-time-parser]
    [cmr.common.services.errors :as errors]))
+
+(defn- parse-date-time-param
+  [param-name date-time]
+  (if-let [date-time-value (date-time-parser/try-parse-datetime date-time)]
+    date-time-value
+    (errors/throw-service-error
+     :invalid-data (msg/invalid-datetime date-time))))
+
+(defn- end-of-day
+  [date-time]
+  (time/plus (time/date-time (time/year date-time)
+                             (time/month date-time)
+                             (time/day date-time))
+             (time/days 1)))
+
+(defn- parse-positive-hours
+  [hours]
+  (try
+    (let [hours (Long/parseLong hours)]
+      (if (pos? hours)
+        hours
+        (errors/throw-service-error
+         :invalid-data "The hours parameter must be a positive integer.")))
+    (catch NumberFormatException _
+      (errors/throw-service-error
+       :invalid-data "The hours parameter must be a positive integer."))))
+
+(defn- parse-between-date-time-range
+  [params]
+  (let [start-date-time (:start_date_time params)
+        end-date-time (:end_date_time params)
+        hours (:hours params)]
+    (when-not start-date-time
+      (errors/throw-service-error
+       :invalid-data (msg/required-params :start_date_time)))
+    (when (and end-date-time hours)
+      (errors/throw-service-error
+       :invalid-data "Only one of end_date_time or hours may be provided."))
+    (let [start-date-time-value (parse-date-time-param :start_date_time start-date-time)
+          end-date-time-value (cond
+                                end-date-time
+                                (parse-date-time-param :end_date_time end-date-time)
+
+                                hours
+                                (time/plus start-date-time-value
+                                           (time/hours (parse-positive-hours hours)))
+
+                                :else
+                                (end-of-day start-date-time-value))]
+      (when-not (time/before? start-date-time-value end-date-time-value)
+        (errors/throw-service-error
+         :invalid-data "The end date-time must be after the start date-time."))
+      {:start-date-time start-date-time-value
+       :end-date-time end-date-time-value})))
 
 (defn index-provider
   "Index all the collections and granules for a given provider."
@@ -56,6 +111,20 @@
       ;; Can't parse date-time.
       (errors/throw-service-error
        :invalid-data (msg/invalid-datetime date-time)))))
+
+(defn data-between-date-time
+  "Index all the data with revision-date between the given date-times."
+  [context body params]
+  (let [dispatcher (api-util/get-dispatcher context params :index-data-between-date-time)
+        provider-ids (get body "provider_ids")
+        {:keys [start-date-time end-date-time]} (parse-between-date-time-range params)]
+    {:status 202
+     :body {:message (msg/data-between-date-time
+                      params
+                      (service/index-data-between-date-time
+                       context dispatcher provider-ids start-date-time end-date-time)
+                      start-date-time
+                      end-date-time)}}))
 
 (defn index-system-concepts
   "Index all tags, acls, and access-groups."

--- a/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/bulk_index.clj
@@ -2,18 +2,28 @@
   "Defines the bulk index functions for the bootstrap API."
   (:require
    [clj-time.core :as time]
+   [cmr.bootstrap.config :as bootstrap-config]
    [cmr.bootstrap.api.messages :as msg]
    [cmr.bootstrap.api.util :as api-util]
    [cmr.bootstrap.services.bootstrap-service :as service]
    [cmr.common.date-time-parser :as date-time-parser]
-   [cmr.common.services.errors :as errors]))
+   [cmr.common.services.errors :as errors]
+   [cmr.common.time-keeper :as time-keeper]))
 
 (defn- parse-date-time-param
-  [param-name date-time]
+  [_param-name date-time]
   (if-let [date-time-value (date-time-parser/try-parse-datetime date-time)]
     date-time-value
     (errors/throw-service-error
      :invalid-data (msg/invalid-datetime date-time))))
+
+(defn- validate-date-time-range
+  [start-date-time end-date-time]
+  (when-not (time/before? start-date-time end-date-time)
+    (errors/throw-service-error
+     :invalid-data "The end date-time must be after the start date-time."))
+  {:start-date-time start-date-time
+   :end-date-time end-date-time})
 
 (defn- end-of-day
   [date-time]
@@ -56,11 +66,18 @@
 
                                 :else
                                 (end-of-day start-date-time-value))]
-      (when-not (time/before? start-date-time-value end-date-time-value)
-        (errors/throw-service-error
-         :invalid-data "The end date-time must be after the start date-time."))
-      {:start-date-time start-date-time-value
-       :end-date-time end-date-time-value})))
+      (validate-date-time-range start-date-time-value end-date-time-value))))
+
+(defn- validate-after-date-time-window
+  [start-date-time end-date-time]
+  (let [max-window-hours (bootstrap-config/bulk-index-after-date-time-max-window-hours)
+        max-end-date-time (time/plus start-date-time (time/hours max-window-hours))]
+    (when (time/after? end-date-time max-end-date-time)
+      (errors/throw-service-error
+       :invalid-data
+       (format (str "/bulk_index/after_date_time is limited to %d hours. "
+                    "Use /bulk_index/between_date_time with a smaller explicit range.")
+               max-window-hours)))))
 
 (defn index-provider
   "Index all the collections and granules for a given provider."
@@ -96,21 +113,21 @@
      :body {:message (msg/index-collection params result collection-id)}}))
 
 (defn data-later-than-date-time
-  "Index all the data with a revision-date later than a given date-time."
+  "Index all the data with a revision-date later than a given date-time, bounded to now."
   [context body params]
-  (let [dispatcher (api-util/get-dispatcher context params :index-data-later-than-date-time)
+  (let [dispatcher (api-util/get-dispatcher context params :index-data-between-date-time)
         provider-ids (get body "provider_ids")
         date-time (:date_time params)]
-    (if-let [date-time-value (date-time-parser/try-parse-datetime date-time)]
+    (let [start-date-time (parse-date-time-param :date_time date-time)
+          end-date-time (time-keeper/now)]
+      (validate-date-time-range start-date-time end-date-time)
+      (validate-after-date-time-window start-date-time end-date-time)
       {:status 202
        :body {:message (msg/data-later-than-date-time
                         params
-                        (service/index-data-later-than-date-time
-                         context dispatcher provider-ids date-time-value)
-                        date-time)}}
-      ;; Can't parse date-time.
-      (errors/throw-service-error
-       :invalid-data (msg/invalid-datetime date-time)))))
+                        (service/index-data-between-date-time
+                         context dispatcher provider-ids start-date-time end-date-time)
+                        date-time)}})))
 
 (defn data-between-date-time
   "Index all the data with revision-date between the given date-times."

--- a/bootstrap-app/src/cmr/bootstrap/api/messages.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/messages.clj
@@ -73,6 +73,15 @@
     (:message result)
     (format "%s Processing data after %s for bulk indexing" msg/bulk-index-msg-general date-time)))
 
+(defn data-between-date-time
+  [params result start-date-time end-date-time]
+  (if (api-util/synchronous? params)
+    (:message result)
+    (format "%s Processing data between %s and %s for bulk indexing"
+            msg/bulk-index-msg-general
+            start-date-time
+            end-date-time)))
+
 (defn invalid-datetime
   [date-time]
   (str date-time " is not a valid date-time."))

--- a/bootstrap-app/src/cmr/bootstrap/api/routes.clj
+++ b/bootstrap-app/src/cmr/bootstrap/api/routes.clj
@@ -64,6 +64,9 @@
        (POST "/after_date_time" {:keys [request-context body params]}
          (acl/verify-ingest-management-permission request-context :update)
          (bulk-index/data-later-than-date-time request-context body params))
+       (POST "/between_date_time" {:keys [request-context body params]}
+         (acl/verify-ingest-management-permission request-context :update)
+         (bulk-index/data-between-date-time request-context body params))
        (POST "/system_concepts" {:keys [request-context params]}
          (acl/verify-ingest-management-permission request-context :update)
          (bulk-index/index-system-concepts request-context params))

--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -46,6 +46,11 @@
   {:default 1
    :type Long})
 
+(defconfig bulk-index-between-date-time-window-hours
+  "Maximum number of hours for each /bulk_index/between_date_time indexing chunk."
+  {:default 1
+   :type Long})
+
 (declare initialize-kms-on-boot)
 (defconfig initialize-kms-on-boot
   "Set to the number of seconds to wait before trying to initialize the Keyword Managment System

--- a/bootstrap-app/src/cmr/bootstrap/config.clj
+++ b/bootstrap-app/src/cmr/bootstrap/config.clj
@@ -51,6 +51,12 @@
   {:default 1
    :type Long})
 
+(defconfig bulk-index-after-date-time-max-window-hours
+  "Maximum number of hours allowed for /bulk_index/after_date_time. Larger windows should use
+  /bulk_index/between_date_time explicitly."
+  {:default 168
+   :type Long})
+
 (declare initialize-kms-on-boot)
 (defconfig initialize-kms-on-boot
   "Set to the number of seconds to wait before trying to initialize the Keyword Managment System

--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -519,7 +519,8 @@
     {:message indexing-complete-message
      :max-revision-date (apply util/max-compare
                                (map :max-revision-date
-                                    (apply conj provider-response-map system-concept-response-map)))}))
+                                    (conj (vec provider-response-map)
+                                          system-concept-response-map)))}))
 
 (defn index-data-between-date-time
   "Index all concept revisions created within the given date-time range
@@ -556,7 +557,8 @@
     {:message indexing-complete-message
      :max-revision-date (apply util/max-compare
                                (map :max-revision-date
-                                    (apply conj provider-response-map system-concept-response-map)))}))
+                                    (conj (vec provider-response-map)
+                                          system-concept-response-map)))}))
 
 ;; Background task to handle bulk index requests
 (defn handle-bulk-index-requests

--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -2,12 +2,15 @@
   "Functions to support concurrent bulk indexing."
   (:require
    [clj-time.coerce :as time-coerce]
+   [clj-time.format :as time-format]
    [clojure.core.async :as async :refer [<!!]]
+   [clojure.string :as string]
    [cmr.access-control.data.bulk-index :as ac-bulk-index]
    [cmr.bootstrap.api.messages-bulk-index :as msg]
    [cmr.bootstrap.embedded-system-helper :as helper]
    [cmr.common.concepts :as cc]
    [cmr.common.config :as cfg :refer [defconfig]]
+   [cmr.common.date-time-parser :as date-time-parser]
    [cmr.common.log :refer (info warn error)]
    [cmr.common.util :as util]
    [cmr.elastic-utils.config :as es-config]
@@ -17,6 +20,7 @@
    [cmr.indexer.services.index-service :as index]
    [cmr.indexer.services.index-set-service :as index-set-service]
    [cmr.metadata-db.data.concepts :as db]
+   [cmr.metadata-db.data.oracle.concept-tables :as concept-tables]
    [cmr.metadata-db.data.providers :as p]))
 
 (defconfig collection-index-channel-worker-count
@@ -46,6 +50,21 @@
 (def ^:private misc-concept-types
   "The list of miscellaneous concept types that are provider based but saved in a single system table"
   [:variable :service :tool :subscription])
+
+(def ^:private sql-timestamp-formatter
+  (time-format/formatter "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+
+(defn- sql-quote
+  [s]
+  (string/replace s #"'" "''"))
+
+(defn- date-time->sql-timestamp-literal
+  [date-time]
+  (let [date-time (if (string? date-time)
+                    (date-time-parser/parse-datetime date-time)
+                    date-time)]
+    (format "TO_TIMESTAMP_TZ('%s', 'YYYY-MM-DD\"T\"HH24:MI:SS.FF3\"Z\"')"
+            (time-format/unparse sql-timestamp-formatter date-time))))
 
 (defn elastic-retry-handler
   "A custom http retry handler for use with elastic connections"
@@ -257,6 +276,55 @@
     {:max-revision-date max-revision-date
      :num-indexed num-indexed}))
 
+(defn- find-concepts-between-date-times-sql
+  [provider concept-type start-date-time end-date-time]
+  (let [table (concept-tables/get-table-name provider concept-type)
+        provider-id (:provider-id provider)
+        provider-clause (when (or (= :access-group concept-type)
+                                  (and (some #{concept-type} misc-concept-types)
+                                       (not= system-concept-provider provider-id)))
+                          (format " and provider_id = '%s'" (sql-quote (:provider-id provider))))]
+    (format (str "select * from %s where revision_date >= %s and revision_date < %s%s")
+            table
+            (date-time->sql-timestamp-literal start-date-time)
+            (date-time->sql-timestamp-literal end-date-time)
+            (or provider-clause ""))))
+
+(defn- fetch-and-index-concepts-between-date-times
+  "Get batches of concepts for a given provider/concept type that have a revision-date
+  within the half-open date-time range and then index them."
+  [system provider concept-type start-date-time end-date-time]
+  (let [db (helper/get-metadata-db-db system)
+        provider-id (:provider-id provider)
+        params {:concept-type concept-type
+                :provider-id provider-id}
+        stmt (find-concepts-between-date-times-sql
+              provider concept-type start-date-time end-date-time)
+        _ (info (format (str "Fetching %s batches for provider %s with revision-date "
+                             "between %s and %s.")
+                        concept-type provider-id start-date-time end-date-time))
+        concept-batches (db/find-concepts-in-batches-with-stmt
+                         db provider params stmt (:db-batch-size system))
+        num-of-concepts (apply + (map count concept-batches))
+        _ (info (format "Found %d %s(s) for provider %s."
+                        num-of-concepts (name concept-type) provider-id))
+        es-cluster-name (if (= concept-type :granule)
+                          es-config/gran-elastic-name
+                          es-config/elastic-name)
+        {:keys [max-revision-date num-indexed]} (if (contains? #{:acl :access-group} concept-type)
+                                                  (index-access-control-concepts system concept-batches)
+                                                  (index-concepts system concept-batches es-cluster-name))]
+    (info (format (str "Indexed %d %s(s) for provider %s with revision-date between %s and %s "
+                       "and max revision date was %s.")
+                  num-indexed
+                  (name concept-type)
+                  provider-id
+                  start-date-time
+                  end-date-time
+                  max-revision-date))
+    {:max-revision-date max-revision-date
+     :num-indexed num-indexed}))
+
 (defn index-system-concepts
   "Bulk index tags, acls, and access-groups."
   [system start-index]
@@ -348,6 +416,23 @@
     {:max-revision-date max-revision-date
      :num-indexed system-concept-count}))
 
+(defn- index-system-misc-concepts-between-date-times
+  "Index all system and miscellaneous concepts created within the given date-time range.
+  Returns a map of :max-revision-date and :num-indexed."
+  [system start-date-time end-date-time]
+  (let [system-concept-response-map (for [concept-type (concat system-concept-types misc-concept-types)]
+                                      (fetch-and-index-concepts-between-date-times
+                                       system
+                                       {:provider-id system-concept-provider}
+                                       concept-type
+                                       start-date-time
+                                       end-date-time))
+        max-revision-date (apply util/max-compare
+                                 (map :max-revision-date system-concept-response-map))
+        system-concept-count (reduce + (map :num-indexed system-concept-response-map))]
+    {:max-revision-date max-revision-date
+     :num-indexed system-concept-count}))
+
 (defn index-provider-data-later-than-date-time
   "Index all concept revisions created later than or equal to the given date-time for a given provider."
   [system provider-id date-time]
@@ -366,6 +451,41 @@
     (info (msg/index-provider-data-later-than-date-time-completed date-time provider-id))
     (catch Throwable e
       (error e (msg/index-provider-data-later-than-date-time-failed date-time provider-id (.getMessage e))))))
+
+(defn index-provider-data-between-date-time
+  "Index all concept revisions created within the given date-time range for a given provider."
+  [system provider-id start-date-time end-date-time]
+  (try
+    (info (format "%s Indexing concepts with revision-date between [%s] and [%s] for provider [%s] started."
+                  msg/bulk-index-prefix-queue
+                  start-date-time
+                  end-date-time
+                  provider-id))
+    (if (= system-concept-provider provider-id)
+      (let [{:keys [num-indexed]} (index-system-misc-concepts-between-date-times
+                                   system start-date-time end-date-time)]
+        (info (msg/index-provider-data-later-than-date-time-sys-concepts num-indexed)))
+
+      (let [provider (helper/get-provider system provider-id)
+            provider-response-map (for [concept-type [:collection :granule]]
+                                    (fetch-and-index-concepts-between-date-times
+                                     system provider concept-type start-date-time end-date-time))
+            provider-concept-count (reduce + (map :num-indexed provider-response-map))]
+        (info (msg/index-provider-data-later-than-date-post provider-concept-count))))
+    (info (format "%s Indexing concepts with revision-date between [%s] and [%s] for provider [%s] completed."
+                  msg/bulk-index-prefix-queue
+                  start-date-time
+                  end-date-time
+                  provider-id))
+    (catch Throwable e
+      (error e
+             (format
+              "%s Indexing concepts with revision-date between [%s] and [%s] for provider [%s] completed but failed because << %s >>!"
+              msg/bulk-index-prefix-queue
+              start-date-time
+              end-date-time
+              provider-id
+              (.getMessage e))))))
 
 (defn index-data-later-than-date-time
   "Index all concept revisions created later than or equal to the given date-time
@@ -394,6 +514,43 @@
                                           system-concept-count)]
     (info (format "Indexing concepts with revision-date later than %s for providers %s completed."
                   date-time
+                  provider-ids))
+    (info indexing-complete-message)
+    {:message indexing-complete-message
+     :max-revision-date (apply util/max-compare
+                               (map :max-revision-date
+                                    (apply conj provider-response-map system-concept-response-map)))}))
+
+(defn index-data-between-date-time
+  "Index all concept revisions created within the given date-time range
+  for the given providers. If provider-ids is empty, then all providers are indexed."
+  [system provider-ids start-date-time end-date-time]
+  (info (format "Indexing concepts with revision-date between %s and %s for providers %s started."
+                start-date-time
+                end-date-time
+                provider-ids))
+  (let [has-cmr-provider? (or (empty? provider-ids)
+                              (some #{system-concept-provider} provider-ids))
+        providers (if (seq provider-ids)
+                    (map #(helper/get-provider system %) (remove #(= system-concept-provider %) provider-ids))
+                    ;; all providers
+                    (helper/get-providers system))
+        provider-response-map (for [provider providers
+                                    concept-type [:collection :granule]]
+                                (fetch-and-index-concepts-between-date-times
+                                 system provider concept-type start-date-time end-date-time))
+        provider-concept-count (reduce + (map :num-indexed provider-response-map))
+        system-concept-response-map (if has-cmr-provider?
+                                      (index-system-misc-concepts-between-date-times
+                                       system start-date-time end-date-time)
+                                      {:num-indexed 0})
+        system-concept-count (:num-indexed system-concept-response-map)
+        indexing-complete-message (format "Indexed %d provider concepts and %d system concepts."
+                                          provider-concept-count
+                                          system-concept-count)]
+    (info (format "Indexing concepts with revision-date between %s and %s for providers %s completed."
+                  start-date-time
+                  end-date-time
                   provider-ids))
     (info indexing-complete-message)
     {:message indexing-complete-message

--- a/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/bulk_index.clj
@@ -284,7 +284,7 @@
                                   (and (some #{concept-type} misc-concept-types)
                                        (not= system-concept-provider provider-id)))
                           (format " and provider_id = '%s'" (sql-quote (:provider-id provider))))]
-    (format (str "select * from %s where revision_date >= %s and revision_date < %s%s")
+    (format "select * from %s where revision_date >= %s and revision_date < %s%s"
             table
             (date-time->sql-timestamp-literal start-date-time)
             (date-time->sql-timestamp-literal end-date-time)

--- a/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/data/message_queue.clj
@@ -25,6 +25,14 @@
     :provider-id provider-id
     :date-time date-time}))
 
+(defn bootstrap-provider-between-date-time-event
+  "Creates an event indicating to bootstrap provider data within a date-time range."
+  [provider-id start-date-time end-date-time]
+  {:action :index-provider-between-date-time
+   :provider-id provider-id
+   :start-date-time start-date-time
+   :end-date-time end-date-time})
+
 (defn publish-bootstrap-concepts-event
   "Put a bootstrap variables event on the message queue."
   [context msg]

--- a/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/bootstrap_service.clj
@@ -31,6 +31,7 @@
    :index-subscriptions :message-queue-dispatcher
    :index-generics :message-queue-dispatcher
    :index-data-later-than-date-time :message-queue-dispatcher
+   :index-data-between-date-time :message-queue-dispatcher
    :index-collection :core-async-dispatcher
    :index-system-concepts :core-async-dispatcher
    :index-concepts-by-id :core-async-dispatcher
@@ -90,6 +91,12 @@
   "Bulk index all the concepts with a revision date later than the given date-time."
   [context dispatcher provider-ids date-time]
   (dispatch/index-data-later-than-date-time dispatcher context provider-ids date-time))
+
+(defn index-data-between-date-time
+  "Bulk index all the concepts with revision dates between the given date-times."
+  [context dispatcher provider-ids start-date-time end-date-time]
+  (dispatch/index-data-between-date-time
+   dispatcher context provider-ids start-date-time end-date-time))
 
 (defn index-collection
   "Bulk index all the granules in a collection"
@@ -327,4 +334,3 @@
 
     ;; Minimize likelihood of triggering race condition (see `finalize-rebalance-collection` above)
     (wait-until-index-set-hash-cache-times-out)))
-

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/core.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/core.clj
@@ -30,6 +30,10 @@
     [this context provider-ids date-time]
     "Bulk index all the concepts with a revision date later than the given date-time.")
 
+  (index-data-between-date-time
+    [this context provider-ids start-date-time end-date-time]
+    "Bulk index all the concepts with revision dates between the given date-times.")
+
   (index-collection
     [this context provider-id collection-id options]
     "Bulk index all the granules in a collection.")

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/async.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/async.clj
@@ -106,6 +106,7 @@
    :index-variables (partial not-implemented :index-variables)
    :index-services (partial not-implemented :index-services)
    :index-data-later-than-date-time (partial not-implemented :index-data-later-than-date-time)
+   :index-data-between-date-time (partial not-implemented :index-data-between-date-time)
    :index-collection index-collection
    :index-system-concepts index-system-concepts
    :index-concepts-by-id index-concepts-by-id

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/message_queue.clj
@@ -2,6 +2,7 @@
   "Functions implementing the dispatch protocol to support bootstrap operations using a message
   queue."
   (:require
+   [clj-time.core :as time]
    [cmr.bootstrap.api.messages-bulk-index :as msg]
    [cmr.bootstrap.config :as config]
    [cmr.bootstrap.data.bulk-index :as bulk-index]
@@ -122,6 +123,43 @@
        (message-queue/bootstrap-provider-event provider-id nil date-time)))
     (info (msg/index-data-later-than-date-time-done))))
 
+(defn- date-time-chunks
+  "Returns half-open date-time ranges no larger than chunk-hours."
+  [start-date-time end-date-time chunk-hours]
+  (let [chunk-period (time/hours chunk-hours)]
+    (loop [chunk-start start-date-time
+           chunks []]
+      (if (time/before? chunk-start end-date-time)
+        (let [candidate-end (time/plus chunk-start chunk-period)
+              chunk-end (if (time/before? candidate-end end-date-time)
+                          candidate-end
+                          end-date-time)]
+          (recur chunk-end (conj chunks [chunk-start chunk-end])))
+        chunks))))
+
+(defn- index-data-between-date-time
+  "Bulk index all the concepts with revision dates between the given date-times."
+  [_this context provider-ids start-date-time end-date-time]
+  (info (format "Publishing bulk index messages between [%s] and [%s]."
+                start-date-time end-date-time))
+  (let [provider-ids (if (seq provider-ids)
+                       provider-ids
+                       ;; all providers including CMR provider which is for system concepts
+                       (conj (map :provider-id (helper/get-providers (:system context))) "CMR"))
+        chunk-hours (max 1 (config/bulk-index-between-date-time-window-hours))
+        chunks (date-time-chunks start-date-time end-date-time chunk-hours)]
+    (doseq [provider-id provider-ids
+            [chunk-start chunk-end] chunks]
+      (message-queue/publish-bootstrap-concepts-event
+       context
+       (message-queue/bootstrap-provider-between-date-time-event
+        provider-id chunk-start chunk-end)))
+    (info (format "Published %d bulk index messages between [%s] and [%s] using %d hour chunks."
+                  (* (count provider-ids) (count chunks))
+                  start-date-time
+                  end-date-time
+                  chunk-hours))))
+
 (defn- fingerprint-variables
   "Update fingerprints of variables. If a provider is passed, only update fingerprints of the
   variables for that provider."
@@ -153,6 +191,7 @@
    :index-subscriptions index-subscriptions
    :index-generics index-generics
    :index-data-later-than-date-time index-data-later-than-date-time
+   :index-data-between-date-time index-data-between-date-time
    :index-collection (partial not-implemented :index-collection)
    :index-system-concepts (partial not-implemented :index-system-concepts)
    :index-concepts-by-id (partial not-implemented :index-concepts-by-id)
@@ -174,6 +213,14 @@
     (bulk-index/index-provider (:system context) (:provider-id msg) start-index msg/bulk-index-prefix-queue)
     (bulk-index/index-provider-data-later-than-date-time
      (:system context) (:provider-id msg) (:date-time msg))))
+
+(defmethod handle-bootstrap-event :index-provider-between-date-time
+  [context msg]
+  (bulk-index/index-provider-data-between-date-time
+   (:system context)
+   (:provider-id msg)
+   (:start-date-time msg)
+   (:end-date-time msg)))
 
 (defmethod handle-bootstrap-event :index-variables
   [context msg]

--- a/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/sync.clj
+++ b/bootstrap-app/src/cmr/bootstrap/services/dispatch/impl/sync.clj
@@ -28,6 +28,12 @@
   [_this context provider-ids date-time]
   (bulk-index/index-data-later-than-date-time (:system context) provider-ids date-time))
 
+(defn- index-data-between-date-time
+  "Bulk index all the concepts with revision dates between the given date-times."
+  [_this context provider-ids start-date-time end-date-time]
+  (bulk-index/index-data-between-date-time
+   (:system context) provider-ids start-date-time end-date-time))
+
 (defn- index-collection
   "Bulk index all the granules in a collection"
   [_this context provider-id collection-id options]
@@ -119,6 +125,7 @@
    :index-subscriptions index-subscriptions
    :index-generics index-generics
    :index-data-later-than-date-time index-data-later-than-date-time
+   :index-data-between-date-time index-data-between-date-time
    :index-collection index-collection
    :index-system-concepts index-system-concepts
    :index-concepts-by-id index-concepts-by-id

--- a/bootstrap-app/test/cmr/bootstrap/test/api/bulk_index_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/api/bulk_index_test.clj
@@ -1,0 +1,158 @@
+(ns cmr.bootstrap.test.api.bulk-index-test
+  (:require
+   [clj-time.core :as time]
+   [clojure.test :refer [deftest is testing]]
+   [cmr.bootstrap.api.bulk-index :as bulk-index]
+   [cmr.bootstrap.api.util :as api-util]
+   [cmr.bootstrap.config :as bootstrap-config]
+   [cmr.bootstrap.services.bootstrap-service :as service]
+   [cmr.common.time-keeper :as time-keeper]))
+
+(defn- service-error
+  [f]
+  (try
+    (f)
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
+(deftest data-between-date-time-delegates-to-between-service
+  (let [calls (atom [])
+        context {:system :system}
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 3 0)]
+    (with-redefs [api-util/get-dispatcher (fn [& args]
+                                            (swap! calls conj [:dispatcher args])
+                                            :dispatcher)
+                  service/index-data-between-date-time
+                  (fn [& args]
+                    (swap! calls conj [:service args])
+                    {:message "indexed"})]
+      (let [{:keys [status]} (bulk-index/data-between-date-time
+                              context
+                              {"provider_ids" ["PROV1"]}
+                              {:start_date_time "2026-05-13T01:00:00Z"
+                               :end_date_time "2026-05-13T03:00:00Z"})]
+        (is (= 202 status))
+        (is (= [[:dispatcher [context
+                              {:start_date_time "2026-05-13T01:00:00Z"
+                               :end_date_time "2026-05-13T03:00:00Z"}
+                              :index-data-between-date-time]]
+                [:service [context :dispatcher ["PROV1"] start end]]]
+               @calls))))))
+
+(deftest data-between-date-time-supports-hours-and-default-end-of-day
+  (testing "hours creates the end date-time from the start date-time"
+    (let [service-call (atom nil)
+          context {:system :system}]
+      (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                    service/index-data-between-date-time
+                    (fn [& args]
+                      (reset! service-call args)
+                      {:message "indexed"})]
+        (bulk-index/data-between-date-time
+         context
+         {}
+         {:start_date_time "2026-05-13T01:00:00Z"
+          :hours "2"})
+        (is (= [context
+                :dispatcher
+                nil
+                (time/date-time 2026 5 13 1 0)
+                (time/date-time 2026 5 13 3 0)]
+               @service-call)))))
+
+  (testing "missing end date-time defaults to the start date's end-of-day"
+    (let [service-call (atom nil)
+          context {:system :system}]
+      (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                    service/index-data-between-date-time
+                    (fn [& args]
+                      (reset! service-call args)
+                      {:message "indexed"})]
+        (bulk-index/data-between-date-time
+         context
+         {}
+         {:start_date_time "2026-05-13T01:00:00Z"})
+        (is (= [context
+                :dispatcher
+                nil
+                (time/date-time 2026 5 13 1 0)
+                (time/date-time 2026 5 14 0 0)]
+               @service-call))))))
+
+(deftest data-between-date-time-validates-request
+  (let [context {:system :system}]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)]
+      (testing "start date-time is required"
+        (is (= {:type :invalid-data
+                :errors ["The parameters [:start_date_time] are required"]}
+               (service-error
+                #(bulk-index/data-between-date-time context {} {})))))
+
+      (testing "only one end selector may be provided"
+        (is (= {:type :invalid-data
+                :errors ["Only one of end_date_time or hours may be provided."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "2026-05-13T01:00:00Z"
+                   :end_date_time "2026-05-13T03:00:00Z"
+                   :hours "1"})))))
+
+      (testing "hours must be positive"
+        (is (= {:type :invalid-data
+                :errors ["The hours parameter must be a positive integer."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "2026-05-13T01:00:00Z"
+                   :hours "0"})))))
+
+      (testing "end date-time must be after start date-time"
+        (is (= {:type :invalid-data
+                :errors ["The end date-time must be after the start date-time."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "2026-05-13T03:00:00Z"
+                   :end_date_time "2026-05-13T01:00:00Z"}))))))))
+
+(deftest data-later-than-date-time-delegates-to-bounded-between-service
+  (let [service-call (atom nil)
+        context {:system :system}
+        now (time/date-time 2026 5 13 3 0)]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                  time-keeper/now (constantly now)
+                  bootstrap-config/bulk-index-after-date-time-max-window-hours (constantly 3)
+                  service/index-data-between-date-time
+                  (fn [& args]
+                    (reset! service-call args)
+                    {:message "indexed"})]
+      (let [{:keys [status]} (bulk-index/data-later-than-date-time
+                              context
+                              {"provider_ids" ["PROV1"]}
+                              {:date_time "2026-05-13T01:00:00Z"})]
+        (is (= 202 status))
+        (is (= [context
+                :dispatcher
+                ["PROV1"]
+                (time/date-time 2026 5 13 1 0)
+                now]
+               @service-call))))))
+
+(deftest data-later-than-date-time-rejects-large-window
+  (let [context {:system :system}]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                  time-keeper/now (constantly (time/date-time 2026 5 13 5 0))
+                  bootstrap-config/bulk-index-after-date-time-max-window-hours (constantly 3)]
+      (is (= {:type :invalid-data
+              :errors [(str "/bulk_index/after_date_time is limited to 3 hours. "
+                            "Use /bulk_index/between_date_time with a smaller explicit range.")]}
+             (service-error
+              #(bulk-index/data-later-than-date-time
+                context
+                {}
+                {:date_time "2026-05-13T01:00:00Z"})))))))

--- a/bootstrap-app/test/cmr/bootstrap/test/api/bulk_index_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/api/bulk_index_test.clj
@@ -120,6 +120,53 @@
                   {:start_date_time "2026-05-13T03:00:00Z"
                    :end_date_time "2026-05-13T01:00:00Z"}))))))))
 
+(deftest data-between-date-time-validates-date-time-strings
+  (let [context {:system :system}]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)]
+      (testing "start date-time must parse"
+        (is (= {:type :invalid-data
+                :errors ["bad-start is not a valid date-time."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "bad-start"
+                   :end_date_time "2026-05-13T01:00:00Z"})))))
+
+      (testing "end date-time must parse"
+        (is (= {:type :invalid-data
+                :errors ["bad-end is not a valid date-time."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "2026-05-13T01:00:00Z"
+                   :end_date_time "bad-end"})))))
+
+      (testing "hours must be numeric"
+        (is (= {:type :invalid-data
+                :errors ["The hours parameter must be a positive integer."]}
+               (service-error
+                #(bulk-index/data-between-date-time
+                  context
+                  {}
+                  {:start_date_time "2026-05-13T01:00:00Z"
+                   :hours "two"}))))))))
+
+(deftest data-between-date-time-returns-sync-message
+  (let [context {:system :system}]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                  service/index-data-between-date-time
+                  (constantly {:message "Indexed 2 provider concepts and 1 system concepts."})]
+      (is (= {:status 202
+              :body {:message "Indexed 2 provider concepts and 1 system concepts."}}
+             (bulk-index/data-between-date-time
+              context
+              {}
+              {:start_date_time "2026-05-13T01:00:00Z"
+               :end_date_time "2026-05-13T02:00:00Z"
+               :synchronous "true"}))))))
+
 (deftest data-later-than-date-time-delegates-to-bounded-between-service
   (let [service-call (atom nil)
         context {:system :system}
@@ -156,3 +203,26 @@
                 context
                 {}
                 {:date_time "2026-05-13T01:00:00Z"})))))))
+
+(deftest data-later-than-date-time-validates-range
+  (let [context {:system :system}]
+    (with-redefs [api-util/get-dispatcher (constantly :dispatcher)
+                  time-keeper/now (constantly (time/date-time 2026 5 13 1 0))
+                  bootstrap-config/bulk-index-after-date-time-max-window-hours (constantly 3)]
+      (testing "date-time must parse"
+        (is (= {:type :invalid-data
+                :errors ["bad-date is not a valid date-time."]}
+               (service-error
+                #(bulk-index/data-later-than-date-time
+                  context
+                  {}
+                  {:date_time "bad-date"})))))
+
+      (testing "date-time must be before now"
+        (is (= {:type :invalid-data
+                :errors ["The end date-time must be after the start date-time."]}
+               (service-error
+                #(bulk-index/data-later-than-date-time
+                  context
+                  {}
+                  {:date_time "2026-05-13T01:00:00Z"}))))))))

--- a/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [cmr.bootstrap.data.bulk-index :as bulk-index]
+   [cmr.bootstrap.embedded-system-helper :as helper]
    [cmr.metadata-db.data.oracle.concept-tables :as concept-tables]))
 
 (deftest date-time->sql-timestamp-literal-test
@@ -36,3 +37,37 @@
                  "2026-05-13T01:00:00Z"
                  "2026-05-13T02:00:00Z")]
         (is (string/includes? sql "and provider_id = 'PROV''1'"))))))
+
+(deftest index-data-between-date-time-aggregates-provider-and-system-results
+  (let [calls (atom [])
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 2 0)
+        collection-max (time/date-time 2026 5 13 1 15)
+        granule-max (time/date-time 2026 5 13 1 30)
+        system-max (time/date-time 2026 5 13 1 45)]
+    (with-redefs [helper/get-provider (fn [_system provider-id]
+                                        {:provider-id provider-id})
+                  bulk-index/fetch-and-index-concepts-between-date-times
+                  (fn [_system provider concept-type start-date-time end-date-time]
+                    (swap! calls conj [(:provider-id provider)
+                                       concept-type
+                                       start-date-time
+                                       end-date-time])
+                    (case concept-type
+                      :collection {:num-indexed 2 :max-revision-date collection-max}
+                      :granule {:num-indexed 3 :max-revision-date granule-max}))
+                  bulk-index/index-system-misc-concepts-between-date-times
+                  (fn [_system start-date-time end-date-time]
+                    (swap! calls conj ["CMR" :system start-date-time end-date-time])
+                    {:num-indexed 4 :max-revision-date system-max})]
+      (is (= {:message "Indexed 5 provider concepts and 4 system concepts."
+              :max-revision-date system-max}
+             (bulk-index/index-data-between-date-time
+              {:db-batch-size 10}
+              ["PROV1" "CMR"]
+              start
+              end)))
+      (is (= [["PROV1" :collection start end]
+              ["PROV1" :granule start end]
+              ["CMR" :system start end]]
+             @calls)))))

--- a/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
@@ -36,7 +36,23 @@
                  :access-group
                  "2026-05-13T01:00:00Z"
                  "2026-05-13T02:00:00Z")]
-        (is (string/includes? sql "and provider_id = 'PROV''1'"))))))
+        (is (string/includes? sql "and provider_id = 'PROV''1'"))))
+
+    (testing "adds provider clause for miscellaneous provider concepts"
+      (let [sql (#'bulk-index/find-concepts-between-date-times-sql
+                 {:provider-id "PROV1"}
+                 :variable
+                 "2026-05-13T01:00:00Z"
+                 "2026-05-13T02:00:00Z")]
+        (is (string/includes? sql "and provider_id = 'PROV1'"))))
+
+    (testing "does not add provider clause for CMR miscellaneous concepts"
+      (let [sql (#'bulk-index/find-concepts-between-date-times-sql
+                 {:provider-id "CMR"}
+                 :variable
+                 "2026-05-13T01:00:00Z"
+                 "2026-05-13T02:00:00Z")]
+        (is (not (string/includes? sql "provider_id =")))))))
 
 (deftest index-data-between-date-time-aggregates-provider-and-system-results
   (let [calls (atom [])
@@ -71,3 +87,49 @@
               ["PROV1" :granule start end]
               ["CMR" :system start end]]
              @calls)))))
+
+(deftest index-data-between-date-time-indexes-all-providers-when-provider-ids-empty
+  (let [calls (atom [])
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 2 0)]
+    (with-redefs [helper/get-providers (constantly [{:provider-id "PROV1"}
+                                                    {:provider-id "PROV2"}])
+                  bulk-index/fetch-and-index-concepts-between-date-times
+                  (fn [_system provider concept-type start-date-time end-date-time]
+                    (swap! calls conj [(:provider-id provider)
+                                       concept-type
+                                       start-date-time
+                                       end-date-time])
+                    {:num-indexed 1 :max-revision-date start-date-time})
+                  bulk-index/index-system-misc-concepts-between-date-times
+                  (fn [_system start-date-time end-date-time]
+                    (swap! calls conj ["CMR" :system start-date-time end-date-time])
+                    {:num-indexed 2 :max-revision-date end-date-time})]
+      (is (= {:message "Indexed 4 provider concepts and 2 system concepts."
+              :max-revision-date end}
+             (bulk-index/index-data-between-date-time
+              {:db-batch-size 10}
+              nil
+              start
+              end)))
+      (is (= [["PROV1" :collection start end]
+              ["PROV1" :granule start end]
+              ["PROV2" :collection start end]
+              ["PROV2" :granule start end]
+              ["CMR" :system start end]]
+             @calls)))))
+
+(deftest index-provider-data-between-date-time-routes-cmr-to-system-concepts
+  (let [calls (atom [])
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 2 0)]
+    (with-redefs [bulk-index/index-system-misc-concepts-between-date-times
+                  (fn [_system start-date-time end-date-time]
+                    (swap! calls conj [:system start-date-time end-date-time])
+                    {:num-indexed 3 :max-revision-date end-date-time})]
+      (bulk-index/index-provider-data-between-date-time
+       {:db-batch-size 10}
+       "CMR"
+       start
+       end)
+      (is (= [[:system start end]] @calls)))))

--- a/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/data/bulk_index_test.clj
@@ -1,0 +1,38 @@
+(ns cmr.bootstrap.test.data.bulk-index-test
+  (:require
+   [clj-time.core :as time]
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]]
+   [cmr.bootstrap.data.bulk-index :as bulk-index]
+   [cmr.metadata-db.data.oracle.concept-tables :as concept-tables]))
+
+(deftest date-time->sql-timestamp-literal-test
+  (is (= "TO_TIMESTAMP_TZ('2026-05-13T01:02:03.004Z', 'YYYY-MM-DD\"T\"HH24:MI:SS.FF3\"Z\"')"
+         (#'bulk-index/date-time->sql-timestamp-literal
+          (time/date-time 2026 5 13 1 2 3 4))))
+  (is (= "TO_TIMESTAMP_TZ('2026-05-13T01:02:03.004Z', 'YYYY-MM-DD\"T\"HH24:MI:SS.FF3\"Z\"')"
+         (#'bulk-index/date-time->sql-timestamp-literal
+          "2026-05-13T01:02:03.004Z"))))
+
+(deftest find-concepts-between-date-times-sql-test
+  (with-redefs [concept-tables/get-table-name (constantly "concepts_table")]
+    (testing "uses a half-open revision-date range"
+      (let [sql (#'bulk-index/find-concepts-between-date-times-sql
+                 {:provider-id "PROV1"}
+                 :collection
+                 (time/date-time 2026 5 13 1 0)
+                 (time/date-time 2026 5 13 2 0))]
+        (is (= (str "select * from concepts_table where revision_date >= "
+                    "TO_TIMESTAMP_TZ('2026-05-13T01:00:00.000Z', "
+                    "'YYYY-MM-DD\"T\"HH24:MI:SS.FF3\"Z\"') and revision_date < "
+                    "TO_TIMESTAMP_TZ('2026-05-13T02:00:00.000Z', "
+                    "'YYYY-MM-DD\"T\"HH24:MI:SS.FF3\"Z\"')")
+               sql))))
+
+    (testing "escapes provider ids in provider-specific clauses"
+      (let [sql (#'bulk-index/find-concepts-between-date-times-sql
+                 {:provider-id "PROV'1"}
+                 :access-group
+                 "2026-05-13T01:00:00Z"
+                 "2026-05-13T02:00:00Z")]
+        (is (string/includes? sql "and provider_id = 'PROV''1'"))))))

--- a/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
@@ -1,0 +1,87 @@
+(ns cmr.bootstrap.test.services.dispatch.impl.message-queue-test
+  (:require
+   [clj-time.core :as time]
+   [clojure.test :refer [deftest is testing]]
+   [cmr.bootstrap.config :as config]
+   [cmr.bootstrap.data.message-queue :as message-queue]
+   [cmr.bootstrap.embedded-system-helper :as helper]
+   [cmr.bootstrap.services.dispatch.core :as dispatch]
+   [cmr.bootstrap.services.dispatch.impl.message-queue :as message-queue-dispatcher]))
+
+(deftest date-time-chunks-creates-half-open-ranges
+  (let [start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 4 30)]
+    (is (= [[(time/date-time 2026 5 13 1 0)
+             (time/date-time 2026 5 13 2 0)]
+            [(time/date-time 2026 5 13 2 0)
+             (time/date-time 2026 5 13 3 0)]
+            [(time/date-time 2026 5 13 3 0)
+             (time/date-time 2026 5 13 4 0)]
+            [(time/date-time 2026 5 13 4 0)
+             (time/date-time 2026 5 13 4 30)]]
+           (#'message-queue-dispatcher/date-time-chunks start end 1)))))
+
+(deftest index-data-between-date-time-publishes-provider-chunks
+  (let [published (atom [])
+        context {:system {:providers [{:provider-id "PROV1"}]}}
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 3 30)]
+    (with-redefs [config/bulk-index-between-date-time-window-hours (constantly 1)
+                  message-queue/publish-bootstrap-concepts-event
+                  (fn [_context msg]
+                    (swap! published conj msg))]
+      (dispatch/index-data-between-date-time
+       (message-queue-dispatcher/->MessageQueueDispatcher)
+       context
+       ["PROV1"]
+       start
+       end)
+      (is (= [{:action :index-provider-between-date-time
+               :provider-id "PROV1"
+               :start-date-time (time/date-time 2026 5 13 1 0)
+               :end-date-time (time/date-time 2026 5 13 2 0)}
+              {:action :index-provider-between-date-time
+               :provider-id "PROV1"
+               :start-date-time (time/date-time 2026 5 13 2 0)
+               :end-date-time (time/date-time 2026 5 13 3 0)}
+              {:action :index-provider-between-date-time
+               :provider-id "PROV1"
+               :start-date-time (time/date-time 2026 5 13 3 0)
+               :end-date-time (time/date-time 2026 5 13 3 30)}]
+             @published)))))
+
+(deftest index-data-between-date-time-expands-empty-provider-list
+  (let [published (atom [])
+        context {:system :system}
+        start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 2 0)]
+    (with-redefs [helper/get-providers (constantly [{:provider-id "PROV1"}
+                                                    {:provider-id "PROV2"}])
+                  config/bulk-index-between-date-time-window-hours (constantly 0)
+                  message-queue/publish-bootstrap-concepts-event
+                  (fn [_context msg]
+                    (swap! published conj msg))]
+      (testing "empty provider ids uses all providers plus CMR and clamps chunk hours to one"
+        (dispatch/index-data-between-date-time
+         (message-queue-dispatcher/->MessageQueueDispatcher)
+         context
+         nil
+         start
+         end)
+        (is (= ["CMR" "PROV1" "PROV2"] (map :provider-id @published)))
+        (is (every? #(= start (:start-date-time %)) @published))
+        (is (every? #(= end (:end-date-time %)) @published))))))
+
+(deftest handle-bootstrap-event-index-provider-between-date-time
+  (let [call (atom nil)]
+    (with-redefs [cmr.bootstrap.data.bulk-index/index-provider-data-between-date-time
+                  (fn [& args]
+                    (reset! call args))]
+      (message-queue-dispatcher/handle-bootstrap-event
+       {:system :system}
+       {:action :index-provider-between-date-time
+        :provider-id "PROV1"
+        :start-date-time "2026-05-13T01:00:00Z"
+        :end-date-time "2026-05-13T02:00:00Z"})
+      (is (= [:system "PROV1" "2026-05-13T01:00:00Z" "2026-05-13T02:00:00Z"]
+             @call)))))

--- a/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
@@ -3,6 +3,7 @@
    [clj-time.core :as time]
    [clojure.test :refer [deftest is testing]]
    [cmr.bootstrap.config :as config]
+   [cmr.bootstrap.data.bulk-index :as bulk-index-data]
    [cmr.bootstrap.data.message-queue :as message-queue]
    [cmr.bootstrap.embedded-system-helper :as helper]
    [cmr.bootstrap.services.dispatch.core :as dispatch]
@@ -90,7 +91,7 @@
 
 (deftest handle-bootstrap-event-index-provider-between-date-time
   (let [call (atom nil)]
-    (with-redefs [cmr.bootstrap.data.bulk-index/index-provider-data-between-date-time
+    (with-redefs [bulk-index-data/index-provider-data-between-date-time
                   (fn [& args]
                     (reset! call args))]
       (message-queue-dispatcher/handle-bootstrap-event

--- a/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
+++ b/bootstrap-app/test/cmr/bootstrap/test/services/dispatch/impl/message_queue_test.clj
@@ -21,6 +21,22 @@
              (time/date-time 2026 5 13 4 30)]]
            (#'message-queue-dispatcher/date-time-chunks start end 1)))))
 
+(deftest date-time-chunks-returns-empty-when-range-is-empty
+  (let [start (time/date-time 2026 5 13 1 0)]
+    (is (= [] (#'message-queue-dispatcher/date-time-chunks start start 1)))))
+
+(deftest bootstrap-provider-between-date-time-event-test
+  (let [start (time/date-time 2026 5 13 1 0)
+        end (time/date-time 2026 5 13 2 0)]
+    (is (= {:action :index-provider-between-date-time
+            :provider-id "PROV1"
+            :start-date-time start
+            :end-date-time end}
+           (message-queue/bootstrap-provider-between-date-time-event
+            "PROV1"
+            start
+            end)))))
+
 (deftest index-data-between-date-time-publishes-provider-chunks
   (let [published (atom [])
         context {:system {:providers [{:provider-id "PROV1"}]}}

--- a/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/bootstrap_util.clj
@@ -45,6 +45,37 @@
          body (json/decode (:body response) true)]
      (assoc body :status (:status response)))))
 
+(defn bulk-index-between-date-time
+  "Call the bootstrap app to bulk index concepts with revision dates between the given datetimes."
+  ([start-date-time end-date-time]
+   (bulk-index-between-date-time
+    start-date-time end-date-time {transmit-config/token-header (transmit-config/echo-system-token)}))
+  ([start-date-time end-date-time headers]
+   (let [response (client/request
+                   {:method :post
+                    :headers headers
+                    :query-params {:synchronous true}
+                    :url (url/bulk-index-between-date-time-url start-date-time end-date-time)
+                    :content-type :json
+                    :accept :json
+                    :throw-exceptions false
+                    :connection-manager (s/conn-mgr)})
+         body (json/decode (:body response) true)]
+     (assoc body :status (:status response))))
+  ([start-date-time end-date-time headers provider-ids]
+   (let [response (client/request
+                   {:method :post
+                    :headers headers
+                    :query-params {:synchronous true}
+                    :url (url/bulk-index-between-date-time-url start-date-time end-date-time)
+                    :body (json/generate-string {:provider_ids provider-ids})
+                    :content-type :json
+                    :accept :json
+                    :throw-exceptions false
+                    :connection-manager (s/conn-mgr)})
+         body (json/decode (:body response) true)]
+     (assoc body :status (:status response)))))
+
 (defn bulk-index-concepts
   "Call the bootstrap app to bulk index concepts by id."
   ([provider-id concept-type concept-ids]

--- a/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
+++ b/system-int-test/src/cmr/system_int_test/utils/url_helper.clj
@@ -549,6 +549,13 @@
           (transmit-config/bootstrap-port)
           date-time))
 
+(defn bulk-index-between-date-time-url
+  [start-date-time end-date-time]
+  (format "http://localhost:%s/bulk_index/between_date_time?start_date_time=%s&end_date_time=%s"
+          (transmit-config/bootstrap-port)
+          start-date-time
+          end-date-time))
+
 (defn bulk-index-concepts-url
   []
   (format "http://localhost:%s/bulk_index/concepts" (transmit-config/bootstrap-port)))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/concepts_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/bulk_index/concepts_test.clj
@@ -9,6 +9,7 @@
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.system :as s]
    [cmr.system-int-test.utils.bootstrap-util :as bootstrap]
+   [cmr.system-int-test.utils.dev-system-util :as dev-sys-util]
    [cmr.system-int-test.utils.index-util :as index]
    [cmr.system-int-test.utils.ingest-util :as ingest]
    [cmr.system-int-test.utils.search-util :as search]
@@ -227,6 +228,78 @@
      (testing "Concepts are indexed."
        (verify-collections-granules-are-indexed [coll1 coll2] [gran2])
        (assert-indexed-tags [tag1])))))
+
+(deftest ^:oracle bulk-index-between-date-time
+  (s/only-with-real-database
+   (let [;; saved but not indexed
+         coll1 (core/save-collection "PROV1" 1 {:revision-date "3016-01-01T10:00:00Z"})
+         gran1 (core/save-granule "PROV1" 1 coll1 {:revision-date "3016-01-01T10:00:00Z"})
+         coll2 (core/save-collection "PROV1" 2 {:revision-date "3016-01-02T10:00:00Z"})
+         gran2 (core/save-granule "PROV1" 2 coll2 {:revision-date "3016-01-02T10:00:00Z"})
+         coll3 (core/save-collection "PROV2" 3 {:revision-date "3016-01-01T10:00:00Z"})
+         gran3 (core/save-granule "PROV2" 3 coll3 {:revision-date "3016-01-01T10:00:00Z"})
+         {:keys [status errors]} (bootstrap/bulk-index-between-date-time
+                                  "3016-01-01T00:00:00Z"
+                                  "3016-01-02T00:00:00Z"
+                                  nil
+                                  ["PROV1"])]
+
+     (is (= [401 ["You do not have permission to perform that action."]]
+            [status errors]))
+
+     (bootstrap/bulk-index-between-date-time
+      "3016-01-01T00:00:00Z"
+      "3016-01-02T00:00:00Z"
+      {tc/token-header (tc/echo-system-token)}
+      ["PROV1"])
+     (index/wait-until-indexed)
+
+     (testing "Only provider concepts within the date-time range are indexed."
+       (verify-collections-granules-are-indexed [coll1] [gran1] (tc/echo-system-token))))))
+
+(deftest ^:oracle bulk-index-after-date-time-uses-bounded-range
+  (s/only-with-real-database
+   (try
+     (dev-sys-util/freeze-time! "3016-01-02T00:00:00Z")
+     (let [;; saved but not indexed
+           coll1 (core/save-collection "PROV1" 1 {:revision-date "3016-01-01T10:00:00Z"})
+           gran1 (core/save-granule "PROV1" 1 coll1 {:revision-date "3016-01-01T10:00:00Z"})
+           coll2 (core/save-collection "PROV1" 2 {:revision-date "3016-01-02T10:00:00Z"})
+           gran2 (core/save-granule "PROV1" 2 coll2 {:revision-date "3016-01-02T10:00:00Z"})
+           coll3 (core/save-collection "PROV2" 3 {:revision-date "3016-01-01T10:00:00Z"})
+           gran3 (core/save-granule "PROV2" 3 coll3 {:revision-date "3016-01-01T10:00:00Z"})
+           {:keys [status errors]} (bootstrap/bulk-index-after-date-time
+                                    "3016-01-01T00:00:00Z"
+                                    nil
+                                    ["PROV1"])]
+
+       (is (= [401 ["You do not have permission to perform that action."]]
+              [status errors]))
+
+       (bootstrap/bulk-index-after-date-time
+        "3016-01-01T00:00:00Z"
+        {tc/token-header (tc/echo-system-token)}
+        ["PROV1"])
+       (index/wait-until-indexed)
+
+       (testing "Only provider concepts after the date-time and before now are indexed."
+         (verify-collections-granules-are-indexed [coll1] [gran1] (tc/echo-system-token))))
+     (finally
+       (dev-sys-util/clear-current-time!)))))
+
+(deftest ^:oracle bulk-index-after-date-time-rejects-large-window
+  (s/only-with-real-database
+   (try
+     (dev-sys-util/freeze-time! "3016-01-10T00:00:00Z")
+     (let [{:keys [status errors]} (bootstrap/bulk-index-after-date-time
+                                    "3016-01-02T00:00:00Z"
+                                    {tc/token-header (tc/echo-system-token)}
+                                    ["PROV1"])]
+       (is (= 422 status))
+       (is (re-find #"/bulk_index/after_date_time is limited to 168 hours"
+                    (first errors))))
+     (finally
+       (dev-sys-util/clear-current-time!)))))
 
 (deftest ^{:kaocha/skip true
            :oracle true} zzz_bulk-index-after-date-time


### PR DESCRIPTION
# Overview

### What is the objective?

Redesign bulk index with timeframe underneath so that large timeframes of data requested can be chunked and processed to improve efficiency.

### What are the changes?

Added a new `/bulk_index/between_date_time` endpoint that indexes provider/system concepts within an explicit revision-date range, chunking the work into smaller configurable batches. Updated `/bulk_index/after_date_time` to reuse that same bounded range logic by treating it as date_time -> now, with a max 168-hour (also default and configurable) window to prevent overly large requests. Added the service, dispatcher, message queue, Oracle SQL, config, and README wiring needed to support these changes. Added integration test coverage for the new endpoint, the safer /after_date_time behavior, and rejection of too large /after_date_time windows.

### What areas of the application does this impact?

bootstrap-app

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
