### PR TITLE
CMR-11136: Update reshard errors to return more helpful messages

### DIFF
--- a/indexer-app/src/cmr/indexer/api/routes.clj
+++ b/indexer-app/src/cmr/indexer/api/routes.clj
@@ -129,7 +129,7 @@
 
         (GET "/status" {:keys [request-context params]}
           (acl/verify-ingest-management-permission request-context :update)
-          (r/response (index-set-svc/get-reshard-status request-context id index params)))
+          (r/response (index-set-svc/get-index-resharding-status request-context id index params)))
 
         ;; Finalizes resharding of an index, culminating in deleting the index which is replaced
         ;; by a new index

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -764,12 +764,12 @@
                                   :not-found
                                   (format "Index [%s] does not exist." index)))
 
-        ;; validate that the index is not already being resharded
-        reshard-status (get-reshard-status elastic-index-set index)
-        _ (when-not (nil? reshard-status)
-            (errors/throw-service-error
-              :bad-request
-              (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status)))
+        ;; validate that the source and target index is not already being resharded
+        _ (when (is-resharding? elastic-index-set index)
+            (let [reshard-status (get-reshard-status elastic-index-set index)]
+              (errors/throw-service-error
+                :bad-request
+                (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status))))
 
         ;; Find the original index configuration
         orig-index-config (get-index-config elastic-index-set concept-type canonical-index-name)

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -713,6 +713,16 @@
               concept-type))
           (get-in index-set [:index-set :concepts]))))
 
+(defn- get-reshard-status
+  "Validate that resharding has completed successfully for the given index via the index set status"
+  [context index-set-id index elastic-name]
+  (let [index-set (index-set-util/get-index-set context elastic-name index-set-id)
+        concept-type (get-concept-type-for-index index-set index)
+        _ (when-not concept-type
+            (errors/throw-service-error :not-found (format "The index [%s] does not exist." index)))
+        status (get-in index-set [:index-set concept-type :resharding-status (keyword index)])]
+    status))
+
 (defn- validate-elastic-name
   [elastic-name]
   (when (string/blank? elastic-name)
@@ -754,6 +764,14 @@
         _ (when-not concept-type (errors/throw-service-error
                                   :not-found
                                   (format "Index [%s] does not exist." index)))
+
+        ;; validate that the index is not already being resharded
+        reshard-status (get-reshard-status context index-set-id index elastic-name)
+        validate-index-not-being-resharded (when-not (nil? reshard-status)
+                                             (errors/throw-service-error
+                                               :bad-request
+                                               (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status)))
+
         ;; Find the original index configuration
         orig-index-config (get-index-config index-set concept-type canonical-index-name)
 
@@ -807,7 +825,7 @@
             revision-id (save-combined-index-set-to-mdb context updated-index-set elastic-name)]
         (update-index-set context elastic-name updated-index-set revision-id)))))
 
-(defn get-reshard-status
+(defn get-index-resharding-status
   "Get the resharding status for the given index"
   [context index-set-id index params]
   (let [elastic-name (:elastic_name params)
@@ -868,25 +886,16 @@
        (format
         "The index [%s] is not being resharded." index)))))
 
-(defn- validate-resharding-complete
-  "Validate that resharding has completed successfully for the given index via the index set status"
-  [context index-set-id index elastic-name]
-  (let [index-set (index-set-util/get-index-set context elastic-name index-set-id)
-        concept-type (get-concept-type-for-index index-set index)
-        _ (when-not concept-type
-            (errors/throw-service-error :not-found (format "The index [%s] does not exist." index)))
-        status (get-in index-set [:index-set concept-type :resharding-status (keyword index)])]
-    (when-not (= status (:COMPLETE indexer-util/reshard-status-states))
-      (errors/throw-service-error
-       :bad-request
-       (format "Index [%s] has not completed resharding" index)))))
-
 (defn finalize-index-resharding
   "Complete the resharding of the given index"
   [context index-set-id index params]
   (let [elastic-name (:elastic_name params)
         _ (validate-elastic-name elastic-name)
-        _ (validate-resharding-complete context index-set-id index elastic-name)
+        reshard-status (get-reshard-status context, index-set-id index elastic-name)
+        validate-resharding-complete (when-not (= reshard-status (:COMPLETE indexer-util/reshard-status-states))
+                                       (errors/throw-service-error
+                                         :bad-request
+                                         (format "Index [%s] has not completed resharding" index)))
         index-set (index-set-util/get-index-set context elastic-name index-set-id)
         ;; search for index name in index-set :concepts to get concept type
         concept-type (get-concept-type-for-index index-set index)

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -714,13 +714,12 @@
           (get-in index-set [:index-set :concepts]))))
 
 (defn- get-reshard-status
-  "Validate that resharding has completed successfully for the given index via the index set status"
-  [context index-set-id index elastic-name]
-  (let [index-set (index-set-util/get-index-set context elastic-name index-set-id)
-        concept-type (get-concept-type-for-index index-set index)
+  "Get the current resharding status of the given index set from a specific elastic cluster"
+  [elastic-index-set index]
+  (let [concept-type (get-concept-type-for-index elastic-index-set index)
         _ (when-not concept-type
             (errors/throw-service-error :not-found (format "The index [%s] does not exist." index)))
-        status (get-in index-set [:index-set concept-type :resharding-status (keyword index)])]
+        status (get-in elastic-index-set [:index-set concept-type :resharding-status (keyword index)])]
     status))
 
 (defn- validate-elastic-name
@@ -747,33 +746,33 @@
         target-index (get-resharded-index-name index num-shards)
         _ (info (format "Starting to reshard index [%s] to [%s]" index target-index))
         target-index-no-index-set-id (string/replace-first target-index #".*?_" "")
-        index-set (index-set-util/get-index-set context elastic-name index-set-id)
+        elastic-index-set (index-set-util/get-index-set context elastic-name index-set-id)
         ;; Don't allow conflicts with rebalancing
-        _ (when (is-rebalancing? index-set index)
+        _ (when (is-rebalancing? elastic-index-set index)
             (errors/throw-service-error
              :bad-request
              (format "%s cannot be resharded as it is being used for rebalancing." index)))
-        _ (when (is-rebalancing? index-set target-index)
+        _ (when (is-rebalancing? elastic-index-set target-index)
             (errors/throw-service-error
              :bad-request
              (format "%s cannot be resharded as its target %s is being used for rebalancing."
                      index target-index)))
         ;; search for index name in index-set :concepts to get concept type and to validate the
         ;; index exists
-        concept-type (get-concept-type-for-index index-set index)
+        concept-type (get-concept-type-for-index elastic-index-set index)
         _ (when-not concept-type (errors/throw-service-error
                                   :not-found
                                   (format "Index [%s] does not exist." index)))
 
         ;; validate that the index is not already being resharded
-        reshard-status (get-reshard-status context index-set-id index elastic-name)
-        validate-index-not-being-resharded (when-not (nil? reshard-status)
-                                             (errors/throw-service-error
-                                               :bad-request
-                                               (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status)))
+        reshard-status (get-reshard-status elastic-index-set index)
+        _ (when-not (nil? reshard-status)
+            (errors/throw-service-error
+              :bad-request
+              (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status)))
 
         ;; Find the original index configuration
-        orig-index-config (get-index-config index-set concept-type canonical-index-name)
+        orig-index-config (get-index-config elastic-index-set concept-type canonical-index-name)
 
         ;; Copy and modify it for the new index
         new-index-config (-> orig-index-config
@@ -782,7 +781,7 @@
         ;; Update index-set: add new entry, mark resharding status
         ;; update the index-set to have the new index config and to mark the original index
         ;; as resharding
-        new-index-set (-> index-set
+        new-index-set (-> elastic-index-set
                           (update-in
                            [:index-set concept-type :indexes] conj new-index-config)
                           (update-in
@@ -891,11 +890,12 @@
   [context index-set-id index params]
   (let [elastic-name (:elastic_name params)
         _ (validate-elastic-name elastic-name)
-        reshard-status (get-reshard-status context, index-set-id index elastic-name)
-        validate-resharding-complete (when-not (= reshard-status (:COMPLETE indexer-util/reshard-status-states))
-                                       (errors/throw-service-error
-                                         :bad-request
-                                         (format "Index [%s] has not completed resharding" index)))
+        elastic-index-set (index-set-util/get-index-set context elastic-name index-set-id)
+        reshard-status (get-reshard-status elastic-index-set index)
+        _ (when-not (= reshard-status (:COMPLETE indexer-util/reshard-status-states))
+            (errors/throw-service-error
+              :bad-request
+              (format "Index [%s] has not completed resharding" index)))
         index-set (index-set-util/get-index-set context elastic-name index-set-id)
         ;; search for index name in index-set :concepts to get concept type
         concept-type (get-concept-type-for-index index-set index)

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -769,7 +769,7 @@
             (let [reshard-status (get-reshard-status elastic-index-set index)]
               (errors/throw-service-error
                 :bad-request
-                (format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." index reshard-status))))
+                (format "Index [%s] has a resharding state of [%s]. You cannot start a new reshard on an index that is in a existing reshard state." index reshard-status))))
 
         ;; Find the original index configuration
         orig-index-config (get-index-config elastic-index-set concept-type canonical-index-name)

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -420,20 +420,20 @@
     (testing "elastic name is not valid"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Empty elastic name is not allowed"
-                            (svc/get-reshard-status context index-set-id small-collections-index {:task_id "task1"}))))
+                            (svc/get-index-resharding-status context index-set-id small-collections-index {:task_id "task1"}))))
     (testing "concept-type is missing"
       (with-redefs [indexer-util/context->conn (fn [_context _elastic-name] nil)
                     idx-set-util/get-index-set (fn [_context _elastic-name _index-set-id] empty-index-set)]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"The index \[.*\] does not exist\."
-                              (svc/get-reshard-status context index-set-id small-collections-index valid-params)))))
+                              (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))))
     (testing "current target is missing because index is not being resharded"
       (with-redefs [indexer-util/context->conn (fn [_context _elastic-name] nil)
                     idx-set-util/get-index-set (fn [_context _elastic-name _index-set-id] empty-index-set)
                     svc/get-concept-type-for-index (fn [_index-set _index] :granule)]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"The index \[.*\] is not being resharded."
-                              (svc/get-reshard-status context index-set-id small-collections-index valid-params)))))
+                              (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))))
     (testing "current status of index is nil because it's not being resharded"
       (with-redefs [indexer-util/context->conn (fn [_context _elastic-name] nil)
                     idx-set-util/get-index-set (fn [_context _elastic-name _index-set-id]
@@ -441,7 +441,7 @@
                     svc/get-concept-type-for-index (fn [_index-set _index] :granule)]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"The status of resharding index \[.*\] is not found."
-                              (svc/get-reshard-status context index-set-id small-collections-index valid-params)))))
+                              (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))))
     (testing "index exists but status is complete already"
       (with-redefs [indexer-util/context->conn (fn [_context _elastic-name] nil)
                     idx-set-util/get-index-set (fn [_context _elastic-name _index-set-id]
@@ -451,7 +451,7 @@
         (is (= {:original-index small-collections-index
                 :reshard-index "1_small_collections_10_shards"
                 :reshard-status "COMPLETE"}
-               (svc/get-reshard-status context index-set-id small-collections-index valid-params)))))
+               (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))))
     (testing "index exists and status is not complete and reindexing is still in progress, then current status will be returned as is."
       (with-redefs [indexer-util/context->conn (fn [_context _elastic-name] nil)
                     idx-set-util/get-index-set (fn [_context _elastic-name _index-set-id]
@@ -464,7 +464,7 @@
         (is (= {:original-index small-collections-index
                 :reshard-index  "1_small_collections_10_shards"
                 :reshard-status "IN_PROGRESS"}
-               (svc/get-reshard-status context index-set-id small-collections-index valid-params)))))
+               (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))))
     (testing "when index exists and status is not complete and reindexing is done, then status will be updated to COMPLETE and index set will be updated. Correct status resp will be returned."
       (let [mock-calls (atom 0)
             get-index-set-mock-fn (fn [& _args]
@@ -487,7 +487,7 @@
           (is (= {:original-index small-collections-index
                   :reshard-index "1_small_collections_10_shards"
                   :reshard-status "COMPLETE"}
-                 (svc/get-reshard-status context index-set-id small-collections-index valid-params)))
+                 (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))
           (is (= "COMPLETE" @captured-payload))
           )))
     (testing "when index exists and reindex status is not complete and reindexing has failed, then status will be updated to FAILED and index set will be updated. Correct status resp will be returned."
@@ -519,7 +519,7 @@
           (is (= {:original-index small-collections-index
                   :reshard-index "1_small_collections_10_shards"
                   :reshard-status "FAILED"}
-                 (svc/get-reshard-status context index-set-id small-collections-index valid-params)))
+                 (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))
 
           (is (= "FAILED" @captured-payload)))))
     (testing "when index exists, reindex status is not complete, reindexing has returned internal errors, then status will be updated to FAILED and index set will be updated. Correct status resp will be returned."
@@ -545,7 +545,7 @@
           (is (= {:original-index small-collections-index
                   :reshard-index "1_small_collections_10_shards"
                   :reshard-status "FAILED"}
-                 (svc/get-reshard-status context index-set-id small-collections-index valid-params)))
+                 (svc/get-index-resharding-status context index-set-id small-collections-index valid-params)))
 
           (is (= "FAILED" @captured-payload)))))
     ))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/reshard_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/reshard_index_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [cmr.indexer.services.index-set-service :as index-set-service]
    [cmr.system-int-test.data2.collection :as dc]
    [cmr.system-int-test.data2.core :as d]
    [cmr.system-int-test.data2.granule :as dg]
@@ -18,12 +19,15 @@
 (use-fixtures :each (ingest/reset-fixture {"provguid1" "PROV1"
                                            "provguid2" "PROV2"}))
 
-(deftest reshard-index-error-test
+(deftest ^:oracle reshard-index-error-test
   (s/only-with-real-database
    (let [coll1 (d/ingest "PROV1" (dc/collection {:entry-title "coll1"}) {:validate-keywords false})
          _ (d/ingest "PROV1" (dg/granule coll1 {:granule-ur "gran1"}))
-         coll2 (d/ingest "PROV1" (dc/collection {:entry-title "coll2"}) {:validate-keywords false})
-         _ (d/ingest "PROV1" (dg/granule coll2 {:granule-ur "gran2"}))
+         coll-for-rebalance-check (d/ingest "PROV1" (dc/collection {:entry-title "coll-for-rebalance-check"}) {:validate-keywords false})
+         coll-concept-id-for-rebalance-check (:concept-id coll-for-rebalance-check)
+         index-for-rebalance-check (index-set-service/gen-valid-index-name 1 coll-concept-id-for-rebalance-check)
+         _ (d/ingest (:provider-id coll-for-rebalance-check) (dg/granule coll-for-rebalance-check {:granule-ur "gran-for-rebalance-check-ur"}))
+         services-index "1_services"
          gran-elastic-name "gran-elastic"
          elastic-name "elastic"]
      (index/wait-until-indexed)
@@ -63,18 +67,61 @@
        (is (= {:status 400
                :errors ["Invalid num_shards [abc]. Only integers greater than zero are allowed."]}
               (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards "abc" :elastic-name gran-elastic-name}))))
-     (testing "index must exist"
+     (testing "non-existent index will throw error"
        (is (= {:status 404
                :errors [(format "Index [%s] does not exist in the Elasticsearch cluster [%s]" "1_non-existing-index" gran-elastic-name)]}
               (bootstrap/start-reshard-index "1_non-existing-index" {:synchronous false :num-shards 1 :elastic-name gran-elastic-name}))))
-     (testing "attempting to reshard an index that is already being resharded fails"
-       (let [reshard-resp (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 100 :elastic-name gran-elastic-name})]
+     (testing "attempting to reshard an index that is already being resharded should throw error"
+       (let [reshard-resp (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 4 :elastic-name gran-elastic-name})]
          (is (= 200 (:status reshard-resp)))
          (is (= "Resharding started for index 1_small_collections" (:message reshard-resp)))
          (is (= false (nil? (:task-id reshard-resp)))))
        (is (= {:status 400
-               :errors ["The index set already contains resharding index [1_small_collections]"]}
-              (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 100 :elastic-name gran-elastic-name}))))
+               :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." "1_small_collections" "IN_PROGRESS")]}
+              (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 4 :elastic-name gran-elastic-name}))))
+     (testing "trying to reshard an index that is currently rebalancing should throw error"
+       (bootstrap/rollback-reshard-index "1_small_collections" {:elastic-name gran-elastic-name})
+       (index/wait-until-indexed)
+
+       (bootstrap/start-rebalance-collection coll-concept-id-for-rebalance-check)
+       (index/wait-until-indexed)
+
+       (is (= {:status 400
+               :errors [(format "%s cannot be resharded as it is being used for rebalancing." "1_small_collections")]}
+              (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 7 :elastic-name gran-elastic-name}))))
+     (testing "trying to reshard a COMPLETE resharded index, should return 400 error"
+       (let [index-set (update-in (index/get-index-set-by-id 1)
+                                  [:index-set :service]
+                                  merge
+                                  {:resharding-indexes #{services-index}
+                                   :resharding-targets {services-index (str services-index "_5_shards")}
+                                   :resharding-status {services-index "COMPLETE"}})
+             _ (index/update-index-set index-set 1)]
+         (is (= {:status 400
+                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "COMPLETE")]}
+                (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
+     (testing "trying to reshard an IN_PROGRESS resharding index, should return 400 error"
+       (let [index-set (update-in (index/get-index-set-by-id 1)
+                                  [:index-set :service]
+                                  merge
+                                  {:resharding-indexes #{services-index}
+                                   :resharding-targets {services-index (str services-index "_5_shards")}
+                                   :resharding-status {services-index "IN_PROGRESS"}})
+             _ (index/update-index-set index-set 1)]
+         (is (= {:status 400
+                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "IN_PROGRESS")]}
+                (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
+     (testing "trying to reshard a FAILED resharded index, should return 400 error"
+       (let [index-set (update-in (index/get-index-set-by-id 1)
+                                  [:index-set :service]
+                                  merge
+                                  {:resharding-indexes #{services-index}
+                                   :resharding-targets {services-index (str services-index "_5_shards")}
+                                   :resharding-status {services-index "FAILED"}})
+             _ (index/update-index-set index-set 1)]
+         (is (= {:status 400
+                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "FAILED")]}
+                (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
      (testing "no elastic name given to get resharding status"
        (is (= {:status 400
                :errors ["Empty elastic cluster name is not allowed."]}

--- a/system-int-test/test/cmr/system_int_test/bootstrap/reshard_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/reshard_index_test.clj
@@ -77,7 +77,7 @@
          (is (= "Resharding started for index 1_small_collections" (:message reshard-resp)))
          (is (= false (nil? (:task-id reshard-resp)))))
        (is (= {:status 400
-               :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." "1_small_collections" "IN_PROGRESS")]}
+               :errors [(format "Index [%s] has a resharding state of [%s]. You cannot start a new reshard on an index that is in a existing reshard state." "1_small_collections" "IN_PROGRESS")]}
               (bootstrap/start-reshard-index "1_small_collections" {:synchronous false :num-shards 4 :elastic-name gran-elastic-name}))))
      (testing "trying to reshard an index that is currently rebalancing should throw error"
        (bootstrap/rollback-reshard-index "1_small_collections" {:elastic-name gran-elastic-name})
@@ -98,7 +98,7 @@
                                    :resharding-status {services-index "COMPLETE"}})
              _ (index/update-index-set index-set 1)]
          (is (= {:status 400
-                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "COMPLETE")]}
+                 :errors [(format "Index [%s] has a resharding state of [%s]. You cannot start a new reshard on an index that is in a existing reshard state." services-index "COMPLETE")]}
                 (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
      (testing "trying to reshard an IN_PROGRESS resharding index, should return 400 error"
        (let [index-set (update-in (index/get-index-set-by-id 1)
@@ -109,7 +109,7 @@
                                    :resharding-status {services-index "IN_PROGRESS"}})
              _ (index/update-index-set index-set 1)]
          (is (= {:status 400
-                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "IN_PROGRESS")]}
+                 :errors [(format "Index [%s] has a resharding state of [%s]. You cannot start a new reshard on an index that is in a existing reshard state." services-index "IN_PROGRESS")]}
                 (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
      (testing "trying to reshard a FAILED resharded index, should return 400 error"
        (let [index-set (update-in (index/get-index-set-by-id 1)
@@ -120,7 +120,7 @@
                                    :resharding-status {services-index "FAILED"}})
              _ (index/update-index-set index-set 1)]
          (is (= {:status 400
-                 :errors [(format "Index [%s] is in a current resharding state of [%s]. You cannot reshard an index that is currently being resharded." services-index "FAILED")]}
+                 :errors [(format "Index [%s] has a resharding state of [%s]. You cannot start a new reshard on an index that is in a existing reshard state." services-index "FAILED")]}
                 (bootstrap/start-reshard-index services-index {:synchronous false :num-shards 7 :elastic-name elastic-name})))))
      (testing "no elastic name given to get resharding status"
        (is (= {:status 400

--- a/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/autocomplete/suggestion_reindex_test.clj
@@ -196,6 +196,7 @@
 
 (deftest reindex-suggestions-test
   (testing "Ensure that response is in proper format and results are correct"
+    (index/wait-until-indexed)
     (compare-autocomplete-results
      (get-in (search/get-autocomplete-json "q=l") [:feed :entry])
      [{:type "organization" :value "Langley DAAC User Services" :fields "Langley DAAC User Services"}


### PR DESCRIPTION
# Overview

### What is the objective?

When trying to reshard indexes and a failed or non finalized resharded index from another CMR session exists, the start end point fails with a 500 Error.

What should happen is a more descriptive error is returned so that users know what the actual issue is. A different http status code and message.

### What are the changes?

Updated 'already exist' or 'already resharding' or 'already rebalancing' errors to return 400 instead of 500 with better messaging

### What areas of the application does this impact?

Indexer

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
