### PR TITLE
CMR-11419: fix error handling for ES8 query complexity limit

### DIFF
--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -217,7 +217,7 @@
            :payload-too-large
            "The search is creating more buckets than allowed by CMR. Please narrow your search."))
 
-        (when (re-find #"maxClauseCount is set to 1024" body)
+        (when (re-find #"(?i)(?:maxClauseCount is set to [0-9]+|too many clauses)" body)
           (errors/throw-service-error
            :payload-too-large
            "The search is creating more clauses than allowed by CMR. Please narrow your search."))

--- a/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
+++ b/elastic-utils-lib/src/cmr/elastic_utils/search/es_index.clj
@@ -217,7 +217,8 @@
            :payload-too-large
            "The search is creating more buckets than allowed by CMR. Please narrow your search."))
 
-        (when (re-find #"(?i)(?:maxClauseCount is set to [0-9]+|too many clauses)" body)
+        (when (and (= 400 (:status (ex-data e)))
+                   (re-find #"(?i)(?:maxClauseCount is set to [0-9]+|too many clauses)" body))
           (errors/throw-service-error
            :payload-too-large
            "The search is creating more clauses than allowed by CMR. Please narrow your search."))

--- a/elastic-utils-lib/test/cmr/elastic_utils/test/es_index.clj
+++ b/elastic-utils-lib/test/cmr/elastic_utils/test/es_index.clj
@@ -11,11 +11,11 @@
   "The search is creating more clauses than allowed by CMR. Please narrow your search.")
 
 (defn- send-query-with-es-error
-  [body]
+  [status body]
   (with-redefs [es-index/context->conn (constantly nil)
                 es-helper/search (fn [& _]
                                    (throw (ex-info "Elasticsearch request failed"
-                                                   {:status 400
+                                                   {:status status
                                                     :body body})))]
     (#'es-index/do-send-with-retry
      {}
@@ -34,12 +34,21 @@
                  "\"reason\":\"Query rewrite failed: too many clauses\"}]},\"status\":400}")]]]
     (testing description
       (let [exception (try
-                        (send-query-with-es-error body)
+                        (send-query-with-es-error 400 body)
                         nil
                         (catch clojure.lang.ExceptionInfo e
                           e))]
         (is (= :payload-too-large (:type (ex-data exception))))
         (is (= [clause-limit-message] (:errors (ex-data exception))))))))
+
+(deftest clause-limit-errors-require-bad-request-status
+  (let [exception (try
+                    (send-query-with-es-error 500 "Query rewrite failed: too many clauses")
+                    nil
+                    (catch clojure.lang.ExceptionInfo e
+                      e))]
+    (is (nil? (:type (ex-data exception))))
+    (is (= 500 (:status (ex-data (ex-cause exception)))))))
 
 (deftest test-query->execution-params
   (let [query->execution-params #'es-index/query->execution-params

--- a/elastic-utils-lib/test/cmr/elastic_utils/test/es_index.clj
+++ b/elastic-utils-lib/test/cmr/elastic_utils/test/es_index.clj
@@ -3,8 +3,43 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [cmr.common.services.search.query-model :as qm]
+   [cmr.elastic-utils.es-helper :as es-helper]
    [cmr.elastic-utils.search.es-group-query-conditions :as gc]
    [cmr.elastic-utils.search.es-index :as es-index]))
+
+(def clause-limit-message
+  "The search is creating more clauses than allowed by CMR. Please narrow your search.")
+
+(defn- send-query-with-es-error
+  [body]
+  (with-redefs [es-index/context->conn (constantly nil)
+                es-helper/search (fn [& _]
+                                   (throw (ex-info "Elasticsearch request failed"
+                                                   {:status 400
+                                                    :body body})))]
+    (#'es-index/do-send-with-retry
+     {}
+     {:index-name "test-index" :type-name "collection"}
+     {}
+     1)))
+
+(deftest clause-limit-errors-are-payload-too-large
+  (doseq [[description body]
+          [["Elasticsearch 7 default clause limit error"
+            "maxClauseCount is set to 1024"]
+           ["Elasticsearch 7 configured clause limit error"
+            "maxClauseCount is set to 4096"]
+           ["Elasticsearch 8 clause limit error"
+            (str "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\","
+                 "\"reason\":\"Query rewrite failed: too many clauses\"}]},\"status\":400}")]]]
+    (testing description
+      (let [exception (try
+                        (send-query-with-es-error body)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e
+                          e))]
+        (is (= :payload-too-large (:type (ex-data exception))))
+        (is (= [clause-limit-message] (:errors (ex-data exception))))))))
 
 (deftest test-query->execution-params
   (let [query->execution-params #'es-index/query->execution-params


### PR DESCRIPTION
# Overview

### What is the objective?

Fix error handling for query complexity limit change in ES8.

### What are the changes?

The "payload too large" error handling has been expanded to cover both the ES7 and ES8 responses.

### What areas of the application does this impact?

search-app

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
