### PR TITLE
CMR-11413: Update jackson core and move to parent

### DIFF
--- a/access-control-app/int-test/cmr/access_control/int_test/acl_search_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_search_test.clj
@@ -45,17 +45,25 @@
                                {:foo "bar"}
                                {:token (transmit-config/echo-system-token) :raw? true})))))
 
+(defn group-permission->flat-query
+  "Converts a map of group permissions to a flat query map with bracket notation.
+  Example: (group-permission->flat-query 0 {:permitted-group \"guest\"})
+           => {\"group-permission[0][permitted-group]\" \"guest\"}"
+  [index permission-map]
+  (into {}
+        (for [[k v] permission-map]
+          [(str "group-permission[" index "][" (name k) "]") v])))
+
 (defn- generate-query-map-for-group-permissions
   "Returns a query map generated from group permission pairs.
-  group-permissions should be a sequence of group/user-identifer permission pairs such as
+  group-permissions should be a sequence of group/user-identifier permission pairs such as
   [\"guest\" \"read\" \"AG10000-PROV1\" \"create\" \"registered\" \"order\"]"
   [group-permissions]
-  (reduce (fn [query-map [index [group permission]]]
-            (assoc query-map
-              (str "group-permission[" index "][permitted-group]") group
-              (str "group-permission[" index "][permission]") permission))
-          {}
-          (map-indexed vector (partition 2 group-permissions))))
+  (into {}
+        (map-indexed
+          (fn [index [group permission]]
+            (group-permission->flat-query index {:permitted-group group :permission permission}))
+          (partition 2 group-permissions))))
 
 (deftest acl-search-order-test
   ;; Conforms to requirements set out in CMR-3590, alphabetical order regardless of case
@@ -413,9 +421,7 @@
     ;; CMR-3154 acceptance criterium 3
     (testing "Search ACLs by group permission just group or permission"
       (are3 [query-map acls]
-        (let [flat-query (into {}
-                               (for [[k v] query-map]
-                                 [(str "group-permission[0][" (name k) "]") v]))
+        (let [flat-query (group-permission->flat-query 0 query-map)
               ;; Merge the flattened query with the page_size parameter
               response (ac/search-for-acls (u/conn-context)
                                            (merge flat-query {:page_size 20})

--- a/access-control-app/int-test/cmr/access_control/int_test/acl_search_test.clj
+++ b/access-control-app/int-test/cmr/access_control/int_test/acl_search_test.clj
@@ -47,17 +47,15 @@
 
 (defn- generate-query-map-for-group-permissions
   "Returns a query map generated from group permission pairs.
-  group-permissions should be a seqeuence of group/user-identifer permission pairs such as
+  group-permissions should be a sequence of group/user-identifer permission pairs such as
   [\"guest\" \"read\" \"AG10000-PROV1\" \"create\" \"registered\" \"order\"]"
   [group-permissions]
-  (first (reduce (fn [[m count] [group permission]]
-                   [(assoc-in m
-                              [:group-permission (keyword (str count))]
-                              {:permitted-group group
-                               :permission permission})
-                    (inc count)])
-                 [{} 0]
-                 (partition 2 group-permissions))))
+  (reduce (fn [query-map [index [group permission]]]
+            (assoc query-map
+              (str "group-permission[" index "][permitted-group]") group
+              (str "group-permission[" index "][permission]") permission))
+          {}
+          (map-indexed vector (partition 2 group-permissions))))
 
 (deftest acl-search-order-test
   ;; Conforms to requirements set out in CMR-3590, alphabetical order regardless of case
@@ -415,11 +413,16 @@
     ;; CMR-3154 acceptance criterium 3
     (testing "Search ACLs by group permission just group or permission"
       (are3 [query-map acls]
-        (let [response (ac/search-for-acls (u/conn-context)
-                                           {:group-permission {:0 query-map} :page_size 20}
+        (let [flat-query (into {}
+                               (for [[k v] query-map]
+                                 [(str "group-permission[0][" (name k) "]") v]))
+              ;; Merge the flattened query with the page_size parameter
+              response (ac/search-for-acls (u/conn-context)
+                                           (merge flat-query {:page_size 20})
                                            {:token token})]
           (is (= (u/acls->search-response (count acls) acls)
                  (dissoc response :took))))
+
         "Just user type"
         {:permitted-group "guest"} guest-acls
 
@@ -434,7 +437,8 @@
 
     ;; CMR-3154 acceptance criterium 4
     (testing "Search ACLS by group permission with non integer index is an error"
-      (let [query {:group-permission {:foo {:permitted-group "guest" :permission "read"}}}]
+      (let [query {"group-permission[foo][permitted-group]" "guest"
+                   "group-permission[foo][permission]" "read"}]
         (is (= {:status 400
                 :body {:errors ["Parameter group_permission has invalid index value [foo]. Only integers greater than or equal to zero may be specified."]}
                 :content-type :json}
@@ -442,14 +446,16 @@
 
     ;; CMR-3154 acceptance criterium 5
     (testing "Search ACLS by group permission with subfield other than permitted_group or permission is an error"
-      (let [query {:group-permission {:0 {:allowed-group "guest" :permission "read"}}}]
+      (let [query {"group-permission[0][allowed-group]" "guest"
+                   "group-permission[0][permission]" "read"}]
         (is (= {:status 400
                 :body {:errors ["Parameter group_permission has invalid subfield [allowed_group]. Only 'permitted_group' and 'permission' are allowed."]}
                 :content-type :json}
                (ac/search-for-acls (u/conn-context) query {:token token :raw? true})))))
 
     (testing "Searching ACLS by group permission with permission values other than read, create, update, delete, or order is an error"
-      (let [query {:group-permission {:0 {:permitted_group "guest" :permission "foo"}}}]
+      (let [query {"group-permission[0][permitted_group]" "guest"
+                   "group-permission[0][permission]" "foo"}]
         (is (= {:status 400
                 :body {:errors ["Sub-parameter permission of parameter group_permissions has invalid values [foo]. Only 'read', 'update', 'create', 'delete', or 'order' may be specified."]}
                 :content-type :json}

--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -30,10 +30,14 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/access-control-app"
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies ~(concat '[[cheshire "5.12.0"
-                            :exclusions [com.fasterxml.jackson.core/jackson-core]]
+  :dependencies ~(concat '[[cheshire
+                            :exclusions [com.fasterxml.jackson.core/jackson-core
+                                         com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+                                         com.fasterxml.jackson.dataformat/jackson-dataformat-smile]]
                            [clj-time "0.15.1"]
                            [com.fasterxml.jackson.core/jackson-core]
+                           [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
+                           [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                            [commons-codec/commons-codec "1.11"]
                            [commons-io "2.18.0"]
                            [compojure "1.6.1"

--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -28,10 +28,12 @@
 (defproject nasa-cmr/cmr-access-control-app "0.1.0-SNAPSHOT"
   :description "Implements the CMR access control application."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/access-control-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies ~(concat '[[cheshire "5.12.0"
                             :exclusions [com.fasterxml.jackson.core/jackson-core]]
                            [clj-time "0.15.1"]
-                           [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                           [com.fasterxml.jackson.core/jackson-core]
                            [commons-codec/commons-codec "1.11"]
                            [commons-io "2.18.0"]
                            [compojure "1.6.1"
@@ -52,8 +54,9 @@
                             :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                            [ring/ring-json "0.5.1"]]
                          project-dependencies)
-  :plugins [[lein-modules "0.3.11"]
-            [lein-exec "0.3.7"]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-modules "0.3.11"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/bootstrap-app"
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies [[cheshire "5.12.0"
+  :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "2.3.0"]
                  [com.fasterxml.jackson.core/jackson-core]

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -1,10 +1,12 @@
 (defproject nasa-cmr/cmr-bootstrap-app "0.1.0-SNAPSHOT"
   :description "Bootstrap is a CMR application that can bootstrap the CMR with data from Catalog REST."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/bootstrap-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "2.3.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io "2.18.0"]
@@ -37,6 +39,7 @@
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT" :exclusions [clojure-tools]]
             [lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-app-lib"
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies [[cheshire "5.12.0"
+  :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [clj-time "0.15.1"]

--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -1,9 +1,11 @@
 (defproject nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"
   :description "Library containing application services code common to multiple CMR applications."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/common-app-lib"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [clj-time "0.15.1"]
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
@@ -22,7 +24,8 @@
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                  [ring/ring-json "0.5.1"]
                  [selmer "1.12.5"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.4.1"]]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -18,7 +18,7 @@
 
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.2"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [com.gfredericks/test.chuck "0.2.9"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -19,8 +19,7 @@
                  [clojusc/ltest "0.3.0"]
                  [com.dadrox/quiet-slf4j "0.1"]
                  [com.fasterxml.jackson.core/jackson-core]
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.2"
-                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                  [com.gfredericks/test.chuck "0.2.9"]
                  [com.taoensso/timbre "5.1.0"]
                  [commons-codec/commons-codec "1.11"]

--- a/es-spatial-plugin/project.clj
+++ b/es-spatial-plugin/project.clj
@@ -91,7 +91,7 @@
                                cmr.elasticsearch.plugins.spatial.engine.core
                                cmr.elasticsearch.plugins.spatial.plugin]}
              :dev {:dependencies [[criterium "0.4.4"]
-                                  [cheshire "5.12.0"]
+                                  [cheshire "6.2.0"]
                                   [org.clojure/tools.reader "1.3.2"]
                                   [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                                   [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -2,10 +2,12 @@
   :description "The metadata db is a micro-service that provides
                support for persisting metadata concepts."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/metadata-db-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[cheshire "5.12.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "3.11.0"]
                  [clj-time "0.15.1"]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [commons-io "2.18.0"] ;; used by migration
                  [compojure "1.6.1" :exclusions [commons-fileupload]]
                  [inflections "0.13.0"]
@@ -35,6 +37,7 @@
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT" :exclusions [clojure-tools]]
             [lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/metadata-db-app"
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies [[cheshire "5.12.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+  :dependencies [[cheshire :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [clj-http "3.11.0"]
                  [clj-time "0.15.1"]
                  [com.fasterxml.jackson.core/jackson-core]

--- a/project.clj
+++ b/project.clj
@@ -22,8 +22,8 @@
                           [clj-http "3.11.0"] ;; latest is 3.13.1
                           [clj-time "0.15.1"] ;; latest is 0.15.2
                           [com.fasterxml.jackson.core/jackson-annotations "2.21"]
-                          [com.fasterxml.jackson.core/jackson-core "2.21.4"]
-                          [com.fasterxml.jackson.core/jackson-databind "2.21.4"]
+                          [com.fasterxml.jackson.core/jackson-core "2.21.5"]
+                          [com.fasterxml.jackson.core/jackson-databind "2.21.5"]
                           [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.5"]
                           [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.21.5"]
                           [org.clojure/clojure "1.11.2"] ;; latest is 1.11.4 or 1.12.2

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
    :managed-dependencies [[at.yawk.lz4/lz4-java "1.11.1"]
-                          [cheshire "6.2.0"] ;; latest is 6.1.0
+                          [cheshire "6.2.0"]
                           [clj-http "3.11.0"] ;; latest is 3.13.1
                           [clj-time "0.15.1"] ;; latest is 0.15.2
                           [com.fasterxml.jackson.core/jackson-annotations "2.21"]

--- a/project.clj
+++ b/project.clj
@@ -18,12 +18,14 @@
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
    :managed-dependencies [[at.yawk.lz4/lz4-java "1.11.1"]
-                          [cheshire "5.12.0"] ;; latest is 6.1.0
+                          [cheshire "6.2.0"] ;; latest is 6.1.0
                           [clj-http "3.11.0"] ;; latest is 3.13.1
                           [clj-time "0.15.1"] ;; latest is 0.15.2
                           [com.fasterxml.jackson.core/jackson-annotations "2.21"]
                           [com.fasterxml.jackson.core/jackson-core "2.21.4"]
                           [com.fasterxml.jackson.core/jackson-databind "2.21.4"]
+                          [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.4"]
+                          [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.21.4"]
                           [org.clojure/clojure "1.11.2"] ;; latest is 1.11.4 or 1.12.2
                           [org.apache.commons/commons-compress "1.28.0"] ;; see testcontainers
                           [org.apache.logging.log4j/log4j-api "2.25.4"]

--- a/project.clj
+++ b/project.clj
@@ -24,8 +24,8 @@
                           [com.fasterxml.jackson.core/jackson-annotations "2.21"]
                           [com.fasterxml.jackson.core/jackson-core "2.21.4"]
                           [com.fasterxml.jackson.core/jackson-databind "2.21.4"]
-                          [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.4"]
-                          [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.21.4"]
+                          [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.21.5"]
+                          [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.21.5"]
                           [org.clojure/clojure "1.11.2"] ;; latest is 1.11.4 or 1.12.2
                           [org.apache.commons/commons-compress "1.28.0"] ;; see testcontainers
                           [org.apache.logging.log4j/log4j-api "2.25.4"]

--- a/schema-validation-lib/project.clj
+++ b/schema-validation-lib/project.clj
@@ -6,7 +6,7 @@
   :plugins [[lein-exec "0.3.7"]
             [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
-  :dependencies [[cheshire "5.12.0"
+  :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [com.github.everit-org.json-schema/org.everit.json.schema "1.14.3"]

--- a/schema-validation-lib/project.clj
+++ b/schema-validation-lib/project.clj
@@ -1,11 +1,14 @@
 (defproject nasa-cmr/cmr-schema-validation-lib "0.1.0-SNAPSHOT"
   :description "Provides json schema validation code"
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/schema-validation-lib"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :plugins [[lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :dependencies [[cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [com.github.everit-org.json-schema/org.everit.json.schema "1.14.3"]
                  [org.clojure/clojure "1.11.2"]]
   :repositories [["jitpack.io" "https://jitpack.io"]]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -1,9 +1,11 @@
 (defproject nasa-cmr/cmr-search-app "0.1.0-SNAPSHOT"
   :description "Provides a public search API for concepts in the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io/commons-io "2.18.0"]
@@ -55,7 +57,8 @@
   :repositories [["osgeo" "https://download.osgeo.org/webdav/geotools"]
                  ["geo" "https://repo.osgeo.org/repository/release"]
                  ["geo-snapshot" "https://repo.osgeo.org/repository/snapshot"]]
-  :plugins [[lein-exec "0.3.7"]]
+  :plugins [[lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]]
   :repl-options {:init-ns user
                  :timeout 120000}
   :jvm-opts ^:replace ["-server"

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-app"
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies [[cheshire "5.12.0"
+  :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [clj-time "0.15.1"]

--- a/search-relevancy-test/project.clj
+++ b/search-relevancy-test/project.clj
@@ -1,12 +1,14 @@
 (defproject nasa-cmr/cmr-search-relevancy-test "0.1.0-SNAPSHOT"
   :description "Tests for measuring CMR search relevancy"
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/search-relevancy-test"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[camel-snake-kebab "0.4.0"]
                  [cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [clj-http "2.3.0"]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
@@ -19,7 +21,8 @@
                  [org.clojure/clojure "1.11.2"]
                  [org.clojure/tools.reader "1.3.2"]
                  [potemkin "0.4.5"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   :main ^:skip-aot search-relevancy-test.runner
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"

--- a/search-relevancy-test/project.clj
+++ b/search-relevancy-test/project.clj
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[camel-snake-kebab "0.4.0"]
-                 [cheshire "5.12.0"
+                 [cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [clj-http "2.3.0"]

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -5,7 +5,7 @@
                    :inherit [:managed-dependencies]}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[cheshire "5.12.0"
+  :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [clj-http "2.3.0"]

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -1,11 +1,13 @@
 (defproject nasa-cmr/cmr-system-int-test "0.1.0-SNAPSHOT"
   :description "This project provides end to end integration testing for CMR components."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/system-int-test"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.12.0"
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [com.fasterxml.jackson.core/jackson-core "2.21.2"]
+                 [com.fasterxml.jackson.core/jackson-core]
                  [clj-http "2.3.0"]
                  [clj-time "0.15.1"]
                  [clj-xml-validation "1.0.2"]
@@ -46,7 +48,8 @@
                  [org.eclipse.jetty/jetty-http "12.1.8"]
                  [org.eclipse.jetty/jetty-util "12.1.8"]
                  [org.eclipse.jetty/jetty-io "12.1.8"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Dclojure.compiler.direct-linking=true"


### PR DESCRIPTION
# Overview

### What is the objective?

Update jackson-core dep version

### What are the changes?

- Update jackson-core dep version
- Update cheshire version
- Centralized jackson-core, jackson-databind, jackson-dataformat-cbor, jackson-dataformat-smile, cheshire to parent project level
- Update access-control sys test to use flat string instead of a nested Clojure map, because of how new version of jackson-core and cheshire works with old clj-http

### What areas of the application does this impact?

All

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
