### PR TITLE
CMR-11421: Prevent multiple calls to KMS fixer service on CMR

### DIFF
--- a/ingest-app/src/cmr/ingest/api/collections.clj
+++ b/ingest-app/src/cmr/ingest/api/collections.clj
@@ -13,6 +13,7 @@
 (def VALIDATE_KEYWORDS_HEADER "cmr-validate-keywords")
 (def ENABLE_UMM_C_VALIDATION_HEADER "cmr-validate-umm-c")
 (def TESTING_EXISTING_ERRORS_HEADER "cmr-test-existing-errors")
+(def SEND_KMS_METADATA_FIXER_HEADER "cmr-send-kms-metadata-fixer")
 (def COLLECTION_WARNING_CONTEXT "After translating item to UMM-C the metadata had the following issue(s): ")
 (def COLLECTION_EXISTING_ERROR_CONTEXT "After translating item to UMM-C the metadata had the following existing error(s): ")
 
@@ -28,7 +29,8 @@
                                   (= "true" (get headers VALIDATE_KEYWORDS_HEADER)))]
     {:validate-keywords? validate-keywords-value
      :validate-umm? (= "true" (get headers ENABLE_UMM_C_VALIDATION_HEADER))
-     :test-existing-errors? (= "true" (get headers TESTING_EXISTING_ERRORS_HEADER))}))
+     :test-existing-errors? (= "true" (get headers TESTING_EXISTING_ERRORS_HEADER))
+     :send-metadata-fixer? (not= "false" (get headers SEND_KMS_METADATA_FIXER_HEADER))}))
 
 (defn validate-collection
   [provider-id native-id request]

--- a/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
+++ b/ingest-app/src/cmr/ingest/services/ingest_service/collection.clj
@@ -123,7 +123,8 @@
                       (common-context/context->user-id context)
                       "unknown user"))))
     ;; When a keyword error is detected but, ingest is alllowed send to kms fixer to resolve keyword
-    (when (should-notify-kms? has-keyword-error? existing-errors warnings)
+    (when (and (should-notify-kms? has-keyword-error? existing-errors warnings)
+               (:send-metadata-fixer? validation-options))
       (transmit-kms/notify-kms context concept-id))
     {:entry-title entry-title
      :concept-id concept-id

--- a/ingest-app/test/cmr/ingest/api/collections_test.clj
+++ b/ingest-app/test/cmr/ingest/api/collections_test.clj
@@ -1,13 +1,13 @@
 (ns cmr.ingest.api.collections-test
-   "Unit tests for cmr.ingest.api.collections, starting with
+  "Unit tests for cmr.ingest.api.collections, starting with
    get-validation-options. More tests for other functions in this
    namespace can be added here over time."
   (:require [clojure.test :refer [deftest testing is]]
             [cmr.ingest.api.collections :as v :refer [get-validation-options
-                                             VALIDATE_KEYWORDS_HEADER
-                                             ENABLE_UMM_C_VALIDATION_HEADER
-                                             TESTING_EXISTING_ERRORS_HEADER
-                                             SEND_KMS_METADATA_FIXER_HEADER]]))
+                                                      VALIDATE_KEYWORDS_HEADER
+                                                      ENABLE_UMM_C_VALIDATION_HEADER
+                                                      TESTING_EXISTING_ERRORS_HEADER
+                                                      SEND_KMS_METADATA_FIXER_HEADER]]))
 
 ;; ---------------------------------------------------------------------
 ;; :validate-keywords? — default-true-enabled? = true

--- a/ingest-app/test/cmr/ingest/api/collections_test.clj
+++ b/ingest-app/test/cmr/ingest/api/collections_test.clj
@@ -1,0 +1,143 @@
+(ns cmr.ingest.api.collections-test
+   "Unit tests for cmr.ingest.api.collections, starting with
+   get-validation-options. More tests for other functions in this
+   namespace can be added here over time."
+  (:require [clojure.test :refer [deftest testing is]]
+            [cmr.ingest.api.collections :as v :refer [get-validation-options
+                                             VALIDATE_KEYWORDS_HEADER
+                                             ENABLE_UMM_C_VALIDATION_HEADER
+                                             TESTING_EXISTING_ERRORS_HEADER
+                                             SEND_KMS_METADATA_FIXER_HEADER]]))
+
+;; ---------------------------------------------------------------------
+;; :validate-keywords? — default-true-enabled? = true
+;;   (only an explicit "false" header value turns validation off)
+;; ---------------------------------------------------------------------
+(deftest validate-keywords-default-true-enabled-true
+  (with-redefs [v/validate-keywords-default-true-enabled? true]
+    (testing "header explicitly \"false\" -> false"
+      (is (= false (:validate-keywords?
+                    (get-validation-options {VALIDATE_KEYWORDS_HEADER "false"})))))
+
+    (testing "header explicitly \"true\" -> true"
+      (is (= true (:validate-keywords?
+                   (get-validation-options {VALIDATE_KEYWORDS_HEADER "true"})))))
+
+    (testing "header missing -> true (defaults on)"
+      (is (= true (:validate-keywords?
+                   (get-validation-options {})))))
+
+    (testing "header present but garbage value -> true (defaults on)"
+      (is (= true (:validate-keywords?
+                   (get-validation-options {VALIDATE_KEYWORDS_HEADER "nope"})))))))
+
+;; ---------------------------------------------------------------------
+;; :validate-keywords? — default-true-enabled? = false
+;;   (must explicitly opt in with "true")
+;; ---------------------------------------------------------------------
+(deftest validate-keywords-default-true-enabled-false
+  (with-redefs [v/validate-keywords-default-true-enabled? false]
+    (testing "header explicitly \"true\" -> true"
+      (is (= true (:validate-keywords?
+                   (get-validation-options {VALIDATE_KEYWORDS_HEADER "true"})))))
+
+    (testing "header explicitly \"false\" -> false"
+      (is (= false (:validate-keywords?
+                    (get-validation-options {VALIDATE_KEYWORDS_HEADER "false"})))))
+
+    (testing "header missing -> false (defaults off)"
+      (is (= false (:validate-keywords?
+                    (get-validation-options {})))))
+
+    (testing "header present but garbage value -> false (defaults off)"
+      (is (= false (:validate-keywords?
+                    (get-validation-options {VALIDATE_KEYWORDS_HEADER "nope"})))))))
+
+;; ---------------------------------------------------------------------
+;; :validate-umm?  — defaults to false, only "true" turns it on
+;; ---------------------------------------------------------------------
+(deftest validate-umm-test
+  (testing "header \"true\" -> true"
+    (is (= true (:validate-umm?
+                 (get-validation-options {ENABLE_UMM_C_VALIDATION_HEADER "true"})))))
+
+  (testing "header missing -> false"
+    (is (= false (:validate-umm? (get-validation-options {})))))
+
+  (testing "header \"false\" -> false"
+    (is (= false (:validate-umm?
+                  (get-validation-options {ENABLE_UMM_C_VALIDATION_HEADER "false"})))))
+
+  (testing "header garbage value -> false"
+    (is (= false (:validate-umm?
+                  (get-validation-options {ENABLE_UMM_C_VALIDATION_HEADER "yes"}))))))
+
+;; ---------------------------------------------------------------------
+;; :test-existing-errors? — defaults to false, only "true" turns it on
+;; ---------------------------------------------------------------------
+(deftest test-existing-errors-test
+  (testing "header \"true\" -> true"
+    (is (= true (:test-existing-errors?
+                 (get-validation-options {TESTING_EXISTING_ERRORS_HEADER "true"})))))
+
+  (testing "header missing -> false"
+    (is (= false (:test-existing-errors? (get-validation-options {})))))
+
+  (testing "header \"false\" -> false"
+    (is (= false (:test-existing-errors?
+                  (get-validation-options {TESTING_EXISTING_ERRORS_HEADER "false"})))))
+
+  (testing "header garbage value -> false"
+    (is (= false (:test-existing-errors?
+                  (get-validation-options {TESTING_EXISTING_ERRORS_HEADER "yes"}))))))
+
+;; ---------------------------------------------------------------------
+;; :send-metadata-fixer? — defaults to true, only explicit "false" turns it off
+;; ---------------------------------------------------------------------
+(deftest send-metadata-fixer-test
+  (testing "header missing -> true (defaults on)"
+    (is (= true (:send-metadata-fixer? (get-validation-options {})))))
+
+  (testing "header \"true\" -> true"
+    (is (= true (:send-metadata-fixer?
+                 (get-validation-options {SEND_KMS_METADATA_FIXER_HEADER "true"})))))
+
+  (testing "header \"false\" -> false"
+    (is (= false (:send-metadata-fixer?
+                  (get-validation-options {SEND_KMS_METADATA_FIXER_HEADER "false"})))))
+
+  (testing "header garbage value -> true (anything other than \"false\" is on)"
+    (is (= true (:send-metadata-fixer?
+                 (get-validation-options {SEND_KMS_METADATA_FIXER_HEADER "nope"}))))))
+
+;; ---------------------------------------------------------------------
+;; Combination / full-map tests
+;; ---------------------------------------------------------------------
+(deftest get-validation-options-combined-test
+  (testing "empty headers map, default-true-enabled? true -> keywords on, rest off/on defaults"
+    (with-redefs [v/validate-keywords-default-true-enabled? true]
+      (is (= {:validate-keywords? true
+              :validate-umm? false
+              :test-existing-errors? false
+              :send-metadata-fixer? true}
+             (get-validation-options {})))))
+
+  (testing "empty headers map, default-true-enabled? false -> keywords off, rest off/on defaults"
+    (with-redefs [v/validate-keywords-default-true-enabled? false]
+      (is (= {:validate-keywords? false
+              :validate-umm? false
+              :test-existing-errors? false
+              :send-metadata-fixer? true}
+             (get-validation-options {})))))
+
+  (testing "all headers explicitly set"
+    (with-redefs [v/validate-keywords-default-true-enabled? true]
+      (is (= {:validate-keywords? false
+              :validate-umm? true
+              :test-existing-errors? true
+              :send-metadata-fixer? false}
+             (get-validation-options
+              {VALIDATE_KEYWORDS_HEADER "false"
+               ENABLE_UMM_C_VALIDATION_HEADER "true"
+               TESTING_EXISTING_ERRORS_HEADER "true"
+               SEND_KMS_METADATA_FIXER_HEADER "false"}))))))


### PR DESCRIPTION
# Overview

### What is the objective?

We noticed in some SIT testing that we could occassionaly get into a loop condition where CMR sends a collection to KMS to fix keyword issues KMS will fix those and then ingest to CMR. This is usually fine if all fixes work but, if the service is only able to fix part of the metadata e.g. if some of the keywords can be fixed because they were old keywords that have been moved/renamed, but, some are "garbage" values meaning they have never existed in KMS we cannot resolve those directly but, we will ingest the revision on KMS to fix the ones we can fix. That results in a subsequent call to KMS. There are several things on the KMS side that make this not an infinite loop but, we still want to be able to just stop this cycle from the KMS call.

Thus this ticket will include a KMS PR to just use the header in the ingest call

### What are the changes?

Create new header for collections pull it out in the validation-options and use that in the conditional for whether or not we send a request to the KMS fixer service

### What areas of the application does this impact?

Collection ingest

# Testing
<img width="934" height="707" alt="image" src="https://github.com/user-attachments/assets/67d65312-6473-4591-a52a-e811c8d22632" />
I added a tap to 
<img width="592" height="180" alt="image" src="https://github.com/user-attachments/assets/d930be7a-4b83-498f-9441-0949a31b38b6" />
the kms transmit. Ran it three times. On the final time I used `cmr-send-kms-metadata-fixer` which is the flag that KMS will callout


I don't think this is a flag we want to show on the docs. Its not sensitive but, its really only applicable to the KMS-CMR exchange

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [x] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
