### PR TITLE
Correct commit message

### DIFF
--- a/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
+++ b/umm-spec-lib/src/cmr/umm_spec/test/iso_shared.clj
@@ -196,4 +196,11 @@
   "Returns the expected Quality."
   [quality]
   (when (:Summary quality)
-    (assoc quality :Summary (string/trim (:Summary quality)))))
+    (let [trimmed-details (some->> (get quality :QualityContentDetails)
+                                   (map (fn [[k v]]
+                                          [k (when v (string/trim v))]))
+                                   (filter (fn [[_ v]] (seq v)))
+                                   (into {}))]
+      (cond-> (assoc quality :Summary (string/trim (:Summary quality)))
+        (seq trimmed-details) (assoc :QualityContentDetails trimmed-details)
+        (empty? trimmed-details) (dissoc :QualityContentDetails)))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/generate_and_parse.clj
@@ -216,7 +216,7 @@
   (checking "collection round tripping" 100
     [umm-record (gen/no-shrink umm-gen/umm-c-generator)
      metadata-format (gen/elements tested-collection-formats)]
-    (let [;; CMR-8128 remove OrbitParameters 
+    (let [;; CMR-8128 remove OrbitParameters
           ;; there are many situations when a parameter is not
           ;; preserved after the roundtrip. We will have to make many special cases
           ;; in order to do the comparison. Since they have been tested in other tests, we will
@@ -236,7 +236,7 @@
                                            {:Date (t/date-time 2013)
                                             :Type "UPDATE"}]))
           ;; Collection version 1.17.2 changes yet to be implemented in echo10, iso. 
-          ;; 1. For now, EULAIdentifiers needs to exist (as nil) if UseConstraints exists, 
+          ;; 1. For now, EULAIdentifiers needs to exist (as nil) if UseConstraints exists,
           ;; because it gets added back in (as nil) when round-tripping.
           umm-record (if (and (seq (:UseConstraints umm-record))
                               (or (= metadata-format :echo10) (= metadata-format :iso19115) (= metadata-format :iso-smap)))
@@ -266,7 +266,7 @@
 ;; expected output with the result of the actual conversions. This test runs a record
 ;; through all of the supported formats.
 (deftest roundtrip-generated-collection-records-with-seed
-  (checking-with-seed "collection round tripping seed" 100 1496683985472
+  (checking-with-seed "collection round tripping seed" 100 1783446834701
     [umm-record (gen/no-shrink umm-gen/umm-c-generator)
      metadata-format (gen/elements tested-collection-formats)]
     (let [;; CMR-8128 remove OrbitParameters for the same reason as the previous test.

--- a/umm-spec-lib/test/cmr/umm_spec/test/umm_to_xml_mappings/iso_shared/quality.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/umm_to_xml_mappings/iso_shared/quality.clj
@@ -42,12 +42,23 @@
       (is (= [:gco:CharacterString expected-text] (second eval-method)))))
 
   (testing "5. Verifies explicit schema ordering within the details map block"
-    ;; Verifies that the vector layout ordering forces Strengths to appear before Limitations 
+    ;; Verifies that the vector layout ordering forces Strengths to appear before Limitations
     ;; even if the input map key ordering changes.
     (let [input {:Quality {:Summary "Overview."
                            :QualityContentDetails {:Limitations "B text."
                                                    :Strengths "A text."}}}
           expected-text "Summary: Overview. Strengths: A text. Limitations: B text."
+          result (quality/generate-quality input)
+          eval-method (get-in result [1 1])]
+      (is (= [:gco:CharacterString expected-text] (second eval-method)))))
+
+  (testing "6. Trims trailing whitespace in the final serialized quality string"
+    (let [input {:Quality {:Summary "Overview."
+                           :QualityContentDetails {:Strengths "A text with trailing space "
+                                                   :Limitations nil
+                                                   :KnownIssues nil
+                                                   :Other nil}}}
+          expected-text "Summary: Overview. Strengths: A text with trailing space"
           result (quality/generate-quality input)
           eval-method (get-in result [1 1])]
       (is (= [:gco:CharacterString expected-text] (second eval-method))))))

--- a/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso_shared/quality.clj
+++ b/umm-spec-lib/test/cmr/umm_spec/test/xml_to_umm_mappings/iso_shared/quality.clj
@@ -43,4 +43,12 @@
                    "</CharacterString></evaluationMethodDescription></DQ_QuantitativeAttributeAccuracy></report>")
           expected {:Summary "Overview"
                     :QualityContentDetails {:Strengths "Good data"}}]
+      (is (= expected (parse-quality doc text-xpath true)))))
+
+  (testing "6. Parses non-canonical delimiter spacing via base parser behavior"
+    (let [doc (str "<report><DQ_QuantitativeAttributeAccuracy><evaluationMethodDescription><CharacterString>"
+                   "Summary: Overview text. Strengths:Exact "
+                   "</CharacterString></evaluationMethodDescription></DQ_QuantitativeAttributeAccuracy></report>")
+          expected {:Summary "Overview text."
+                    :QualityContentDetails {:Strengths "Exact"}}]
       (is (= expected (parse-quality doc text-xpath true))))))


### PR DESCRIPTION


# Overview

Correct the commit message. I accidentally gave a message with the Jira ticket item using the Jira project abbreviation of a previous project i worked with. It currently is: ACES-11360 instead of CMR-11360. This PR is to correct that commit message

Please summarize the reason for the changes made in this PR.

The only change in this PR is the commit message for the previous merge.

### What are the changes?

Commit message changed only

### What areas of the application does this impact?

None

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
