### PR TITLE
CMR-11271:  Fix Cascade collection delete does not delete from index-set when index is separate from small_collections

### DIFF
--- a/indexer-app/src/cmr/indexer/data/elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/elasticsearch.clj
@@ -287,10 +287,14 @@
   [context index]
   (info (format "Deleting granule index %s from elastic" index))
   (try
-    (esi/delete-index (indexer-util/context->conn context es-config/gran-elastic-name) index)
+    (assoc (esi/delete-index
+            (indexer-util/context->conn context es-config/gran-elastic-name)
+            index)
+           :status 200)
     (catch Throwable e
       (error e (str "Failed to delete granule index: "
-                    (pr-str index))))))
+                    (pr-str index)))
+      {:status (or (:status (ex-data e)) 500)})))
 
 (defn reset-es-store
   "Delete elasticsearch indexes via deleting the index-set and re-create them via index-set app. A nuclear option just for the development team."

--- a/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
@@ -156,7 +156,8 @@
                                    :throw-exceptions false})
           status (:status response)]
       (when-not (some #{200 202 204} [status])
-        (errors/internal-error! (m/index-delete-failure-msg response))))))
+        (errors/internal-error! (m/index-delete-failure-msg response)))
+      response)))
 
 (defn save-document-in-elastic
   "Save the document in Elasticsearch in specific elastic cluster, raise error on failure."

--- a/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
+++ b/indexer-app/src/cmr/indexer/data/index_set_elasticsearch.clj
@@ -156,8 +156,7 @@
                                    :throw-exceptions false})
           status (:status response)]
       (when-not (some #{200 202 204} [status])
-        (errors/internal-error! (m/index-delete-failure-msg response)))
-      response)))
+        (errors/internal-error! (m/index-delete-failure-msg response))))))
 
 (defn save-document-in-elastic
   "Save the document in Elasticsearch in specific elastic cluster, raise error on failure."

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -25,6 +25,7 @@
    [cmr.indexer.data.humanizer-fetcher :as humanizer-fetcher]
    [cmr.indexer.data.index-set :as idx-set]
    [cmr.indexer.data.metrics-fetcher :as metrics-fetcher]
+   [cmr.indexer.services.index-set-service :as idx-set-svc]
    [cmr.indexer.indexer-util :as indexer-util]
    [cmr.message-queue.queue.queue-protocol :as queue-protocol]
    [cmr.message-queue.services.queue :as queue]
@@ -670,7 +671,8 @@
   (let [small-collections-index-name (-> (idx-set/get-concept-type-index-names context)
                                          (:index-names)
                                          (:granule)
-                                         (:small_collections))]
+                                         (:small_collections))
+        deleted-separate-index? (volatile! false)]
     (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)]
       (if (= index small-collections-index-name)
         (let [resp (es-helper/delete-by-query
@@ -685,11 +687,16 @@
         ;; a collection index, we are just deleting the index. This is
         ;; in line with ES best practices
         (let [resp (es/delete-granule-index context index)]
+          (vreset! deleted-separate-index? true)
           (when (not= (get resp :status) 200)
-            (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp)))))))
+            (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
+    ;; If the collection had an individual granule index (not small_collections),
+    ;; remove its mapping from the gran index-set so it is not recreated on restart.
+    (when @deleted-separate-index?
+      (idx-set-svc/remove-collection-granule-index-if-exists context concept-id))
 
-  ;; reindex variables associated with the collection
-  (reindex-associated-variables context concept-id revision-id))
+    ;; reindex variables associated with the collection
+    (reindex-associated-variables context concept-id revision-id)))
 
 (defn get-concept-delete-log-string
   "Get the log string for concept-delete. Appends granules deleted if concept-type is collection"

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -671,8 +671,7 @@
   (let [small-collections-index-name (-> (idx-set/get-concept-type-index-names context)
                                          (:index-names)
                                          (:granule)
-                                         (:small_collections))
-        deleted-separate-index? (volatile! false)]
+                                         (:small_collections))]
     (doseq [index (idx-set/get-granule-index-names-for-collection context concept-id)]
       (if (= index small-collections-index-name)
         (let [resp (es-helper/delete-by-query
@@ -689,12 +688,9 @@
         (let [resp (es/delete-granule-index context index)
               status (get resp :status)]
           (if (contains? #{200 404} status)
-            (vreset! deleted-separate-index? true)
+            ;; Remove the mapping so the deleted index is not recreated on restart.
+            (idx-set-svc/remove-collection-granule-index-if-exists context concept-id)
             (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200/404 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
-    ;; If the collection had an individual granule index (not small_collections),
-    ;; remove its mapping from the gran index-set so it is not recreated on restart.
-    (when @deleted-separate-index?
-      (idx-set-svc/remove-collection-granule-index-if-exists context concept-id))
 
     ;; reindex variables associated with the collection
     (reindex-associated-variables context concept-id revision-id)))

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -686,10 +686,11 @@
         ;; Instead of running a delete-by-query to remove all granules from
         ;; a collection index, we are just deleting the index. This is
         ;; in line with ES best practices
-        (let [resp (es/delete-granule-index context index)]
-          (if (= (get resp :status) 200)
+        (let [resp (es/delete-granule-index context index)
+              status (get resp :status)]
+          (if (contains? #{200 404} status)
             (vreset! deleted-separate-index? true)
-            (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
+            (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200/404 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
     ;; If the collection had an individual granule index (not small_collections),
     ;; remove its mapping from the gran index-set so it is not recreated on restart.
     (when @deleted-separate-index?

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -689,7 +689,8 @@
               status (get resp :status)]
           (if (contains? #{200 404} status)
             ;; Remove the mapping so the deleted index is not recreated on restart.
-            (idx-set-svc/remove-collection-granule-index-if-exists context concept-id)
+            (idx-set-svc/remove-collection-granule-index-if-exists
+             context idx-set/index-set-id concept-id)
             (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200/404 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
 
     ;; reindex variables associated with the collection

--- a/indexer-app/src/cmr/indexer/services/index_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_service.clj
@@ -687,8 +687,8 @@
         ;; a collection index, we are just deleting the index. This is
         ;; in line with ES best practices
         (let [resp (es/delete-granule-index context index)]
-          (vreset! deleted-separate-index? true)
-          (when (not= (get resp :status) 200)
+          (if (= (get resp :status) 200)
+            (vreset! deleted-separate-index? true)
             (warn (format "Cascade collection delete for concept id %s and revision id %s did not return 200 status response on deleting index %s. Elastic delete index resp = %s" concept-id revision-id index resp))))))
     ;; If the collection had an individual granule index (not small_collections),
     ;; remove its mapping from the gran index-set so it is not recreated on restart.

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -592,6 +592,36 @@
         index-set (update-in index-set [:index-set :concepts :granule] dissoc coll-base-name)]
     index-set))
 
+(defn remove-collection-granule-index-if-exists
+  "Removes a collection's separate granule index from the index-set if it exists.
+
+   No-op cases:
+   - collection has no explicit granule index mapping in the index-set
+   - collection currently maps to the small_collections index"
+  [context concept-id]
+  (let [index-set-id index-set/index-set-id
+        gran-index-set (index-set-util/get-index-set context es-config/gran-elastic-name index-set-id)
+        collection-key (keyword concept-id)
+        mapped-index (get-in gran-index-set [:index-set :concepts :granule collection-key])
+        small-collections-index (get-in gran-index-set [:index-set :concepts :granule :small_collections])]
+    (cond
+      (nil? mapped-index)
+      (do
+        (info (format "No separate granule index mapping found for collection [%s]; skipping index-set cleanup." concept-id))
+        {:status 200})
+
+      (= mapped-index small-collections-index)
+      (do
+        (info (format "Collection [%s] is mapped to small_collections; no index-set cleanup needed." concept-id))
+        {:status 200})
+
+      :else
+      (let [updated-gran-index-set (remove-granule-index-from-index-set gran-index-set concept-id)]
+        ;; Update the index set. This keeps metadata-db and ES index-set documents in sync.
+        (validate-requested-index-set context es-config/gran-elastic-name updated-gran-index-set true)
+        (let [revision-id (save-combined-index-set-to-mdb context updated-gran-index-set es-config/gran-elastic-name)]
+          (update-index-set context es-config/gran-elastic-name updated-gran-index-set revision-id))))))
+
 (defn mark-collection-as-rebalancing
   "Marks the given collection as rebalancing in the index set."
   [context index-set-id concept-id target]

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -374,9 +374,13 @@
   [context index-set-id es-cluster-name]
   (let [index-names (get-index-names (index-set-util/get-index-set context es-cluster-name index-set-id) es-cluster-name)
         {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
-        idx-mapping-type (first (keys mapping))]
-    (dorun (map #(es/delete-index (indexer-util/context->es-store context es-cluster-name) %) index-names))
-    (es/delete-document context index-name idx-mapping-type index-set-id es-cluster-name)))
+        idx-mapping-type (first (keys mapping))
+        delete-responses (keep #(es/delete-index (indexer-util/context->es-store context es-cluster-name) %) index-names)
+        non-200-delete-responses (remove #(= 200 (:status %)) delete-responses)]
+    (if (empty? non-200-delete-responses)
+      (es/delete-document context index-name idx-mapping-type index-set-id es-cluster-name)
+      (errors/internal-error!
+       (m/index-delete-failure-msg non-200-delete-responses)))))
 
 (defn delete-index-set
   "Delete the index-set from all elastic clusters and save a tombstone in metadata-db.

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -593,29 +593,17 @@
     index-set))
 
 (defn remove-collection-granule-index-if-exists
-  "Removes a collection's separate granule index from the index-set if it exists.
+  "Removes a collection's separate granule index from the given CMR index-set.
 
-   No-op cases:
-   - collection has no explicit granule index mapping in the index-set
-   - collection currently maps to the small_collections index"
-  [context concept-id]
-  (let [index-set-id index-set/index-set-id
-        gran-index-set (index-set-util/get-index-set context es-config/gran-elastic-name index-set-id)
-        collection-key (keyword concept-id)
-        mapped-index (get-in gran-index-set [:index-set :concepts :granule collection-key])
-        small-collections-index (get-in gran-index-set [:index-set :concepts :granule :small_collections])]
-    (cond
-      (nil? mapped-index)
+   Leaves the index-set unchanged when the collection has no separate granule index."
+  [context index-set-id concept-id]
+  (let [gran-index-set (index-set-util/get-index-set context es-config/gran-elastic-name index-set-id)
+        separate-index-exists? (contains? (collection-ids-from-granule-indexes gran-index-set)
+                                          concept-id)]
+    (if-not separate-index-exists?
       (do
-        (info (format "No separate granule index mapping found for collection [%s]; skipping index-set cleanup." concept-id))
+        (info (format "No separate granule index found for collection [%s]; skipping index-set cleanup." concept-id))
         {:status 200})
-
-      (= mapped-index small-collections-index)
-      (do
-        (info (format "Collection [%s] is mapped to small_collections; no index-set cleanup needed." concept-id))
-        {:status 200})
-
-      :else
       (let [updated-gran-index-set (remove-granule-index-from-index-set gran-index-set concept-id)]
         ;; Update the index set. This keeps metadata-db and ES index-set documents in sync.
         (validate-requested-index-set context es-config/gran-elastic-name updated-gran-index-set true)

--- a/indexer-app/src/cmr/indexer/services/index_set_service.clj
+++ b/indexer-app/src/cmr/indexer/services/index_set_service.clj
@@ -374,13 +374,9 @@
   [context index-set-id es-cluster-name]
   (let [index-names (get-index-names (index-set-util/get-index-set context es-cluster-name index-set-id) es-cluster-name)
         {:keys [index-name mapping]} (config/idx-cfg-for-index-sets es-cluster-name)
-        idx-mapping-type (first (keys mapping))
-        delete-responses (keep #(es/delete-index (indexer-util/context->es-store context es-cluster-name) %) index-names)
-        non-200-delete-responses (remove #(= 200 (:status %)) delete-responses)]
-    (if (empty? non-200-delete-responses)
-      (es/delete-document context index-name idx-mapping-type index-set-id es-cluster-name)
-      (errors/internal-error!
-       (m/index-delete-failure-msg non-200-delete-responses)))))
+        idx-mapping-type (first (keys mapping))]
+    (dorun (map #(es/delete-index (indexer-util/context->es-store context es-cluster-name) %) index-names))
+    (es/delete-document context index-name idx-mapping-type index-set-id es-cluster-name)))
 
 (defn delete-index-set
   "Delete the index-set from all elastic clusters and save a tombstone in metadata-db.

--- a/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
+++ b/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
@@ -1,9 +1,11 @@
 (ns cmr.indexer.test.data.elasticsearch
   (:require
    [clojure.test :refer [deftest is testing]]
+   [cmr.elastic-utils.index-util :as esi]
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.data.index-set :as i]
-   [cmr.indexer.data.index-set-generics :as index-set-gen]))
+   [cmr.indexer.data.index-set-generics :as index-set-gen]
+   [cmr.indexer.indexer-util :as indexer-util]))
 
 (def test-index-set
   "A real copy of an index set from UAT with the mappings replaced to be smaller and reduce churn"
@@ -94,6 +96,28 @@
       (try
         (is (= nil (#'es/handle-bulk-index-response fake-resp)))
         (catch Exception e (is (= nil e) (.getMessage e)))))))
+
+(deftest delete-granule-index-test
+  (with-redefs [indexer-util/context->conn (constantly :connection)]
+    (testing "adds the HTTP success status to the decoded Elasticsearch response"
+      (with-redefs [esi/delete-index (fn [connection index]
+                                      (is (= :connection connection))
+                                      (is (= "granule-index" index))
+                                      {:acknowledged true})]
+        (is (= {:acknowledged true :status 200}
+               (es/delete-granule-index {} "granule-index")))))
+
+    (testing "returns the HTTP status from an Elasticsearch exception"
+      (with-redefs [esi/delete-index (fn [_connection _index]
+                                      (throw (ex-info "Not found" {:status 404})))]
+        (is (= {:status 404}
+               (es/delete-granule-index {} "missing-granule-index")))))
+
+    (testing "returns an internal error status when an exception has no HTTP status"
+      (with-redefs [esi/delete-index (fn [_connection _index]
+                                      (throw (RuntimeException. "Connection failed")))]
+        (is (= {:status 500}
+               (es/delete-granule-index {} "granule-index")))))))
 
 (deftest extra-granule-indexes-test
   (testing "extra indexes configured"

--- a/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
+++ b/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
@@ -99,7 +99,7 @@
 
 (deftest delete-granule-index-test
   (with-redefs [indexer-util/context->conn (constantly :connection)]
-    (testing "when Elasticsearch deletes the index, then add status 200 to its response"
+    (testing "when Elasticsearch successfully deletes the index, then delete-granule-index returns a status 200"
       (with-redefs [esi/delete-index (fn [connection index]
                                       (is (= :connection connection))
                                       (is (= "granule-index" index))
@@ -107,13 +107,13 @@
         (is (= {:acknowledged true :status 200}
                (es/delete-granule-index {} "granule-index")))))
 
-    (testing "when Elasticsearch throws an exception with an HTTP status, then return that status"
+    (testing "when Elasticsearch reports that the index is missing with status 404, then delete-granule-index returns a response with status 404"
       (with-redefs [esi/delete-index (fn [_connection _index]
                                       (throw (ex-info "Not found" {:status 404})))]
         (is (= {:status 404}
                (es/delete-granule-index {} "missing-granule-index")))))
 
-    (testing "when Elasticsearch throws an exception without an HTTP status, then return status 500"
+    (testing "when Elasticsearch throws an exception without an HTTP status, then delete-granule-index returns a status 500"
       (with-redefs [esi/delete-index (fn [_connection _index]
                                       (throw (RuntimeException. "Connection failed")))]
         (is (= {:status 500}

--- a/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
+++ b/indexer-app/test/cmr/indexer/test/data/elasticsearch.clj
@@ -99,7 +99,7 @@
 
 (deftest delete-granule-index-test
   (with-redefs [indexer-util/context->conn (constantly :connection)]
-    (testing "adds the HTTP success status to the decoded Elasticsearch response"
+    (testing "when Elasticsearch deletes the index, then add status 200 to its response"
       (with-redefs [esi/delete-index (fn [connection index]
                                       (is (= :connection connection))
                                       (is (= "granule-index" index))
@@ -107,13 +107,13 @@
         (is (= {:acknowledged true :status 200}
                (es/delete-granule-index {} "granule-index")))))
 
-    (testing "returns the HTTP status from an Elasticsearch exception"
+    (testing "when Elasticsearch throws an exception with an HTTP status, then return that status"
       (with-redefs [esi/delete-index (fn [_connection _index]
                                       (throw (ex-info "Not found" {:status 404})))]
         (is (= {:status 404}
                (es/delete-granule-index {} "missing-granule-index")))))
 
-    (testing "returns an internal error status when an exception has no HTTP status"
+    (testing "when Elasticsearch throws an exception without an HTTP status, then return status 500"
       (with-redefs [esi/delete-index (fn [_connection _index]
                                       (throw (RuntimeException. "Connection failed")))]
         (is (= {:status 500}

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -86,8 +86,8 @@
                               :ok)}
                      cleanup-var
                      (assoc cleanup-var
-                            (fn [_context concept-id-param]
-                              (swap! cleanup-calls conj concept-id-param)
+                            (fn [_context index-set-id-param concept-id-param]
+                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
                               {:status 200})))]
     (is (some? cleanup-var)
         "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
@@ -95,7 +95,9 @@
       #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
          (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
     (when cleanup-var
-      (is (= [concept-id concept-id] @cleanup-calls)
+      (is (= [[idx-set/index-set-id concept-id]
+              [idx-set/index-set-id concept-id]]
+             @cleanup-calls)
           "Each successful index delete should trigger index-set cleanup"))))
 
 (deftest cascade-collection-delete-does-not-call-index-set-cleanup-for-small-collections-test
@@ -123,8 +125,8 @@
                               :ok)}
                      cleanup-var
                      (assoc cleanup-var
-                            (fn [_context concept-id-param]
-                              (swap! cleanup-calls conj concept-id-param)
+                            (fn [_context index-set-id-param concept-id-param]
+                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
                               {:status 200})))]
     (is (some? cleanup-var)
         "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
@@ -160,8 +162,8 @@
                               :ok)}
                      cleanup-var
                      (assoc cleanup-var
-                            (fn [_context concept-id-param]
-                              (swap! cleanup-calls conj concept-id-param)
+                            (fn [_context index-set-id-param concept-id-param]
+                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
                               {:status 200})))]
     (is (some? cleanup-var)
         "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
@@ -197,8 +199,8 @@
                               :ok)}
                      cleanup-var
                      (assoc cleanup-var
-                            (fn [_context concept-id-param]
-                              (swap! cleanup-calls conj concept-id-param)
+                            (fn [_context index-set-id-param concept-id-param]
+                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
                               {:status 200})))]
     (is (some? cleanup-var)
         "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
@@ -206,5 +208,5 @@
       #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
          (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
     (when cleanup-var
-      (is (= [concept-id] @cleanup-calls)
+      (is (= [[idx-set/index-set-id concept-id]] @cleanup-calls)
           "Collection delete should trigger index-set cleanup when separate index is already missing (404)"))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -4,7 +4,12 @@
    [cheshire.core :as json]
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3]]
-   [cmr.indexer.services.index-service :as index-svc]))
+   [cmr.elastic-utils.es-helper :as es-helper]
+   [cmr.indexer.data.elasticsearch :as es]
+   [cmr.indexer.data.index-set :as idx-set]
+   [cmr.indexer.indexer-util :as indexer-util]
+   [cmr.indexer.services.index-service :as index-svc]
+   [cmr.indexer.services.index-set-service :as idx-set-svc]))
 
 (deftest index-concept-invalid-input-test
   (testing "invalid input"
@@ -55,3 +60,77 @@
       (is (some? data) "time-to-visibility-json parsing test")
       (is (= "ACL" (:ct data)) "Checking concept type")
       (is (= "index-vis" (:mg data)) "Checking message id"))))
+
+(deftest cascade-collection-delete-calls-index-set-cleanup-for-separate-index-test
+  (let [concept-id "C1234-PROV1"
+        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
+                                'remove-collection-granule-index-if-exists)
+        cleanup-calls (atom [])
+        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
+                            (fn [_context]
+                              {:index-names {:granule {:small_collections "1_small_collections"}}})
+                            #'idx-set/get-granule-index-names-for-collection
+                            (fn [_context _concept-id]
+                              ["1_c1234_prov1"])
+                            #'indexer-util/context->conn
+                            (fn [_context _cluster-name]
+                              nil)
+                            #'es/delete-granule-index
+                            (fn [_context _index-name]
+                              {:status 200})
+                            #'es-helper/delete-by-query
+                            (fn [& _args]
+                              {:status 200})
+                            #'index-svc/reindex-associated-variables
+                            (fn [& _args]
+                              :ok)}
+                     cleanup-var
+                     (assoc cleanup-var
+                            (fn [_context concept-id-param]
+                              (swap! cleanup-calls conj concept-id-param)
+                              {:status 200})))]
+    (is (some? cleanup-var)
+        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
+    (with-redefs-fn redefs-map
+      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
+         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
+    (when cleanup-var
+      (is (= [concept-id] @cleanup-calls)
+          "Collection delete should trigger index-set cleanup when granules are in a separate index"))))
+
+(deftest cascade-collection-delete-does-not-call-index-set-cleanup-for-small-collections-test
+  (let [concept-id "C1234-PROV1"
+        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
+                                'remove-collection-granule-index-if-exists)
+        cleanup-calls (atom [])
+        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
+                            (fn [_context]
+                              {:index-names {:granule {:small_collections "1_small_collections"}}})
+                            #'idx-set/get-granule-index-names-for-collection
+                            (fn [_context _concept-id]
+                              ["1_small_collections"])
+                            #'indexer-util/context->conn
+                            (fn [_context _cluster-name]
+                              nil)
+                            #'es/delete-granule-index
+                            (fn [_context _index-name]
+                              {:status 200})
+                            #'es-helper/delete-by-query
+                            (fn [& _args]
+                              {:status 200})
+                            #'index-svc/reindex-associated-variables
+                            (fn [& _args]
+                              :ok)}
+                     cleanup-var
+                     (assoc cleanup-var
+                            (fn [_context concept-id-param]
+                              (swap! cleanup-calls conj concept-id-param)
+                              {:status 200})))]
+    (is (some? cleanup-var)
+        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
+    (with-redefs-fn redefs-map
+      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
+         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
+    (when cleanup-var
+      (is (empty? @cleanup-calls)
+          "Collection delete should not trigger index-set cleanup for small_collections path"))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -171,3 +171,40 @@
     (when cleanup-var
       (is (empty? @cleanup-calls)
           "Collection delete should not trigger index-set cleanup when separate index deletion fails"))))
+
+(deftest cascade-collection-delete-calls-index-set-cleanup-when-separate-index-already-missing-test
+  (let [concept-id "C1234-PROV1"
+        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
+                                'remove-collection-granule-index-if-exists)
+        cleanup-calls (atom [])
+        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
+                            (fn [_context]
+                              {:index-names {:granule {:small_collections "1_small_collections"}}})
+                            #'idx-set/get-granule-index-names-for-collection
+                            (fn [_context _concept-id]
+                              ["1_c1234_prov1"])
+                            #'indexer-util/context->conn
+                            (fn [_context _cluster-name]
+                              nil)
+                            #'es/delete-granule-index
+                            (fn [_context _index-name]
+                              {:status 404})
+                            #'es-helper/delete-by-query
+                            (fn [& _args]
+                              {:status 200})
+                            #'index-svc/reindex-associated-variables
+                            (fn [& _args]
+                              :ok)}
+                     cleanup-var
+                     (assoc cleanup-var
+                            (fn [_context concept-id-param]
+                              (swap! cleanup-calls conj concept-id-param)
+                              {:status 200})))]
+    (is (some? cleanup-var)
+        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
+    (with-redefs-fn redefs-map
+      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
+         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
+    (when cleanup-var
+      (is (= [concept-id] @cleanup-calls)
+          "Collection delete should trigger index-set cleanup when separate index is already missing (404)"))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -61,7 +61,7 @@
       (is (= "ACL" (:ct data)) "Checking concept type")
       (is (= "index-vis" (:mg data)) "Checking message id"))))
 
-(deftest cascade-collection-delete-calls-index-set-cleanup-for-separate-index-test
+(deftest when-separate-index-deletes-succeed-then-call-index-set-cleanup-for-each-index
   (let [concept-id "C1234-PROV1"
         cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
                                 'remove-collection-granule-index-if-exists)
@@ -71,7 +71,7 @@
                               {:index-names {:granule {:small_collections "1_small_collections"}}})
                             #'idx-set/get-granule-index-names-for-collection
                             (fn [_context _concept-id]
-                              ["1_c1234_prov1"])
+                              ["1_c1234_prov1" "1_c1234_prov1_8_shards"])
                             #'indexer-util/context->conn
                             (fn [_context _cluster-name]
                               nil)
@@ -95,8 +95,8 @@
       #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
          (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
     (when cleanup-var
-      (is (= [concept-id] @cleanup-calls)
-          "Collection delete should trigger index-set cleanup when granules are in a separate index"))))
+      (is (= [concept-id concept-id] @cleanup-calls)
+          "Each successful index delete should trigger index-set cleanup"))))
 
 (deftest cascade-collection-delete-does-not-call-index-set-cleanup-for-small-collections-test
   (let [concept-id "C1234-PROV1"

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -134,3 +134,40 @@
     (when cleanup-var
       (is (empty? @cleanup-calls)
           "Collection delete should not trigger index-set cleanup for small_collections path"))))
+
+(deftest cascade-collection-delete-does-not-call-index-set-cleanup-when-separate-index-delete-fails-test
+  (let [concept-id "C1234-PROV1"
+        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
+                                'remove-collection-granule-index-if-exists)
+        cleanup-calls (atom [])
+        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
+                            (fn [_context]
+                              {:index-names {:granule {:small_collections "1_small_collections"}}})
+                            #'idx-set/get-granule-index-names-for-collection
+                            (fn [_context _concept-id]
+                              ["1_c1234_prov1"])
+                            #'indexer-util/context->conn
+                            (fn [_context _cluster-name]
+                              nil)
+                            #'es/delete-granule-index
+                            (fn [_context _index-name]
+                              {:status 500})
+                            #'es-helper/delete-by-query
+                            (fn [& _args]
+                              {:status 200})
+                            #'index-svc/reindex-associated-variables
+                            (fn [& _args]
+                              :ok)}
+                     cleanup-var
+                     (assoc cleanup-var
+                            (fn [_context concept-id-param]
+                              (swap! cleanup-calls conj concept-id-param)
+                              {:status 200})))]
+    (is (some? cleanup-var)
+        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
+    (with-redefs-fn redefs-map
+      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
+         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
+    (when cleanup-var
+      (is (empty? @cleanup-calls)
+          "Collection delete should not trigger index-set cleanup when separate index deletion fails"))))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -122,13 +122,16 @@
              (cascade-collection-delete-index-set-result
               gran-index-set granule-index-names delete-index-status)))
 
-      "when deletion of a separate index succeeds, then cascade-collection-delete removes its mapping and definition from the index set"
+      "when deletion of a separate index succeeds, then cascade-collection-delete 
+       removes its mapping and definition from the index set"
       updated-index-set separate-index-set [separate-index] 200
 
-      "when a separate index is missing from Elasticsearch, then cascade-collection-delete removes its stale mapping and definition from the index set"
+      "when a separate index is missing from Elasticsearch, then cascade-collection-delete 
+       removes its stale mapping and definition from the index set"
       updated-index-set separate-index-set [separate-index] 404
 
-      "when deletion of a separate index fails, then cascade-collection-delete does not update the index set"
+      "when deletion of a separate index fails, then cascade-collection-delete 
+       does not update the index set"
       nil separate-index-set [separate-index] 500
 
       "when the collection uses small_collections, then cascade-collection-delete does not update the index set"

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [cmr.common.util :refer [are3]]
    [cmr.elastic-utils.es-helper :as es-helper]
+   [cmr.indexer.common.index-set-util :as idx-set-util]
    [cmr.indexer.data.elasticsearch :as es]
    [cmr.indexer.data.index-set :as idx-set]
    [cmr.indexer.indexer-util :as indexer-util]
@@ -61,152 +62,71 @@
       (is (= "ACL" (:ct data)) "Checking concept type")
       (is (= "index-vis" (:mg data)) "Checking message id"))))
 
-(deftest when-separate-index-deletes-succeed-then-call-index-set-cleanup-for-each-index
+(defn- cascade-collection-delete-index-set-result
+  [gran-index-set granule-index-names delete-index-status]
   (let [concept-id "C1234-PROV1"
-        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
-                                'remove-collection-granule-index-if-exists)
-        cleanup-calls (atom [])
-        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
-                            (fn [_context]
-                              {:index-names {:granule {:small_collections "1_small_collections"}}})
-                            #'idx-set/get-granule-index-names-for-collection
-                            (fn [_context _concept-id]
-                              ["1_c1234_prov1" "1_c1234_prov1_8_shards"])
-                            #'indexer-util/context->conn
-                            (fn [_context _cluster-name]
-                              nil)
-                            #'es/delete-granule-index
-                            (fn [_context _index-name]
-                              {:status 200})
-                            #'es-helper/delete-by-query
-                            (fn [& _args]
-                              {:status 200})
-                            #'index-svc/reindex-associated-variables
-                            (fn [& _args]
-                              :ok)}
-                     cleanup-var
-                     (assoc cleanup-var
-                            (fn [_context index-set-id-param concept-id-param]
-                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
-                              {:status 200})))]
-    (is (some? cleanup-var)
-        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
-    (with-redefs-fn redefs-map
-      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
-         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
-    (when cleanup-var
-      (is (= [[idx-set/index-set-id concept-id]
-              [idx-set/index-set-id concept-id]]
-             @cleanup-calls)
-          "Each successful index delete should trigger index-set cleanup"))))
+        updated-index-set (atom nil)]
+    (with-redefs [idx-set/get-concept-type-index-names
+                  (fn [_context]
+                    {:index-names {:granule {:small_collections "1_small_collections"}}})
+                  idx-set/get-granule-index-names-for-collection
+                  (fn [_context _concept-id]
+                    granule-index-names)
+                  idx-set-util/get-index-set
+                  (fn [_context _elastic-name _index-set-id]
+                    gran-index-set)
+                  indexer-util/context->conn
+                  (fn [_context _cluster-name]
+                    nil)
+                  es/delete-granule-index
+                  (fn [_context _index-name]
+                    {:status delete-index-status})
+                  es-helper/delete-by-query
+                  (fn [& _args]
+                    {:status 200})
+                  idx-set-svc/validate-requested-index-set
+                  (fn [& _args])
+                  idx-set-svc/save-combined-index-set-to-mdb
+                  (fn [& _args]
+                    33)
+                  idx-set-svc/update-index-set
+                  (fn [_context _elastic-name index-set _revision-id]
+                    (reset! updated-index-set index-set)
+                    {:status 200})
+                  index-svc/reindex-associated-variables
+                  (fn [& _args]
+                    :ok)]
+      (#'index-svc/cascade-collection-delete {} {:granule "granule"} concept-id 7))
+    @updated-index-set))
 
-(deftest cascade-collection-delete-does-not-call-index-set-cleanup-for-small-collections-test
+(deftest cascade-collection-delete-index-set-result-test
   (let [concept-id "C1234-PROV1"
-        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
-                                'remove-collection-granule-index-if-exists)
-        cleanup-calls (atom [])
-        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
-                            (fn [_context]
-                              {:index-names {:granule {:small_collections "1_small_collections"}}})
-                            #'idx-set/get-granule-index-names-for-collection
-                            (fn [_context _concept-id]
-                              ["1_small_collections"])
-                            #'indexer-util/context->conn
-                            (fn [_context _cluster-name]
-                              nil)
-                            #'es/delete-granule-index
-                            (fn [_context _index-name]
-                              {:status 200})
-                            #'es-helper/delete-by-query
-                            (fn [& _args]
-                              {:status 200})
-                            #'index-svc/reindex-associated-variables
-                            (fn [& _args]
-                              :ok)}
-                     cleanup-var
-                     (assoc cleanup-var
-                            (fn [_context index-set-id-param concept-id-param]
-                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
-                              {:status 200})))]
-    (is (some? cleanup-var)
-        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
-    (with-redefs-fn redefs-map
-      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
-         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
-    (when cleanup-var
-      (is (empty? @cleanup-calls)
-          "Collection delete should not trigger index-set cleanup for small_collections path"))))
+        small-index "1_small_collections"
+        separate-index "1_c1234_prov1"
+        separate-index-set {:index-set
+                            {:concepts {:granule {:small_collections small-index
+                                                 (keyword concept-id) separate-index}}
+                             :granule {:indexes [{:name separate-index
+                                                  :number_of_shards 5}]}}}
+        small-index-set {:index-set
+                         {:concepts {:granule {:small_collections small-index}}
+                          :granule {:indexes [{:name small-index}]}}}
+        updated-index-set {:index-set
+                           {:concepts {:granule {:small_collections small-index}}
+                            :granule {:indexes []}}}]
+    (are3 [expected gran-index-set granule-index-names delete-index-status]
+      (is (= expected
+             (cascade-collection-delete-index-set-result
+              gran-index-set granule-index-names delete-index-status)))
 
-(deftest cascade-collection-delete-does-not-call-index-set-cleanup-when-separate-index-delete-fails-test
-  (let [concept-id "C1234-PROV1"
-        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
-                                'remove-collection-granule-index-if-exists)
-        cleanup-calls (atom [])
-        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
-                            (fn [_context]
-                              {:index-names {:granule {:small_collections "1_small_collections"}}})
-                            #'idx-set/get-granule-index-names-for-collection
-                            (fn [_context _concept-id]
-                              ["1_c1234_prov1"])
-                            #'indexer-util/context->conn
-                            (fn [_context _cluster-name]
-                              nil)
-                            #'es/delete-granule-index
-                            (fn [_context _index-name]
-                              {:status 500})
-                            #'es-helper/delete-by-query
-                            (fn [& _args]
-                              {:status 200})
-                            #'index-svc/reindex-associated-variables
-                            (fn [& _args]
-                              :ok)}
-                     cleanup-var
-                     (assoc cleanup-var
-                            (fn [_context index-set-id-param concept-id-param]
-                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
-                              {:status 200})))]
-    (is (some? cleanup-var)
-        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
-    (with-redefs-fn redefs-map
-      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
-         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
-    (when cleanup-var
-      (is (empty? @cleanup-calls)
-          "Collection delete should not trigger index-set cleanup when separate index deletion fails"))))
+      "when separate index deletion returns 200, then remove its index-set configuration"
+      updated-index-set separate-index-set [separate-index] 200
 
-(deftest cascade-collection-delete-calls-index-set-cleanup-when-separate-index-already-missing-test
-  (let [concept-id "C1234-PROV1"
-        cleanup-var (ns-resolve 'cmr.indexer.services.index-set-service
-                                'remove-collection-granule-index-if-exists)
-        cleanup-calls (atom [])
-        redefs-map (cond-> {#'idx-set/get-concept-type-index-names
-                            (fn [_context]
-                              {:index-names {:granule {:small_collections "1_small_collections"}}})
-                            #'idx-set/get-granule-index-names-for-collection
-                            (fn [_context _concept-id]
-                              ["1_c1234_prov1"])
-                            #'indexer-util/context->conn
-                            (fn [_context _cluster-name]
-                              nil)
-                            #'es/delete-granule-index
-                            (fn [_context _index-name]
-                              {:status 404})
-                            #'es-helper/delete-by-query
-                            (fn [& _args]
-                              {:status 200})
-                            #'index-svc/reindex-associated-variables
-                            (fn [& _args]
-                              :ok)}
-                     cleanup-var
-                     (assoc cleanup-var
-                            (fn [_context index-set-id-param concept-id-param]
-                              (swap! cleanup-calls conj [index-set-id-param concept-id-param])
-                              {:status 200})))]
-    (is (some? cleanup-var)
-        "Expected public function remove-collection-granule-index-if-exists to exist in index-set-service")
-    (with-redefs-fn redefs-map
-      #(let [cascade-delete-fn (var index-svc/cascade-collection-delete)]
-         (cascade-delete-fn {} {:granule "granule"} concept-id 7)))
-    (when cleanup-var
-      (is (= [[idx-set/index-set-id concept-id]] @cleanup-calls)
-          "Collection delete should trigger index-set cleanup when separate index is already missing (404)"))))
+      "when separate index deletion returns 404, then remove its stale index-set configuration"
+      updated-index-set separate-index-set [separate-index] 404
+
+      "when separate index deletion fails, then leave the index-set unchanged"
+      nil separate-index-set [separate-index] 500
+
+      "when collection uses small_collections, then leave the index-set unchanged"
+      nil small-index-set [small-index] nil)))

--- a/indexer-app/test/cmr/indexer/test/services/index_service.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_service.clj
@@ -63,6 +63,8 @@
       (is (= "index-vis" (:mg data)) "Checking message id"))))
 
 (defn- cascade-collection-delete-index-set-result
+  "Calls cascade-collection-delete with mocked dependencies and returns the index set passed to
+  update-index-set, or nil when no index-set update occurs."
   [gran-index-set granule-index-names delete-index-status]
   (let [concept-id "C1234-PROV1"
         updated-index-set (atom nil)]
@@ -106,27 +108,28 @@
         separate-index-set {:index-set
                             {:concepts {:granule {:small_collections small-index
                                                  (keyword concept-id) separate-index}}
-                             :granule {:indexes [{:name separate-index
+                             :granule {:indexes [{:name small-index}
+                                                 {:name separate-index
                                                   :number_of_shards 5}]}}}
         small-index-set {:index-set
                          {:concepts {:granule {:small_collections small-index}}
                           :granule {:indexes [{:name small-index}]}}}
         updated-index-set {:index-set
                            {:concepts {:granule {:small_collections small-index}}
-                            :granule {:indexes []}}}]
+                            :granule {:indexes [{:name small-index}]}}}]
     (are3 [expected gran-index-set granule-index-names delete-index-status]
       (is (= expected
              (cascade-collection-delete-index-set-result
               gran-index-set granule-index-names delete-index-status)))
 
-      "when separate index deletion returns 200, then remove its index-set configuration"
+      "when deletion of a separate index succeeds, then cascade-collection-delete removes its mapping and definition from the index set"
       updated-index-set separate-index-set [separate-index] 200
 
-      "when separate index deletion returns 404, then remove its stale index-set configuration"
+      "when a separate index is missing from Elasticsearch, then cascade-collection-delete removes its stale mapping and definition from the index set"
       updated-index-set separate-index-set [separate-index] 404
 
-      "when separate index deletion fails, then leave the index-set unchanged"
+      "when deletion of a separate index fails, then cascade-collection-delete does not update the index set"
       nil separate-index-set [separate-index] 500
 
-      "when collection uses small_collections, then leave the index-set unchanged"
+      "when the collection uses small_collections, then cascade-collection-delete does not update the index set"
       nil small-index-set [small-index] nil)))

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -6,8 +6,6 @@
    [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.common.index-set-util :as idx-set-util]
-   [cmr.indexer.config :as config]
-   [cmr.indexer.data.index-set-elasticsearch :as es]
    [cmr.indexer.data.index-set-generics :as index-set-gen]
    [cmr.indexer.indexer-util :as indexer-util]
    [cmr.indexer.services.index-set-service :as svc]
@@ -643,32 +641,3 @@
           (is (= es-config/gran-elastic-name (:elastic-name @update-args)))
           (is (= @validate-arg (:index-set @update-args)))
           (is (= 33 (:revision-id @update-args))))))))
-
-(deftest delete-index-set-indices-gates-index-set-doc-delete-on-200-status
-  (testing "deletes index-set document when all index deletes return 200"
-    (let [delete-document-called? (atom false)]
-      (with-redefs [svc/get-index-names (fn [_ _] ["1_c123_prov" "1_c456_prov"])
-                    idx-set-util/get-index-set (fn [_ _ _] {:index-set {}})
-                    config/idx-cfg-for-index-sets (fn [_] {:index-name "index-sets" :mapping {:index-set {}}})
-                    indexer-util/context->es-store (fn [_ _] {})
-                    es/delete-index (fn [_ _] {:status 200})
-                    es/delete-document (fn [& _] (reset! delete-document-called? true))]
-        (#'svc/delete-index-set-indices {} 1 es-config/elastic-name)
-        (is (true? @delete-document-called?)))))
-
-  (testing "does not delete index-set document when any index delete is non-200"
-    (let [delete-document-called? (atom false)]
-      (with-redefs [svc/get-index-names (fn [_ _] ["1_c123_prov" "1_c456_prov"])
-                    idx-set-util/get-index-set (fn [_ _ _] {:index-set {}})
-                    config/idx-cfg-for-index-sets (fn [_] {:index-name "index-sets" :mapping {:index-set {}}})
-                    indexer-util/context->es-store (fn [_ _] {})
-                    es/delete-index (fn [_ index-name]
-                                      (if (= index-name "1_c123_prov")
-                                        {:status 200}
-                                        {:status 202}))
-                    es/delete-document (fn [& _] (reset! delete-document-called? true))]
-        (is (thrown-with-msg?
-             java.lang.Exception
-             #"index delete operation failed"
-             (#'svc/delete-index-set-indices {} 1 es-config/elastic-name)))
-        (is (false? @delete-document-called?))))))

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -582,7 +582,9 @@
         collection-key (keyword concept-id)
         small-index "1_small_collections"
         separate-index "1_c1234_prov1_8_shards"]
-    (testing "when collection has no separate index, then index-set remains unchanged"
+    (testing "when a collection has no separate granule index, then 
+              remove-collection-granule-index-if-exists returns status 200 
+              without making any changes to the index set"
       (let [validate-called? (atom false)
             save-called? (atom false)
             update-called? (atom false)]
@@ -599,7 +601,9 @@
           (is (false? @save-called?))
           (is (false? @update-called?)))))
 
-    (testing "when collection has a resharded separate index, then remove and persist it"
+    (testing "when a collection has a separate granule index, then 
+              remove-collection-granule-index-if-exists removes the mapping and index definition
+              from the index set and returns status 200"
       (let [validate-arg (atom nil)
             save-arg (atom nil)
             update-args (atom nil)]

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -577,48 +577,34 @@
 
 (deftest remove-collection-granule-index-if-exists-test
   (let [context {}
+        index-set-id 42
         concept-id "C1234-PROV1"
         collection-key (keyword concept-id)
         small-index "1_small_collections"
-        separate-index "1_c1234_prov1"]
-    (testing "no-ops when collection has no explicit mapping"
+        separate-index "1_c1234_prov1_8_shards"]
+    (testing "when collection has no separate index, then index-set remains unchanged"
       (let [validate-called? (atom false)
             save-called? (atom false)
             update-called? (atom false)]
-        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
+        (with-redefs [idx-set-util/get-index-set (fn [_ _ requested-index-set-id]
+                                                   (is (= index-set-id requested-index-set-id))
                                                    {:index-set {:concepts {:granule {:small_collections small-index}}
                                                                 :granule {:indexes []}}})
                       svc/validate-requested-index-set (fn [& _] (reset! validate-called? true))
                       svc/save-combined-index-set-to-mdb (fn [& _] (reset! save-called? true) 2)
                       svc/update-index-set (fn [& _] (reset! update-called? true) {:status 200})]
           (is (= {:status 200}
-                 (svc/remove-collection-granule-index-if-exists context concept-id)))
+                 (svc/remove-collection-granule-index-if-exists context index-set-id concept-id)))
           (is (false? @validate-called?))
           (is (false? @save-called?))
           (is (false? @update-called?)))))
 
-    (testing "no-ops when collection maps to small_collections"
-      (let [validate-called? (atom false)
-            save-called? (atom false)
-            update-called? (atom false)]
-        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
-                                                   {:index-set {:concepts {:granule {:small_collections small-index
-                                                                                     collection-key small-index}}
-                                                                :granule {:indexes []}}})
-                      svc/validate-requested-index-set (fn [& _] (reset! validate-called? true))
-                      svc/save-combined-index-set-to-mdb (fn [& _] (reset! save-called? true) 2)
-                      svc/update-index-set (fn [& _] (reset! update-called? true) {:status 200})]
-          (is (= {:status 200}
-                 (svc/remove-collection-granule-index-if-exists context concept-id)))
-          (is (false? @validate-called?))
-          (is (false? @save-called?))
-          (is (false? @update-called?)))))
-
-    (testing "removes mapping and persists updated index-set when separate index exists"
+    (testing "when collection has a resharded separate index, then remove and persist it"
       (let [validate-arg (atom nil)
             save-arg (atom nil)
             update-args (atom nil)]
-        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
+        (with-redefs [idx-set-util/get-index-set (fn [_ _ requested-index-set-id]
+                                                   (is (= index-set-id requested-index-set-id))
                                                    {:index-set {:concepts {:granule {:small_collections small-index
                                                                                      collection-key separate-index}}
                                                                 :granule {:indexes [{:name separate-index :number_of_shards 5}]}}})
@@ -633,7 +619,7 @@
                                                                   :revision-id revision-id})
                                              {:status 200})]
           (is (= {:status 200}
-                 (svc/remove-collection-granule-index-if-exists context concept-id)))
+                 (svc/remove-collection-granule-index-if-exists context index-set-id concept-id)))
           (is (= {:index-set {:concepts {:granule {:small_collections small-index}}
                               :granule {:indexes []}}}
                  @validate-arg))

--- a/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
+++ b/indexer-app/test/cmr/indexer/test/services/index_set_service_test.clj
@@ -6,6 +6,8 @@
    [cmr.elastic-utils.config :as es-config]
    [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.indexer.common.index-set-util :as idx-set-util]
+   [cmr.indexer.config :as config]
+   [cmr.indexer.data.index-set-elasticsearch :as es]
    [cmr.indexer.data.index-set-generics :as index-set-gen]
    [cmr.indexer.indexer-util :as indexer-util]
    [cmr.indexer.services.index-set-service :as svc]
@@ -574,3 +576,99 @@
 
     (testing "returns expected index-set structure"
       (is (= expected-index-set result)))))
+
+(deftest remove-collection-granule-index-if-exists-test
+  (let [context {}
+        concept-id "C1234-PROV1"
+        collection-key (keyword concept-id)
+        small-index "1_small_collections"
+        separate-index "1_c1234_prov1"]
+    (testing "no-ops when collection has no explicit mapping"
+      (let [validate-called? (atom false)
+            save-called? (atom false)
+            update-called? (atom false)]
+        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
+                                                   {:index-set {:concepts {:granule {:small_collections small-index}}
+                                                                :granule {:indexes []}}})
+                      svc/validate-requested-index-set (fn [& _] (reset! validate-called? true))
+                      svc/save-combined-index-set-to-mdb (fn [& _] (reset! save-called? true) 2)
+                      svc/update-index-set (fn [& _] (reset! update-called? true) {:status 200})]
+          (is (= {:status 200}
+                 (svc/remove-collection-granule-index-if-exists context concept-id)))
+          (is (false? @validate-called?))
+          (is (false? @save-called?))
+          (is (false? @update-called?)))))
+
+    (testing "no-ops when collection maps to small_collections"
+      (let [validate-called? (atom false)
+            save-called? (atom false)
+            update-called? (atom false)]
+        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
+                                                   {:index-set {:concepts {:granule {:small_collections small-index
+                                                                                     collection-key small-index}}
+                                                                :granule {:indexes []}}})
+                      svc/validate-requested-index-set (fn [& _] (reset! validate-called? true))
+                      svc/save-combined-index-set-to-mdb (fn [& _] (reset! save-called? true) 2)
+                      svc/update-index-set (fn [& _] (reset! update-called? true) {:status 200})]
+          (is (= {:status 200}
+                 (svc/remove-collection-granule-index-if-exists context concept-id)))
+          (is (false? @validate-called?))
+          (is (false? @save-called?))
+          (is (false? @update-called?)))))
+
+    (testing "removes mapping and persists updated index-set when separate index exists"
+      (let [validate-arg (atom nil)
+            save-arg (atom nil)
+            update-args (atom nil)]
+        (with-redefs [idx-set-util/get-index-set (fn [_ _ _]
+                                                   {:index-set {:concepts {:granule {:small_collections small-index
+                                                                                     collection-key separate-index}}
+                                                                :granule {:indexes [{:name separate-index :number_of_shards 5}]}}})
+                      svc/validate-requested-index-set (fn [_ _ updated-index-set _]
+                                                        (reset! validate-arg updated-index-set))
+                      svc/save-combined-index-set-to-mdb (fn [_ updated-index-set _]
+                                                           (reset! save-arg updated-index-set)
+                                                           33)
+                      svc/update-index-set (fn [_ elastic-name updated-index-set revision-id]
+                                             (reset! update-args {:elastic-name elastic-name
+                                                                  :index-set updated-index-set
+                                                                  :revision-id revision-id})
+                                             {:status 200})]
+          (is (= {:status 200}
+                 (svc/remove-collection-granule-index-if-exists context concept-id)))
+          (is (= {:index-set {:concepts {:granule {:small_collections small-index}}
+                              :granule {:indexes []}}}
+                 @validate-arg))
+          (is (= @validate-arg @save-arg))
+          (is (= es-config/gran-elastic-name (:elastic-name @update-args)))
+          (is (= @validate-arg (:index-set @update-args)))
+          (is (= 33 (:revision-id @update-args))))))))
+
+(deftest delete-index-set-indices-gates-index-set-doc-delete-on-200-status
+  (testing "deletes index-set document when all index deletes return 200"
+    (let [delete-document-called? (atom false)]
+      (with-redefs [svc/get-index-names (fn [_ _] ["1_c123_prov" "1_c456_prov"])
+                    idx-set-util/get-index-set (fn [_ _ _] {:index-set {}})
+                    config/idx-cfg-for-index-sets (fn [_] {:index-name "index-sets" :mapping {:index-set {}}})
+                    indexer-util/context->es-store (fn [_ _] {})
+                    es/delete-index (fn [_ _] {:status 200})
+                    es/delete-document (fn [& _] (reset! delete-document-called? true))]
+        (#'svc/delete-index-set-indices {} 1 es-config/elastic-name)
+        (is (true? @delete-document-called?)))))
+
+  (testing "does not delete index-set document when any index delete is non-200"
+    (let [delete-document-called? (atom false)]
+      (with-redefs [svc/get-index-names (fn [_ _] ["1_c123_prov" "1_c456_prov"])
+                    idx-set-util/get-index-set (fn [_ _ _] {:index-set {}})
+                    config/idx-cfg-for-index-sets (fn [_] {:index-name "index-sets" :mapping {:index-set {}}})
+                    indexer-util/context->es-store (fn [_ _] {})
+                    es/delete-index (fn [_ index-name]
+                                      (if (= index-name "1_c123_prov")
+                                        {:status 200}
+                                        {:status 202}))
+                    es/delete-document (fn [& _] (reset! delete-document-called? true))]
+        (is (thrown-with-msg?
+             java.lang.Exception
+             #"index delete operation failed"
+             (#'svc/delete-index-set-indices {} 1 es-config/elastic-name)))
+        (is (false? @delete-document-called?))))))

--- a/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
+++ b/system-int-test/test/cmr/system_int_test/bootstrap/rebalance_collections_test.clj
@@ -467,11 +467,18 @@
      (is (= 404 (:status (search/retrieve-concept (:concept-id deleted-coll) 1))))
      (is (= 404 (:status (search/retrieve-concept (:concept-id deleted-coll) 2))))
 
-     ;; Rebalance to small-collections
-     (bootstrap/start-rebalance-collection (:concept-id deleted-coll) {:target "small-collections"})
-     (index/wait-until-indexed)
-     (bootstrap/assert-rebalance-status {:small-collections 0 :separate-index 0 :rebalancing-status "COMPLETE"} deleted-coll)
-     (bootstrap/finalize-rebalance-collection (:concept-id deleted-coll))
+     ;; Rebalance to small-collections should fail because collection delete cleanup removes
+     ;; the separate index mapping from the index-set.
+     (is (= {:status 400
+             :errors [(format "The collection [%s] does not have a separate granule index."
+                              (:concept-id deleted-coll))]}
+            (bootstrap/start-rebalance-collection
+             (:concept-id deleted-coll)
+             {:target "small-collections"})))
+
+     ;; Verify collection remains not rebalancing and has no separate index mapping.
+     (bootstrap/assert-rebalance-status {:small-collections 0 :rebalancing-status "NOT_REBALANCING"}
+                                        deleted-coll)
 
      ;; Index is already removed, search for granules
      (index/wait-until-indexed)

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granule_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granule_index_test.clj
@@ -19,23 +19,23 @@
                     {:validate-keywords false})
         concept-id (:concept-id collection)
         concept-key (keyword concept-id)]
-    (bootstrap/start-rebalance-collection concept-id)
-    (index/wait-until-indexed)
-    (bootstrap/finalize-rebalance-collection concept-id)
-    (index/wait-until-indexed)
+    (testing "When a collection with a separate granule index is deleted, 
+              then cascade deletion removes the index and its index-set entries"
+      (bootstrap/start-rebalance-collection concept-id)
+      (index/wait-until-indexed)
+      (bootstrap/finalize-rebalance-collection concept-id)
+      (index/wait-until-indexed)
 
-    (testing "the separate index exists before collection deletion"
       (let [index-set (index/get-index-set-by-id 1)]
         (is (= 200 (:status index-set)))
         (is (some? (get-in index-set [:index-set :concepts :granule concept-key])))
         (is (some #(= concept-id (:name %))
                   (get-in index-set [:index-set :granule :indexes])))
-        (is (= 200 (:status (index/gran-elastic-index-exists? collection))))))
+        (is (= 200 (:status (index/gran-elastic-index-exists? collection)))))
 
-    (ingest/delete-concept (data-core/umm-c-collection->concept collection :echo10) {})
-    (index/wait-until-indexed)
+      (ingest/delete-concept (data-core/umm-c-collection->concept collection :echo10) {})
+      (index/wait-until-indexed)
 
-    (testing "cascade deletion removes the separate index and its index-set entries"
       (let [index-set (index/get-index-set-by-id 1)]
         (is (= 200 (:status index-set)))
         (is (nil? (get-in index-set [:index-set :concepts :granule concept-key])))

--- a/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granule_index_test.clj
+++ b/system-int-test/test/cmr/system_int_test/ingest/misc/deleted_granule_index_test.clj
@@ -12,6 +12,37 @@
 
 (use-fixtures :once (ingest/reset-fixture {"provguid1" "PROV1"}))
 
+(deftest cascade-collection-delete-removes-separate-granule-index-test
+  (let [collection (data-core/ingest-umm-spec-collection
+                    "PROV1"
+                    (data-umm-c/collection {})
+                    {:validate-keywords false})
+        concept-id (:concept-id collection)
+        concept-key (keyword concept-id)]
+    (bootstrap/start-rebalance-collection concept-id)
+    (index/wait-until-indexed)
+    (bootstrap/finalize-rebalance-collection concept-id)
+    (index/wait-until-indexed)
+
+    (testing "the separate index exists before collection deletion"
+      (let [index-set (index/get-index-set-by-id 1)]
+        (is (= 200 (:status index-set)))
+        (is (some? (get-in index-set [:index-set :concepts :granule concept-key])))
+        (is (some #(= concept-id (:name %))
+                  (get-in index-set [:index-set :granule :indexes])))
+        (is (= 200 (:status (index/gran-elastic-index-exists? collection))))))
+
+    (ingest/delete-concept (data-core/umm-c-collection->concept collection :echo10) {})
+    (index/wait-until-indexed)
+
+    (testing "cascade deletion removes the separate index and its index-set entries"
+      (let [index-set (index/get-index-set-by-id 1)]
+        (is (= 200 (:status index-set)))
+        (is (nil? (get-in index-set [:index-set :concepts :granule concept-key])))
+        (is (not-any? #(= concept-id (:name %))
+                      (get-in index-set [:index-set :granule :indexes])))
+        (is (= 404 (:status (index/gran-elastic-index-exists? collection))))))))
+
 (deftest deleted-granule-test-index
   (testing "Ingest collection, rebalance collection, delete collection"
     (let [collection (data-core/ingest-umm-spec-collection "PROV1"


### PR DESCRIPTION
# Overview

### What is the objective?

Ensure that deleting a collection with a separate granule index also removes the corresponding mapping from the index set, avoiding recreation of deleted indexes and preventing invalid rebalancing attempts.

### What are the changes?

* Added HTTP status information for individual granule-index deletions in delete-granule-index. Added unit tests to confirm behavior.
* Updated `cascade-collection-delete` to remove the index-set mapping only when ES returns 200 or 404. If the underlying index deletion in ES fails, the index-set is not updated. Added unit tests to confirm behavior.
* Added `remove-collection-granule-index-if-exists` to remove and persist the deletion of the of the separate granule-index mapping. It also handles missing mappings and collections included in `small_collections`. Added unit tests to confirm behavior.
* Added integration test to verify that separate index is deleted when cascade-collection-delete is called
* Added integration test to verify that a deleted collection does not rebalance after its separate index mapping is removed

### What areas of the application does this impact?

* indexer-app
* system-int-test

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
