### PR TITLE
CMR-11254: Change to debug UMM-C Spec validation results logs

### DIFF
--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -6,7 +6,7 @@
    [clojure.edn :as edn]
    [clojure.string :as string]
    [cmr.common-app.services.kms-lookup :as kms-lookup]
-   [cmr.common.log :as log :refer (warn)]
+   [cmr.common.log :as log :refer (debug warn)]
    [cmr.common.mime-types :as mt]
    [cmr.common.services.errors :as errors]
    [cmr.common.validations.core :as v]

--- a/ingest-app/src/cmr/ingest/validation/validation.clj
+++ b/ingest-app/src/cmr/ingest/validation/validation.clj
@@ -403,7 +403,7 @@
              err-messages))
          (errors/throw-service-errors :invalid-data err-messages))
        (do
-         (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
+         (debug "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
          err-messages)))))
 
 (defn umm-spec-validate-collection-warnings
@@ -417,7 +417,7 @@
             (config/return-umm-spec-validation-errors))
       (errors/throw-service-errors :invalid-data err-messages)
       (do
-        (warn "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
+        (debug "UMM-C UMM Spec Validation Errors: " (pr-str (vec err-messages)))
         err-messages))))
 
 (defn validate-granule-umm-spec


### PR DESCRIPTION
# Overview

### What is the objective?

UMM-C spec logs are long and aren't needed at INFO level

### What are the changes?

Moved these logs to DEBUG level

### What areas of the application does this impact?

Ingest

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
