### PR TITLE
CMR-11311 - Initializing additional caches to prevent CmrHashCache error

### DIFF
--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -225,29 +225,6 @@
   []
   (create-kms-uuid-cache kms-temporal-keywords-cache-key))
 
-(defn create-all-kms-caches
-  "Creates all KMS caches required by create-kms-index and lookup functions.
-  Intended for centralized context setup to avoid missing-cache test failures when
-  new KMS cache keys are introduced."
-  []
-  {kms-short-name-cache-key (create-kms-short-name-cache)
-   kms-projects-cache-key (create-kms-project-uuid-cache)
-   kms-umm-c-cache-key (create-kms-umm-c-cache)
-   kms-location-cache-key (create-kms-location-cache)
-   kms-measurement-cache-key (create-kms-measurement-cache)
-   kms-processing-level-cache-key (create-kms-processing-level-uuid-cache)
-   kms-science-keywords-cache-key (create-kms-science-keywords-uuid-cache)
-   kms-platforms-cache-key (create-kms-platforms-uuid-cache)
-   kms-instruments-cache-key (create-kms-instruments-uuid-cache)
-   kms-providers-cache-key (create-kms-providers-uuid-cache)
-   kms-spatial-keywords-cache-key (create-kms-spatial-keywords-uuid-cache)
-   kms-concepts-cache-key (create-kms-concepts-uuid-cache)
-   kms-iso-topic-categories-cache-key (create-kms-iso-topic-categories-uuid-cache)
-   kms-granule-data-format-cache-key (create-kms-granule-data-format-uuid-cache)
-   kms-mime-type-cache-key (create-kms-mime-type-uuid-cache)
-   kms-related-urls-cache-key (create-kms-related-urls-uuid-cache)
-   kms-temporal-keywords-cache-key (create-kms-temporal-keywords-uuid-cache)})
-
 (def kms-scheme->fields-for-umm-c-lookup
   "Maps the KMS keyword scheme to the list of fields that should be matched when
   comparing fields between KMS and UMM-C, UMM-G, UMM-S, UMM-T, or UMM-Var."

--- a/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/services/kms_lookup.clj
@@ -225,6 +225,29 @@
   []
   (create-kms-uuid-cache kms-temporal-keywords-cache-key))
 
+(defn create-all-kms-caches
+  "Creates all KMS caches required by create-kms-index and lookup functions.
+  Intended for centralized context setup to avoid missing-cache test failures when
+  new KMS cache keys are introduced."
+  []
+  {kms-short-name-cache-key (create-kms-short-name-cache)
+   kms-projects-cache-key (create-kms-project-uuid-cache)
+   kms-umm-c-cache-key (create-kms-umm-c-cache)
+   kms-location-cache-key (create-kms-location-cache)
+   kms-measurement-cache-key (create-kms-measurement-cache)
+   kms-processing-level-cache-key (create-kms-processing-level-uuid-cache)
+   kms-science-keywords-cache-key (create-kms-science-keywords-uuid-cache)
+   kms-platforms-cache-key (create-kms-platforms-uuid-cache)
+   kms-instruments-cache-key (create-kms-instruments-uuid-cache)
+   kms-providers-cache-key (create-kms-providers-uuid-cache)
+   kms-spatial-keywords-cache-key (create-kms-spatial-keywords-uuid-cache)
+   kms-concepts-cache-key (create-kms-concepts-uuid-cache)
+   kms-iso-topic-categories-cache-key (create-kms-iso-topic-categories-uuid-cache)
+   kms-granule-data-format-cache-key (create-kms-granule-data-format-uuid-cache)
+   kms-mime-type-cache-key (create-kms-mime-type-uuid-cache)
+   kms-related-urls-cache-key (create-kms-related-urls-uuid-cache)
+   kms-temporal-keywords-cache-key (create-kms-temporal-keywords-uuid-cache)})
+
 (def kms-scheme->fields-for-umm-c-lookup
   "Maps the KMS keyword scheme to the list of fields that should be matched when
   comparing fields between KMS and UMM-C, UMM-G, UMM-S, UMM-T, or UMM-Var."

--- a/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
@@ -3,7 +3,7 @@
   (:require
    [cmr.common-app.services.kms-lookup :as kms-lookup]))
 
-(defn create-all-kms-caches
+(defn create-kms-caches-for-testing
   "Creates all KMS caches required by create-kms-index and lookup functions.
   Intended for centralized context setup to avoid missing-cache test failures when
   new KMS cache keys are introduced."

--- a/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
@@ -1,0 +1,27 @@
+(ns cmr.common-app.test.kms-lookup
+  "Shared test helpers for setting up KMS caches."
+  (:require
+   [cmr.common-app.services.kms-lookup :as kms-lookup]))
+
+(defn create-all-kms-caches
+  "Creates all KMS caches required by create-kms-index and lookup functions.
+  Intended for centralized context setup to avoid missing-cache test failures when
+  new KMS cache keys are introduced."
+  []
+  {kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
+   kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
+   kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
+   kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
+   kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
+   kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
+   kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
+   kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
+   kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
+   kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
+   kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
+   kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
+   kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
+   kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
+   kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
+   kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
+   kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)})

--- a/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
+++ b/common-app-lib/src/cmr/common_app/test/kms_lookup.clj
@@ -6,7 +6,7 @@
 (defn create-kms-caches-for-testing
   "Creates all KMS caches required by create-kms-index and lookup functions.
   Intended for centralized context setup to avoid missing-cache test failures when
-  new KMS cache keys are introduced."
+  new KMS cache keys are introduced. This is only for testing."
   []
   {kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
    kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
@@ -55,21 +55,21 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (test-kms-lookup/create-all-kms-caches)}})
+  {:system {:caches (test-kms-lookup/create-kms-caches-for-testing)}})
 
-(deftest create-all-kms-caches-coverage-test
-  (testing "create-all-kms-caches includes every *-cache-key defined in kms-lookup"
+(deftest create-kms-caches-for-testing-coverage-test
+  (testing "create-kms-caches-for-testing includes every *-cache-key defined in kms-lookup"
     (let [expected-cache-keys (->> (ns-publics 'cmr.common-app.services.kms-lookup)
                                    (filter (fn [[sym _]]
                                              (string/ends-with? (name sym) "-cache-key")))
                                    (map (fn [[_ v]] (var-get v)))
                                    set)
-          actual-cache-keys (-> (test-kms-lookup/create-all-kms-caches)
+          actual-cache-keys (-> (test-kms-lookup/create-kms-caches-for-testing)
                                 keys
                                 set)]
       (is (= expected-cache-keys actual-cache-keys)
           (str "KMS cache helper is out of sync. When adding a new `*-cache-key` in "
-               "cmr.common-app.services.kms-lookup, also update create-all-kms-caches so "
+               "cmr.common-app.services.kms-lookup, also update create-kms-caches-for-testing so "
                "test contexts across modules keep working.")))))
 
 (defn redis-cache-fixture

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
@@ -1,6 +1,7 @@
 (ns cmr.common-app.test.services.kms-lookup
   "Unit tests for KMS lookup namespace."
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
    [cmr.common-app.services.kms-lookup :as kms-lookup]
    [cmr.common.util :refer [are3]]
@@ -53,23 +54,22 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches {kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
-                     kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
-                     kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
-                     kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
-                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
-                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
-                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
-                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
-                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
-                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
-                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
-                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
-                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
-                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
-                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
-                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}})
+  {:system {:caches (kms-lookup/create-all-kms-caches)}})
+
+(deftest create-all-kms-caches-coverage-test
+  (testing "create-all-kms-caches includes every *-cache-key defined in kms-lookup"
+    (let [expected-cache-keys (->> (ns-publics 'cmr.common-app.services.kms-lookup)
+                                   (filter (fn [[sym _]]
+                                             (string/ends-with? (name sym) "-cache-key")))
+                                   (map (fn [[_ v]] (var-get v)))
+                                   set)
+          actual-cache-keys (-> (kms-lookup/create-all-kms-caches)
+                                keys
+                                set)]
+      (is (= expected-cache-keys actual-cache-keys)
+          (str "KMS cache helper is out of sync. When adding a new `*-cache-key` in "
+               "cmr.common-app.services.kms-lookup, also update create-all-kms-caches so "
+               "test contexts across modules keep working.")))))
 
 (defn redis-cache-fixture
   "Sets up the redis cache fixture to load data into the caches for testing."

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
@@ -4,6 +4,7 @@
    [clojure.string :as string]
    [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
    [cmr.common-app.services.kms-lookup :as kms-lookup]
+   [cmr.common-app.test.kms-lookup :as test-kms-lookup]
    [cmr.common.util :refer [are3]]
    [cmr.redis-utils.test.test-util :as redis-embedded-fixture]))
 
@@ -54,7 +55,7 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (kms-lookup/create-all-kms-caches)}})
+  {:system {:caches (test-kms-lookup/create-all-kms-caches)}})
 
 (deftest create-all-kms-caches-coverage-test
   (testing "create-all-kms-caches includes every *-cache-key defined in kms-lookup"
@@ -63,7 +64,7 @@
                                              (string/ends-with? (name sym) "-cache-key")))
                                    (map (fn [[_ v]] (var-get v)))
                                    set)
-          actual-cache-keys (-> (kms-lookup/create-all-kms-caches)
+          actual-cache-keys (-> (test-kms-lookup/create-all-kms-caches)
                                 keys
                                 set)]
       (is (= expected-cache-keys actual-cache-keys)

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup.clj
@@ -57,7 +57,19 @@
                      kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
                      kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
                      kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)}}})
+                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
+                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
+                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
+                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
+                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
+                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
+                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
+                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
+                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
+                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
+                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
+                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
+                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}})
 
 (defn redis-cache-fixture
   "Sets up the redis cache fixture to load data into the caches for testing."

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
@@ -1,4 +1,4 @@
-(ns cmr.common-app.test.services.kms-lookup-errors-test
+`(ns cmr.common-app.test.services.kms-lookup-errors-test
   "Unit tests for specific connection errors coming from kms-lookup"
   (:require
     [clojure.test :refer [deftest is testing]]
@@ -10,7 +10,19 @@
                      kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
                      kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
                      kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)}}})
+                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
+                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
+                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
+                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
+                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
+                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
+                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
+                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
+                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
+                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
+                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
+                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
+                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}})
 
 (def create-context-broken
   "Creates a testing concept with the KMS caches."
@@ -18,7 +30,19 @@
                          kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
                          kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
                          kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                         kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)}}}
+                         kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
+                         kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
+                         kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
+                         kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
+                         kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
+                         kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
+                         kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
+                         kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
+                         kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
+                         kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
+                         kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
+                         kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
+                         kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}}
       (update-in
        [:system :caches :kms-measurement-index :read-connection :spec :host]
        (constantly "example.gov"))))

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
@@ -2,15 +2,16 @@
   "Unit tests for specific connection errors coming from kms-lookup"
   (:require
     [clojure.test :refer [deftest is testing]]
-    [cmr.common-app.services.kms-lookup :as kms-lookup]))
+    [cmr.common-app.services.kms-lookup :as kms-lookup]
+    [cmr.common-app.test.kms-lookup :as test-kms-lookup]))
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (kms-lookup/create-all-kms-caches)}})
+  {:system {:caches (test-kms-lookup/create-all-kms-caches)}})
 
 (def create-context-broken
   "Creates a testing concept with the KMS caches."
-  (-> {:system {:caches (kms-lookup/create-all-kms-caches)}}
+  (-> {:system {:caches (test-kms-lookup/create-all-kms-caches)}}
       (update-in
        [:system :caches :kms-measurement-index :read-connection :spec :host]
        (constantly "example.gov"))))

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
@@ -7,11 +7,11 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (test-kms-lookup/create-all-kms-caches)}})
+  {:system {:caches (test-kms-lookup/create-kms-caches-for-testing)}})
 
 (def create-context-broken
   "Creates a testing concept with the KMS caches."
-  (-> {:system {:caches (test-kms-lookup/create-all-kms-caches)}}
+  (-> {:system {:caches (test-kms-lookup/create-kms-caches-for-testing)}}
       (update-in
        [:system :caches :kms-measurement-index :read-connection :spec :host]
        (constantly "example.gov"))))

--- a/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
+++ b/common-app-lib/test/cmr/common_app/test/services/kms_lookup_errors_test.clj
@@ -1,4 +1,4 @@
-`(ns cmr.common-app.test.services.kms-lookup-errors-test
+(ns cmr.common-app.test.services.kms-lookup-errors-test
   "Unit tests for specific connection errors coming from kms-lookup"
   (:require
     [clojure.test :refer [deftest is testing]]
@@ -6,43 +6,11 @@
 
 (def create-context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches {kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
-                     kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
-                     kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
-                     kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
-                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
-                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
-                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
-                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
-                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
-                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
-                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
-                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
-                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
-                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
-                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
-                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}})
+  {:system {:caches (kms-lookup/create-all-kms-caches)}})
 
 (def create-context-broken
   "Creates a testing concept with the KMS caches."
-  (-> {:system {:caches {kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
-                         kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)
-                         kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
-                         kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                         kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
-                         kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
-                         kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
-                         kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
-                         kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
-                         kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
-                         kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
-                         kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
-                         kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
-                         kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
-                         kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
-                         kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
-                         kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)}}}
+  (-> {:system {:caches (kms-lookup/create-all-kms-caches)}}
       (update-in
        [:system :caches :kms-measurement-index :read-connection :spec :host]
        (constantly "example.gov"))))

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
@@ -19,7 +19,7 @@
 (def create-context
   (let [humanizer-cache (imc/create-in-memory-cache)]
     {:system {:caches (merge {hf/humanizer-cache-key humanizer-cache}
-                             (test-kms-lookup/create-all-kms-caches))}}))
+                             (test-kms-lookup/create-kms-caches-for-testing))}}))
 
 (defn redis-cache-fixture
   [f]

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
@@ -15,13 +15,15 @@
    {:platforms [{:basis "Space-based Platforms", :category "Earth Observation Satellites" :sub-category nil :short-name "Terra" :long-name "Earth Observing System, Terra (AM-1)" :uuid "80eca755-c564-4616-b910-a4c4387b7c54"}
                 {:basis "Space-based Platforms", :category "Space Stations/Crewed Spacecraft", :sub-category "Space Station", :short-name "ISS", :long-name "International Space Station", :uuid "93c5d18c-be62-46c4-9545-42f73a854d85"}]})
 
+(defn- create-kms-caches
+  "Creates KMS caches using the centralized helper."
+  []
+  (kms-lookup/create-all-kms-caches))
+
 (def create-context
   (let [humanizer-cache (imc/create-in-memory-cache)]
-    {:system {:caches {hf/humanizer-cache-key humanizer-cache
-                       kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
-                       kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
-                       kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                       kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)}}}))
+    {:system {:caches (merge {hf/humanizer-cache-key humanizer-cache}
+                             (create-kms-caches))}}))
 
 (defn redis-cache-fixture
   [f]

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
@@ -5,6 +5,7 @@
    [cmr.common.util :refer [are3]]
    [cmr.common-app.services.kms-lookup :as kms-lookup]
    [cmr.common-app.test.sample-humanizer :as sh]
+   [cmr.common-app.test.kms-lookup :as test-kms-lookup]
    [cmr.common.cache :as cache]
    [cmr.common.cache.in-memory-cache :as imc]
    [cmr.indexer.data.concepts.collection.humanizer :as humanizer]
@@ -18,7 +19,7 @@
 (defn- create-kms-caches
   "Creates KMS caches using the centralized helper."
   []
-  (kms-lookup/create-all-kms-caches))
+  (test-kms-lookup/create-all-kms-caches))
 
 (def create-context
   (let [humanizer-cache (imc/create-in-memory-cache)]

--- a/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
+++ b/indexer-app/test/cmr/indexer/test/data/concepts/collection/humanizer.clj
@@ -16,15 +16,10 @@
    {:platforms [{:basis "Space-based Platforms", :category "Earth Observation Satellites" :sub-category nil :short-name "Terra" :long-name "Earth Observing System, Terra (AM-1)" :uuid "80eca755-c564-4616-b910-a4c4387b7c54"}
                 {:basis "Space-based Platforms", :category "Space Stations/Crewed Spacecraft", :sub-category "Space Station", :short-name "ISS", :long-name "International Space Station", :uuid "93c5d18c-be62-46c4-9545-42f73a854d85"}]})
 
-(defn- create-kms-caches
-  "Creates KMS caches using the centralized helper."
-  []
-  (test-kms-lookup/create-all-kms-caches))
-
 (def create-context
   (let [humanizer-cache (imc/create-in-memory-cache)]
     {:system {:caches (merge {hf/humanizer-cache-key humanizer-cache}
-                             (create-kms-caches))}}))
+                             (test-kms-lookup/create-all-kms-caches))}}))
 
 (defn redis-cache-fixture
   [f]

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
@@ -42,7 +42,7 @@
 
 (def ^:private context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (test-kms-lookup/create-all-kms-caches)}
+  {:system {:caches (test-kms-lookup/create-kms-caches-for-testing)}
    :ignore-kms-keywords true})
 
 (defn redis-cache-fixture

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
@@ -39,12 +39,14 @@
                        :variable-level-1 "VL1" :variable-level-2 "VL2"
                        :variable-level-3 "VL3" :uuid "sk1-uuid"}]})
 
+(defn- create-kms-caches
+  "Creates KMS caches using the centralized helper."
+  []
+  (kl/create-all-kms-caches))
+
 (def ^:private context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches {kl/kms-short-name-cache-key (kl/create-kms-short-name-cache)
-                     kl/kms-umm-c-cache-key (kl/create-kms-umm-c-cache)
-                     kl/kms-location-cache-key (kl/create-kms-location-cache)
-                     kl/kms-measurement-cache-key (kl/create-kms-measurement-cache)}}
+  {:system {:caches (create-kms-caches)}
    :ignore-kms-keywords true})
 
 (defn redis-cache-fixture

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
    [cmr.common.util :as util :refer [are3]]
    [cmr.common-app.services.kms-lookup :as kl]
+   [cmr.common-app.test.kms-lookup :as test-kms-lookup]
    [cmr.ingest.services.granule-bulk-update.additional-file.umm-g :as umm-g]
    [cmr.redis-utils.test.test-util :as redis-embedded-fixture]))
 
@@ -42,7 +43,7 @@
 (defn- create-kms-caches
   "Creates KMS caches using the centralized helper."
   []
-  (kl/create-all-kms-caches))
+  (test-kms-lookup/create-all-kms-caches))
 
 (def ^:private context
   "Creates a testing concept with the KMS caches."

--- a/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
+++ b/ingest-app/test/cmr/ingest/services/granule_bulk_update/additional_file/umm_g_test.clj
@@ -40,14 +40,9 @@
                        :variable-level-1 "VL1" :variable-level-2 "VL2"
                        :variable-level-3 "VL3" :uuid "sk1-uuid"}]})
 
-(defn- create-kms-caches
-  "Creates KMS caches using the centralized helper."
-  []
-  (test-kms-lookup/create-all-kms-caches))
-
 (def ^:private context
   "Creates a testing concept with the KMS caches."
-  {:system {:caches (create-kms-caches)}
+  {:system {:caches (test-kms-lookup/create-all-kms-caches)}
    :ignore-kms-keywords true})
 
 (defn redis-cache-fixture

--- a/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
@@ -28,7 +28,20 @@
                      kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
                      kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
                      kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)}}})
+                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
+                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
+                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
+                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
+                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
+                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
+                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
+                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
+                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
+                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
+                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
+                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
+                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)
+                     kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)}}})
 
 (defn redis-cache-fixture
   "This fixture wraps any tests that use it with a set of values

--- a/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
@@ -26,7 +26,7 @@
 (def create-context
   "Simple context that setups KMS caches for testing."
   {:system {:caches (merge {kf/kms-cache-key (kf/create-kms-cache)}
-                           (test-kms-lookup/create-all-kms-caches))}})
+                           (test-kms-lookup/create-kms-caches-for-testing))}})
 
 (defn redis-cache-fixture
   "This fixture wraps any tests that use it with a set of values

--- a/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
@@ -22,26 +22,15 @@
                        {:category "CONTINENT", :type "AFRICA", :subregion-1 "CENTRAL AFRICA", :subregion-2 "ANGOLA", :uuid "9b0a194d-d617-4fed-9625-df176319892d"}
                        {:category "CONTINENT", :type "AFRICA", :subregion-1 "CENTRAL AFRICA", :subregion-2 "LAKE CHAD", :uuid "a1810ec4-2d03-4d98-b049-2cad380fb789"}]})
 
+(defn- create-kms-caches
+  "Creates KMS caches using the centralized helper."
+  []
+  (kms-lookup/create-all-kms-caches))
+
 (def create-context
   "Simple context that setups KMS caches for testing."
-  {:system {:caches {kf/kms-cache-key (kf/create-kms-cache)
-                     kms-lookup/kms-short-name-cache-key (kms-lookup/create-kms-short-name-cache)
-                     kms-lookup/kms-umm-c-cache-key (kms-lookup/create-kms-umm-c-cache)
-                     kms-lookup/kms-location-cache-key (kms-lookup/create-kms-location-cache)
-                     kms-lookup/kms-measurement-cache-key (kms-lookup/create-kms-measurement-cache)
-                     kms-lookup/kms-processing-level-cache-key (kms-lookup/create-kms-processing-level-uuid-cache)
-                     kms-lookup/kms-science-keywords-cache-key (kms-lookup/create-kms-science-keywords-uuid-cache)
-                     kms-lookup/kms-platforms-cache-key (kms-lookup/create-kms-platforms-uuid-cache)
-                     kms-lookup/kms-instruments-cache-key (kms-lookup/create-kms-instruments-uuid-cache)
-                     kms-lookup/kms-providers-cache-key (kms-lookup/create-kms-providers-uuid-cache)
-                     kms-lookup/kms-spatial-keywords-cache-key (kms-lookup/create-kms-spatial-keywords-uuid-cache)
-                     kms-lookup/kms-concepts-cache-key (kms-lookup/create-kms-concepts-uuid-cache)
-                     kms-lookup/kms-iso-topic-categories-cache-key (kms-lookup/create-kms-iso-topic-categories-uuid-cache)
-                     kms-lookup/kms-granule-data-format-cache-key (kms-lookup/create-kms-granule-data-format-uuid-cache)
-                     kms-lookup/kms-mime-type-cache-key (kms-lookup/create-kms-mime-type-uuid-cache)
-                     kms-lookup/kms-related-urls-cache-key (kms-lookup/create-kms-related-urls-uuid-cache)
-                     kms-lookup/kms-temporal-keywords-cache-key (kms-lookup/create-kms-temporal-keywords-uuid-cache)
-                     kms-lookup/kms-projects-cache-key (kms-lookup/create-kms-project-uuid-cache)}}})
+  {:system {:caches (merge {kf/kms-cache-key (kf/create-kms-cache)}
+                           (create-kms-caches))}})
 
 (defn redis-cache-fixture
   "This fixture wraps any tests that use it with a set of values

--- a/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/location_keywords_helper.clj
@@ -3,6 +3,7 @@
   (:require
    [cmr.common-app.services.kms-fetcher :as kf]
    [cmr.common-app.services.kms-lookup :as kms-lookup]
+   [cmr.common-app.test.kms-lookup :as test-kms-lookup]
    [cmr.common.cache :as cache]))
 
 (def ^:private sample-keyword-map
@@ -22,15 +23,10 @@
                        {:category "CONTINENT", :type "AFRICA", :subregion-1 "CENTRAL AFRICA", :subregion-2 "ANGOLA", :uuid "9b0a194d-d617-4fed-9625-df176319892d"}
                        {:category "CONTINENT", :type "AFRICA", :subregion-1 "CENTRAL AFRICA", :subregion-2 "LAKE CHAD", :uuid "a1810ec4-2d03-4d98-b049-2cad380fb789"}]})
 
-(defn- create-kms-caches
-  "Creates KMS caches using the centralized helper."
-  []
-  (kms-lookup/create-all-kms-caches))
-
 (def create-context
   "Simple context that setups KMS caches for testing."
   {:system {:caches (merge {kf/kms-cache-key (kf/create-kms-cache)}
-                           (create-kms-caches))}})
+                           (test-kms-lookup/create-all-kms-caches))}})
 
 (defn redis-cache-fixture
   "This fixture wraps any tests that use it with a set of values


### PR DESCRIPTION
# Overview

### What is the objective?

Ensure unit tests for umm-spec-lib, common-app-lib, indexer-app, and ingest-app have necessary KMS caches enabled to prevent a CmrHashCache error.

### What are the changes?

Created a create-kms-caches-for-testing method in common-app-lib that can be utilized in other modules where KMS caches are required. Additionally, a unit test was added to attempt to assist developers when new caches are added so they're also added for tests.

### What areas of the application does this impact?

* umm-spec-lib
* common-app-lib
* indexer-app
* ingest-app

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
