### PR TITLE
CMR-11289 fix the java docker builder

### DIFF
--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -12,7 +12,7 @@ RUN apt-get update \
  && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*
 
-#RUN mkdir -p /root/.lein \
-#  && cd /root/.lein \
-#  && curl --silent --location --remote-name \
-#  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj
+RUN mkdir -p /root/.lein \
+  && cd /root/.lein \
+  && curl --silent --location --remote-name \
+  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -16,4 +16,3 @@ RUN mkdir -p \$HOME/.lein \
   && cd \$HOME/.lein \
   && curl --silent --location --remote-name \
   https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj
-

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -12,7 +12,7 @@ RUN apt-get update \
  && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p \$HOME/.lein \
-  && cd \$HOME/.lein \
+RUN mkdir -p /root/.lein \
+  && cd /root/.lein \
   && curl --silent --location --remote-name \
   https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -12,7 +12,7 @@ RUN apt-get update \
  && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /root/.lein \
-  && cd /root/.lein \
-  && curl --silent --location --remote-name \
-  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj
+#RUN mkdir -p /root/.lein \
+#  && cd /root/.lein \
+#  && curl --silent --location --remote-name \
+#  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -8,4 +8,6 @@ RUN apt-get update \
       netbase \
       unzip \
       zip \
+      ca-certificates \
+ && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -8,11 +8,7 @@ RUN apt-get update \
       netbase \
       unzip \
       zip \
-      ca-certificates \
- && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /root/.lein \
-  && cd /root/.lein \
-  && curl --silent --location --remote-name \
-  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj
+RUN mkdir -p /root/.lein
+COPY profiles.bamboo.clj /root/.lein/profiles.clj

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -11,3 +11,9 @@ RUN apt-get update \
       ca-certificates \
  && update-ca-certificates -f \
  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p \$HOME/.lein \
+  && cd \$HOME/.lein \
+  && curl --silent --location --remote-name \
+  https://maven.earthdata.nasa.gov/repository/cmr/profiles.clj
+

--- a/dev-system/Dockerfile.java17.builder
+++ b/dev-system/Dockerfile.java17.builder
@@ -1,4 +1,4 @@
-FROM clojure:temurin-17-lein-bullseye
+FROM clojure:temurin-17-lein-trixie
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \

--- a/dev-system/profiles.bamboo.clj
+++ b/dev-system/profiles.bamboo.clj
@@ -1,3 +1,7 @@
 {:user
  {:repositories
-  {"earthdata-nexus" {:url "https://maven.earthdata.nasa.gov/repository/maven-public"}}}}
+  {"earthdata-nexus"   {:url "https://maven.earthdata.nasa.gov/repository/maven-public"}
+   "central"           {:url "https://repo1.maven.org/maven2/"}
+   "clojars"           {:url "https://repo.clojars.org/"}
+   "sonatype-releases" {:url "https://oss.sonatype.org/content/repositories/releases/"}
+   "apache-releases"   {:url "https://repository.apache.org/content/repositories/releases/"}}}}

--- a/dev-system/profiles.bamboo.clj
+++ b/dev-system/profiles.bamboo.clj
@@ -1,6 +1,6 @@
 {:user
  {:repositories
-  {"earthdata-nexus"   {:url "https://maven.earthdata.nasa.gov/repository/maven-public"}
+  {"earthdata-nexus"   {:url "https://maven.earthdata.nasa.gov/repository/maven-public/"}
    "central"           {:url "https://repo1.maven.org/maven2/"}
    "clojars"           {:url "https://repo.clojars.org/"}
    "sonatype-releases" {:url "https://oss.sonatype.org/content/repositories/releases/"}

--- a/dev-system/profiles.bamboo.clj
+++ b/dev-system/profiles.bamboo.clj
@@ -1,0 +1,3 @@
+{:user
+ {:repositories
+  {"earthdata-nexus" {:url "https://maven.earthdata.nasa.gov/repository/maven-public"}}}}

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -7,6 +7,9 @@
                    :inherit [:managed-dependencies]}
   :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [com.fasterxml.jackson.core/jackson-core]
+                 [com.fasterxml.jackson.core/jackson-databind]
+
                  [clj-http]
                  [clojurewerkz/elastisch "5.0.0-beta1"]
                  [commons-codec/commons-codec "1.11"]


### PR DESCRIPTION
# Overview
Fix the java docker builder image used by bamboo

### What is the objective?
Change the way that repositories are used by lein add adding more repositories and trying to set the order at which to use them.

### What are the changes?
1. Adding a profile.clj to the java docker file
2. found an exclusion of com.fasterxml.jackson.core/jackson-core but never added the newer one

### What areas of the application does this impact?
* Elastic Utils Lib
* Docker image used in bamboo

NOTE: This docker image is only used in the nightly build script to build a new image and then push it up to maven. Pushing this release to bamboo will not show any impact till that build process runs.