### PR TITLE
CMR-11252: fix collection granule agg cache

### DIFF
--- a/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
+++ b/indexer-app/src/cmr/indexer/data/collection_granule_aggregation_cache.clj
@@ -51,7 +51,9 @@
       (consistent-cache/create-consistent-cache
        {:hash-timeout-seconds (coll-gran-agg-cache-consistent-timeout-seconds)})
       (redis-cache/create-redis-cache {:read-connection (redis-config/redis-read-conn-opts)
-                                       :primary-connection (redis-config/redis-conn-opts)}))))
+                                       :primary-connection (redis-config/redis-conn-opts)
+                                       :key-match-pattern
+                                       (redis-cache/serialize coll-gran-aggregate-cache-key)}))))
 
 (def ^:private collection-aggregations
   "Defines the aggregations to use to find information about all the granules in a collection."

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -23,7 +23,8 @@
                  ;; testcontainers needs a newer version of commons-compress, for now
                  ;; we will force it to use the latest version
                  [org.apache.commons/commons-compress]
-                 [org.testcontainers/testcontainers]]
+                 [org.testcontainers/testcontainers]
+                 [ring/ring-jetty-adapter "1.15.4"]]
   :plugins [[lein-exec "0.3.7"]
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
@@ -56,9 +57,7 @@
              :internal-repos {}
              :kaocha {:dependencies [[lambdaisland/kaocha "1.0.732"]
                                      [lambdaisland/kaocha-cloverage "1.0.75"]
-                                     [lambdaisland/kaocha-junit-xml "0.0.76"]
-                                     ;; ring is needed or this fails in sys int group3
-                                     [ring/ring-jetty-adapter "1.15.4"]]}}
+                                     [lambdaisland/kaocha-junit-xml "0.0.76"]]}}
   :aliases {"bikeshed" ["with-profile" "lint" "bikeshed" "--max-line-length=100"]
             "check-deps" ["with-profile" "lint" "ancient" ":all"]
             "check-sec" ["with-profile" "security" "dependency-check"]

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -24,7 +24,7 @@
                  ;; we will force it to use the latest version
                  [org.apache.commons/commons-compress]
                  [org.testcontainers/testcontainers]
-                 [ring/ring-jetty-adapter "1.15.4"]]
+                 [ring/ring-jetty-adapter]]
   :plugins [[lein-exec "0.3.7"]
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]

--- a/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
+++ b/redis-utils-lib/src/cmr/redis_utils/redis_cache.clj
@@ -20,6 +20,16 @@
   [v]
   (when v (edn/read-string v)))
 
+(def ^:private invalid-cache-key ::invalid-cache-key)
+
+(defn- safe-deserialize
+  "Deserializes v, marking keys that were not written through this cache."
+  [v]
+  (try
+    (deserialize v)
+    (catch RuntimeException _e
+      invalid-cache-key)))
+
 ;; Implements the CmrCache protocol by saving data in Redis.
 (defrecord RedisCache
   [
@@ -38,12 +48,16 @@
    read-connection
 
    ;; The connection used to write data to redis, this is the primary node.
-   primary-connection]
+   primary-connection
+
+   ;; Optional Redis SCAN match pattern used when listing cache keys.
+   key-match-pattern]
 
   cache/CmrCache
   (get-keys
     [_this]
-    (map deserialize (redis/get-keys read-connection)))
+    (remove #{invalid-cache-key}
+            (map safe-deserialize (redis/get-keys (or key-match-pattern "*") read-connection))))
 
   (key-exists
     [_this key]
@@ -110,10 +124,13 @@
        be a candidate for eviction.
       :refresh-ttl?
        When a GET operation is called called on the key then the ttl is refreshed
-       to the time to live set by the initial cache."
+       to the time to live set by the initial cache.
+      :key-match-pattern
+       A Redis SCAN match pattern used by get-keys. Defaults to *."
   [options]
   (->RedisCache (:keys-to-track options)
                 (:ttl options)
                 (get options :refresh-ttl? false)
                 (:read-connection options)
-                (:primary-connection options)))
+                (:primary-connection options)
+                (:key-match-pattern options)))

--- a/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
+++ b/redis-utils-lib/test/cmr/redis_utils/test/test_redis_cache.clj
@@ -83,6 +83,25 @@
     (is (= (redis-config/redis-max-scan-keys)
            (count (redis/get-keys "get-keys-pattern-2#-*" (redis-config/redis-conn-opts)))))))
 
+(deftest redis-cache-get-keys-skips-non-edn-keys
+  (let [cache-key :redis-cache-get-keys-skips-non-edn-keys
+        rcache (redis-cache/create-redis-cache {:read-connection (redis-config/redis-read-conn-opts)
+                                                :primary-connection (redis-config/redis-conn-opts)})]
+    (wcar* "SIT-GRAN:" false (redis-config/redis-conn-opts) (carmine/set "SIT-GRAN:" "test"))
+    (cache/set-value rcache cache-key "test")
+    (is (contains? (set (cache/get-keys rcache)) cache-key))))
+
+(deftest redis-cache-get-keys-supports-match-pattern
+  (let [cache-key :redis-cache-get-keys-supports-match-pattern
+        other-cache-key :redis-cache-get-keys-supports-match-pattern-other
+        rcache (redis-cache/create-redis-cache {:read-connection (redis-config/redis-read-conn-opts)
+                                                :primary-connection (redis-config/redis-conn-opts)
+                                                :key-match-pattern (redis-cache/serialize cache-key)})]
+    (wcar* "SIT-GRAN:" false (redis-config/redis-conn-opts) (carmine/set "SIT-GRAN:" "test"))
+    (cache/set-value rcache cache-key "test")
+    (cache/set-value rcache other-cache-key "test")
+    (is (= [cache-key] (cache/get-keys rcache)))))
+
 (def field-value-map
   {"C1200000001-PROV1"
    {:concept-id "C1200000001-PROV1",


### PR DESCRIPTION
# Overview

### What is the objective?

Fix internal error thrown when hitting `/indexer/caches/collection-granule-aggregation-cache"` in cloud environments. ("java.lang.RuntimeException: Invalid token: SIT-GRAN:")

Root cause:

- The indexer cache endpoint lists cache keys through RedisCache/get-keys.
- In cloud environments, shared Redis can contain unrelated raw keys such as "SIT-GRAN:".
- RedisCache/get-keys attempted to EDN-parse every scanned Redis key, so non-EDN keys caused the error.

### What are the changes?

- Hardened RedisCache/get-keys to skip Redis keys that cannot be EDN-deserialized.
- Added optional :key-match-pattern support to RedisCache so callers can scope Redis SCAN operations.
- Scoped collection-granule-aggregation-cache key listing to its own serialized Redis key.
- Moved ring/ring-jetty-adapter into normal redis-utils-lib dependencies so focused lein test commands have the required classpath.
- Added Redis cache regression tests covering non-EDN Redis keys and scoped key scans.

### What areas of the application does this impact?

redis-utils-lib , indexer-app

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
