### PR TITLE
CMR-11310: fix unit test Python runner

### DIFF
--- a/bin/unit_test_script/run_unit_tests.py
+++ b/bin/unit_test_script/run_unit_tests.py
@@ -17,6 +17,7 @@ import datetime
 import multiprocessing
 import os
 import subprocess
+import sys
 import time
 
 # Originally written using https://github.com/jceaser/shellwrap, the color file
@@ -34,6 +35,7 @@ active_threads = 0 # pylint: disable=invalid-name
 total_time = 0 # pylint: disable=invalid-name
 total_jobs = 0 # pylint: disable=invalid-name
 work_list = [] # will hold a list of modules from lein to test
+failed_tasks = [] # will hold module test failures
 base = os.getcwd()
 
 opt_out = ["cmr-dev-system",
@@ -57,6 +59,12 @@ def update_total_time_locking(durration):
     with lock:
         total_time = total_time + durration
 
+def record_failed_task_locking(task, returncode):
+    "Record a failed task, but make sure only one thread at a time can do this"
+    global failed_tasks
+    with lock:
+        failed_tasks.append((task, returncode))
+
 def get_work_list():
     "Get a dump of all the projects that lein manages"
     cmd_result = subprocess.run(["lein", "dump"], check=True, capture_output=True)
@@ -79,8 +87,10 @@ def worker(_context, id_number):
 
     update_active_threads_locking(1)
 
-    while 0 < len(work_list):
+    while True:
         with lock:
+            if len(work_list) < 1:
+                break
             total_jobs = total_jobs + 1
             task = work_list.pop()
 
@@ -96,10 +106,25 @@ def worker(_context, id_number):
         # Run the external command in the task directory inside a try/except
         # block, to ensure thread never dies
         try:
-            os.chdir(base+"/"+task)
-            subprocess.run(["lein", "ci-utest"], check=True, capture_output=True)
+            subprocess.run(["lein", "ci-utest"], check=True, capture_output=True,
+                           cwd=os.path.join(base, task), text=True)
+        except subprocess.CalledProcessError as e:
+            record_failed_task_locking(task, e.returncode)
+            with lock:
+                color.cprint(color.tcode.red,
+                             f"{id_number}: {task} failed with exit code {e.returncode}",
+                             verbose=color.VMode.ERROR,
+                             environment=env)
+                if e.stdout:
+                    print(f"===== {task} stdout =====")
+                    print(e.stdout, end="" if e.stdout.endswith("\n") else "\n")
+                if e.stderr:
+                    print(f"===== {task} stderr =====")
+                    print(e.stderr, end="" if e.stderr.endswith("\n") else "\n")
         except Exception as e: # pylint: disable=broad-exception-caught
-            color.cprint(color.tcode.red, f"{id_number}: {task} - {e}", environment=env)
+            record_failed_task_locking(task, "unknown")
+            color.cprint(color.tcode.red, f"{id_number}: {task} - {e}",
+                         verbose=color.VMode.ERROR, environment=env)
         et = time.time()
         update_total_time_locking(et-st)
 
@@ -149,7 +174,7 @@ def main():
         work_list = get_work_list()
 
         color.cprint(color.tcode.yellow,
-            "Using {args.threads} threads on {len(work_list)} tasks.",
+            f"Using {args.threads} threads on {len(work_list)} tasks.",
             environment=env)
 
         jobs = []
@@ -180,7 +205,14 @@ def main():
 
     color.cprint(color.tcode.yellow, f"Done processing {total_jobs}", environment=env)
     color.cprint(color.tcode.yellow, f"Total: {total_time:.3f}s", environment=env)
-    color.cprint(color.tcode.yellow, f"Average: {total_time/total_jobs:.3f}s", environment=env)
+    if total_jobs > 0:
+        color.cprint(color.tcode.yellow, f"Average: {total_time/total_jobs:.3f}s", environment=env)
+    if failed_tasks:
+        print("Failed unit test modules:")
+        for task, returncode in failed_tasks:
+            print(f"  {task}: {returncode}")
+        print (f"{datetime.datetime.now()}")
+        sys.exit(1)
     print (f"{datetime.datetime.now()}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview

### What is the objective?

Updated bin/unit_test_script/run_unit_tests.py so root `lein ci-utest` (which calls the Python script) no longer hides failing module tests, allowing Bamboo to fail the unit test task correctly.

### What are the changes?

Changes:
- Print captured stdout/stderr for modules whose `lein ci-utest` invocation fails.
- Track failed modules and exit with status 1 when any module fails.
- Replace thread-wide os.chdir calls with per-command cwd= to avoid cross-thread working directory races.
- Fix the thread/task count log interpolation.
- Avoid divide-by-zero in summary output if no jobs run.

### What areas of the application does this impact?

Unit tests

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
