### PR TITLE
CMR-11323: bumping up netty to the latest in our series

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -8,7 +8,7 @@
 
 (def netty-version
   "The netty version to use."
-  "4.1.134.Final") ;; latest as of 2026-05-05 for v3 - 2026-05-20 for v4
+  "4.1.135.Final") ;; latest as of 2026-06-0
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."


### PR DESCRIPTION
# Overview

Bump of the netty library version number in the message-queue-lib

### What areas of the application does this impact?

this will affect all applications that use the message queue

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [-] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings
