### PR TITLE
CMR-11364: Fix intermittent fail of int test on CICD

### DIFF
--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
@@ -76,6 +76,22 @@
           (Thread/sleep delay-ms)
           (recur (inc retries)))))))
 
+(defn- retry-search-until-success
+  "Retries a shapefile search until it succeeds or max retries reached.
+  Returns the final response map with :status and :errors."
+  [params max-retries delay-ms expected-status expected-status-desc]
+  (loop [retries 0]
+    (let [{:keys [status errors] :as response} (search/find-refs-with-multi-part-form-post :collection params)
+          errors-vec (when errors (vec errors))
+          success? (= status expected-status)]
+      (if success?
+        (assoc response :errors errors-vec)
+        (if (>= retries max-retries)
+          (assoc response :errors errors-vec)
+          (do
+            (Thread/sleep delay-ms)
+            (recur (inc retries))))))))
+
 (deftest collection-shapefile-search-test
   (let [_ (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))
         ;; Wait for the flag to actually be enabled with retries to handle race conditions
@@ -229,7 +245,7 @@
                        :content "true"}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (retry-search-until-success params 3 200 nil "success")]
           (is (nil? status)
               (str "Should pass validation with force-cartesian=true. Got status: " status " errors: " errors))))
 
@@ -239,9 +255,10 @@
                        :mime-type mt/geojson}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)
+              errors-vec (when errors (vec errors))]
           (is (= 400 status)
-              (str "Should fail validation without force-cartesian. Got status: " status " errors: " errors))))
+              (str "Should fail validation without force-cartesian. Got status: " status " errors: " errors-vec))))
 
       (testing "with force-cartesian=false should fail validation"
         (let [params [{:name "shapefile"
@@ -251,6 +268,7 @@
                        :content "false"}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)
+              errors-vec (when errors (vec errors))]
           (is (= 400 status)
-              (str "Should fail validation with force-cartesian=false. Got status: " status " errors: " errors)))))))
+              (str "Should fail validation with force-cartesian=false. Got status: " status " errors: " errors-vec)))))))

--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
@@ -47,6 +47,8 @@
 
 (deftest collection-shapefile-search-test
   (let [_ (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))
+        ;; Wait for the flag to actually be enabled with retries to handle race conditions
+        _ (wait-for-shapefile-flag-enabled 5 200)
         ;; Lines
         normal-line (make-coll :geodetic "normal-line"
                                (l/ords->line-string :geodetic [22.681 -8.839, 18.309 -11.426, 22.705 -6.557]))
@@ -182,9 +184,42 @@
           "southern_africa with force-cartesian=true"
           "southern_africa" true [whole-world polygon-with-holes polygon-with-holes-cart normal-line normal-line-cart normal-brs wide-south-cart])))))
 
+(defn- wait-for-shapefile-flag-enabled
+  "Waits for the shapefile flag to be enabled by attempting a simple search and verifying
+  it doesn't return a 'Searching by shapefile is not enabled' error. Retries up to max-retries
+  times with a delay."
+  [max-retries delay-ms]
+  (loop [retries 0]
+    (let [test-params [{:name "shapefile"
+                        :content (io/file (io/resource "shapefiles/box.geojson"))
+                        :mime-type mt/geojson}
+                       {:name "provider"
+                        :content "PROV1"}]
+          {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection test-params)
+          ;; Check if we got the "not enabled" error specifically
+          not-enabled-error? (and (= 400 status)
+                                  errors
+                                  (some #(re-find #"Searching by shapefile is not enabled" %) errors))]
+      (cond
+        ;; Success - flag is enabled (we got any response OTHER than "not enabled")
+        (not not-enabled-error?)
+        :enabled
+
+        ;; Max retries reached - flag still not enabled
+        (>= retries max-retries)
+        (throw (Exception. (str "Shapefile flag not enabled after " max-retries " retries. Last status: " status " errors: " errors)))
+
+        ;; Retry - flag not enabled yet
+        :else
+        (do
+          (Thread/sleep delay-ms)
+          (recur (inc retries)))))))
+
 (deftest collection-shapefile-force-cartesian-validation-test
   "Test that cartesian-only shapefiles require force-cartesian=true to pass validation"
-  (let [_ (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))]
+  (let [_ (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))
+        ;; Wait for the flag to actually be enabled with retries to handle race conditions
+        _ (wait-for-shapefile-flag-enabled 5 200)]
     (testing "scotland_cartesian.json is only valid when processed as cartesian"
       (testing "with force-cartesian=true should pass validation"
         (let [params [{:name "shapefile"
@@ -194,9 +229,9 @@
                        :content "true"}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
           (is (nil? status)
-              "Should pass validation with force-cartesian=true")))
+              (str "Should pass validation with force-cartesian=true. Got status: " status " errors: " errors))))
 
       (testing "without force-cartesian should fail validation"
         (let [params [{:name "shapefile"
@@ -204,9 +239,9 @@
                        :mime-type mt/geojson}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
           (is (= 400 status)
-              "Should fail validation without force-cartesian")))
+              (str "Should fail validation without force-cartesian. Got status: " status " errors: " errors))))
 
       (testing "with force-cartesian=false should fail validation"
         (let [params [{:name "shapefile"
@@ -216,6 +251,6 @@
                        :content "false"}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)]
           (is (= 400 status)
-              "Should fail validation with force-cartesian=false"))))))
+              (str "Should fail validation with force-cartesian=false. Got status: " status " errors: " errors)))))))

--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
@@ -45,6 +45,37 @@
                                                :geometries shapes})})
               {:validate-keywords false})))
 
+(defn- wait-for-shapefile-flag-enabled
+  "Waits for the shapefile flag to be enabled by attempting a simple search and verifying
+  it doesn't return a 'Searching by shapefile is not enabled' error. Retries up to max-retries
+  times with a delay."
+  [max-retries delay-ms]
+  (loop [retries 0]
+    (let [test-params [{:name "shapefile"
+                        :content (io/file (io/resource "shapefiles/box.geojson"))
+                        :mime-type mt/geojson}
+                       {:name "provider"
+                        :content "PROV1"}]
+          {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection test-params)
+          ;; Check if we got the "not enabled" error specifically
+          not-enabled-error? (and (= 400 status)
+                                  errors
+                                  (some #(re-find #"Searching by shapefile is not enabled" %) errors))]
+      (cond
+        ;; Success - flag is enabled (we got any response OTHER than "not enabled")
+        (not not-enabled-error?)
+        :enabled
+
+        ;; Max retries reached - flag still not enabled
+        (>= retries max-retries)
+        (throw (Exception. (str "Shapefile flag not enabled after " max-retries " retries. Last status: " status " errors: " errors)))
+
+        ;; Retry - flag not enabled yet
+        :else
+        (do
+          (Thread/sleep delay-ms)
+          (recur (inc retries)))))))
+
 (deftest collection-shapefile-search-test
   (let [_ (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))
         ;; Wait for the flag to actually be enabled with retries to handle race conditions
@@ -183,37 +214,6 @@
 
           "southern_africa with force-cartesian=true"
           "southern_africa" true [whole-world polygon-with-holes polygon-with-holes-cart normal-line normal-line-cart normal-brs wide-south-cart])))))
-
-(defn- wait-for-shapefile-flag-enabled
-  "Waits for the shapefile flag to be enabled by attempting a simple search and verifying
-  it doesn't return a 'Searching by shapefile is not enabled' error. Retries up to max-retries
-  times with a delay."
-  [max-retries delay-ms]
-  (loop [retries 0]
-    (let [test-params [{:name "shapefile"
-                        :content (io/file (io/resource "shapefiles/box.geojson"))
-                        :mime-type mt/geojson}
-                       {:name "provider"
-                        :content "PROV1"}]
-          {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection test-params)
-          ;; Check if we got the "not enabled" error specifically
-          not-enabled-error? (and (= 400 status)
-                                  errors
-                                  (some #(re-find #"Searching by shapefile is not enabled" %) errors))]
-      (cond
-        ;; Success - flag is enabled (we got any response OTHER than "not enabled")
-        (not not-enabled-error?)
-        :enabled
-
-        ;; Max retries reached - flag still not enabled
-        (>= retries max-retries)
-        (throw (Exception. (str "Shapefile flag not enabled after " max-retries " retries. Last status: " status " errors: " errors)))
-
-        ;; Retry - flag not enabled yet
-        :else
-        (do
-          (Thread/sleep delay-ms)
-          (recur (inc retries)))))))
 
 (deftest collection-shapefile-force-cartesian-validation-test
   "Test that cartesian-only shapefiles require force-cartesian=true to pass validation"


### PR DESCRIPTION
# Overview

### What is the objective?

Fix bug where collection-shapefile-force-cartesian-validation-test was failing intermittently, getting a 404 instead of successful search response.

### What are the changes?

This test was failing due to timing issues that pop up on the CICD server. It used side/eval-form to enable the shapefile flag via async HTTP, then immediately made search requests before the flag was actually set in the running system. Added retry logic with `wait-for-shapefile-flag-enabled` to verify the flag is enabled before proceeding, and `retry-search-until-success` to handle timing issues during shapefile processing itself.

Error messages were also enhanced to display actual validation errors instead of lazy sequence references for easier debugging.

### What areas of the application does this impact?

system-int-test

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
