### PR TITLE
CMR-11416: Update search proxy to use parameter store for lanes.json

### DIFF
--- a/search-proxy/README.md
+++ b/search-proxy/README.md
@@ -38,7 +38,8 @@ All settings are environment variables with the `CMR_PROXY_` prefix.
 |----------|---------|-------------|
 | `CMR_PROXY_BACKEND_URL` | required | CMR search base URL (no `/search` suffix) |
 | `CMR_PROXY_REDIS_URL` | required | Redis connection URL |
-| `CMR_PROXY_LANES_CONFIG` | `lanes.json` | Path to lanes config file |
+| `CMR_PROXY_LANES_CONFIG` | `lanes.json` | Path to lanes config file; used when `CMR_PROXY_LANES_JSON` is not set |
+| `CMR_PROXY_LANES_JSON` | — | Lanes config as a JSON string; takes precedence over `CMR_PROXY_LANES_CONFIG` when set. Intended for deployments that inject the value from Parameter Store as an environment variable |
 | `CMR_PROXY_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`) |
 | `CMR_PROXY_MAX_REQUEST_BODY_BYTES` | `52428800` | Max POST body size (50MB) |
 | `CMR_PROXY_MAX_CACHE_RESPONSE_BYTES` | `1048576` | Max response size to cache (1MB) |

--- a/search-proxy/src/proxy/app.py
+++ b/search-proxy/src/proxy/app.py
@@ -68,7 +68,7 @@ async def lifespan(app: FastAPI):
     """Initialize shared resources on startup, clean up on shutdown."""
     settings = ProxySettings()
     setup_logging(settings.log_level)
-    if settings.lanes_json:
+    if settings.lanes_json is not None:
         lanes_config = parse_lanes_config(settings.lanes_json)
         logger.info("lanes_config_source", extra={"source": "env"})
     else:
@@ -85,6 +85,19 @@ async def lifespan(app: FastAPI):
     }
 
     logger.info("toggles_loaded", extra={"toggles": app.state.toggles})
+    logger.info(
+        "settings_loaded",
+        extra={
+            "backend_url": settings.backend_url,
+            "lanes_config_source": "env" if settings.lanes_json is not None else settings.lanes_config,
+            "lanes": [{"name": l.name, "permits": l.permits, "overflow": l.overflow, "cache_ttl": l.cache_ttl} for l in lanes_config.lanes],
+            "cache_enabled": settings.cache_enabled,
+            "load_shedding_enabled": settings.load_shedding_enabled,
+            "bypass_enabled": settings.bypass_enabled,
+            "redis_max_connections": settings.redis_max_connections or (sum(l.permits for l in lanes_config.lanes) + 100),
+            "backend_timeout_seconds": settings.backend_timeout_seconds,
+        },
+    )
 
     # Connection-pooled httpx client for forwarding requests to the backend
     app.state.backend = httpx.AsyncClient(

--- a/search-proxy/src/proxy/app.py
+++ b/search-proxy/src/proxy/app.py
@@ -13,7 +13,7 @@ from pythonjsonlogger import json as jsonlogger
 
 from proxy.cache import ResponseCache
 from proxy.classifier import classify_request
-from proxy.config import ProxySettings, load_lanes_config
+from proxy.config import ProxySettings, load_lanes_config, parse_lanes_config
 from proxy.lanes import LoadSheddingError, RequestLanes
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,12 @@ async def lifespan(app: FastAPI):
     """Initialize shared resources on startup, clean up on shutdown."""
     settings = ProxySettings()
     setup_logging(settings.log_level)
-    lanes_config = load_lanes_config(settings.lanes_config)
+    if settings.lanes_json:
+        lanes_config = parse_lanes_config(settings.lanes_json)
+        logger.info("lanes_config_source", extra={"source": "env"})
+    else:
+        lanes_config = load_lanes_config(settings.lanes_config)
+        logger.info("lanes_config_source", extra={"source": settings.lanes_config})
 
     app.state.settings = settings
     app.state.lanes_config = lanes_config

--- a/search-proxy/src/proxy/config.py
+++ b/search-proxy/src/proxy/config.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -41,6 +41,27 @@ class LaneConfig(BaseModel):
     retry_after: int = 5
     default: bool = False
 
+    @field_validator("permits")
+    @classmethod
+    def permits_must_be_positive(cls, v):
+        if v < 1:
+            raise ValueError(f"permits must be at least 1, got {v}")
+        return v
+
+    @field_validator("cache_ttl")
+    @classmethod
+    def cache_ttl_must_be_non_negative(cls, v):
+        if v < 0:
+            raise ValueError(f"cache_ttl must be >= 0, got {v}")
+        return v
+
+    @field_validator("retry_after")
+    @classmethod
+    def retry_after_must_be_positive(cls, v):
+        if v < 1:
+            raise ValueError(f"retry_after must be at least 1, got {v}")
+        return v
+
 
 class LanesConfig(BaseModel):
     """Validated collection of lane definitions loaded from lanes.json."""
@@ -49,7 +70,17 @@ class LanesConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_lanes(self):
-        names = {lane.name for lane in self.lanes}
+        all_names = [lane.name for lane in self.lanes]
+        names = set(all_names)
+
+        # Lane names must be unique
+        if len(all_names) != len(names):
+            seen, dupes = set(), []
+            for n in all_names:
+                if n in seen:
+                    dupes.append(n)
+                seen.add(n)
+            raise ValueError(f"Duplicate lane names: {sorted(dupes)}")
 
         # Every overflow target must reference an existing lane
         for lane in self.lanes:

--- a/search-proxy/src/proxy/config.py
+++ b/search-proxy/src/proxy/config.py
@@ -20,6 +20,7 @@ class ProxySettings(BaseSettings):
     backend_max_keepalive: int = 200
 
     lanes_config: str = "lanes.json"
+    lanes_json: str | None = None
 
     log_level: str = "INFO"
     bypass_enabled: bool = False
@@ -78,6 +79,11 @@ class LanesConfig(BaseModel):
             if lane.name == name:
                 return lane
         return next(lane for lane in self.lanes if lane.default)
+
+
+def parse_lanes_config(json_str: str) -> LanesConfig:
+    """Parse and validate lanes config from a JSON string."""
+    return LanesConfig(lanes=json.loads(json_str))
 
 
 def load_lanes_config(path: str = "lanes.json") -> LanesConfig:

--- a/search-proxy/src/proxy/config.py
+++ b/search-proxy/src/proxy/config.py
@@ -41,6 +41,13 @@ class LaneConfig(BaseModel):
     retry_after: int = 5
     default: bool = False
 
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_blank(cls, v):
+        if not v.strip():
+            raise ValueError("lane name must not be blank or whitespace-only")
+        return v
+
     @field_validator("permits")
     @classmethod
     def permits_must_be_positive(cls, v):
@@ -89,6 +96,22 @@ class LanesConfig(BaseModel):
                     f"Lane '{lane.name}' overflows to '{lane.overflow}' "
                     f"which does not exist. Available: {sorted(names)}"
                 )
+
+        # Self-overflow and cycle detection
+        for lane in self.lanes:
+            if lane.overflow == lane.name:
+                raise ValueError(f"Lane '{lane.name}' overflows to itself")
+
+        overflow_map = {lane.name: lane.overflow for lane in self.lanes}
+        for start in overflow_map:
+            visited, current = {start}, overflow_map.get(start)
+            while current:
+                if current in visited:
+                    raise ValueError(
+                        f"Overflow cycle detected involving lane '{current}'"
+                    )
+                visited.add(current)
+                current = overflow_map.get(current)
 
         # Exactly one lane must be marked as default
         defaults = [lane for lane in self.lanes if lane.default]

--- a/search-proxy/test/test_config.py
+++ b/search-proxy/test/test_config.py
@@ -96,12 +96,23 @@ class TestEnvVarOverrides:
         monkeypatch.setenv("CMR_PROXY_LANES_JSON", '[{"name":"x","permits":1,"default":true}]')
         s = ProxySettings()
         assert s.lanes_json is not None
+        config = parse_lanes_config(s.lanes_json)
+        assert config.default_lane == "x"
+        assert config.get("x").permits == 1
 
 
 # Lane config model
 
 
 class TestLaneConfigValidation:
+    def test_blank_name_raises(self):
+        with pytest.raises(ValidationError, match="blank"):
+            LaneConfig(name="   ", permits=10)
+
+    def test_empty_name_raises(self):
+        with pytest.raises(ValidationError, match="blank"):
+            LaneConfig(name="", permits=10)
+
     def test_permits_zero_raises(self):
         with pytest.raises(ValidationError, match="permits"):
             LaneConfig(name="x", permits=0)
@@ -213,6 +224,23 @@ class TestLanesConfigValidation:
         lane = config.get("slow")
         assert lane.name == "slow"
         assert lane.permits == 5
+
+    def test_self_overflow_raises(self):
+        with pytest.raises(ValidationError, match="itself"):
+            LanesConfig(
+                lanes=[
+                    LaneConfig(name="express", permits=200, overflow="express", default=True),
+                ]
+            )
+
+    def test_overflow_cycle_raises(self):
+        with pytest.raises(ValidationError, match="cycle"):
+            LanesConfig(
+                lanes=[
+                    LaneConfig(name="a", permits=10, overflow="b", default=True),
+                    LaneConfig(name="b", permits=10, overflow="a"),
+                ]
+            )
 
     def test_get_unknown_lane_returns_default(self):
         config = LanesConfig(

--- a/search-proxy/test/test_config.py
+++ b/search-proxy/test/test_config.py
@@ -101,6 +101,32 @@ class TestEnvVarOverrides:
 # Lane config model
 
 
+class TestLaneConfigValidation:
+    def test_permits_zero_raises(self):
+        with pytest.raises(ValidationError, match="permits"):
+            LaneConfig(name="x", permits=0)
+
+    def test_permits_negative_raises(self):
+        with pytest.raises(ValidationError, match="permits"):
+            LaneConfig(name="x", permits=-1)
+
+    def test_cache_ttl_negative_raises(self):
+        with pytest.raises(ValidationError, match="cache_ttl"):
+            LaneConfig(name="x", permits=10, cache_ttl=-1)
+
+    def test_retry_after_zero_raises(self):
+        with pytest.raises(ValidationError, match="retry_after"):
+            LaneConfig(name="x", permits=10, retry_after=0)
+
+    def test_retry_after_negative_raises(self):
+        with pytest.raises(ValidationError, match="retry_after"):
+            LaneConfig(name="x", permits=10, retry_after=-5)
+
+    def test_cache_ttl_zero_is_valid(self):
+        lane = LaneConfig(name="x", permits=10, cache_ttl=0)
+        assert lane.cache_ttl == 0
+
+
 class TestLaneConfigModel:
     def test_minimal_lane(self):
         lane = LaneConfig(name="test", permits=10)
@@ -139,6 +165,15 @@ class TestLanesConfigValidation:
         )
         assert config.default_lane == "express"
         assert len(config.lanes) == 3
+
+    def test_duplicate_lane_names_raises(self):
+        with pytest.raises(ValidationError, match="Duplicate"):
+            LanesConfig(
+                lanes=[
+                    LaneConfig(name="express", permits=200, default=True),
+                    LaneConfig(name="express", permits=100),
+                ]
+            )
 
     def test_overflow_to_nonexistent_lane_fails(self):
         with pytest.raises(ValidationError, match="does not exist"):

--- a/search-proxy/test/test_config.py
+++ b/search-proxy/test/test_config.py
@@ -267,9 +267,38 @@ class TestParseLanesConfig:
         assert config.get("heavy").retry_after == 10
 
     def test_invalid_json_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(json.JSONDecodeError):
             parse_lanes_config("not-valid-json{{")
 
     def test_invalid_schema_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             parse_lanes_config(json.dumps([{"name": "broken"}]))
+
+    def test_empty_string_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            parse_lanes_config("")
+
+
+class TestLanesConfigSourceSelection:
+    """Verify the is-not-None semantics that drive the lifespan branch selection."""
+
+    def test_lanes_json_set_is_not_none(self, monkeypatch):
+        """When CMR_PROXY_LANES_JSON is set, settings.lanes_json is not None and parse_lanes_config succeeds."""
+        monkeypatch.setenv("CMR_PROXY_LANES_JSON", VALID_LANES_JSON)
+        settings = ProxySettings()
+        assert settings.lanes_json is not None
+        config = parse_lanes_config(settings.lanes_json)
+        assert config.default_lane == "express"
+
+    def test_empty_lanes_json_is_not_none(self, monkeypatch):
+        """An empty string is not None — lifespan calls parse_lanes_config, which raises rather than silently falling back to the file."""
+        monkeypatch.setenv("CMR_PROXY_LANES_JSON", "")
+        settings = ProxySettings()
+        assert settings.lanes_json is not None
+        with pytest.raises(json.JSONDecodeError):
+            parse_lanes_config(settings.lanes_json)
+
+    def test_unset_lanes_json_is_none(self):
+        """When CMR_PROXY_LANES_JSON is not set, lanes_json is None and the file path is used."""
+        settings = ProxySettings()
+        assert settings.lanes_json is None

--- a/search-proxy/test/test_config.py
+++ b/search-proxy/test/test_config.py
@@ -242,6 +242,27 @@ class TestLanesConfigValidation:
                 ]
             )
 
+    def test_three_node_cycle_raises(self):
+        with pytest.raises(ValidationError, match="cycle"):
+            LanesConfig(
+                lanes=[
+                    LaneConfig(name="a", permits=10, overflow="b", default=True),
+                    LaneConfig(name="b", permits=10, overflow="c"),
+                    LaneConfig(name="c", permits=10, overflow="a"),
+                ]
+            )
+
+    def test_rho_shape_cycle_raises(self):
+        """A→B→C→B: cycle not involving the start node."""
+        with pytest.raises(ValidationError, match="cycle"):
+            LanesConfig(
+                lanes=[
+                    LaneConfig(name="a", permits=10, overflow="b", default=True),
+                    LaneConfig(name="b", permits=10, overflow="c"),
+                    LaneConfig(name="c", permits=10, overflow="b"),
+                ]
+            )
+
     def test_get_unknown_lane_returns_default(self):
         config = LanesConfig(
             lanes=[

--- a/search-proxy/test/test_config.py
+++ b/search-proxy/test/test_config.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from pydantic import ValidationError
 
-from proxy.config import LaneConfig, LanesConfig, ProxySettings, load_lanes_config
+from proxy.config import LaneConfig, LanesConfig, ProxySettings, load_lanes_config, parse_lanes_config
 
 
 class TestProxySettingsDefaults:
@@ -87,6 +87,15 @@ class TestEnvVarOverrides:
         monkeypatch.setenv("CMR_PROXY_LANES_CONFIG", "/etc/cmr/lanes.json")
         s = ProxySettings()
         assert s.lanes_config == "/etc/cmr/lanes.json"
+
+    def test_proxy_lanes_json_default_is_none(self):
+        s = ProxySettings()
+        assert s.lanes_json is None
+
+    def test_proxy_lanes_json_override(self, monkeypatch):
+        monkeypatch.setenv("CMR_PROXY_LANES_JSON", '[{"name":"x","permits":1,"default":true}]')
+        s = ProxySettings()
+        assert s.lanes_json is not None
 
 
 # Lane config model
@@ -234,3 +243,33 @@ class TestLoadLanesConfig:
         assert len(config.lanes) == 4
         assert config.get("bulk").retry_after == 30
         assert config.get("slow").permits == 100
+
+
+# Parsing from a JSON string
+
+
+VALID_LANES_JSON = json.dumps([
+    {"name": "express", "permits": 200, "overflow": "standard", "cache_ttl": 10, "retry_after": 5, "default": True},
+    {"name": "standard", "permits": 150, "cache_ttl": 15, "retry_after": 5},
+    {"name": "heavy", "permits": 50, "cache_ttl": 30, "retry_after": 10},
+])
+
+
+class TestParseLanesConfig:
+    def test_parses_valid_json(self):
+        config = parse_lanes_config(VALID_LANES_JSON)
+        assert len(config.lanes) == 3
+        assert config.default_lane == "express"
+
+    def test_parsed_values_match_input(self):
+        config = parse_lanes_config(VALID_LANES_JSON)
+        assert config.get("heavy").permits == 50
+        assert config.get("heavy").retry_after == 10
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(Exception):
+            parse_lanes_config("not-valid-json{{")
+
+    def test_invalid_schema_raises(self):
+        with pytest.raises(Exception):
+            parse_lanes_config(json.dumps([{"name": "broken"}]))


### PR DESCRIPTION
# Overview

### What is the objective?

Allow the lanes configuration to be injected as an environment variable rather than requiring a JSON file on the container. 

### What are the changes?

Added CMR_PROXY_LANES_JSON environment variable support to ProxySettings. When set, its value is parsed directly as the lanes config JSON and takes precedence over CMR_PROXY_LANES_CONFIG (the file path).  A structured settings_loaded log event was also added at startup to surface the active configuration (lanes, permits, toggles, backend URL, connection pool size) in CloudWatch.  Some basic validation for the parameter store json value is also done.

### What areas of the application does this impact?

The search proxy (search-proxy/).  Specifically startup configuration loading. No changes to request handling, lane semaphore logic, or caching behavior.

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [x] I have removed unnecessary/dead code and imports in files I have changed
- [x] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
