### PR TITLE
CMR-11386: Refactor search-proxy semaphore

### DIFF
--- a/search-proxy/README.md
+++ b/search-proxy/README.md
@@ -45,7 +45,7 @@ All settings are environment variables with the `CMR_PROXY_` prefix.
 | `CMR_PROXY_BACKEND_TIMEOUT_SECONDS` | `300.0` | Backend request timeout |
 | `CMR_PROXY_BACKEND_MAX_CONNECTIONS` | `500` | httpx connection pool size |
 | `CMR_PROXY_BACKEND_MAX_KEEPALIVE` | `200` | httpx keepalive connection pool size |
-| `CMR_PROXY_REDIS_MAX_CONNECTIONS` | auto | Redis pool size; defaults to total lane permits + 50 |
+| `CMR_PROXY_REDIS_MAX_CONNECTIONS` | auto | Redis pool size; defaults to total lane permits + 100 |
 | `CMR_PROXY_REDIS_SOCKET_CONNECT_TIMEOUT` | `2.0` | Redis connection timeout in seconds |
 | `CMR_PROXY_REDIS_SOCKET_TIMEOUT` | `2.0` | Redis read/write timeout in seconds |
 | `CMR_PROXY_REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds between Redis keepalive pings |
@@ -131,6 +131,6 @@ pytest
 
 ## Operational notes
 
-**Leaked permits**: If a task is killed mid-request or Redis is briefly unavailable during release, the permit entry is not removed. It will expire automatically once its TTL score passes (defaulting to the backend timeout, 300 seconds). If a lane shows sustained at-capacity pressure before entries age out, the sorted sets can be cleared directly from Redis: `lane:express:active`, `lane:standard:active`, `lane:heavy:active`.
+**Leaked permits**: A permit leaks when a task is killed before `_release` runs, or when Redis is briefly unavailable during release (the exception is swallowed so the ASGI handler can still return a response). Once a leaked entry's TTL score passes (defaulting to `backend_timeout_seconds`, 300 seconds), it stops affecting lane counts — the health endpoint's `ZCOUNT` filters on the current timestamp as a lower bound, and each acquire's `ZCARD` runs after `ZREMRANGEBYSCORE` prunes expired-score entries. Physical removal from Redis happens on the next acquire for that lane. Note: if Redis is unavailable during acquire, the fail-open path applies — no permit is stored and no release is attempted, so there is no leak in that case. To immediately reset a lane without waiting for TTL, delete its sorted set key from Redis: `lane:express:active`, `lane:standard:active`, `lane:heavy:active`.
 
 **Debugging**: Set `CMR_PROXY_LOG_LEVEL=DEBUG` to log backend response details including content encoding and actual byte counts. Remove when done — debug logging is verbose under load.

--- a/search-proxy/README.md
+++ b/search-proxy/README.md
@@ -14,11 +14,11 @@ Every request is classified into one of three lanes based on query complexity:
 
 **Classification rules** (first match wins):
 
-- **Heavy**: `include_facets`, `online_only`, `cloud_cover`, temporal facet params (`temporal_facet[`), cycle/pass params (`cycle[`, `passes[`), `options[readable_granule_name][pattern]`, shapefile uploads, `polygon[]` (multi-polygon, always heavy), single `polygon` with >20 vertices, bounding boxes with area >5000 sq degrees, more than 2 bounding boxes (`bounding_box[]` with 3+ values)
+- **Heavy**: `include_facets`, `online_only`, `cloud_cover`, temporal facet params (`temporal_facet[`), cycle/pass params (`cycle[`, `passes[`), `options[readable_granule_name][pattern]`, `options[granule_ur][pattern]`, `options[producer_granule_id][pattern]`, shapefile uploads, `polygon[]` (multi-polygon, always heavy), single `polygon` with >20 vertices, bounding boxes with area >5000 sq degrees, more than 2 bounding boxes (`bounding_box[]` with 3+ values)
 - **Standard**: `temporal`, `updated_since`, `revision_date`, `orbit_number`, `point`, `point[]`, single `circle`, small polygon (≤20 vertices), small bounding box (≤5000 sq degrees)
 - **Express**: `circle[]` (explicit fast path — always express regardless of other params), and everything not matched above
 
-**Concurrency**: each lane has a Redis counter (`lane:{name}:active`). When a request arrives, the counter is atomically incremented. If it exceeds the permit limit, the request either overflows to the configured overflow lane or is rejected with a 429. The counter is decremented when the request completes.
+**Concurrency**: each lane has a Redis sorted set (`lane:{name}:active`). When a request arrives, expired entries are pruned, the active count is checked against the permit limit, and if under the limit the request is added as a member scored by its expiry epoch. If the lane is full, the request either overflows to the configured overflow lane or is rejected with a 429. The entry is removed when the request completes. Entries whose score has passed are pruned automatically on the next acquire, so permits from crashed tasks recover without manual intervention.
 
 **Cache**: successful (2xx) responses are stored in Redis keyed on a SHA-256 hash of method, path, query string, hashed auth token, `Accept` header, `cmr-search-after` header, and POST body. Cache hits skip lane acquisition entirely.
 
@@ -56,7 +56,7 @@ All settings are environment variables with the `CMR_PROXY_` prefix.
 |----------|---------|-------------|
 | `CMR_PROXY_BYPASS_ENABLED` | `false` | Skip classification, cache, and lanes — pure transparent proxy |
 | `CMR_PROXY_CACHE_ENABLED` | `true` | Enable response caching |
-| `CMR_PROXY_LOAD_SHEDDING_ENABLED` | `true` | Return 429 when lanes are full; when false, requests proceed over capacity but the counter still increments so pressure remains visible in `/health` |
+| `CMR_PROXY_LOAD_SHEDDING_ENABLED` | `true` | Return 429 when lanes are full; when false, requests proceed over capacity but are still counted in the sorted set so pressure remains visible in `/health` |
 | `CMR_PROXY_CLASSIFICATION_ENABLED` | `true` | Classify requests; when false, all traffic routes to the default lane |
 
 ## Lanes configuration
@@ -131,6 +131,6 @@ pytest
 
 ## Operational notes
 
-**Leaked permits**: If a task is killed mid-request or Redis becomes briefly unavailable, lane counters can accumulate without being decremented. Monitor the health endpoint for lanes that stay near capacity. To reset, delete the lane counter keys from Redis: `lane:express:active`, `lane:standard:active`, `lane:heavy:active`.
+**Leaked permits**: If a task is killed mid-request or Redis is briefly unavailable during release, the permit entry is not removed. It will expire automatically once its TTL score passes (defaulting to the backend timeout, 300 seconds). If a lane shows sustained at-capacity pressure before entries age out, the sorted sets can be cleared directly from Redis: `lane:express:active`, `lane:standard:active`, `lane:heavy:active`.
 
 **Debugging**: Set `CMR_PROXY_LOG_LEVEL=DEBUG` to log backend response details including content encoding and actual byte counts. Remove when done — debug logging is verbose under load.

--- a/search-proxy/src/proxy/app.py
+++ b/search-proxy/src/proxy/app.py
@@ -91,12 +91,15 @@ async def lifespan(app: FastAPI):
         ),
     )
     # Redis connection for distributed lane semaphores and response cache.
-    # Pool size defaults to total lane permits + 50 so it always exceeds the
-    # maximum number of concurrent Redis operations (one per in-flight request).
+    # Pool size defaults to total lane permits + 100. Each acquire involves 3
+    # sequential Redis ops (TIME, ZREMRANGEBYSCORE, ZCARD, ZADD) plus a ZREM
+    # on release and a GET/SET for cache. Connections are released between ops
+    # so peak concurrent demand tracks concurrent requests, not ops per request.
+    # The +100 provides headroom for health checks and reconnect storms.
     # Override with CMR_PROXY_REDIS_MAX_CONNECTIONS if permits change without
     # a redeploy or if additional headroom is needed.
     redis_max_connections = settings.redis_max_connections or (
-        sum(lane.permits for lane in lanes_config.lanes) + 50
+        sum(lane.permits for lane in lanes_config.lanes) + 100
     )
     app.state.redis = redis.asyncio.from_url(
         settings.redis_url,
@@ -106,7 +109,11 @@ async def lifespan(app: FastAPI):
         health_check_interval=settings.redis_health_check_interval,
         max_connections=redis_max_connections,
     )
-    app.state.lanes = RequestLanes(lanes_config, app.state.redis)
+    app.state.lanes = RequestLanes(
+        lanes_config,
+        app.state.redis,
+        permit_ttl=int(settings.backend_timeout_seconds),
+    )
     app.state.cache = ResponseCache(app.state.redis, settings.max_cache_response_bytes)
     yield
     await app.state.backend.aclose()
@@ -125,7 +132,7 @@ def _extract_auth_token(request: Request) -> str:
         "Authorization", ""
     )
     if token:
-        return hashlib.sha256(token.encode()).hexdigest()[:16]
+        return hashlib.sha256(token.encode()).hexdigest()
     return "guest"
 
 
@@ -236,29 +243,33 @@ async def health(request: Request):
     except Exception as exc:
         dependencies["search"] = {"ok?": True, "problem": str(exc)}  # informational
 
-    # Lane utilization
+    # Lane utilization — count only non-expired entries (score > wall clock now)
     lanes_config = request.app.state.lanes_config
     redis_client = request.app.state.redis
+    wall_now = time.time()
     for lane in lanes_config.lanes:
         key = f"lane:{lane.name}:active"
-        active_raw = await redis_client.get(key)
-        active = int(active_raw) if active_raw else 0
-        at_capacity = active >= lane.permits
-        dep = {
-            "ok?": True,
-            "active": active,
-            "permits": lane.permits,
-            "at_capacity": at_capacity,
-        }
-        if at_capacity:
-            dep["note"] = "at capacity"
+        try:
+            active = await redis_client.zcount(key, wall_now, "+inf")
+            at_capacity = active >= lane.permits
+            dep = {
+                "ok?": True,
+                "active": active,
+                "permits": lane.permits,
+                "at_capacity": at_capacity,
+            }
+            if at_capacity:
+                dep["note"] = "at capacity"
+        except Exception as exc:
+            dep = {"ok?": True, "problem": str(exc)}  # informational
         dependencies[f"lane-{lane.name}"] = dep
 
     ok = all(dep["ok?"] for dep in dependencies.values())
     status_code = 200 if ok else 503
     content = {"ok?": ok, "dependencies": dependencies}
 
-    # Only cache healthy results so recovery is visible on the next check
+    # Only cache healthy results so recovery is visible on the next check.
+    # Use monotonic time (consistent with the check at the top of this function).
     if status_code == 200:
         _health_cache["result"] = {"status_code": status_code, "content": content}
         _health_cache["expires"] = now + _HEALTH_CACHE_TTL
@@ -282,7 +293,10 @@ async def proxy(request: Request, path: str):
     full_path = f"/{path}"
     toggles = request.app.state.toggles
 
-    # Reject oversized POST bodies before reading into memory
+    # Read POST body once; reused for size check, form param extraction, and cache key
+    content_type = request.headers.get("content-type", "")
+    body = b""
+    body_hash = ""
     if request.method == "POST":
         content_length = request.headers.get("content-length")
         try:
@@ -295,7 +309,6 @@ async def proxy(request: Request, path: str):
                 content={"errors": ["Request body too large"]},
                 headers={"CMR-Request-Id": _extract_request_id(request)},
             )
-
         body = await request.body()
         if len(body) > request.app.state.settings.max_request_body_bytes:
             return JSONResponse(
@@ -303,13 +316,10 @@ async def proxy(request: Request, path: str):
                 content={"errors": ["Request body too large"]},
                 headers={"CMR-Request-Id": _extract_request_id(request)},
             )
+        body_hash = hashlib.sha256(body).hexdigest()
 
-    # Merge POST form body params into query params for classification
-    content_type = request.headers.get("content-type", "")
     params = dict(request.query_params)
-
     if request.method == "POST" and "application/x-www-form-urlencoded" in content_type:
-        body = await request.body()
         try:
             body_params = parse_qs(body.decode(), keep_blank_values=True)
             for param_name, param_values in body_params.items():
@@ -328,11 +338,6 @@ async def proxy(request: Request, path: str):
     query_string = str(request.url.query)
     search_after = request.headers.get("cmr-search-after", "")
     accept = request.headers.get("accept", "")
-    # Hash POST body into the cache key so different bodies don't collide
-    body_hash = ""
-    if request.method == "POST":
-        raw_body = await request.body()
-        body_hash = hashlib.sha256(raw_body).hexdigest()[:16]
 
     # Bypass: skip classification, cache, and lanes — pure transparent proxy
     if toggles["bypass_enabled"]:
@@ -433,7 +438,7 @@ async def proxy(request: Request, path: str):
                 response.headers["CMR-Request-Id"] = request_id
                 return response
         except Exception:
-            logger.warning("Cache read failed", exc_info=True)
+            logger.warning("cache_read_failed", extra={"request_id": request_id}, exc_info=True)
 
     # Acquire a distributed semaphore permit for this lane, then forward
     try:
@@ -488,7 +493,7 @@ async def proxy(request: Request, path: str):
                     )
                     cache_stored = True
                 except Exception:
-                    logger.warning("Cache write failed", exc_info=True)
+                    logger.warning("cache_write_failed", extra={"request_id": request_id}, exc_info=True)
 
             # Strip hop-by-hop headers and attach the request ID
             resp_headers = filter_hop_headers(backend_response.headers)

--- a/search-proxy/src/proxy/app.py
+++ b/search-proxy/src/proxy/app.py
@@ -91,7 +91,7 @@ async def lifespan(app: FastAPI):
         ),
     )
     # Redis connection for distributed lane semaphores and response cache.
-    # Pool size defaults to total lane permits + 100. Each acquire involves 3
+    # Pool size defaults to total lane permits + 100. Each acquire involves 4
     # sequential Redis ops (TIME, ZREMRANGEBYSCORE, ZCARD, ZADD) plus a ZREM
     # on release and a GET/SET for cache. Connections are released between ops
     # so peak concurrent demand tracks concurrent requests, not ops per request.

--- a/search-proxy/src/proxy/classifier.py
+++ b/search-proxy/src/proxy/classifier.py
@@ -18,6 +18,8 @@ HEAVY_PREFIXES = (
     "cycle[",
     "passes[",
     "options[readable_granule_name][pattern]",
+    "options[granule_ur][pattern]",
+    "options[producer_granule_id][pattern]",
 )
 
 # Non-spatial standard signals

--- a/search-proxy/src/proxy/lanes.py
+++ b/search-proxy/src/proxy/lanes.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from contextlib import asynccontextmanager
 
 import redis.asyncio
@@ -17,41 +18,55 @@ class LoadSheddingError(Exception):
 class RequestLanes:
     """Redis-backed distributed traffic lanes.
 
-    Permits are tracked as atomic counters in Redis, shared across all
-    proxy instances. Each lane key (lane:{name}:active) holds the current
-    number of in-flight requests for that lane."""
+    Each lane's active permits are tracked in a Redis sorted set keyed
+    lane:{name}:active. Each in-flight request occupies one member (its UUID);
+    the score is the expiry epoch from Redis server time. Entries whose score
+    has passed are pruned on the next acquire, so leaked permits from crashed
+    tasks recover automatically without manual intervention.
 
-    def __init__(self, config: LanesConfig, redis_client: redis.asyncio.Redis):
+    When Redis is unavailable, acquire fails open: requests are forwarded
+    without a permit rather than 429'd. This degrades gracefully under
+    infrastructure failure at the cost of temporary over-capacity."""
+
+    def __init__(
+        self,
+        config: LanesConfig,
+        redis_client: redis.asyncio.Redis,
+        permit_ttl: int = 300,
+    ):
         self.config = config
         self.redis = redis_client
+        self.permit_ttl = permit_ttl
 
     def _lane_key(self, lane_name: str) -> str:
         return f"lane:{lane_name}:active"
 
-    async def _try_acquire(self, lane_name: str, permits: int) -> bool:
-        """Atomically increment the lane counter and check against limit.
+    async def _redis_now(self) -> float:
+        """Return current time from the Redis server to avoid ECS task clock skew."""
+        seconds, microseconds = await self.redis.time()
+        return seconds + microseconds / 1_000_000
 
-        Uses INCR for atomicity — if the post-increment value exceeds
-        the permit limit, immediately DECR to roll back."""
+    async def _try_acquire(self, lane_name: str, permits: int, request_id: str, redis_now: float) -> bool:
+        """Prune expired entries, count active, and add this request if under limit.
+
+        Redis exceptions propagate to the caller, which decides fail-open vs fail-closed."""
         key = self._lane_key(lane_name)
-        current = await self.redis.incr(key)
-        if current > permits:
-            await self.redis.decr(key)
+        await self.redis.zremrangebyscore(key, "-inf", redis_now)
+        count = await self.redis.zcard(key)
+        if count >= permits:
             return False
+        await self.redis.zadd(key, {request_id: redis_now + self.permit_ttl})
         return True
 
-    async def _release(self, lane_name: str) -> None:
-        """Decrement the lane counter. Floors at zero to prevent
-        negative counts from orphaned releases."""
+    async def _release(self, lane_name: str, request_id: str) -> None:
+        """Remove this request's permit entry from the sorted set."""
         key = self._lane_key(lane_name)
         try:
-            result = await self.redis.decr(key)
-            if result < 0:
-                await self.redis.set(key, 0)
+            await self.redis.zrem(key, request_id)
         except Exception:
             # Log and swallow so a Redis failure here doesn't propagate out of
             # the finally block and crash the ASGI handler. The permit leaks
-            # but the client still gets a response.
+            # but will expire naturally via the TTL score.
             logger.error(
                 "permit_release_failed",
                 extra={"lane": lane_name},
@@ -59,35 +74,49 @@ class RequestLanes:
             )
 
     async def _acquire_permit(
-        self, lane_name: str, load_shedding_enabled: bool = True
-    ) -> str:
-        """Try to acquire a permit, returning the lane name on success.
+        self, lane_name: str, load_shedding_enabled: bool, request_id: str
+    ) -> tuple[str, bool]:
+        """Try to acquire a permit, returning (lane_name, permit_stored).
 
-        Tries the requested lane first. If full and an overflow lane is
-        configured, tries that. When load_shedding_enabled is False,
-        force-acquires the original lane instead of shedding — so the
-        counter still reflects over-capacity pressure in the health endpoint."""
+        permit_stored is False when Redis is unavailable and the request is
+        allowed through without a permit (fail-open). The caller must not
+        attempt a release in that case."""
         lane = self.config.get(lane_name)
 
-        if await self._try_acquire(lane.name, lane.permits):
-            return lane.name
+        try:
+            redis_now = await self._redis_now()
 
-        # Primary lane full — try overflow if configured
-        if lane.overflow:
-            overflow_lane = self.config.get(lane.overflow)
-            if await self._try_acquire(overflow_lane.name, overflow_lane.permits):
-                return overflow_lane.name
+            if await self._try_acquire(lane.name, lane.permits, request_id, redis_now):
+                return lane.name, True
 
-        if not load_shedding_enabled:
-            # Increment without limit so health shows real pressure
-            await self.redis.incr(self._lane_key(lane.name))
-            logger.warning(
-                "load_shed_suppressed",
-                extra={"lane": lane.name, "load_shedding_enabled": False},
+            if lane.overflow:
+                overflow_lane = self.config.get(lane.overflow)
+                if await self._try_acquire(overflow_lane.name, overflow_lane.permits, request_id, redis_now):
+                    return overflow_lane.name, True
+
+            if not load_shedding_enabled:
+                await self.redis.zadd(self._lane_key(lane.name), {request_id: redis_now + self.permit_ttl})
+                logger.warning(
+                    "load_shed_suppressed",
+                    extra={"lane": lane.name, "load_shedding_enabled": False},
+                )
+                return lane.name, True
+
+            raise LoadSheddingError(lane.name, lane.retry_after)
+
+        except LoadSheddingError:
+            raise
+        except Exception:
+            logger.error(
+                "permit_acquire_failed",
+                extra={"lane": lane.name},
+                exc_info=True,
             )
-            return lane.name
-
-        raise LoadSheddingError(lane.name, lane.retry_after)
+            logger.warning(
+                "permit_bypassed",
+                extra={"lane": lane.name, "reason": "redis_unavailable"},
+            )
+            return lane.name, False
 
     @asynccontextmanager
     async def acquire(self, lane_name: str, load_shedding_enabled: bool = True):
@@ -95,9 +124,12 @@ class RequestLanes:
 
         Yields the name of the lane that was actually acquired (may differ
         from the requested lane if overflow occurred). The permit is always
-        released when the context exits, even on exception."""
-        actual_name = await self._acquire_permit(lane_name, load_shedding_enabled)
+        released when the context exits, even on exception. If Redis was
+        unavailable during acquire (fail-open), no release is attempted."""
+        request_id = str(uuid.uuid4())
+        actual_name, permit_stored = await self._acquire_permit(lane_name, load_shedding_enabled, request_id)
         try:
             yield actual_name
         finally:
-            await self._release(actual_name)
+            if permit_stored:
+                await self._release(actual_name, request_id)

--- a/search-proxy/test/test_app.py
+++ b/search-proxy/test/test_app.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import time
 from unittest.mock import AsyncMock
 
 import fakeredis.aioredis
@@ -128,7 +129,8 @@ class TestRouting:
         """Health reports at_capacity but remains ok? true — informational only."""
         app.state.backend.get.return_value = make_backend_response()
         fake_redis = app.state.redis
-        await fake_redis.set("lane:heavy:active", 50)
+        future = time.time() + 300
+        await fake_redis.zadd("lane:heavy:active", {f"req-{i}": future for i in range(50)})
         _health_cache["result"] = None
         _health_cache["expires"] = 0.0
         resp = await client.get("/health")
@@ -242,7 +244,7 @@ class TestLoadShedding:
         app.state.lanes = RequestLanes(config, fake_redis)
 
         # Fill the heavy lane via Redis
-        await fake_redis.set("lane:heavy:active", 1)
+        await fake_redis.zadd("lane:heavy:active", {"blocking-req": time.time() + 300})
         resp = await client.get("/search/granules.json?include_facets=v2")
         assert resp.status_code == 429
         assert "Retry-After" in resp.headers
@@ -517,7 +519,7 @@ class TestLoadSheddingToggle:
         fake_redis = app.state.redis
         config = make_lanes_config(heavy_permits=1)
         app.state.lanes = RequestLanes(config, fake_redis)
-        await fake_redis.set("lane:heavy:active", 1)
+        await fake_redis.zadd("lane:heavy:active", {"blocking-req": time.time() + 300})
         try:
             resp = await client.get("/search/granules.json?include_facets=v2")
             assert resp.status_code == 200

--- a/search-proxy/test/test_classifier.py
+++ b/search-proxy/test/test_classifier.py
@@ -37,6 +37,12 @@ class TestHeavyPatternSignals:
             == HEAVY
         )
 
+    def test_options_granule_ur_pattern(self):
+        assert classify_request({"options[granule_ur][pattern]": "true"}) == HEAVY
+
+    def test_options_producer_granule_id_pattern(self):
+        assert classify_request({"options[producer_granule_id][pattern]": "true"}) == HEAVY
+
 
 # Shapefile detection
 

--- a/search-proxy/test/test_lanes.py
+++ b/search-proxy/test/test_lanes.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import AsyncMock, patch
 
 import fakeredis.aioredis
@@ -102,13 +103,12 @@ class TestDistributedCounting:
                 assert a == "heavy"
                 assert b == "heavy"
 
-                # Third attempt from either instance should be shed
                 with pytest.raises(LoadSheddingError):
                     async with lanes_a.acquire("heavy"):
                         pass
 
-    async def test_redis_counter_returns_to_zero(self, redis_client):
-        """After all permits are released, the counter should be zero."""
+    async def test_active_count_is_zero_after_all_releases(self, redis_client):
+        """After all permits are released, the sorted set should be empty."""
         config = make_config(heavy_permits=5)
         lanes = RequestLanes(config, redis_client)
 
@@ -116,8 +116,8 @@ class TestDistributedCounting:
             async with lanes.acquire("heavy"):
                 pass
 
-        counter = await redis_client.get("lane:heavy:active")
-        assert int(counter) == 0
+        count = await redis_client.zcard("lane:heavy:active")
+        assert count == 0
 
 
 class TestExpressOverflow:
@@ -183,10 +183,35 @@ class TestUnknownLaneFallback:
             assert actual == "express"
 
 
+class TestRedisFailOpen:
+    async def test_acquire_succeeds_when_redis_unavailable(self, lanes):
+        """When Redis is down, acquire fails open rather than 429ing the request."""
+        with patch.object(lanes.redis, "time", new=AsyncMock(side_effect=Exception("Redis down"))):
+            async with lanes.acquire("heavy") as actual:
+                assert actual == "heavy"
+
+    async def test_no_release_attempted_on_fail_open(self, lanes):
+        """When Redis fails during acquire, no release is attempted (nothing was stored)."""
+        with patch.object(lanes.redis, "time", new=AsyncMock(side_effect=Exception("Redis down"))):
+            with patch.object(lanes.redis, "zrem", new=AsyncMock()) as mock_zrem:
+                async with lanes.acquire("heavy"):
+                    pass
+                mock_zrem.assert_not_called()
+
+    async def test_fail_open_does_not_propagate_exception(self, lanes):
+        """A Redis error during acquire must not surface to the caller as an exception."""
+        with patch.object(lanes.redis, "time", new=AsyncMock(side_effect=Exception("Redis down"))):
+            try:
+                async with lanes.acquire("heavy"):
+                    pass
+            except Exception:
+                pytest.fail("Redis exception escaped from acquire")
+
+
 class TestReleaseFailure:
     async def test_release_redis_error_does_not_propagate(self, lanes):
         """MaxConnectionsError in _release must not escape to the caller."""
-        with patch.object(lanes.redis, "decr", new=AsyncMock(side_effect=MaxConnectionsError("Too many connections"))):
+        with patch.object(lanes.redis, "zrem", new=AsyncMock(side_effect=MaxConnectionsError("Too many connections"))):
             try:
                 async with lanes.acquire("heavy"):
                     pass
@@ -195,7 +220,7 @@ class TestReleaseFailure:
 
     async def test_release_redis_error_is_logged(self, lanes, caplog):
         import logging
-        with patch.object(lanes.redis, "decr", new=AsyncMock(side_effect=MaxConnectionsError("Too many connections"))):
+        with patch.object(lanes.redis, "zrem", new=AsyncMock(side_effect=MaxConnectionsError("Too many connections"))):
             with caplog.at_level(logging.ERROR, logger="proxy.lanes"):
                 async with lanes.acquire("heavy"):
                     pass
@@ -216,3 +241,82 @@ class TestLoadSheddingDisabled:
                     pass
             except LoadSheddingError:
                 pytest.fail("LoadSheddingError raised with load_shedding_enabled=False")
+
+
+class TestTTLExpiry:
+    async def test_expired_permit_is_pruned_on_next_acquire(self, redis_client):
+        """A leaked permit with an expired score is cleaned up on the next acquire."""
+        config = make_config(heavy_permits=1)
+        lanes = RequestLanes(config, redis_client)
+
+        # Simulate a leaked permit: score is in the past so it is already expired
+        expired_score = time.time() - 10
+        await redis_client.zadd("lane:heavy:active", {"leaked-request-id": expired_score})
+
+        # The expired entry should be pruned and the slot freed for a new request
+        async with lanes.acquire("heavy") as actual:
+            assert actual == "heavy"
+
+    async def test_non_expired_permit_blocks_acquire(self, redis_client):
+        """A permit with a future score is still counted as active."""
+        config = make_config(heavy_permits=1)
+        lanes = RequestLanes(config, redis_client)
+
+        future_score = time.time() + 300
+        await redis_client.zadd("lane:heavy:active", {"active-request-id": future_score})
+
+        with pytest.raises(LoadSheddingError):
+            async with lanes.acquire("heavy"):
+                pass
+
+    async def test_multiple_expired_permits_all_pruned(self, redis_client):
+        """Multiple leaked permits are all removed before counting capacity."""
+        config = make_config(heavy_permits=2)
+        lanes = RequestLanes(config, redis_client)
+
+        expired = time.time() - 10
+        await redis_client.zadd("lane:heavy:active", {
+            "leaked-1": expired,
+            "leaked-2": expired,
+            "leaked-3": expired,
+        })
+
+        # All three expired entries pruned — both permits now free
+        async with lanes.acquire("heavy"):
+            async with lanes.acquire("heavy") as actual:
+                assert actual == "heavy"
+
+
+class TestUniquePermitSlots:
+    async def test_identical_concurrent_requests_each_occupy_a_slot(self, redis_client):
+        """Two concurrent requests occupy two distinct slots in the sorted set."""
+        config = make_config(express_permits=2)
+        lanes = RequestLanes(config, redis_client)
+
+        async with lanes.acquire("express"):
+            async with lanes.acquire("express"):
+                count = await redis_client.zcard("lane:express:active")
+                assert count == 2
+
+    async def test_third_request_shed_when_two_permit_lane_full(self, redis_client):
+        """A third request is shed when a 2-permit no-overflow lane is fully occupied."""
+        config = make_config(heavy_permits=2)
+        lanes = RequestLanes(config, redis_client)
+
+        async with lanes.acquire("heavy"):
+            async with lanes.acquire("heavy"):
+                with pytest.raises(LoadSheddingError):
+                    async with lanes.acquire("heavy"):
+                        pass
+
+    async def test_permit_slot_removed_on_release(self, redis_client):
+        """Each release removes exactly one entry from the sorted set."""
+        config = make_config(heavy_permits=3)
+        lanes = RequestLanes(config, redis_client)
+
+        async with lanes.acquire("heavy"):
+            async with lanes.acquire("heavy"):
+                count_during = await redis_client.zcard("lane:heavy:active")
+                assert count_during == 2
+            count_after_one_release = await redis_client.zcard("lane:heavy:active")
+            assert count_after_one_release == 1

--- a/search-proxy/test/test_lanes.py
+++ b/search-proxy/test/test_lanes.py
@@ -199,7 +199,7 @@ class TestRedisFailOpen:
                 mock_zrem.assert_not_called()
 
     async def test_fail_open_does_not_propagate_exception(self, lanes):
-        """A Redis error during acquire must not surface to the caller as an exception."""
+        """When Redis is unavailable during acquire, then no exception surfaces to the caller."""
         with patch.object(lanes.redis, "time", new=AsyncMock(side_effect=Exception("Redis down"))):
             try:
                 async with lanes.acquire("heavy"):
@@ -245,7 +245,7 @@ class TestLoadSheddingDisabled:
 
 class TestTTLExpiry:
     async def test_expired_permit_is_pruned_on_next_acquire(self, redis_client):
-        """A leaked permit with an expired score is cleaned up on the next acquire."""
+        """When a permit's TTL score has passed, then it is pruned on the next acquire and the slot is freed."""
         config = make_config(heavy_permits=1)
         lanes = RequestLanes(config, redis_client)
 
@@ -258,7 +258,7 @@ class TestTTLExpiry:
             assert actual == "heavy"
 
     async def test_non_expired_permit_blocks_acquire(self, redis_client):
-        """A permit with a future score is still counted as active."""
+        """When a permit's TTL score is in the future, then it is counted as active and blocks acquisition."""
         config = make_config(heavy_permits=1)
         lanes = RequestLanes(config, redis_client)
 
@@ -270,7 +270,7 @@ class TestTTLExpiry:
                 pass
 
     async def test_multiple_expired_permits_all_pruned(self, redis_client):
-        """Multiple leaked permits are all removed before counting capacity."""
+        """When multiple permits have expired scores, then all are pruned before counting capacity."""
         config = make_config(heavy_permits=2)
         lanes = RequestLanes(config, redis_client)
 


### PR DESCRIPTION
# Overview

### What is the objective?

Harden the search proxy's distributed lane semaphore against permit leaks from crashed tasks, fix several correctness bugs discovered during review of CMR-11195, and extend the request classifier to route two additional wildcard pattern params to the heavy lane.

### What are the changes?

Sorted-set semaphore (lanes.py) — replaced the previous INCR/DECR counter approach with a Redis sorted set where each in-flight request occupies one member (a UUID) scored by its expiry epoch (redis_now + permit_ttl). On each acquire, ZREMRANGEBYSCORE prunes entries whose score has passed before checking the count, so leaked permits from crashed tasks self-heal automatically after backend_timeout_seconds (300s default) without manual intervention. Redis server time is used for scores to avoid ECS task clock skew across instances.

Fail-open behavior was added to fix a bug where a Redis blip during acquire caused the exception to propagate up to the proxy handler, which only catches LoadSheddingError — so users were receiving dropped requests or 500 errors during any transient Redis unavailability. With fail-open, Redis exceptions during acquire are caught, logged, and the request is forwarded without a permit rather than returned as an error to the user.

Bug fixes (app.py):

- Hash truncation removed — auth token and POST body hashes were previously truncated to 16 characters ([:16]), reducing collision resistance and risking wrong cached responses being served to different users or bodies
- POST body double-read eliminated — await request.body() was called up to three times per request; body and body hash are now computed once up front and reused
- Health endpoint lane counts updated to use ZCOUNT key wall_now +inf (counts only non-expired sorted set entries) instead of GET key, which read the old INCR counter that no longer exists

Classifier (classifier.py) — added options[granule_ur][pattern] and options[producer_granule_id][pattern] to the heavy lane prefix list, consistent with the existing options[readable_granule_name][pattern] rule. Both trigger wildcard scans on large granule ID fields and carry the same performance profile.

README — updated concurrency, leaked permits, and configuration sections to reflect the sorted set implementation and corrected the Redis pool default (+50 → +100).

### What areas of the application does this impact?

The search proxy (search-proxy/) only — specifically the Redis-backed lane semaphore, the request classifier, and the response cache key logic. No changes to CMR search itself or any other service.

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
