### PR TITLE
Fix group 4 test

### DIFF
--- a/system-int-test/test/cmr/system_int_test/ingest/granule/granule_validation_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/granule/granule_validation_test.clj
@@ -22,7 +22,9 @@
     [cmr.umm.umm-granule :as umm-g]
     [cmr.umm.umm-spatial :as umm-s]))
 
-(use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}))
+(use-fixtures :each (fn [f]
+                      (ingest/enable-ingest-writes)
+                      ((ingest/reset-fixture {"provguid1" "PROV1" "provguid2" "PROV2"}) f)))
 
 (comment
   (do
@@ -478,7 +480,7 @@
                               :short-name "S1"
                               :version-id "V1"}
         collection (data-umm-c/collection collection-attrs)
-        coll-concept (d/umm-c-collection->concept collection :iso-smap)]
+        coll-concept (d/umm-c-collection->concept collection :echo10)]
     (testing "valid UMM-G granule"
       (let [granule (assoc (dg/granule-with-umm-spec-collection collection nil)
                            :collection-ref


### PR DESCRIPTION
# Overview

### What is the objective?

Fix group4 test. We believe curl version changed in our machine and thus it's no longer reading 'application/iso:smap+xml' correcting due to not being able to read past colon and thus failing with "The collection given for validating the granule was invalid: &quot;Invalid content-type: application/iso"

### What are the changes?

Update test to use echo10 instead of iso and force ingest write enable

### What areas of the application does this impact?

List impacted applications

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
