### PR TITLE
CMR-11364: fix shapefile test cleanup timing

### DIFF
--- a/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/collection/collection_shapefile_search_test.clj
@@ -1,12 +1,14 @@
 (ns cmr.system-int-test.search.collection.collection-shapefile-search-test
   (:require
     [clojure.test :refer :all]
+    [clojure.edn :as edn]
     [clojure.java.io :as io]
     [cmr.common.log :refer [debug]]
     [cmr.common.mime-types :as mt]
     [cmr.common.util :as util :refer [are3]]
     [cmr.common-app.test.side-api :as side]
     [cmr.search.services.parameters.converters.shapefile :as shapefile]
+    [cmr.search.middleware.shapefile :as shapefile-middleware]
     [cmr.spatial.line-string :as l]
     [cmr.spatial.mbr :as m]
     [cmr.spatial.point :as p]
@@ -33,6 +35,17 @@
   {"ESRI" {:extension "zip" :mime-type mt/shapefile}
    "GeoJSON" {:extension "geojson" :mime-type mt/geojson}
    "KML" {:extension "kml" :mime-type mt/kml}})
+
+(defn- shapefile-config
+  "Returns the shapefile configuration currently active in the search app."
+  []
+  (-> (side/eval-form
+        `{:enabled? (shapefile/enable-shapefile-parameter-flag)
+          :max-size (shapefile-middleware/max-shapefile-size)
+          :max-features (shapefile/max-shapefile-features)
+          :max-points (shapefile/max-shapefile-points)})
+      :body
+      edn/read-string))
 
 (defn make-coll
   [coord-sys et & shapes]
@@ -194,9 +207,12 @@
                        :content "true"}
                       {:name "provider"
                        :content "PROV1"}]
-              {:keys [status]} (search/find-refs-with-multi-part-form-post :collection params)]
+              {:keys [status errors]} (search/find-refs-with-multi-part-form-post :collection params)
+              config (when status (shapefile-config))]
           (is (nil? status)
-              "Should pass validation with force-cartesian=true")))
+              (format (str "Should pass validation with force-cartesian=true; "
+                           "status=%s errors=%s shapefile-config=%s")
+                      status (pr-str (vec errors)) (pr-str config)))))
 
       (testing "without force-cartesian should fail validation"
         (let [params [{:name "shapefile"

--- a/system-int-test/test/cmr/system_int_test/search/granule/granule_shapefile_search_test.clj
+++ b/system-int-test/test/cmr/system_int_test/search/granule/granule_shapefile_search_test.clj
@@ -43,10 +43,10 @@
         _ (side/eval-form `(shapefile/set-max-shapefile-features! 2))
         saved-shapefile-max-points (shapefile/max-shapefile-points)
         _ (side/eval-form `(shapefile/set-max-shapefile-points! 50))]
-
-    (testing "ESRI Shapefile Failure cases"
-      (are3 [shapefile additional-params regex]
-        (is (re-find regex
+    (try
+      (testing "ESRI Shapefile Failure cases"
+        (are3 [shapefile additional-params regex]
+          (is (re-find regex
                       (first (:errors (search/find-refs-with-multi-part-form-post
                                         :granule
                                         (let [params [{:name "shapefile"
@@ -80,9 +80,9 @@
         "Shapefile has points too close"
         "too_precise.zip" {:name "provider" :content "PROV1"} #"The shape contained duplicate points. Points 1 \[lon=-?\d+\.\d+ lat=\d+\.\d+] and \d \[lon=-?\d+\.\d+ lat=\d+\.\d+].* were considered equivalent or very close"))
 
-    (testing "GeoJSON Failure cases"
-      (are3 [shapefile additional-params regex]
-        (is (re-find regex
+      (testing "GeoJSON Failure cases"
+        (are3 [shapefile additional-params regex]
+          (is (re-find regex
                       (first (:errors (search/find-refs-with-multi-part-form-post
                                         :granule
                                         (let [params [{:name "shapefile"
@@ -110,9 +110,9 @@
         "Shapefile has points too close"
         "too_precise.geojson" {:name "provider" :content "PROV1"} #"The shape contained duplicate points. Points 1 \[lon=-?\d+\.\d+ lat=\d+\.\d+] and \d \[lon=-?\d+\.\d+ lat=\d+\.\d+].* were considered equivalent or very close"))
 
-    (testing "KML Failure cases"
-      (are3 [shapefile additional-params regex]
-        (is (re-find regex
+      (testing "KML Failure cases"
+        (are3 [shapefile additional-params regex]
+          (is (re-find regex
                       (first (:errors (search/find-refs-with-multi-part-form-post
                                         :granule
                                         (let [params [{:name "shapefile"
@@ -139,10 +139,10 @@
 
         "Shapefile has points too close"
         "too_precise.kml" {:name "provider" :content "PROV1"} #"The shape contained duplicate points. Points 1 \[lon=-?\d+\.\d+ lat=\d+\.\d+] and \d \[lon=-?\d+\.\d+ lat=\d+\.\d+].* were considered equivalent or very close"))
-
-    (side/eval-form `(shapefile-middleware/set-max-shapefile-size! ~saved-shapefile-max-size))
-    (side/eval-form `(shapefile/set-max-shapefile-features! ~saved-shapefile-max-features))
-    (side/eval-form `(shapefile/set-max-shapefile-points! ~saved-shapefile-max-points))))
+      (finally
+        (side/eval-form `(shapefile-middleware/set-max-shapefile-size! ~saved-shapefile-max-size))
+        (side/eval-form `(shapefile/set-max-shapefile-features! ~saved-shapefile-max-features))
+        (side/eval-form `(shapefile/set-max-shapefile-points! ~saved-shapefile-max-points))))))
 
 (deftest granule-shapefile-search-test
   (side/eval-form `(shapefile/set-enable-shapefile-parameter-flag! true))


### PR DESCRIPTION
# Overview

### What is the objective?

To fix intermittent system integration test failures while validating force-Cartesian shapefile search behavior. Specifically, the test `collection-shapefile-force-cartesian-validation-test` intermittently received HTTP 400 when force-cartesian=true should have allowed the uploaded GeoJSON.

### What are the changes?

The test in question uses a Scotland file that is approximately 292 KB and contains approximately 3,000 coordinate points. Another test in the same system integration group, granule-shapefile-failure-cases, temporarily changes search-app’s process-wide shapefile limits to 50 KB maximum upload size, 50 maximum points, and 2 maximum features. The Scotland fixture exceeds both temporary size and point limits. This creates a shared-state hazard: if the temporary values leak from the granule failure test—or are observed by another test while active—the force-Cartesian request returns 400 before its intended geometry behavior can be tested.

Previously, those global settings were restored only at the end of the test body. An exception or unexpected exit before reaching the cleanup statements could leave the search application using the test-specific limits. **The change wraps the temporary overrides in `try`/`finally`, ensuring that all three settings are restored even when the test exits abnormally.**

Also, enhanced debugging was added.

### What areas of the application does this impact?

system-int-test

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
