### PR TITLE
Filter null or empty providers from search results to fix #2177

### DIFF
--- a/search-app/src/cmr/search/api/providers.clj
+++ b/search-app/src/cmr/search/api/providers.clj
@@ -57,7 +57,10 @@
         provider-metadata (-> response-body
                               (as-> body (map :metadata body))
                               (as-> metadata-list
-                                    (map #(util/remove-nested-key % [:Administrators]) metadata-list))
+                                  (->> metadata-list
+                                       (map #(util/remove-nested-key % [:Administrators]))
+                                       ;; account for bad metadata and remove null/empty results
+                                       (filter seq)))
                               json/generate-string)
         new-response {}]
     (assoc new-response :hits hits :took time-taken :items (json/parse-string provider-metadata true))))


### PR DESCRIPTION
# Overview

### What is the objective?

Fixes #2177

Null and empty values in the list of providers located at /search/providers

### What are the changes?

This adds a filter to check for truthy values in the list of metadata. This is a HACK fix since the provider data is likely in question.

### What areas of the application does this impact?

Search

