### PR TITLE
CMR-1189: found another place that needed a change

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -8,7 +8,7 @@
 
 (def netty-version
   "The netty version to use."
-  "4.1.133.Final") ;; latest as of 2025-09-05
+  "4.1.134.Final") ;; latest as of 2026-05-05 for v3 - 2026-05-20 for v4
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."

--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -23,7 +23,12 @@
                  [io.netty/netty-codec-http ~netty-version]
                  [io.netty/netty-codec-http2 ~netty-version]
                  [io.netty/netty-codec ~netty-version]
-                 [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version]
+                 [io.netty/netty-transport-classes-epoll ~netty-version]
+                 [com.amazonaws/aws-java-sdk-sns ~aws-java-sdk-version
+                  :exclusions [io.netty/netty-codec
+                               io.netty/netty-codec-http
+                               io.netty/netty-handler
+                               io.netty/netty-transport-classes-epoll]]
                  [com.amazonaws/aws-java-sdk-sqs ~aws-java-sdk-version]
                  [software.amazon.awssdk/regions ~aws-java-sdk2-version]
                  [software.amazon.awssdk/sns ~aws-java-sdk2-version


### PR DESCRIPTION
# Overview

### What is the objective?

While testing it was found that an additional app needed to be change. This was probably missed while we had trouble compiling CMR in bamboo.

Since this change was missed here are the reasons for why I think all issues have been found:
* Locally calls to `lein dept :tree | grep  4.1.132.Final` in this project does not report any other missing libraries. This also affects all the apps that link to this library.
* `snyk test --all-projects --severity-threshold=high .` returns success