### PR TITLE
CMR-11453 - Update netty version to 4.1.137.Final to address Snyk vulnerability

### DIFF
--- a/message-queue-lib/project.clj
+++ b/message-queue-lib/project.clj
@@ -8,7 +8,7 @@
 
 (def netty-version
   "The netty version to use."
-  "4.1.136.Final")
+  "4.1.137.Final")
 
 (defproject nasa-cmr/cmr-message-queue-lib "0.1.0-SNAPSHOT"
   :description "Library containing code to handle message queue interactions within the CMR."


### PR DESCRIPTION
# Overview

### What is the objective?

Updates Netty from 4.1.136.Final to 4.1.137.Final in the CMR message queue library. Addresses SNYK-JAVA-IONETTY-18955131 and SNYK-JAVA-IONETTY-19005879.

### What are the changes?

* Updated the shared Netty version from 4.1.136.Final to 4.1.137.Final
* Updated the resolved version for:
  * io.netty:netty-handler
  * io.netty:netty-codec-http
  * io.netty:netty-codec-http2
  * io.netty:netty-code
  * io.netty:netty-transport-classes-epoll
* No application code or behavior was changed

### What areas of the application does this impact?

* message-queue-lib

# Required Checklist

- [ ] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
