### PR TITLE
CMR-11538: Update jetty-http and jetty-websocket

### DIFF
--- a/access-control-app/project.clj
+++ b/access-control-app/project.clj
@@ -48,8 +48,8 @@
                            [org.clojure/clojure "1.11.2"]
                            [org.clojure/tools.reader "1.3.2"]
                            [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                           [org.eclipse.jetty/jetty-http "12.1.8"]
-                           [org.eclipse.jetty/jetty-util "12.1.8"]
+                           [org.eclipse.jetty/jetty-http]
+                           [org.eclipse.jetty/jetty-util]
                            [ring/ring-core "1.15.4"]
 
                            [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]

--- a/acl-lib/project.clj
+++ b/acl-lib/project.clj
@@ -1,11 +1,14 @@
 (defproject nasa-cmr/cmr-acl-lib "0.1.0-SNAPSHOT"
   :description "Contains utilities for retreiving and working with ACLs."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/acl-lib"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[commons-io "2.18.0"]
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.11.2"]
                  [potemkin "0.4.5"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :profiles {:security {:plugins [[com.livingsocial/lein-dependency-check "1.4.1"]]
@@ -34,6 +37,7 @@
                                      [lambdaisland/kaocha-cloverage "1.0.75"]
                                      [lambdaisland/kaocha-junit-xml "0.0.76"]
                                      [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                                     [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                                      ;; ring is needed or this fails in sys int group3
                                      [ring/ring-jetty-adapter "1.15.4"
                                       :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]]}}

--- a/bootstrap-app/project.clj
+++ b/bootstrap-app/project.clj
@@ -30,8 +30,8 @@
                  [org.clojure/tools.reader "1.3.2"]
                  [potemkin "0.4.5"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                  [ring/ring-jetty-adapter "1.15.4"

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -44,12 +44,10 @@
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.clojure/tools.reader "1.3.2"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 ;; These dependencies should be updated in tandem with the ring dependencies below.
-                 ;; To find the corresponding versions, see: https://clojars.org/ring/ring-core/versions/1.13.0
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
-                 [org.eclipse.jetty/jetty-io "12.1.8"]
-                 [org.eclipse.jetty/jetty-server "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
+                 [org.eclipse.jetty/jetty-io]
+                 [org.eclipse.jetty/jetty-server]
                  ;; load jts core lib first to make sure it is available for shapefile integration,
                  ;; otherwise ES referenced 1.15.0 version will be mistakenly picked for shapefile
                  [org.locationtech.jts/jts-core "1.18.2"]

--- a/common-lib/project.clj
+++ b/common-lib/project.clj
@@ -92,8 +92,8 @@
                                         ; "-Dcom.sun.management.jmxremote.authenticate=false"
                                         ; "-Dcom.sun.management.jmxremote.port=1098"]
                    :source-paths ["src" "dev" "test"]}
-             :static {:dependencies [[org.eclipse.jetty/jetty-http "12.1.8"]
-                                     [org.eclipse.jetty/jetty-util "12.1.8"]]}
+             :static {:dependencies [[org.eclipse.jetty/jetty-http]
+                                     [org.eclipse.jetty/jetty-util]]}
              ;; This profile is used for linting and static analysis. To run for this
              ;; project, use `lein lint` from inside the project directory. To run for
              ;; all projects at the same time, use the same command but from the top-

--- a/dev-system/project.clj
+++ b/dev-system/project.clj
@@ -46,18 +46,22 @@
   :description "Dev System combines together the separate microservices of the CMR into a single
                application to make it simpler to develop."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/dev-system"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies ~(concat '[[commons-codec/commons-codec "1.11"]
                            ;; replaces org.bouncycastle/bcpkix-jdk15on
                            [org.bouncycastle/bcpkix-jdk18on "1.85"]
-                           [org.clojure/clojure "1.11.2"]
+                           [org.clojure/clojure]
                            [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                           [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                            [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                            [ring/ring-jetty-adapter "1.15.4"
                             :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]]
                          project-dependencies)
   :plugins [[lein-environ "1.1.0"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :resource-paths ["resources"]
   :repl-options {:init-ns user

--- a/elastic-utils-lib/project.clj
+++ b/elastic-utils-lib/project.clj
@@ -19,6 +19,7 @@
                  [org.apache.logging.log4j/log4j-core]
                  [org.clojure/clojure]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                 [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
 
@@ -77,6 +78,7 @@
                                      [lambdaisland/kaocha-cloverage "1.0.75"]
                                      [lambdaisland/kaocha-junit-xml "0.0.76"]
                                      [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                                     [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                                      ;; ring is needed or this fails in sys int group3
                                      [ring/ring-jetty-adapter "1.15.4"
                                       :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]]}}

--- a/indexer-app/project.clj
+++ b/indexer-app/project.clj
@@ -1,6 +1,8 @@
 (defproject nasa-cmr/cmr-indexer-app "0.1.0-SNAPSHOT"
   :description "This is the indexer application for the CMR. It is responsible for indexing modified data into Elasticsearch."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/indexer-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[compojure "1.6.1"
                   :exclusions [commons-fileupload]]
                  [instaparse "1.4.10"]
@@ -18,14 +20,15 @@
                  [org.clojure/clojure "1.11.2"]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                  [ring/ring-json "0.5.1"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [lein-parent "0.3.9"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]

--- a/ingest-app/project.clj
+++ b/ingest-app/project.clj
@@ -1,6 +1,8 @@
 (defproject nasa-cmr/cmr-ingest-app "0.1.0-SNAPSHOT"
   :description "Ingest is an external facing CMR service facilitating providers to create and  update their concepts in CMR. Internally it delegates concept persistence operations to metadata db and indexer micro services."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/ingest-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[camel-snake-kebab "0.4.2"]
                  [clj-http "2.3.0"]
                  [com.draines/postal "2.0.3"]
@@ -34,8 +36,8 @@
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [org.quartz-scheduler/quartz "2.3.2"
                   :exclusions [com.mchange/c3p0 com.mchange/mchange-commons-java]]
                  [org.slf4j/slf4j-api "1.7.30"]
@@ -46,7 +48,8 @@
                  [ring/ring-jetty-adapter "1.15.4" :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                  [ring/ring-json "0.5.1"]]
   :plugins [[io.github.jaybarra/drift "1.5.4.2-SNAPSHOT" :exclusions [clojure-tools]]
-            [lein-exec "0.3.7"]]
+            [lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"
@@ -66,8 +69,8 @@
              ;; profile. An agent pool is being started when using the default profile which causes the wait of
              ;; 60 seconds before allowing the JVM to shutdown since no call to shutdown-agents is made.
              ;; Generate docs with: lein generate-static
-             :static {:dependencies [[org.eclipse.jetty/jetty-http "12.1.8"]
-                                     [org.eclipse.jetty/jetty-util "12.1.8"]]}
+             :static {:dependencies [[org.eclipse.jetty/jetty-http]
+                                     [org.eclipse.jetty/jetty-util]]}
              :uberjar {:main cmr.ingest.runner
                        :aot :all}
              ;; This profile is used for linting and static analysis. To run for this

--- a/metadata-db-app/project.clj
+++ b/metadata-db-app/project.clj
@@ -5,8 +5,8 @@
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
   :dependencies [[cheshire :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [clj-http "3.11.0"]
-                 [clj-time "0.15.1"]
+                 [clj-http]
+                 [clj-time]
                  [com.fasterxml.jackson.core/jackson-core]
                  [commons-io "2.18.0"] ;; used by migration
                  [compojure "1.6.1" :exclusions [commons-fileupload]]
@@ -22,12 +22,12 @@
                  [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  ;; replacment for org.bouncycastle/bcpkix-jdk15on
                  [org.bouncycastle/bcpkix-jdk18on "1.85"]
-                 [org.clojure/clojure "1.11.2"]
+                 [org.clojure/clojure]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.clojure/tools.reader "1.3.2"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [org.quartz-scheduler/quartz "2.3.2"]
                  [org.slf4j/slf4j-api "1.7.30"]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]

--- a/mock-echo-app/project.clj
+++ b/mock-echo-app/project.clj
@@ -1,6 +1,8 @@
 (defproject nasa-cmr/cmr-mock-echo-app "0.1.0-SNAPSHOT"
   :description "Mocks out the ECHO REST API."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/mock-echo-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[commons-io "2.18.0"]
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
@@ -9,17 +11,18 @@
                  [nasa-cmr/cmr-transmit-lib "0.1.0-SNAPSHOT"]
                  ;; replacment for org.bouncycastle/bcpkix-jdk15on
                  [org.bouncycastle/bcpkix-jdk18on "1.85"]
-                 [org.clojure/clojure "1.11.2"]
+                 [org.clojure/clojure]
                  [org.clojure/tools.reader "1.3.2"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                  [ring/ring-json "0.5.1"]]
   :plugins [[lein-exec "0.3.7"]
+            [lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :repl-options {:init-ns user}
   :jvm-opts ^:replace ["-server"

--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,10 @@
                           [org.apache.commons/commons-compress "1.28.0"] ;; see testcontainers
                           [org.apache.logging.log4j/log4j-api "2.25.4"]
                           [org.apache.logging.log4j/log4j-core "2.25.4"]
+                          [org.eclipse.jetty.websocket/jetty-websocket-core-common "12.1.12"]
+                          [org.eclipse.jetty/jetty-http "12.1.12"]
+                          [org.eclipse.jetty/jetty-io "12.1.12"]
+                          [org.eclipse.jetty/jetty-util "12.1.12"]
                           [org.testcontainers/testcontainers "2.0.2" ;; latest
                            :exclusions [[org.apache.commons/commons-compress]]]]
   :profiles {:uberjar {:modules {:dirs ["access-control-app"

--- a/project.clj
+++ b/project.clj
@@ -34,6 +34,7 @@
                           [org.eclipse.jetty/jetty-http "12.1.12"]
                           [org.eclipse.jetty/jetty-io "12.1.12"]
                           [org.eclipse.jetty/jetty-util "12.1.12"]
+                          [org.eclipse.jetty/jetty-server "12.1.12"]
                           [org.testcontainers/testcontainers "2.0.2" ;; latest
                            :exclusions [[org.apache.commons/commons-compress]]]]
   :profiles {:uberjar {:modules {:dirs ["access-control-app"

--- a/redis-utils-lib/project.clj
+++ b/redis-utils-lib/project.clj
@@ -25,6 +25,7 @@
                  [org.apache.commons/commons-compress]
                  [org.testcontainers/testcontainers]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                 [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]]
   :plugins [[lein-exec "0.3.7"]

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[cheshire
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
-                 [clj-time "0.15.1"]
+                 [clj-time]
                  [commons-codec/commons-codec "1.11"]
                  [commons-io/commons-io "2.18.0"]
                  [gov.nasa.earthdata/cmr-site-templates "0.1.1-SNAPSHOT"]
@@ -24,7 +24,7 @@
                  [org.apache.httpcomponents/httpclient "4.5.13"]
                  ;; replacment for org.bouncycastle/bcpkix-jdk15on
                  [org.bouncycastle/bcpkix-jdk18on "1.85"]
-                 [org.clojure/clojure "1.11.2"]
+                 [org.clojure/clojure]
                  [org.clojure/data.csv "0.1.4"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.reader "1.3.2"]
@@ -41,8 +41,8 @@
                                org.eclipse.emf/org.eclipse.emf.common]]
                  [org.mozilla/rhino "1.7.15.1"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"

--- a/search-app/project.clj
+++ b/search-app/project.clj
@@ -88,8 +88,8 @@
              ;; before allowing the JVM to shutdown since no call to shutdown-agents is
              ;; made. Generate docs with: lein generate-static (the alias makes use of the
              ;; static profile).
-             :static {:dependencies [[org.eclipse.jetty/jetty-http "12.1.8"]
-                                     [org.eclipse.jetty/jetty-util "12.1.8"]]}
+             :static {:dependencies [[org.eclipse.jetty/jetty-http]
+                                     [org.eclipse.jetty/jetty-util]]}
              :uberjar {:main cmr.search.runner
                        :aot :all}
 

--- a/system-int-test/project.clj
+++ b/system-int-test/project.clj
@@ -9,7 +9,7 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-core]
                  [clj-http "2.3.0"]
-                 [clj-time "0.15.1"]
+                 [clj-time]
                  [clj-xml-validation "1.0.2"]
                  [com.google.code.findbugs/jsr305 "3.0.2"]
                  [commons-codec/commons-codec "1.11"]
@@ -45,9 +45,9 @@
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
-                 [org.eclipse.jetty/jetty-io "12.1.8"]]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
+                 [org.eclipse.jetty/jetty-io]]
   :plugins [[lein-parent "0.3.9"]
             [lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"

--- a/umm-lib/project.clj
+++ b/umm-lib/project.clj
@@ -3,12 +3,15 @@
                model for Metadata Concepts in the CMR along with code to parse and generate the
                various dialects of each concept."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/umm-lib"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[nasa-cmr/cmr-common-app-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-common-lib "0.1.1-SNAPSHOT"]
                  [nasa-cmr/cmr-spatial-lib "0.1.0-SNAPSHOT"]
                  [org.clojure/clojure "1.11.2"]
                  [org.clojure/tools.reader "1.3.2"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   ;; The ^replace is done to disable the tiered compilation for accurate benchmarks
   ;; See https://github.com/technomancy/leiningen/wiki/Faster
   :jvm-opts ^:replace ["-server"
@@ -52,6 +55,7 @@
                                      [lambdaisland/kaocha-cloverage "1.0.75"]
                                      [lambdaisland/kaocha-junit-xml "0.0.76"]
                                      [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
+                                     [org.eclipse.jetty.websocket/jetty-websocket-core-common]
                                      ;; ring is needed or this fails in sys int group3
                                      [ring/ring-jetty-adapter "1.15.4"
                                       :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]]}}

--- a/virtual-product-app/project.clj
+++ b/virtual-product-app/project.clj
@@ -1,6 +1,8 @@
 (defproject nasa-cmr/cmr-virtual-product-app "0.1.0-SNAPSHOT"
   :description "Adds virtual products to the CMR."
   :url "https://github.com/nasa/Common-Metadata-Repository/tree/master/virtual-product-app"
+  :parent-project {:path "../project.clj"
+                   :inherit [:managed-dependencies]}
   :dependencies [[commons-logging "1.2"]
                  [compojure "1.6.1"
                   :exclusions [commons-fileupload]]
@@ -11,17 +13,18 @@
                  [nasa-cmr/cmr-umm-lib "0.1.0-SNAPSHOT"]
                  [nasa-cmr/cmr-umm-spec-lib "0.1.0-SNAPSHOT"]
                  [org.bouncycastle/bcpkix-jdk18on "1.85"]
-                 [org.clojure/clojure "1.11.2"]
+                 [org.clojure/clojure]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.10"]
-                 [org.eclipse.jetty/jetty-http "12.1.8"]
-                 [org.eclipse.jetty/jetty-util "12.1.8"]
+                 [org.eclipse.jetty/jetty-http]
+                 [org.eclipse.jetty/jetty-util]
                  [ring/ring-codec "1.3.0" :exclusions [org.bouncycastle/bcpkix-jdk15on]]
                  [ring/ring-core "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"
                   :exclusions [org.eclipse.jetty.ee9/jetty-ee9-servlet]]
                  [ring/ring-json "0.5.1"]]
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [lein-shell "0.5.0"]]
   :jvm-opts ^:replace ["-server"
                        "-Dclojure.compiler.direct-linking=true"]
   :repl-options {:init-ns user}


### PR DESCRIPTION
# Overview

### What is the objective?

Update jetty-http and jetty-websocket

### What are the changes?

- Update jetty-http and jetty-websocket
- Move them to parent project.clj deps

### What areas of the application does this impact?

All

# Required Checklist

- [x] New and existing unit and int tests pass locally and remotely
- [ ] clj-kondo has been run locally and all errors in changed files are corrected
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made changes to the documentation (if necessary)
- [ ] My changes generate no new warnings

# Additional Checklist
- [ ] I have removed unnecessary/dead code and imports in files I have changed
- [ ] I have cleaned up integration tests by doing one or more of the following:
  - migrated any are2 tests to are3 in files I have changed
  - de-duped, consolidated, removed dead int tests
  - transformed applicable int tests into unit tests
  - reduced number of system state resets by updating fixtures. Ex) (use-fixtures :each (ingest/reset-fixture {})) to be :once instead of :each
