### PR TITLE
CMR-11488 - Snyk - ORG JSOUP

### DIFF
--- a/common-app-lib/project.clj
+++ b/common-app-lib/project.clj
@@ -19,6 +19,7 @@
                  [com.vladsch.flexmark/flexmark-all "0.64.0"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
                  [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.jsoup/jsoup "1.23.2"]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -38,7 +38,7 @@
                  [org.clojure/tools.logging "0.4.0"]
                  [org.clojure/tools.reader "1.3.2"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.jsoup/jsoup "1.14.2"]
+                 [org.jsoup/jsoup "1.23.2"]
                  [potemkin "0.4.5"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]


### PR DESCRIPTION
# Overview

Address the Snyk vulnerability associated with org.jsoup:jsoup 1.14.2

Please summarize the reason for the changes made in this PR.

### What are the changes?

* Upgrade the explicit jsoup dependency in system-int-test from 1.14.2 to 1.23.2
* Adds a direct jsoup dependency to common-app-lib to override the jsoup 1.14.3 transitive dependency brought in by flexmark-all

### What areas of the application does this impact?

* system-int-test
* common-app-lib

**NOTE**: No application behavior is impacted. The direct dependency impacts system integration tests and the common-app-lib impacts a component of flexmark-all that CMR does not currently use 

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [x] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [x] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
